### PR TITLE
Revert "orchagent: Updating the route next hop ID also sets action to forward"

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -440,24 +440,11 @@ bool RouteOrch::addRoute(IpPrefix ipPrefix, IpAddresses nextHops)
     }
     else
     {
-        /* Set the next hop ID to a new value */
         sai_status_t status = sai_route_api->set_route_attribute(&route_entry, &route_attr);
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set route %s with next hop(s) %s",
                     ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
-            return false;
-        }
-
-        /* Set the packet action to forward */
-        route_attr.id = SAI_ROUTE_ATTR_PACKET_ACTION;
-        route_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
-
-        status = sai_route_api->set_route_attribute(&route_entry, &route_attr);
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to set route %s with packet action forward, %d",
-                           ipPrefix.to_string().c_str(), status);
             return false;
         }
 


### PR DESCRIPTION
Reverts Azure/sonic-swss#136

This change breaks the test as the current SAI implementation doesn't support the mid-state that the route with packet action DROP is set with next hop ID and packet action FORWARD by two steps. After the SAI implementation is fixed, this change will be re-introduced.