### PR TITLE
Update Mellanox buffer profile template to work with an incomplete minigraph

### DIFF
--- a/swssconfig/sample/msn27xx.32ports.buffers.json.j2
+++ b/swssconfig/sample/msn27xx.32ports.buffers.json.j2
@@ -169,20 +169,26 @@
 {% set switch_role = DEVICE_METADATA['localhost']['type'] %}
 
 {%- macro cable_length(port_name) -%}
+    {%- set cable_len = [] -%}
     {%- for neighbor in DEVICE_NEIGHBOR -%}
-        {%- if DEVICE_NEIGHBOR[neighbor]['local_port'] == port_name -%}
-            {%- set neighbor_role = DEVICE_NEIGHBOR[neighbor]['type'] -%}
-            {%- set roles1 = switch_role + '_' + neighbor_role %}
-            {%- set roles2 = neighbor_role + '_' + switch_role -%}
-            {%- if roles1 in ports2cable -%}
-                {{ ports2cable[roles1] }}
-            {%- elif roles2 in ports2cable -%}
-                {{ ports2cable[roles2] }}
-            {%- else -%}
-                {{ supported_cable | last }}
-            {%- endif -%}
+        {%- if DEVICE_NEIGHBOR[neighbor].local_port and DEVICE_NEIGHBOR[neighbor].type -%}
+            {%- if DEVICE_NEIGHBOR[neighbor]['local_port'] == port_name -%}
+                {%- set neighbor_role = DEVICE_NEIGHBOR[neighbor]['type'] -%}
+                {%- set roles1 = switch_role + '_' + neighbor_role %}
+                {%- set roles2 = neighbor_role + '_' + switch_role -%}
+                {%- if roles1 in ports2cable -%}
+                    {%- if cable_len.append(ports2cable[roles1]) -%}{%- endif -%}
+                {%- elif roles2 in ports2cable -%}
+                    {%- if cable_len.append(ports2cable[roles2]) -%}{%- endif -%}
+                {%- endif -%}
+            {% endif %}
         {% endif %}
     {%- endfor -%}
+    {%- if cable_len -%}
+        {{ cable_len.0 }}
+    {%- else -%}
+        {{ supported_cable | last }}
+    {%- endif -%}
 {% endmacro %}
 
 {%- macro find_closest_greater_config(speed, cable) -%}
@@ -204,9 +210,13 @@
 {% set ingress_lossless_pg_pool_size =  [] %}
 {% set used_pg_profiles =  [] %}
 {% for port in PORT %}
-    {%- set speed = PORT[port]['speed'] -%}
+    {%- if PORT[port].speed -%}
+        {%- set speed = PORT[port]['speed'] -%}
+    {% else %}
+        {%- set speed = supported_speed|last -%}
+    {%- endif -%}
     {%- set cable = cable_length(port) -%}
-    {%- set port_config = speed + '_' + cable -%}
+    {%- set port_config = speed|string + '_' + cable -%}
     {%- if not port_config in portconfig2profile -%}
         {% set port_config = find_closest_greater_config(speed, cable) -%}
     {%- endif -%}


### PR DESCRIPTION

Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>


**What I did**
Updated buffer profile template to produce config even when there are no ports speed and cable length info in the minigraph

**Why I did it**
Buffer config failed to generate on incomplete minigraph

**How I verified it**
Verified buffer config generated and applied on incomplete minigraph

**Details if related**
By default "worst case values"  are used (100G and 300m)