### PR TITLE
Updated Mellanox buffer profile template to work in 1.0.3

### DIFF
--- a/swssconfig/sample/msn27xx.32ports.buffers.json.j2
+++ b/swssconfig/sample/msn27xx.32ports.buffers.json.j2
@@ -1,9 +1,9 @@
 [
-{% set ethernet_interfaces_names_list = [] %}
-{% for interface in ethernet_interfaces %}
-    {%- if ethernet_interfaces_names_list.append(interface['name']) %}{% endif %}
+{% set port_names_list = [] %}
+{% for port in PORT %}
+    {%- if port_names_list.append(port) %}{% endif %}
 {% endfor %}
-{% set ethernet_interfaces_names = ethernet_interfaces_names_list | join(',') %}
+{% set port_names = port_names_list | join(',') %}
     {
         "BUFFER_POOL_TABLE:ingress_lossless_pool": {
             "size": "3024486",
@@ -69,16 +69,6 @@
         "OP": "SET"
     },
     {
-        "BUFFER_PROFILE_TABLE:pg_lossless_profile": {
-            "pool":"[BUFFER_POOL_TABLE:ingress_lossless_pool]",
-            "xon":"35616",
-            "xoff":"31814",
-            "size":"67430",
-            "dynamic_th":"1"
-        },
-        "OP": "SET"
-    },
-    {
         "BUFFER_PROFILE_TABLE:pg_lossy_profile": {
             "pool":"[BUFFER_POOL_TABLE:ingress_lossy_pool]",
             "size":"0",
@@ -103,13 +93,13 @@
         "OP": "SET"
     },
     {
-        "BUFFER_PORT_INGRESS_PROFILE_LIST:{{ ethernet_interfaces_names }}": {
+        "BUFFER_PORT_INGRESS_PROFILE_LIST:{{ port_names }}": {
             "profile_list" : "[BUFFER_PROFILE_TABLE:ingress_lossless_profile],[BUFFER_PROFILE_TABLE:ingress_lossy_profile]"
         },
         "OP": "SET"
     },
     {
-        "BUFFER_PORT_EGRESS_PROFILE_LIST:{{ ethernet_interfaces_names }}": {
+        "BUFFER_PORT_EGRESS_PROFILE_LIST:{{ port_names }}": {
             "profile_list" : "[BUFFER_PROFILE_TABLE:egress_lossless_profile],[BUFFER_PROFILE_TABLE:egress_lossy_profile]"
         },
         "OP": "SET"
@@ -176,20 +166,23 @@
         }
 %}
 
-{% set switch_role = minigraph_devices[minigraph_hostname]['type'] %}
+{% set switch_role = DEVICE_METADATA['localhost']['type'] %}
 
-{%- macro cable_length(interface_name) -%}
-    {% set nei = '"'+minigraph_neighbors[interface_name]['name']+'"' -%}
-    {% set nei_role = minigraph_devices[nei]['type'] -%}
-    {% set roles1 = switch_role + '_' + nei_role %}
-    {%- set roles2 = nei_role + '_' + switch_role -%}
-    {%- if roles1 in ports2cable -%}
-        {{ ports2cable[roles1] }}
-    {%- elif roles2 in ports2cable -%}
-        {{ ports2cable[roles2] }}
-    {%- else -%}
-        {{ supported_cable | last }}
-    {%- endif -%}
+{%- macro cable_length(port_name) -%}
+    {%- for neighbor in DEVICE_NEIGHBOR -%}
+        {%- if DEVICE_NEIGHBOR[neighbor]['local_port'] == port_name -%}
+            {%- set neighbor_role = DEVICE_NEIGHBOR[neighbor]['type'] -%}
+            {%- set roles1 = switch_role + '_' + neighbor_role %}
+            {%- set roles2 = neighbor_role + '_' + switch_role -%}
+            {%- if roles1 in ports2cable -%}
+                {{ ports2cable[roles1] }}
+            {%- elif roles2 in ports2cable -%}
+                {{ ports2cable[roles2] }}
+            {%- else -%}
+                {{ supported_cable | last }}
+            {%- endif -%}
+        {% endif %}
+    {%- endfor -%}
 {% endmacro %}
 
 {%- macro find_closest_greater_config(speed, cable) -%}
@@ -210,9 +203,9 @@
 
 {% set ingress_lossless_pg_pool_size =  [] %}
 {% set used_pg_profiles =  [] %}
-{% for interface in ethernet_interfaces %}
-    {%- set speed = interface['speed'] -%}
-    {%- set cable = cable_length(interface['name']) -%}
+{% for port in PORT %}
+    {%- set speed = PORT[port]['speed'] -%}
+    {%- set cable = cable_length(port) -%}
     {%- set port_config = speed + '_' + cable -%}
     {%- if not port_config in portconfig2profile -%}
         {% set port_config = find_closest_greater_config(speed, cable) -%}
@@ -222,15 +215,15 @@
     {# add to list profiles which were actually used #}
     {%- if profile not in used_pg_profiles and used_pg_profiles.append(profile) %}{% endif -%}
     {
-        "BUFFER_PG_TABLE:{{ interface['name'] }}:{{ pg_range }}": {
+        "BUFFER_PG_TABLE:{{ port }}:{{ pg_range }}": {
                 "profile" : "[BUFFER_PROFILE_TABLE:{{ profile }}]"
         },
         "OP": "SET"
     },
-
 {% endfor -%}
 
 {# PG profiles declaration #}
+
 {% for profile_name in used_pg_profiles %}
     {%- set profile_config = pg_profiles[profile_name] %}
     {
@@ -255,19 +248,19 @@
         "OP": "SET"
     },
     {
-        "BUFFER_PG_TABLE:{{ ethernet_interfaces_names }}:0-1": {
+        "BUFFER_PG_TABLE:{{ port_names }}:0-1": {
             "profile" : "[BUFFER_PROFILE_TABLE:pg_lossy_profile]"
         },
         "OP": "SET"
     },
     {
-        "BUFFER_QUEUE_TABLE:{{ ethernet_interfaces_names }}:3-4": {
+        "BUFFER_QUEUE_TABLE:{{ port_names }}:3-4": {
             "profile" : "[BUFFER_PROFILE_TABLE:q_lossless_profile]"
         },
         "OP": "SET"
     },
     {
-        "BUFFER_QUEUE_TABLE:{{ ethernet_interfaces_names }}:0-1": {
+        "BUFFER_QUEUE_TABLE:{{ port_names }}:0-1": {
             "profile" : "[BUFFER_PROFILE_TABLE:q_lossy_profile]"
         },
         "OP": "SET"
@@ -282,7 +275,7 @@
         "OP": "SET"
     },
     {
-        "PORT_QOS_MAP_TABLE:{{ ethernet_interfaces_names }}": {
+        "PORT_QOS_MAP_TABLE:{{ port_names }}": {
             "pfc_to_pg_map"   : "[PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE:AZURE]"
         },
         "OP": "SET"


### PR DESCRIPTION
**What I did**
Updated Mellanox buffer profile template to work in 1.0.3

**Why I did it**
Changes in minigraph parser made template incompatible with the new names exported

**How I verified it**
Build SONiC, ensured buffers profile is generated, applied, records in DB created.

**Details if related**
