### PR TITLE
[pfcwdorch]: Allow unlimited restoration time

### DIFF
--- a/orchagent/pfc_restore.lua
+++ b/orchagent/pfc_restore.lua
@@ -18,9 +18,10 @@ for i = n, 1, -1 do
     local counter_keys = redis.call('HKEYS', counters_table_name .. ':' .. KEYS[i])
     local pfc_rx_pkt_key = ''
     local pfc_wd_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_STATUS')
+    local restoration_time = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME')
     local pfc_wd_action = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_ACTION')
-    if pfc_wd_status ~= 'operational'  and pfc_wd_action ~= 'alert' then
-        local restoration_time = tonumber(redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME'))
+    if pfc_wd_status ~= 'operational'  and pfc_wd_action ~= 'alert' and restoration_time ~= '' then
+        restoration_time = tonumber(restoration_time)
         local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME_LEFT')
         if time_left == nil then
             time_left = restoration_time

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -223,12 +223,6 @@ void PfcWdOrch<DropHandler, ForwardHandler>::createEntry(const string& key,
         return;
     }
 
-    if (restorationTime == 0)
-    {
-        SWSS_LOG_ERROR("%s missing", PFC_WD_RESTORATION_TIME);
-        return;
-    }
-
     if (!startWdOnPort(port, detectionTime, restorationTime, action))
     {
         SWSS_LOG_ERROR("Failed to start PFC Watchdog on port %s", port.m_alias.c_str());
@@ -296,7 +290,11 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
         // Store detection and restoration time for plugins
         vector<FieldValueTuple> countersFieldValues;
         countersFieldValues.emplace_back("PFC_WD_DETECTION_TIME", to_string(detectionTime * 1000));
-        countersFieldValues.emplace_back("PFC_WD_RESTORATION_TIME", to_string(restorationTime * 1000));
+        // Restoration time is optional
+        countersFieldValues.emplace_back("PFC_WD_RESTORATION_TIME",
+                restorationTime == 0 ?
+                "" :
+                to_string(restorationTime * 1000));
         countersFieldValues.emplace_back("PFC_WD_ACTION", this->serializeAction(action));
 
         PfcWdOrch<DropHandler, ForwardHandler>::getCountersTable()->set(queueIdStr, countersFieldValues);


### PR DESCRIPTION
In case if user does not pass restoration time, it is assumed that queue
will be mitigated indefinitely in an event of PFC storm until user disables
watchdog on that port.

Signed-off-by: marian-pritsak <marianp@mellanox.com>