### PR TITLE
[teamsyncd]: Add LAG members to syncd when created.

### DIFF
--- a/teamsyncd/Makefile.am
+++ b/teamsyncd/Makefile.am
@@ -12,4 +12,4 @@ teamsyncd_SOURCES = teamsyncd.cpp teamsync.cpp
 
 teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-teamsyncd_LDADD = -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam
+teamsyncd_LDADD = -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam -lteamdctl

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -36,6 +36,7 @@ public:
         virtual bool isMe(fd_set *fd);
         virtual int readCache();
         virtual void readMe();
+        void syncMember(const std::string& intfName);
 
     protected:
         int onChange();
@@ -45,6 +46,7 @@ public:
     private:
         ProducerStateTable *m_lagTable;
         struct team_handle *m_team;
+        struct teamdctl *m_tdc;
         std::string m_lagName;
         int m_ifindex;
         std::map<std::string, bool> m_lagMembers; /* map[ifname] = status (enabled|disabled) */


### PR DESCRIPTION
It is possible that LAG members are created after teamd
creates LAG. In that case we have to monitor RTM_NEWLINK
messages and addd them via teamdctl.

Signed-off-by: marian-pritsak <marianp@mellanox.com>