### PR TITLE
[orchagent]: Add query of NUMBER_OF_ECMP_GROUPS in routeorch

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -7,8 +7,13 @@ extern sai_object_id_t gVirtualRouterId;
 
 extern sai_next_hop_group_api_t*    sai_next_hop_group_api;
 extern sai_route_api_t*             sai_route_api;
+extern sai_switch_api_t*            sai_switch_api;
 
 extern PortsOrch *gPortsOrch;
+
+/* Default maximum number of next hop groups */
+#define DEFAULT_NUMBER_OF_ECMP_GROUPS   128
+#define MLNX_PLATFORM_SUBSTRING "mlnx"
 
 RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch) :
         Orch(db, tableName),
@@ -18,6 +23,32 @@ RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch) :
 {
     SWSS_LOG_ENTER();
 
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_NUMBER_OF_ECMP_GROUPS;
+
+    sai_status_t status = sai_switch_api->get_switch_attribute(1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Failed to get switch attribute number of ECMP groups. \
+                       Use default value. rv:%d", status);
+        m_maxNextHopGroupCount = DEFAULT_NUMBER_OF_ECMP_GROUPS;
+    }
+    else
+    {
+        m_maxNextHopGroupCount = attr.value.s32;
+
+        /*
+         * Workaround to re-calculate maximum ECMP groups on the condition of
+         * maximum ECMP group size is 32 due to a different ECMP mode is used.
+         */
+        char *platform = getenv("platform");
+        if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
+        {
+            m_maxNextHopGroupCount /= 32;
+        }
+    }
+    SWSS_LOG_NOTICE("Maximum number of ECMP groups supported is %d", m_maxNextHopGroupCount);
+
     IpPrefix default_ip_prefix("0.0.0.0/0");
 
     sai_unicast_route_entry_t unicast_route_entry;
@@ -25,11 +56,10 @@ RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch) :
     copy(unicast_route_entry.destination, default_ip_prefix);
     subnet(unicast_route_entry.destination, unicast_route_entry.destination);
 
-    sai_attribute_t attr;
     attr.id = SAI_ROUTE_ATTR_PACKET_ACTION;
     attr.value.s32 = SAI_PACKET_ACTION_DROP;
 
-    sai_status_t status = sai_route_api->create_route(&unicast_route_entry, 1, &attr);
+    status = sai_route_api->create_route(&unicast_route_entry, 1, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create v4 default route with packet action drop");
@@ -359,9 +389,10 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
 
     assert(!hasNextHopGroup(ipAddresses));
 
-    if (m_nextHopGroupCount > NHGRP_MAX_SIZE)
+    if (m_nextHopGroupCount >= m_maxNextHopGroupCount)
     {
-        SWSS_LOG_DEBUG("Failed to create next hop group. Exceeding maximum number of next hop groups.\n");
+        SWSS_LOG_DEBUG("Failed to create new next hop group. \
+                        Reaching maximum number of next hop groups.");
         return false;
     }
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -13,7 +13,8 @@ extern PortsOrch *gPortsOrch;
 
 /* Default maximum number of next hop groups */
 #define DEFAULT_NUMBER_OF_ECMP_GROUPS   128
-#define MLNX_PLATFORM_SUBSTRING "mlnx"
+#define DEFAULT_MAX_ECMP_GROUP_SIZE     32
+#define MLNX_PLATFORM_SUBSTRING         "mlnx"
 
 RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch) :
         Orch(db, tableName),
@@ -38,13 +39,18 @@ RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch) :
         m_maxNextHopGroupCount = attr.value.s32;
 
         /*
-         * Workaround to re-calculate maximum ECMP groups on the condition of
-         * maximum ECMP group size is 32 due to a different ECMP mode is used.
+         * ASIC specific workaround to re-calculate maximum ECMP groups 
+         * according to diferent ECMP mode used.
+         *
+         * On Mellanox platform, the maximum ECMP groups returned is the value
+         * under the condition that the ECMP group size is 1. Deviding this
+         * number by DEFAULT_MAX_ECMP_GROUP_SIZE gets the maximum number of
+         * ECMP groups when the maximum ECMP group size is 32.
          */
         char *platform = getenv("platform");
         if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
         {
-            m_maxNextHopGroupCount /= 32;
+            m_maxNextHopGroupCount /= DEFAULT_MAX_ECMP_GROUP_SIZE;
         }
     }
     SWSS_LOG_NOTICE("Maximum number of ECMP groups supported is %d", m_maxNextHopGroupCount);

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -15,9 +15,6 @@
 using namespace std;
 using namespace swss;
 
-/* Maximum next hop group number */
-#define NHGRP_MAX_SIZE 128
-
 struct NextHopGroupEntry
 {
     sai_object_id_t     next_hop_group_id;  // next hop group id
@@ -59,6 +56,7 @@ private:
     NeighOrch *m_neighOrch;
 
     int m_nextHopGroupCount;
+    int m_maxNextHopGroupCount;
     bool m_resync;
 
     RouteTable m_syncdRoutes;


### PR DESCRIPTION
Instead of using the default value of 128, query the switch first to
get the NUMBER_OF_ECMP_GROUPS and use this value as the maximum supported
number of next hop groups. If the query fails, the default value of 128
will be used.

Also fix the corner case by changing '>' to '>=' when checking the number
of next hop groups.