### PR TITLE
[copporch]: Add trap priority support and update COPP configurations

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -111,6 +111,10 @@ void CoppOrch::initDefaultTrapIds()
     attr.value.s32 = SAI_HOSTIF_TRAP_CHANNEL_NETDEV;
     trap_id_attrs.push_back(attr);
 
+    attr.id = SAI_HOSTIF_TRAP_ATTR_TRAP_PRIORITY;
+    attr.value.u32 = 0;
+    trap_id_attrs.push_back(attr);
+
     if (!applyAttributesToTrapIds(m_trap_group_map[default_trap_group], default_trap_ids, trap_id_attrs))
     {
         SWSS_LOG_ERROR("Failed to set attributes to default trap IDs");
@@ -319,6 +323,12 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
                 sai_packet_action_t trap_action = packet_action_map.at(fvValue(*i));
                 attr.id = SAI_HOSTIF_TRAP_ATTR_PACKET_ACTION;
                 attr.value.s32 = trap_action;
+                trap_id_attribs.push_back(attr);
+            }
+            else if (fvField(*i) == copp_trap_priority_field)
+            {
+                attr.id = SAI_HOSTIF_TRAP_ATTR_TRAP_PRIORITY,
+                attr.value.u32 = stoul(fvValue(*i), nullptr, 0);
                 trap_id_attribs.push_back(attr);
             }
             //

--- a/orchagent/copporch.h
+++ b/orchagent/copporch.h
@@ -6,6 +6,8 @@
 #include "orch.h"
 
 const string copp_trap_id_list                = "trap_ids";
+const string copp_trap_action_field           = "trap_action";
+const string copp_trap_priority_field         = "trap_priority";
 const string copp_queue_field                 = "queue";
 // policer fields
 const string copp_policer_meter_type_field    = "meter_type";
@@ -15,7 +17,6 @@ const string copp_policer_cbs_field           = "cbs";
 const string copp_policer_cir_field           = "cir";
 const string copp_policer_pbs_field           = "pbs";
 const string copp_policer_pir_field           = "pir";
-const string copp_trap_action_field           = "trap_action";
 const string copp_policer_action_green_field  = "green_action";
 const string copp_policer_action_red_field    = "red_action";
 const string copp_policer_action_yellow_field = "yellow_action";

--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -14,6 +14,7 @@
         "COPP_TABLE:trap.group.bgp.lacp": {
             "trap_ids": "bgp,lacp",
             "trap_action":"trap",
+            "trap_priority":"4",
             "queue": "4"
         },
         "OP": "SET"
@@ -22,6 +23,7 @@
         "COPP_TABLE:trap.group.arp": {
             "trap_ids": "arp_req,arp_resp,neigh_discovery",
             "trap_action":"trap",
+            "trap_priority":"4",
             "queue": "4",
             "meter_type":"packets",
             "mode":"sr_tcm",
@@ -35,6 +37,7 @@
         "COPP_TABLE:trap.group.lldp.dhcp": {
             "trap_ids": "lldp,dhcp",
             "trap_action":"trap",
+            "trap_priority":"4",
             "queue": "4"
         },
         "OP": "SET"
@@ -43,6 +46,7 @@
         "COPP_TABLE:trap.group.ip2me": {
             "trap_ids": "ip2me",
             "trap_action":"trap",
+            "trap_priority":"1",
             "queue": "1",
             "meter_type":"packets",
             "mode":"sr_tcm",


### PR DESCRIPTION
Right now we don't have trap priority defined. This will cause packets put into
different queues and dropped due to policer settings. With the trap priority
attribute added, protocol level packets are assigned with higher priorities and
will not be dropped correspondingly.