### PR TITLE
[AclOrch]: refactor doAclTableTask and doAclRuleTask

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1060,6 +1060,108 @@ void AclOrch::doTask(Consumer &consumer)
     }
 }
 
+void AclOrch::addAclTable(AclTable &newTable, string table_id)
+{
+    sai_object_id_t table_oid = getTableById(table_id);
+
+    if (table_oid != SAI_NULL_OBJECT_ID)
+    {
+        // table already exists, delete it first
+        if (deleteUnbindAclTable(table_oid) == SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_INFO("Successfully deleted ACL table %s", table_id.c_str());
+            m_AclTables.erase(table_oid);
+        }
+    }
+    if (createBindAclTable(newTable, table_oid) == SAI_STATUS_SUCCESS)
+    {
+        m_AclTables[table_oid] = newTable;
+        SWSS_LOG_INFO("Successfully created ACL table %s, oid: %lX", newTable.description.c_str(), table_oid);
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Failed to create table %s", table_id.c_str());
+    }
+
+}
+
+void AclOrch::removeAclTable(string table_id)
+{
+    sai_object_id_t table_oid = getTableById(table_id);
+    if (table_oid != SAI_NULL_OBJECT_ID)
+    {
+        if (deleteUnbindAclTable(table_oid) == SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_INFO("Successfully deleted ACL table %s", table_id.c_str());
+            m_AclTables.erase(table_oid);
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to delete ACL table %s", table_id.c_str());
+        }
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Failed to delete ACL table. Table %s does not exist", table_id.c_str());
+    }
+
+}
+
+void AclOrch::addAclRule(shared_ptr<AclRule> newRule, string table_id, string rule_id)
+{
+    sai_object_id_t table_oid = getTableById(table_id);
+    auto ruleIter = m_AclTables[table_oid].rules.find(rule_id);
+    if (ruleIter != m_AclTables[table_oid].rules.end())
+    {
+        // rule already exists - delete it first
+        if (ruleIter->second->remove())
+        {
+            m_AclTables[table_oid].rules.erase(ruleIter);
+            SWSS_LOG_INFO("Successfully deleted ACL rule: %s", rule_id.c_str());
+        }
+    }
+    if (newRule->create())
+    {
+        m_AclTables[table_oid].rules[rule_id] = newRule;
+        SWSS_LOG_INFO("Successfully created ACL rule %s in table %s", rule_id.c_str(), table_id.c_str());
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Failed to create rule in table %s", table_id.c_str());
+    }
+
+}
+
+void AclOrch::removeAclRule(string table_id, string rule_id)
+{
+    sai_object_id_t table_oid = getTableById(table_id);
+    if (table_oid != SAI_NULL_OBJECT_ID)
+    {
+        auto ruleIter = m_AclTables[table_oid].rules.find(rule_id);
+        if (ruleIter != m_AclTables[table_oid].rules.end())
+        {
+            if (ruleIter->second->remove())
+            {
+                m_AclTables[table_oid].rules.erase(ruleIter);
+                SWSS_LOG_INFO("Successfully deleted ACL rule %s", rule_id.c_str());
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Failed to delete ACL rule: %s", table_id.c_str());
+            }
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to delete ACL rule. Unknown rule %s", rule_id.c_str());
+        }
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Failed to delete rule %s from ACL table %s. Table does not exist", rule_id.c_str(), table_id.c_str());
+    }
+
+}
+
 void AclOrch::doAclTableTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -1117,26 +1219,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
             // validate and create ACL Table
             if (bAllAttributesOk && validateAclTable(newTable))
             {
-                sai_object_id_t table_oid = getTableById(table_id);
-
-                if (table_oid != SAI_NULL_OBJECT_ID)
-                {
-                    // table already exists, delete it first
-                    if (deleteUnbindAclTable(table_oid) == SAI_STATUS_SUCCESS)
-                    {
-                        SWSS_LOG_INFO("Successfully deleted ACL table %s", table_id.c_str());
-                        m_AclTables.erase(table_oid);
-                    }
-                }
-                if (createBindAclTable(newTable, table_oid) == SAI_STATUS_SUCCESS)
-                {
-                    m_AclTables[table_oid] = newTable;
-                    SWSS_LOG_INFO("Successfully created ACL table %s, oid: %lX", newTable.description.c_str(), table_oid);
-                }
-                else
-                {
-                    SWSS_LOG_ERROR("Failed to create table %s", table_id.c_str());
-                }
+                addAclTable(newTable, table_id);
             }
             else
             {
@@ -1145,23 +1228,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
         }
         else if (op == DEL_COMMAND)
         {
-            sai_object_id_t table_oid = getTableById(table_id);
-            if (table_oid != SAI_NULL_OBJECT_ID)
-            {
-                if (deleteUnbindAclTable(table_oid) == SAI_STATUS_SUCCESS)
-                {
-                    SWSS_LOG_INFO("Successfully deleted ACL table %s", table_id.c_str());
-                    m_AclTables.erase(table_oid);
-                }
-                else
-                {
-                    SWSS_LOG_ERROR("Failed to delete ACL table %s", table_id.c_str());
-                }
-            }
-            else
-            {
-                SWSS_LOG_ERROR("Failed to delete ACL table. Table %s does not exist", table_id.c_str());
-            }
+            removeAclTable(table_id);
         }
         else
         {
@@ -1237,25 +1304,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             // validate and create ACL rule
             if (bAllAttributesOk && newRule->validate())
             {
-                auto ruleIter = m_AclTables[table_oid].rules.find(rule_id);
-                if (ruleIter != m_AclTables[table_oid].rules.end())
-                {
-                    // rule already exists - delete it first
-                    if (ruleIter->second->remove())
-                    {
-                        m_AclTables[table_oid].rules.erase(ruleIter);
-                        SWSS_LOG_INFO("Successfully deleted ACL rule: %s", rule_id.c_str());
-                    }
-                }
-                if (newRule->create())
-                {
-                    m_AclTables[table_oid].rules[rule_id] = newRule;
-                    SWSS_LOG_INFO("Successfully created ACL rule %s in table %s", rule_id.c_str(), table_id.c_str());
-                }
-                else
-                {
-                    SWSS_LOG_ERROR("Failed to create rule in table %s", table_id.c_str());
-                }
+                addAclRule(newRule, table_id, rule_id);
             }
             else
             {
@@ -1264,31 +1313,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
         }
         else if (op == DEL_COMMAND)
         {
-            sai_object_id_t table_oid = getTableById(table_id);
-            if (table_oid != SAI_NULL_OBJECT_ID)
-            {
-                auto ruleIter = m_AclTables[table_oid].rules.find(rule_id);
-                if (ruleIter != m_AclTables[table_oid].rules.end())
-                {
-                    if (ruleIter->second->remove())
-                    {
-                        m_AclTables[table_oid].rules.erase(ruleIter);
-                        SWSS_LOG_INFO("Successfully deleted ACL rule %s", rule_id.c_str());
-                    }
-                    else
-                    {
-                        SWSS_LOG_ERROR("Failed to delete ACL rule: %s", table_id.c_str());
-                    }
-                }
-                else
-                {
-                    SWSS_LOG_ERROR("Failed to delete ACL rule. Unknown rule %s", rule_id.c_str());
-                }
-            }
-            else
-            {
-                SWSS_LOG_ERROR("Failed to delete rule %s from ACL table %s. Table does not exist", rule_id.c_str(), table_id.c_str());
-            }
+            removeAclRule(table_id, rule_id);
         }
         else
         {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1082,7 +1082,6 @@ void AclOrch::addAclTable(AclTable &newTable, string table_id)
     {
         SWSS_LOG_ERROR("Failed to create table %s", table_id.c_str());
     }
-
 }
 
 void AclOrch::removeAclTable(string table_id)
@@ -1104,7 +1103,6 @@ void AclOrch::removeAclTable(string table_id)
     {
         SWSS_LOG_ERROR("Failed to delete ACL table. Table %s does not exist", table_id.c_str());
     }
-
 }
 
 void AclOrch::addAclRule(shared_ptr<AclRule> newRule, string table_id, string rule_id)
@@ -1129,7 +1127,6 @@ void AclOrch::addAclRule(shared_ptr<AclRule> newRule, string table_id, string ru
     {
         SWSS_LOG_ERROR("Failed to create rule in table %s", table_id.c_str());
     }
-
 }
 
 void AclOrch::removeAclRule(string table_id, string rule_id)
@@ -1159,7 +1156,6 @@ void AclOrch::removeAclRule(string table_id, string rule_id)
     {
         SWSS_LOG_ERROR("Failed to delete rule %s from ACL table %s. Table does not exist", rule_id.c_str(), table_id.c_str());
     }
-
 }
 
 void AclOrch::doAclTableTask(Consumer &consumer)

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -257,6 +257,11 @@ public:
     NeighOrch *m_neighOrch;
     RouteOrch *m_routeOrch;
 
+    void addAclTable(AclTable &aclTable, string table_id);
+    void removeAclTable(string table_id);
+    void addAclRule(shared_ptr<AclRule> aclRule, string table_id, string rule_id);
+    void removeAclRule(string table_id, string rule_id);
+
 private:
     void doTask(Consumer &consumer);
     void doAclTableTask(Consumer &consumer);


### PR DESCRIPTION
After refactoring, users can directly call add/removeAclTable, add/removeAclRule to do the corresponding action. This flexibility is needed for PFC WD, and will be helpful for others as well. 