### PR TITLE
[orchagent]: Fixing bug internal entry not removed after DEL

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -146,7 +146,10 @@ void IntfsOrch::doTask(Consumer &consumer)
                 if (m_syncdIntfses[alias].ip_addresses.getSize() == 0)
                 {
                     if (removeRouterIntfs(port))
+                    {
+                        m_syncdIntfses.erase(alias);
                         it = consumer.m_toSync.erase(it);
+                    }
                     else
                         it++;
                 }


### PR DESCRIPTION
Signed-off-by: Shuotian Cheng <shuche@microsoft.com>

This bug will be triggered when flapping the router interfaces.