### PR TITLE
[swssplayer]: Add swssplayer to replay the swss record file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,6 @@ portsyncd/portsyncd
 orchagent/orchagent
 orchagent/routeresync
 swssconfig/swssconfig
+swssconfig/swssplayer
 
 

--- a/swssconfig/Makefile.am
+++ b/swssconfig/Makefile.am
@@ -1,6 +1,6 @@
 INCLUDES = -I $(top_srcdir)
 
-bin_PROGRAMS = swssconfig
+bin_PROGRAMS = swssconfig swssplayer
 
 if DEBUG
 DBGFLAGS = -ggdb -DDEBUG
@@ -12,4 +12,10 @@ swssconfig_SOURCES = swssconfig.cpp
 
 swssconfig_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 swssconfig_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssconfig_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+swssconfig_LDADD = -lswsscommon
+
+swssplayer_SOURCES = swssplayer.cpp
+
+swssplayer_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
+swssplayer_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
+swssplayer_LDADD = -lswsscommon

--- a/swssconfig/swssplayer.cpp
+++ b/swssconfig/swssplayer.cpp
@@ -1,0 +1,82 @@
+#include <fstream>
+#include <iostream>
+
+#include <dbconnector.h>
+#include <producerstatetable.h>
+#include <schema.h>
+#include <tokenize.h>
+
+using namespace std;
+using namespace swss;
+
+constexpr int DB_PORT = 6379;
+constexpr char* DB_HOSTNAME = "localhost";
+
+static int line_index = 0;
+static DBConnector db(APPL_DB, DB_HOSTNAME, DB_PORT, 0);
+
+void usage()
+{
+	cout << "Usage: swssplayer <file>" << endl;
+	/* TODO: Add sample input file */
+}
+
+vector<FieldValueTuple> processFieldsValuesTuple(string s)
+{
+	vector<FieldValueTuple> result;
+
+	auto tuples = tokenize(s, '|');
+	for (auto tuple : tuples)
+	{
+		auto v_tuple = tokenize(tuple, ':', 1);
+		auto field = v_tuple[0];
+		auto value = v_tuple.size() == 1 ? "" : v_tuple[1];
+		result.push_back(FieldValueTuple(field, value));
+	}
+
+	return result;
+}
+
+void processTokens(vector<string> tokens)
+{
+	auto key = tokens[1];
+
+	/* Process the key */
+	auto v_key = tokenize(key, ':', 1);
+	auto table_name = v_key[0];
+	auto key_name = v_key[1];
+
+	ProducerStateTable producer(&db, table_name);
+
+	/* Process the operation */
+	auto op = tokens[2];
+	if (op == SET_COMMAND)
+	{
+		auto tuples = processFieldsValuesTuple(tokens[3]);
+		producer.set(key_name, tuples, SET_COMMAND);
+	}
+	else if (op == DEL_COMMAND)
+	{
+		producer.del(key_name, DEL_COMMAND);
+	}
+}
+
+int main(int argc, char **argv)
+{
+	if (argc != 2)
+	{
+		usage();
+		exit(EXIT_FAILURE);
+	}
+
+	ifstream file(argv[1]);
+	string line;
+
+	while (getline(file, line))
+	{
+		auto tokens = tokenize(line, '|', 3);
+		processTokens(tokens);
+
+		line_index++;
+	}
+}


### PR DESCRIPTION
Usage: swssplayer <file>

The file is the SwSS record file get from orchagent. This module
enables better debugging to replay all application tasks to orchagent.

It is a similar tool as saiplayer but dedicated for orchagent.