### PR TITLE
swss/orchagent : Fixed the case of removing ip address from the interface.

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -123,16 +123,6 @@ void IntfsOrch::doTask()
                 continue;
             }
 
-            IpPrefix ip_prefix;
-            for (auto it = kfvFieldsValues(t).begin();
-                 it  != kfvFieldsValues(t).end(); it++)
-            {
-                if (fvField(*it) == "ip_prefix")
-                {
-                    ip_prefix = IpPrefix(fvValue(*it));
-                }
-            }
-
             sai_unicast_route_entry_t unicast_route_entry;
             unicast_route_entry.vr_id = gVirtualRouterId;
             unicast_route_entry.destination.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
@@ -159,7 +149,11 @@ void IntfsOrch::doTask()
                 it++;
             }
             else
+            {
+                SWSS_LOG_NOTICE("Remove packet action trap route ip:%s\n", ip_prefix.getIp().to_string().c_str());
+                m_intfs.erase(alias);
                 it = m_toSync.erase(it);
+            }
         }
     }
 }


### PR DESCRIPTION
1. Incorrect ip prefix parsing is fixed.
2. IntfsTable map is updated after removal of ip address from the interface.

Signed-off-by: Denys Haryachyy <Denys.Haryachyy@caviumnetworks.com>