### PR TITLE
[bufferorch]: Replace buffer profile mode to inherit

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -223,7 +223,7 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
             else if (fvField(*i) == buffer_dynamic_th_field_name)
             {
                 attr.id = SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE;
-                attr.value.s32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_DYNAMIC;
+                attr.value.s32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_INHERIT_BUFFER_POOL_MODE;
                 attribs.push_back(attr);
 
                 attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH;
@@ -233,7 +233,7 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
             else if (fvField(*i) == buffer_static_th_field_name)
             {
                 attr.id = SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE;
-                attr.value.s32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_STATIC;
+                attr.value.s32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_INHERIT_BUFFER_POOL_MODE;
                 attribs.push_back(attr);
 
                 attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_STATIC_TH;


### PR DESCRIPTION
[bufferorch]: Replace buffer profile mode to inherit                      
                                                                          
By default, the SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE is set to          
SAI_BUFFER_PROFILE_THRESHOLD_MODE_INHERIT_BUFFER_POOL_MODE. We shall      
use the default attribute value.                                          
                                                                          
Right now, this attribute is required so as to pass the saimetadata check.