### PR TITLE
Add MTU set on port (issue #77)

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <set>
 
+#include <netinet/if_ether.h>
 #include "net/if.h"
 
 #include "logger.h"
@@ -229,15 +230,16 @@ bool PortsOrch::setPortMtu(sai_object_id_t id, sai_uint32_t mtu)
 
     sai_attribute_t attr;
     attr.id = SAI_PORT_ATTR_MTU;
-    attr.value.u32 = mtu;
+    /* mtu + 14 + 4 + 4 = 22 bytes */
+    attr.value.u32 = mtu + sizeof(struct ether_header) + FCS_LEN + VLAN_TAG_LEN;
 
     sai_status_t status = sai_port_api->set_port_attribute(id, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to set MTU %u to port pid:%lx", mtu, id);
+        SWSS_LOG_ERROR("Failed to set MTU %u to port pid:%lx", attr.value.u32, id);
         return false;
     }
-    SWSS_LOG_INFO("Set MTU %u to port pid:%lx", mtu, id);
+    SWSS_LOG_INFO("Set MTU %u to port pid:%lx", attr.value.u32, id);
     return true;
 }
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -9,6 +9,9 @@
 
 #include <map>
 
+#define FCS_LEN 4
+#define VLAN_TAG_LEN 4
+
 static const map<sai_port_oper_status_t, string> oper_status_strings =
 {
     { SAI_PORT_OPER_STATUS_UNKNOWN,     "unknown" },

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -80,6 +80,7 @@ private:
     bool removeLagMember(Port lag, Port port);
 
     bool setPortAdminStatus(sai_object_id_t id, bool up);
+    bool setPortMtu(sai_object_id_t id, sai_uint32_t mtu);
 };
 #endif /* SWSS_PORTSORCH_H */
 


### PR DESCRIPTION
portsyncd synchronizes net device settings with the PORT_TABLE
Added code to set MTU to hardware on PORT_TABLE update 