### PR TITLE
portsyncd: Adding ConfigDone notification in portsyncd

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -25,6 +25,9 @@ void IntfsOrch::doTask(Consumer &consumer)
     if (consumer.m_toSync.empty())
         return;
 
+    if (!m_portsOrch->isInitDone())
+        return;
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -12,6 +12,9 @@ void NeighOrch::doTask(Consumer &consumer)
     if (consumer.m_toSync.empty())
         return;
 
+    if (!m_portsOrch->isInitDone())
+        return;
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -139,6 +139,11 @@ PortsOrch::PortsOrch(DBConnector *db, string tableName) :
     }
 }
 
+bool PortsOrch::isInitDone()
+{
+    return m_initDone;
+}
+
 bool PortsOrch::getPort(string alias, Port &p)
 {
     if (m_portList.find(alias) == m_portList.end())
@@ -178,6 +183,25 @@ void PortsOrch::doTask(Consumer &consumer)
 
         string alias = kfvKey(t);
         string op = kfvOp(t);
+
+        /* Get notification from application */
+        /* portsyncd application:
+         * When portsorch receives 'ConfigDone' message, it indicates port initialization
+         * procedure is done. Before port initialization procedure, none of other tasks
+         * are executed.
+         */
+        if (alias == "ConfigDone")
+        {
+            /* portsyncd restarting case:
+             * When portsyncd restarts, duplicate notifications may be received.
+             */
+            if (m_initDone)
+                return;
+
+            m_initDone = true;
+            SWSS_LOG_INFO("Get ConfigDone notification from portsyncd.\n");
+            return;
+        }
 
         if (op == "SET")
         {

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -13,11 +13,14 @@ class PortsOrch : public Orch
 public:
     PortsOrch(DBConnector *db, string tableName);
 
+    bool isInitDone();
+
     bool getPort(string alias, Port &p);
 
     bool setPortAdminStatus(sai_object_id_t id, bool up);
 
 private:
+    bool m_initDone = false;
     sai_object_id_t m_cpuPort;
 
     sai_uint32_t m_portCount;

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -14,6 +14,9 @@ void RouteOrch::doTask(Consumer& consumer)
     if (consumer.m_toSync.empty())
         return;
 
+    if (!m_portsOrch->isInitDone())
+        return;
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {


### PR DESCRIPTION
    As most of the applications depend on port initialization, we add
    a 'ConfigDone' notification in portsyncd after finishing reading
    the file 'port_config.ini'. Before orchagent receives this notification,
    all other tasks from other applications are stored without actually
    being executed. Only when the orchagent get this notification will all
    other tasks been executed.

    Signed-off-by: Shuotian Cheng <shuche@microsoft.com>
