### PR TITLE
[orch]: Add SwSS record mechanism that record all tasks from applications

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -549,21 +549,17 @@ void BufferOrch::doTask(Consumer &consumer)
             break;
         case task_process_status::task_invalid_entry:
             SWSS_LOG_ERROR("Invalid buffer task item was encountered, removing from queue.");
-            dumpTuple(consumer, tuple);
             it = consumer.m_toSync.erase(it);
             break;
         case task_process_status::task_failed:
             SWSS_LOG_ERROR("Processing buffer task item failed, exiting.");
-            dumpTuple(consumer, tuple);
             return;
         case task_process_status::task_need_retry:
             SWSS_LOG_ERROR("Processing buffer task item failed, will retry.");
-            dumpTuple(consumer, tuple);
             it++;
             break;
         default:
             SWSS_LOG_ERROR("Unknown task status: %d", task_status);
-            dumpTuple(consumer, tuple);
             it = consumer.m_toSync.erase(it);
             break;
         }

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -577,16 +577,13 @@ void CoppOrch::doTask(Consumer &consumer)
                 break;
             case task_process_status::task_invalid_entry:
                 SWSS_LOG_ERROR("Invalid copp task item was encountered, removing from queue.");
-                dumpTuple(consumer, tuple);
                 it = consumer.m_toSync.erase(it);
                 break;
             case task_process_status::task_failed:
                 SWSS_LOG_ERROR("Processing copp task item failed, exiting. ");
-                dumpTuple(consumer, tuple);
                 return;
             case task_process_status::task_need_retry:
                 SWSS_LOG_ERROR("Processing copp task item failed, will retry.");
-                dumpTuple(consumer, tuple);
                 it++;
                 break;
             default:

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -77,7 +77,7 @@ protected:
 
     /* Run doTask against a specific consumer */
     virtual void doTask(Consumer &consumer) = 0;
-    void dumpTuple(Consumer &consumer, KeyOpFieldsValuesTuple &tuple);
+    void recordTuple(Consumer &consumer, KeyOpFieldsValuesTuple &tuple);
     ref_resolve_status resolveFieldRefValue(type_map&, const string&, KeyOpFieldsValuesTuple&, sai_object_id_t&);
     bool parseIndexRange(const string &input, sai_uint32_t &range_low, sai_uint32_t &range_high);
     bool parseReference(type_map &type_maps, string &ref, string &table_name, string &object_name);

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1260,22 +1260,18 @@ void QosOrch::doTask(Consumer &consumer)
         switch(task_status)
         {
             case task_process_status::task_success :
-                dumpTuple(consumer, tuple);
                 it = consumer.m_toSync.erase(it);
                 SWSS_LOG_DEBUG("Successfully processed item, removing from queue.");
                 break;
             case task_process_status::task_invalid_entry :
                 SWSS_LOG_ERROR("Invalid QOS task item was encountered, removing from queue.");
-                dumpTuple(consumer, tuple);
                 it = consumer.m_toSync.erase(it);
                 break;
             case task_process_status::task_failed :
                 SWSS_LOG_ERROR("Processing QOS task item failed, exiting.");
-                dumpTuple(consumer, tuple);
                 return;
             case task_process_status::task_need_retry :
                 SWSS_LOG_INFO("Processing QOS task item failed, will retry.");
-                dumpTuple(consumer, tuple);
                 it++;
                 break;
             default:


### PR DESCRIPTION
Similar to sairedis record, this swss record provides a log that records
all applications tasks according to the sequence of incoming messages from
the Redis database queue. The format follows the sairedis record format:

TIMESTAMP|TABLE_NAME:KEY|OP|FIELD:VALUE|FIELD:VALUE|...

The record file is saved at where the daemon is started from, with the file
name swss.TIMESTAMP.rec.

-R option will control both sairedis record and swss record