### PR TITLE
[portsorch]: Use sai_serialize api to write to DB

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -11,6 +11,7 @@
 
 #include "logger.h"
 #include "schema.h"
+#include "saiserialize.h"
 
 extern sai_switch_api_t *sai_switch_api;
 extern sai_bridge_api_t *sai_bridge_api;
@@ -565,9 +566,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             /* Add port to port list */
                             m_portList[alias] = p;
                             /* Add port name map to counter table */
-                            std::stringstream ss;
-                            ss << hex << p.m_port_id;
-                            FieldValueTuple tuple(p.m_alias, ss.str());
+                            FieldValueTuple tuple(p.m_alias, sai_serialize_object_id(p.m_port_id));
                             vector<FieldValueTuple> vector;
                             vector.push_back(tuple);
                             m_counterTable->set("", vector);


### PR DESCRIPTION
Keep object IDs serializeable in database,
so that they can be reused later by client code