### PR TITLE
Limit FlexPort feature to only Mellanox Platform

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -879,7 +879,7 @@ AclRange *AclRange::create(sai_acl_range_type_t type, int min, int max)
 
         // work around to avoid syncd termination on SAI error due to max count of ranges reached
         // can be removed when syncd start passing errors to the SAI callers
-        char *platform = getenv("onie_platform");
+        char *platform = getenv("platform");
         if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
         {
             if (m_ranges.size() >= MLNX_MAX_RANGES_COUNT)

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -57,7 +57,6 @@
 #define IP_TYPE_ARP_REQUEST     "ARP_REQUEST"
 #define IP_TYPE_ARP_REPLY       "ARP_REPLY"
 
-#define MLNX_PLATFORM_SUBSTRING "mlnx"
 #define MLNX_MAX_RANGES_COUNT   16
 
 typedef enum

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -14,8 +14,6 @@ extern sai_policer_api_t*   sai_policer_api;
 extern sai_switch_api_t*    sai_switch_api;
 extern sai_object_id_t      gSwitchId;
 
-#define MLNX_PLATFORM_SUBSTRING     "mlnx"
-
 map<string, sai_meter_type_t> policer_meter_map = {
     {"packets", SAI_METER_TYPE_PACKETS},
     {"bytes", SAI_METER_TYPE_BYTES}

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -24,6 +24,8 @@ const char ref_end             = ']';
 const char comma               = ',';
 const char range_specifier     = '-';
 
+#define MLNX_PLATFORM_SUBSTRING "mlnx"
+
 typedef enum
 {
     task_success,

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -671,10 +671,19 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     if (m_lanesAliasSpeedMap.find(it->first) == m_lanesAliasSpeedMap.end())
                     {
-                        if (!removePort(it->second))
+                        char *platform = getenv("platform");
+                        if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
                         {
-                            throw runtime_error("PortsOrch initialization failure.");
+                            if (!removePort(it->second))
+                            {
+                                throw runtime_error("PortsOrch initialization failure.");
+                            }
                         }
+                        else
+                        {
+                            SWSS_LOG_NOTICE("Failed to remove Port %lx due to missing SAI remove_port API.", it->second);
+                        }
+
                         it = m_portListLaneMap.erase(it);
                     }
                     else
@@ -685,21 +694,48 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 for (auto it = m_lanesAliasSpeedMap.begin(); it != m_lanesAliasSpeedMap.end();)
                 {
+                    bool port_created = false;
+
                     if (m_portListLaneMap.find(it->first) == m_portListLaneMap.end())
                     {
-                        if (!addPort(it->first, get<1>(it->second)))
+                        // work around to avoid syncd termination on SAI error due missing create_port SAI API
+                        // can be removed when SAI redis return NotImplemented error
+                        char *platform = getenv("platform");
+                        if (platform && strstr(platform, MLNX_PLATFORM_SUBSTRING))
+                        {
+                            if (!addPort(it->first, get<1>(it->second)))
+                            {
+                                throw runtime_error("PortsOrch initialization failure.");
+                            }
+
+                            port_created = true;
+                        }
+                        else
+                        {
+                            SWSS_LOG_NOTICE("Failed to create Port %s due to missing SAI create_port API.", get<0>(it->second).c_str());
+                        }
+                    }
+                    else
+                    {
+                        port_created = true;
+                    }
+
+                    if (port_created)
+                    {
+                        if (!initPort(get<0>(it->second), it->first))
                         {
                             throw runtime_error("PortsOrch initialization failure.");
                         }
                     }
 
-                    if (!initPort(get<0>(it->second), it->first))
-                    {
-                        throw runtime_error("PortsOrch initialization failure.");
-                    }
-
                     it = m_lanesAliasSpeedMap.erase(it);
                 }
+            }
+
+            if (!m_portConfigDone)
+            {
+                it = consumer.m_toSync.erase(it);
+                continue;
             }
 
             Port p;

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -610,7 +610,7 @@ QosOrch::QosOrch(DBConnector *db, vector<string> &tableNames) : Orch(db, tableNa
     // understand the underlying rationale.
 
     // Do not create color ACL on p4 platform as it does not support match dscp and ecn
-    char *platform = getenv("onie_platform");
+    char *platform = getenv("platform");
     if (!platform ||
         (platform && strcmp(platform, "x86_64-barefoot_p4-r0") != 0))
     {

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -15,7 +15,6 @@ extern PortsOrch *gPortsOrch;
 /* Default maximum number of next hop groups */
 #define DEFAULT_NUMBER_OF_ECMP_GROUPS   128
 #define DEFAULT_MAX_ECMP_GROUP_SIZE     32
-#define MLNX_PLATFORM_SUBSTRING         "mlnx"
 
 RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch) :
         Orch(db, tableName),


### PR DESCRIPTION
For other platform that do not support SAI create/remove_port API,
generate a log message instead of crash.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Limit FlexPort feature (port breakout feature) to only Mellanox Platform

**Why I did it**
Only mellanox platform currently support this feature. Other platform would crash if we do not do this limit.

**How I verified it**
Change port_config.ini and tested the new syslog messages.

**Details if related**

```
Oct  5 05:53:16.002653 str-a7050-acs-1 NOTICE orchagent: :- doPortTask: Failed to remove Port 1000000000022 due to missing SAI remove_port API.
Oct  5 05:53:16.011418 str-a7050-acs-1 NOTICE orchagent: :- doPortTask: Failed to create Port Ethernet124 due to missing SAI create_port API.
```