### PR TITLE
[saihelper]: Create initSaiRedis function and put related code inside it

### DIFF
--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -1,3 +1,6 @@
 #pragma once
 
+#include <string>
+
 void initSaiApi();
+void initSaiRedis(const std::string &record_location);


### PR DESCRIPTION
Move SAI Redis initialization related code outside main function.
In the future, global variables could be eliminated to make code cleaner.
getTimestamp could be moved to common library as well.