### PR TITLE
[switchorch]: Add SwitchOrch to deal with switch attributes changes

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -10,7 +10,7 @@ else
 DBGFLAGS = -g -DNDEBUG
 endif
 
-orchagent_SOURCES = main.cpp port.cpp orchdaemon.cpp orch.cpp notifications.cpp routeorch.cpp neighorch.cpp intfsorch.cpp portsorch.cpp copporch.cpp tunneldecaporch.cpp qosorch.cpp bufferorch.cpp mirrororch.cpp fdborch.cpp aclorch.cpp saihelper.cpp
+orchagent_SOURCES = main.cpp port.cpp orchdaemon.cpp orch.cpp notifications.cpp routeorch.cpp neighorch.cpp intfsorch.cpp portsorch.cpp copporch.cpp tunneldecaporch.cpp qosorch.cpp bufferorch.cpp mirrororch.cpp fdborch.cpp aclorch.cpp switchorch.cpp saihelper.cpp
 
 orchagent_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 orchagent_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -37,6 +37,8 @@ bool OrchDaemon::init()
 {
     SWSS_LOG_ENTER();
 
+    SwitchOrch *switch_orch = new SwitchOrch(m_applDb, APP_SWITCH_TABLE_NAME);
+
     vector<string> ports_tables = {
         APP_PORT_TABLE_NAME,
         APP_VLAN_TABLE_NAME,
@@ -84,7 +86,7 @@ bool OrchDaemon::init()
     };
     AclOrch *acl_orch = new AclOrch(m_applDb, acl_tables, gPortsOrch, mirror_orch, neigh_orch, route_orch);
 
-    m_orchList = { gPortsOrch, intfs_orch, neigh_orch, route_orch, copp_orch, tunnel_decap_orch, qos_orch, buffer_orch, mirror_orch, acl_orch, gFdbOrch};
+    m_orchList = { switch_orch, gPortsOrch, intfs_orch, neigh_orch, route_orch, copp_orch, tunnel_decap_orch, qos_orch, buffer_orch, mirror_orch, acl_orch, gFdbOrch};
     m_select = new Select();
 
     return true;

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -17,6 +17,7 @@
 #include "mirrororch.h"
 #include "fdborch.h"
 #include "aclorch.h"
+#include "switchorch.h"
 
 using namespace swss;
 

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -1,0 +1,85 @@
+#include <map>
+
+#include "switchorch.h"
+
+using namespace std;
+using namespace swss;
+
+extern sai_object_id_t gSwitchId;
+extern sai_switch_api_t *sai_switch_api;
+
+const map<string, sai_switch_attr_t> switch_attribute_map =
+{
+    {"fdb_unicast_miss_packet_action",      SAI_SWITCH_ATTR_FDB_UNICAST_MISS_PACKET_ACTION},
+    {"fdb_broadcast_miss_packet_action",    SAI_SWITCH_ATTR_FDB_BROADCAST_MISS_PACKET_ACTION},
+    {"fdb_multicast_miss_packet_action",    SAI_SWITCH_ATTR_FDB_MULTICAST_MISS_PACKET_ACTION}
+};
+
+const map<string, sai_packet_action_t> packet_action_map =
+{
+    {"drop",    SAI_PACKET_ACTION_DROP},
+    {"forward", SAI_PACKET_ACTION_FORWARD},
+    {"trap",    SAI_PACKET_ACTION_TRAP}
+};
+
+SwitchOrch::SwitchOrch(DBConnector *db, string tableName) :
+        Orch(db, tableName)
+{
+}
+
+void SwitchOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        auto t = it->second;
+
+        auto op = kfvOp(t);
+
+        if (op == SET_COMMAND)
+        {
+            for (auto i : kfvFieldsValues(t))
+            {
+                auto attribute = fvField(i);
+
+                if (switch_attribute_map.find(attribute) == switch_attribute_map.end())
+                {
+                    SWSS_LOG_ERROR("Unsupported switch attribute %s", attribute.c_str());
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                auto value = fvValue(i);
+                if (packet_action_map.find(value) == packet_action_map.end())
+                {
+                    SWSS_LOG_ERROR("Unsupported packet action %s", value.c_str());
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                sai_attribute_t attr;
+                attr.id = switch_attribute_map.at(attribute);
+                attr.value.s32 = packet_action_map.at(value);
+
+                sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+                if (status != SAI_STATUS_SUCCESS)
+                {
+                    SWSS_LOG_ERROR("Failed to set switch attribute %s to %s, rv:%d",
+                            attribute.c_str(), value.c_str(), status);
+                    it++;
+                    continue;
+                }
+
+                SWSS_LOG_NOTICE("Set switch attribute %s to %s", attribute.c_str(), value.c_str());
+                it = consumer.m_toSync.erase(it);
+            }
+        }
+        else
+        {
+            SWSS_LOG_WARN("Unsupported operation");
+            it = consumer.m_toSync.erase(it);
+        }
+    }
+}

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "orch.h"
+
+class SwitchOrch : public Orch
+{
+public:
+    SwitchOrch(DBConnector *db, string tableName);
+
+private:
+    void doTask(Consumer &consumer);
+};


### PR DESCRIPTION
Right now, three switch attributes are supported: FDB unicast/multicast/
broadcast miss packet action. The attribute could be set to drop, forward,
or trap.

The current implementation adds switch configuration to the APPL_DB.
In the future, it would be migrated to the CONF_DB.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests

Please also provide the following information in this pull request:
-->

**What I did**
Add the functionality of updating switch attributes. This architecture also allows future expansion for richer attributes other than FDB related ones.

**Why I did it**
It's a feature request from various sources.

**How I verified it**
Use `swssconfig` to load a switch attribute set JSON file and check in the database if this attribute is set.
