### PR TITLE
intfsyncd neighsyncd: Ignoring lo, eth0 and docker0 interfaces

### DIFF
--- a/intfsyncd/intfsync.cpp
+++ b/intfsyncd/intfsync.cpp
@@ -47,6 +47,11 @@ void IntfSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
 
     key = LinkCache::getInstance().ifindexToName(rtnl_addr_get_ifindex(addr));
+
+    /* Don't sync lo, eth0, and docker0 routes */
+    if (key == "lo" || key == "eth0" || key == "docker0")
+        return;
+
     key+= ":";
     nl_addr2str(rtnl_addr_get_local(addr), addrStr, MAX_ADDR_SIZE);
     key+= addrStr;

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -42,6 +42,11 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
 
     key+= LinkCache::getInstance().ifindexToName(rtnl_neigh_get_ifindex(neigh));
+
+    /* Don't sync lo, eth0, and docker0 neighbors */
+    if (key == "lo" || key == "eth0" || key == "docker0")
+        return;
+
     key+= ":";
     nl_addr2str(rtnl_neigh_get_dst(neigh), addrStr, MAX_ADDR_SIZE);
     key+= addrStr;


### PR DESCRIPTION
With this fix, we will only have the entries that we care appearing in the database. This allows the APP_DB to be synced with ASIC_DB and both contents draw the same picture.