### PR TITLE
[portsyncd]: Add producer for state database updates

### DIFF
--- a/portsyncd/linksync.h
+++ b/portsyncd/linksync.h
@@ -14,13 +14,13 @@ class LinkSync : public NetMsg
 public:
     enum { MAX_ADDR_SIZE = 64 };
 
-    LinkSync(DBConnector *db);
+    LinkSync(DBConnector *appl_db, DBConnector *state_db);
 
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);
 
 private:
     ProducerStateTable m_portTableProducer, m_vlanTableProducer, m_vlanMemberTableProducer;
-    Table m_portTableConsumer, m_vlanMemberTableConsumer;
+    Table m_portTable, m_vlanMemberTable, m_statePortTable;
 
     std::map<unsigned int, std::string> m_ifindexNameMap;
 };

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -64,10 +64,11 @@ int main(int argc, char **argv)
         }
     }
 
-    DBConnector db(0, DBConnector::DEFAULT_UNIXSOCKET, 0);
-    ProducerStateTable p(&db, APP_PORT_TABLE_NAME);
+    DBConnector appl_db(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    DBConnector state_db(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    ProducerStateTable p(&appl_db, APP_PORT_TABLE_NAME);
 
-    LinkSync sync(&db);
+    LinkSync sync(&appl_db, &state_db);
     NetDispatcher::getInstance().registerMessageHandler(RTM_NEWLINK, &sync);
     NetDispatcher::getInstance().registerMessageHandler(RTM_DELLINK, &sync);
 


### PR DESCRIPTION
- Add m_stateTableProducer to write to the state database once the ports are ready
- Remove suffix Consumer in some variables since they are not 'consumers'

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
