### PR TITLE
[mirrororch]: Add SAI_MIRROR_SESSION_ATTR_VLAN_HEADER_VALID

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -396,6 +396,10 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
     attr.value.s32 = SAI_MIRROR_SESSION_TYPE_ENHANCED_REMOTE;
     attrs.push_back(attr);
 
+    attr.id = SAI_MIRROR_SESSION_ATTR_VLAN_HEADER_VALID;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
     attr.id =SAI_MIRROR_SESSION_ATTR_VLAN_TPID;
     attr.value.u16 = ETH_P_8021Q;
     attrs.push_back(attr);


### PR DESCRIPTION
This attribute is required to set VLAN TPID and VLAN ID, etc in SAI v1.0