### PR TITLE
[pfcwdorch]: Add alert mode

### DIFF
--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -21,7 +21,7 @@ class PfcWdActionHandler
     public:
         PfcWdActionHandler(sai_object_id_t port, sai_object_id_t queue,
                 uint8_t queueId, shared_ptr<Table> countersTable);
-        virtual ~PfcWdActionHandler(void) = 0;
+        virtual ~PfcWdActionHandler(void);
 
         inline sai_object_id_t getPort(void)
         {

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -97,6 +97,7 @@ PfcWdAction PfcWdOrch<DropHandler, ForwardHandler>::deserializeAction(const stri
     {
         { "forward", PfcWdAction::PFC_WD_ACTION_FORWARD },
         { "drop", PfcWdAction::PFC_WD_ACTION_DROP },
+        { "alert", PfcWdAction::PFC_WD_ACTION_ALERT },
     };
 
     if (actionMap.find(key) == actionMap.end())
@@ -440,6 +441,14 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::handleWdNotification(swss::Notifi
         else if (entry->second.action == PfcWdAction::PFC_WD_ACTION_FORWARD)
         {
             entry->second.handler = make_shared<ForwardHandler>(
+                    entry->second.portId,
+                    entry->first,
+                    entry->second.index,
+                    PfcWdOrch<DropHandler, ForwardHandler>::getCountersTable());
+        }
+        else if (entry->second.action == PfcWdAction::PFC_WD_ACTION_ALERT)
+        {
+            entry->second.handler = make_shared<PfcWdActionHandler>(
                     entry->second.portId,
                     entry->first,
                     entry->second.index,

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -18,6 +18,7 @@ enum class PfcWdAction
     PFC_WD_ACTION_UNKNOWN,
     PFC_WD_ACTION_FORWARD,
     PFC_WD_ACTION_DROP,
+    PFC_WD_ACTION_ALERT,
 };
 
 template <typename DropHandler, typename ForwardHandler>


### PR DESCRIPTION
Alert mode tells watchdog that whenever it detects PFC storm, it should
only write message to the log. It is implemented as a separate action
along with drop and forward.

Signed-off-by: marian-pritsak <marianp@mellanox.com>
