### PR TITLE
swss/orchagent : Fixed the crash on error returned by select.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Build Status](https://sonic-jenkins.westus.cloudapp.azure.com/job/sonic-swss-build/badge/icon)](https://sonic-jenkins.westus.cloudapp.azure.com/job/sonic-swss-build/)
 
-# SONiC - Switch State Service - SwSS
+# SONiC - SWitch State Service - SWSS
 
 ## Description
-The Switch State Service (SwSS) is a collection of software that provides a database interface for communication with and state representation of network applications and network switch hardware.
+The SWitch State Service (SWSS) is a collection of software that provides a database interface for communication with and state representation of network applications and network switch hardware.
 
 ## Getting Started
 
@@ -26,26 +26,33 @@ There are a few different ways you can install SONiC-SWSS.
 
 For your convenience, you can install prepared packages on Debian Jessie:
 
-    sudo apt-get install sonic-swss
+    sudo apt-get install swss
 
 #### Install from Source
 
 Checkout the source: `git clone https://github.com/Azure/sonic-swss.git` and install it yourself.
+
+Get SAI header files into /usr/include/sai. Put the SAI header files that you use to compile
+libsairedis into /usr/include/sai
+
 Get `fpm.h` header file before compiling:
 
     mkdir fpmsyncd/fpm
     wget http://git.savannah.gnu.org/cgit/quagga.git/plain/fpm/fpm.h -O fpmsyncd/fpm/fpm.h
 
+Install prerequisite packages:
+
+    sudo apt-get install libswsscommon libswsscommon-dev libsairedis libsairedis-dev
+
 You can compile and install from source using:
 
     ./autogen.sh
-    ./configure
+    ./configure -with-fpm=fpm
     make && sudo make install
 
 You can also build a debian package using:
 
     ./autogen.sh
-    ./configure
     fakeroot debian/rules binary
 
 ## Need Help?

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -123,16 +123,6 @@ void IntfsOrch::doTask()
                 continue;
             }
 
-            IpPrefix ip_prefix;
-            for (auto it = kfvFieldsValues(t).begin();
-                 it  != kfvFieldsValues(t).end(); it++)
-            {
-                if (fvField(*it) == "ip_prefix")
-                {
-                    ip_prefix = IpPrefix(fvValue(*it));
-                }
-            }
-
             sai_unicast_route_entry_t unicast_route_entry;
             unicast_route_entry.vr_id = gVirtualRouterId;
             unicast_route_entry.destination.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
@@ -159,7 +149,11 @@ void IntfsOrch::doTask()
                 it++;
             }
             else
+            {
+                SWSS_LOG_NOTICE("Remove packet action trap route ip:%s\n", ip_prefix.getIp().to_string().c_str());
+                m_intfs.erase(alias);
                 it = m_toSync.erase(it);
+            }
         }
     }
 }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -52,7 +52,7 @@ void OrchDaemon::start()
         ret = m_select->select(&s, &fd, 1);
         if (ret == Select::ERROR)
         {
-            SWSS_LOG_NOTICE("Error!\n");
+            SWSS_LOG_NOTICE("Error: %s!\n", strerror(errno));
             continue;
         }
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -51,7 +51,10 @@ void OrchDaemon::start()
 
         ret = m_select->select(&s, &fd, 1);
         if (ret == Select::ERROR)
+        {
             SWSS_LOG_NOTICE("Error!\n");
+            continue;
+        }
 
         if (ret == Select::TIMEOUT)
             continue;


### PR DESCRIPTION
Crash happens when the select call in OrchDaemon start method
returns an error and getOrchByConsumer returns a null pointer.

Signed-off-by: Denys Haryachyy <Denys.Haryachyy@caviumnetworks.com>