### PR TITLE
[acl]: Simplify AclOrch class locking schema.

### DIFF
--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -237,11 +237,6 @@ public:
 
     sai_object_id_t getTableById(string table_id);
 
-    static mutex& getContextMutex()
-    {
-        return m_countersMutex;
-    }
-
     static swss::Table& getCountersTable()
     {
         return m_countersTable;


### PR DESCRIPTION
Lock mutex only at the beginning of critical sections.