### PR TITLE
[qosorch]: Add possibility to set min value for WRED thresholds.

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -283,8 +283,9 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
             attr.id = SAI_WRED_ATTR_YELLOW_MAX_THRESHOLD;
             attr.value.s32 = stoi(fvValue(*i));
             attribs.push_back(attr);
-
-            // set min threshold to the same value as MAX
+        }
+        else if (fvField(*i) == yellow_min_threshold_field_name)
+        {
             attr.id = SAI_WRED_ATTR_YELLOW_MIN_THRESHOLD;
             attr.value.s32 = stoi(fvValue(*i));
             attribs.push_back(attr);
@@ -294,19 +295,21 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
             attr.id = SAI_WRED_ATTR_GREEN_MAX_THRESHOLD;
             attr.value.s32 = stoi(fvValue(*i));
             attribs.push_back(attr);
-
-            // set min threshold to the same value as MAX
-            attr.id = SAI_WRED_ATTR_GREEN_MIN_THRESHOLD;
-            attr.value.s32 = stoi(fvValue(*i));
-            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == green_min_threshold_field_name)
+        {
+           attr.id = SAI_WRED_ATTR_GREEN_MIN_THRESHOLD;
+           attr.value.s32 = stoi(fvValue(*i));
+           attribs.push_back(attr);
         }
         else if (fvField(*i) == red_max_threshold_field_name)
         {
             attr.id = SAI_WRED_ATTR_RED_MAX_THRESHOLD;
             attr.value.s32 = stoi(fvValue(*i));
             attribs.push_back(attr);
-
-            // set min threshold to the same value as MAX
+        }
+        else if (fvField(*i) == red_min_threshold_field_name)
+        {
             attr.id = SAI_WRED_ATTR_RED_MIN_THRESHOLD;
             attr.value.s32 = stoi(fvValue(*i));
             attribs.push_back(attr);

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -13,8 +13,11 @@ const string tc_to_pg_map_field_name           = "tc_to_pg_map";
 const string tc_to_queue_field_name            = "tc_to_queue_map";
 const string scheduler_field_name              = "scheduler";
 const string red_max_threshold_field_name      = "red_max_threshold";
+const string red_min_threshold_field_name      = "red_min_threshold";
 const string yellow_max_threshold_field_name   = "yellow_max_threshold";
+const string yellow_min_threshold_field_name   = "yellow_min_threshold";
 const string green_max_threshold_field_name    = "green_max_threshold";
+const string green_min_threshold_field_name    = "green_min_threshold";
 
 const string wred_profile_field_name           = "wred_profile";
 const string wred_red_enable_field_name        = "wred_red_enable";

--- a/swssconfig/sample/msn2700.32ports.qos.json
+++ b/swssconfig/sample/msn2700.32ports.qos.json
@@ -132,8 +132,11 @@
             "wred_yellow_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"512000",
+            "red_min_threshold":"512000",
             "yellow_max_threshold":"512000",
-            "green_max_threshold": "184320"
+            "yellow_min_threshold":"512000",
+            "green_max_threshold": "184320",
+            "green_min_threshold": "184320"
         },
         "OP": "SET"
     },

--- a/swssconfig/sample/msn2740.32ports.qos.json
+++ b/swssconfig/sample/msn2740.32ports.qos.json
@@ -132,8 +132,11 @@
             "wred_yellow_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"512000",
+            "red_min_threshold":"512000",
             "yellow_max_threshold":"512000",
-            "green_max_threshold": "184320"
+            "yellow_min_threshold":"512000",
+            "green_max_threshold": "184320",
+            "green_min_threshold": "184320"
         },
         "OP": "SET"
     },

--- a/swssconfig/sample/td2.32ports.qos.json
+++ b/swssconfig/sample/td2.32ports.qos.json
@@ -132,8 +132,11 @@
             "wred_yellow_enable":"true",
             "ecn":"ecn_all",
             "red_max_threshold":"512000",
+            "red_min_threshold":"512000",
             "yellow_max_threshold":"512000",
-            "green_max_threshold": "184320"
+            "yellow_min_threshold":"512000",
+            "green_max_threshold": "184320",
+            "green_min_threshold": "184320"
         },
         "OP": "SET"
     },


### PR DESCRIPTION
- Set min thresholds equal to max to preserve default behavior.