### PR TITLE
teamsyncd: Use TEAM_OPTION_CHANGE 'enabled' to track LAG membership

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -124,7 +124,7 @@ For example (reorder output)
     speed
 
     key                 = LAG_TABLE:lagname:ifname  ; physical port member of LAG, fk to PORT_TABLE:ifname
-    oper_status         = "down" / "up"        ; Oper status (physical + 802.3ad state)
+    status              = "enabled" / "disabled"    ; selected + distributing/collecting (802.3ad)
     speed               = ; set by LAG application, must match PORT_TABLE.duplex
     duplex              = ; set by LAG application, must match PORT_TABLE.duplex
 
@@ -142,8 +142,8 @@ In addition for each team device, the teamsyncd listens to team events
 and reflects the LAG ports into the redis under: `LAG_TABLE:<team0>:port`
 
     127.0.0.1:6379> HGETALL "LAG_TABLE:team0:veth0"
-    1) "linkup"
-    2) "down"
+    1) "status"
+    2) "disabled"
     3) "speed"
     4) "0Mbit"
     5) "duplex"

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -38,7 +38,7 @@ public:
         virtual void readMe();
 
     protected:
-        int onPortChange(bool isInit);
+        int onChange();
         static int teamdHandler(struct team_handle *th, void *arg,
                                 team_change_type_mask_t type_mask);
         static const struct team_change_handler gPortChangeHandler;
@@ -47,6 +47,7 @@ public:
         struct team_handle *m_team;
         std::string m_lagName;
         int m_ifindex;
+        std::map<std::string, bool> m_lagMembers; /* map[ifname] = status (enabled|disabled) */
     };
 
 protected:


### PR DESCRIPTION
enabled is a more appropriate option/flag to be tracked and syncd
with the ASIC LAG state. Because 802.3ad LACP is used here, port will
only be put into distributing/collecting mode when it is enabled.

In orchagent, LAG member link up/down logic is removed since when
port is not enabled, it will be directly removed from the LAG.