### PR TITLE
[routeorch]: Need to set drop route next hop ID to NULL

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -70,8 +70,8 @@ RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch) :
     status = sai_route_api->create_route_entry(&unicast_route_entry, 1, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to create v4 default route with packet action drop");
-        throw runtime_error("Failed to create v4 default route with packet action drop");
+        SWSS_LOG_ERROR("Failed to create IPv4 default route with packet action drop");
+        throw runtime_error("Failed to create IPv4 default route with packet action drop");
     }
 
     /* Add default IPv4 route into the m_syncdRoutes */
@@ -87,8 +87,8 @@ RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch) :
     status = sai_route_api->create_route_entry(&unicast_route_entry, 1, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to create v6 default route with packet action drop");
-        throw runtime_error("Failed to create v6 default route with packet action drop");
+        SWSS_LOG_ERROR("Failed to create IPv6 default route with packet action drop");
+        throw runtime_error("Failed to create IPv6 default route with packet action drop");
     }
 
     /* Add default IPv6 route into the m_syncdRoutes */
@@ -455,14 +455,13 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
 
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to create next hop group nh:%s\n",
-                       ipAddresses.to_string().c_str());
+        SWSS_LOG_ERROR("Failed to create next hop group %s, rv:%d",
+                       ipAddresses.to_string().c_str(), status);
         return false;
     }
 
     m_nextHopGroupCount ++;
-    SWSS_LOG_NOTICE("Create next hop group nhgid:%lx nh:%s \n",
-                    next_hop_group_id, ipAddresses.to_string().c_str());
+    SWSS_LOG_NOTICE("Create next hop group %s", ipAddresses.to_string().c_str());
 
     NextHopGroupEntry next_hop_group_entry;
     next_hop_group_entry.next_hop_group_id = next_hop_group_id;
@@ -748,9 +747,25 @@ bool RouteOrch::removeRoute(IpPrefix ipPrefix)
         sai_status_t status = sai_route_api->set_route_entry_attribute(&route_entry, &attr);
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_ERROR("Failed to set route %s to drop", ipPrefix.to_string().c_str());
+            SWSS_LOG_ERROR("Failed to set route %s packet action to drop, rv:%d",
+                    ipPrefix.to_string().c_str(), status);
             return false;
         }
+
+        SWSS_LOG_INFO("Set route %s packet action to drop", ipPrefix.to_string().c_str());
+
+        attr.id = SAI_ROUTE_ATTR_NEXT_HOP_ID;
+        attr.value.oid = SAI_NULL_OBJECT_ID;
+
+        status = sai_route_api->set_route_attribute(&route_entry, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set route %s next hop ID to NULL, rv:%d",
+                    ipPrefix.to_string().c_str(), status);
+            return false;
+        }
+
+        SWSS_LOG_INFO("Set route %s next hop ID to NULL", ipPrefix.to_string().c_str());
     }
     else
     {


### PR DESCRIPTION
In orchagent, route's next hop packet action is set to DROP. But the previous
next hop object is still referenced by the route. This will cause the next
hop group removal failure.

Reset the drop route next hop ID to NULL to remove the reference for the
previous next hop object.