### PR TITLE
Optimize orch performance by pops()

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -83,54 +83,58 @@ bool Orch::execute(string tableName)
     }
     Consumer& consumer = consumer_it->second;
 
-    KeyOpFieldsValuesTuple new_data;
-    consumer.m_consumer->pop(new_data);
+    std::deque<KeyOpFieldsValuesTuple> new_data;
+    consumer.m_consumer->pops(new_data);
 
-    string key = kfvKey(new_data);
-    string op  = kfvOp(new_data);
-    /* Possible nothing popped, ie. the oparation is already merged with other operations */
-    if (op.empty())
+    /* Nothing popped */
+    if (new_data.empty())
     {
         return true;
     }
 
-    /* Record incoming tasks */
-    if (gSwssRecord)
+    for (auto new_data1: new_data)
     {
-        recordTuple(consumer, new_data);
-    }
+        string key = kfvKey(new_data1);
+        string op  = kfvOp(new_data1);
 
-    /* If a new task comes or if a DEL task comes, we directly put it into consumer.m_toSync map */
-    if (consumer.m_toSync.find(key) == consumer.m_toSync.end() || op == DEL_COMMAND)
-    {
-       consumer.m_toSync[key] = new_data;
-    }
-    /* If an old task is still there, we combine the old task with new task */
-    else
-    {
-        KeyOpFieldsValuesTuple existing_data = consumer.m_toSync[key];
-
-        auto new_values = kfvFieldsValues(new_data);
-        auto existing_values = kfvFieldsValues(existing_data);
-
-
-        for (auto it : new_values)
+        /* Record incoming tasks */
+        if (gSwssRecord)
         {
-            string field = fvField(it);
-            string value = fvValue(it);
-
-            auto iu = existing_values.begin();
-            while (iu != existing_values.end())
-            {
-                string ofield = fvField(*iu);
-                if (field == ofield)
-                    iu = existing_values.erase(iu);
-                else
-                    iu++;
-            }
-            existing_values.push_back(FieldValueTuple(field, value));
+            recordTuple(consumer, new_data1);
         }
-        consumer.m_toSync[key] = KeyOpFieldsValuesTuple(key, op, existing_values);
+
+        /* If a new task comes or if a DEL task comes, we directly put it into consumer.m_toSync map */
+        if (consumer.m_toSync.find(key) == consumer.m_toSync.end() || op == DEL_COMMAND)
+        {
+           consumer.m_toSync[key] = new_data1;
+        }
+        /* If an old task is still there, we combine the old task with new task */
+        else
+        {
+            KeyOpFieldsValuesTuple existing_data = consumer.m_toSync[key];
+
+            auto new_values = kfvFieldsValues(new_data1);
+            auto existing_values = kfvFieldsValues(existing_data);
+
+
+            for (auto it : new_values)
+            {
+                string field = fvField(it);
+                string value = fvValue(it);
+
+                auto iu = existing_values.begin();
+                while (iu != existing_values.end())
+                {
+                    string ofield = fvField(*iu);
+                    if (field == ofield)
+                        iu = existing_values.erase(iu);
+                    else
+                        iu++;
+                }
+                existing_values.push_back(FieldValueTuple(field, value));
+            }
+            consumer.m_toSync[key] = KeyOpFieldsValuesTuple(key, op, existing_values);
+        }
     }
 
     if (!consumer.m_toSync.empty())

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -83,37 +83,37 @@ bool Orch::execute(string tableName)
     }
     Consumer& consumer = consumer_it->second;
 
-    std::deque<KeyOpFieldsValuesTuple> new_data;
-    consumer.m_consumer->pops(new_data);
+    std::deque<KeyOpFieldsValuesTuple> entries;
+    consumer.m_consumer->pops(entries);
 
     /* Nothing popped */
-    if (new_data.empty())
+    if (entries.empty())
     {
         return true;
     }
 
-    for (auto new_data1: new_data)
+    for (auto entry: entries)
     {
-        string key = kfvKey(new_data1);
-        string op  = kfvOp(new_data1);
+        string key = kfvKey(entry);
+        string op  = kfvOp(entry);
 
         /* Record incoming tasks */
         if (gSwssRecord)
         {
-            recordTuple(consumer, new_data1);
+            recordTuple(consumer, entry);
         }
 
         /* If a new task comes or if a DEL task comes, we directly put it into consumer.m_toSync map */
         if (consumer.m_toSync.find(key) == consumer.m_toSync.end() || op == DEL_COMMAND)
         {
-           consumer.m_toSync[key] = new_data1;
+           consumer.m_toSync[key] = entry;
         }
         /* If an old task is still there, we combine the old task with new task */
         else
         {
             KeyOpFieldsValuesTuple existing_data = consumer.m_toSync[key];
 
-            auto new_values = kfvFieldsValues(new_data1);
+            auto new_values = kfvFieldsValues(entry);
             auto existing_values = kfvFieldsValues(existing_data);
 
 


### PR DESCRIPTION
For route sync performance, original implementation will pop route one-by-one, and go through m_toSync each time. If using pops(), the times of loop m_toSync will decrease largely.