### PR TITLE
portsyncd: added 'alias' field into PORT_TABLE

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -4,6 +4,7 @@
 #include "netlink.h"
 #include "producertable.h"
 #include "portsyncd/linksync.h"
+#include "logger.h"
 
 #include <getopt.h>
 
@@ -154,12 +155,17 @@ void handlePortConfigFile(ProducerTable &p, string file)
         }
 
         istringstream iss(line);
-        string alias, lanes;
-        iss >> alias >> lanes;
+        string name, lanes, alias;
+        iss >> name >> lanes >> alias;
 
         FieldValueTuple lanes_attr("lanes", lanes);
-        vector<FieldValueTuple> attrs = { lanes_attr };
-        p.set(alias, attrs);
+        FieldValueTuple alias_attr("alias", alias);
+        vector<FieldValueTuple> attrs;
+
+        attrs.push_back(lanes_attr);
+        attrs.push_back(alias_attr);
+
+        p.set(name, attrs);
 
         g_portSet.insert(alias);
     }

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -4,7 +4,6 @@
 #include "netlink.h"
 #include "producertable.h"
 #include "portsyncd/linksync.h"
-#include "logger.h"
 
 #include <getopt.h>
 

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -157,10 +157,14 @@ void handlePortConfigFile(ProducerTable &p, string file)
         string name, lanes, alias;
         iss >> name >> lanes >> alias;
 
+        /* If port has no alias, then use its' name as alias */
+        if (alias == "") {
+            alias = name;
+        }
         FieldValueTuple lanes_attr("lanes", lanes);
         FieldValueTuple alias_attr("alias", alias);
-        vector<FieldValueTuple> attrs;
 
+        vector<FieldValueTuple> attrs;
         attrs.push_back(lanes_attr);
         attrs.push_back(alias_attr);
 


### PR DESCRIPTION
Provided the reading of 'alias' field from port_config.ini, and storing it into Redis DB.