### PR TITLE
ECMP acceleration for physical i/f down events

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -3,6 +3,7 @@
 #include "logger.h"
 #include "swssnet.h"
 #include "crmorch.h"
+#include "routeorch.h"
 
 extern sai_neighbor_api_t*         sai_neighbor_api;
 extern sai_next_hop_api_t*         sai_next_hop_api;
@@ -10,6 +11,7 @@ extern sai_next_hop_api_t*         sai_next_hop_api;
 extern PortsOrch *gPortsOrch;
 extern sai_object_id_t gSwitchId;
 extern CrmOrch *gCrmOrch;
+extern RouteOrch *gRouteOrch;
 
 NeighOrch::NeighOrch(DBConnector *db, string tableName, IntfsOrch *intfsOrch) :
         Orch(db, tableName), m_intfsOrch(intfsOrch)
@@ -59,6 +61,8 @@ bool NeighOrch::addNextHop(IpAddress ipAddress, string alias)
     NextHopEntry next_hop_entry;
     next_hop_entry.next_hop_id = next_hop_id;
     next_hop_entry.ref_count = 0;
+    next_hop_entry.nh_flags = 0;
+    next_hop_entry.if_alias = alias;
     m_syncdNextHops[ipAddress] = next_hop_entry;
 
     m_intfsOrch->increaseRouterIntfsRefCount(alias);
@@ -73,6 +77,101 @@ bool NeighOrch::addNextHop(IpAddress ipAddress, string alias)
     }
 
     return true;
+}
+
+bool NeighOrch::setNextHopFlag(const IpAddress &ipaddr, const uint32_t nh_flag)
+{
+    SWSS_LOG_ENTER();
+
+    auto nhop = m_syncdNextHops.find(ipaddr);
+    bool rc = false;
+
+    assert(nhop != m_syncdNextHops.end());
+
+    if (nhop->second.nh_flags & nh_flag) {
+        return (true);
+    }
+
+    nhop->second.nh_flags |= nh_flag;
+
+    switch (nh_flag) {
+        case NHFLAGS_IFDOWN:
+            rc = gRouteOrch->invalidnexthopinNextHopGroup(ipaddr);
+            break;
+        default:
+            assert(0);
+            break;
+    }
+
+    return (rc);
+}
+
+bool NeighOrch::clearNextHopFlag(const IpAddress &ipaddr, const uint32_t nh_flag)
+{
+    SWSS_LOG_ENTER();
+
+    auto nhop = m_syncdNextHops.find(ipaddr);
+    bool rc = false;
+
+    assert(nhop != m_syncdNextHops.end());
+
+    if (!(nhop->second.nh_flags & nh_flag)) {
+        return (true);
+    }
+
+    nhop->second.nh_flags &= ~nh_flag;
+
+    switch (nh_flag) {
+        case NHFLAGS_IFDOWN:
+            rc = gRouteOrch->validnexthopinNextHopGroup(ipaddr);
+            break;
+        default:
+            assert(0);
+            break;
+    }
+
+    return (rc);
+}
+
+bool NeighOrch::isNextHopFlagSet(const IpAddress &ipaddr, const uint32_t nh_flag)
+{
+    SWSS_LOG_ENTER();
+
+    auto nhop = m_syncdNextHops.find(ipaddr);
+
+    assert(nhop != m_syncdNextHops.end());
+
+    if (nhop->second.nh_flags & nh_flag) {
+        return (true);
+    }
+
+    return (false);
+}
+
+bool NeighOrch::ifChangeInformNextHop(const string &alias, bool if_up)
+{
+    SWSS_LOG_ENTER();
+    bool rc = true;
+
+    for (auto nhop = m_syncdNextHops.begin(); nhop != m_syncdNextHops.end(); ++nhop) {
+        if (nhop->second.if_alias != alias) {
+            continue;
+        }
+
+        if (if_up) {
+            rc = clearNextHopFlag(nhop->first, NHFLAGS_IFDOWN);
+        } else {
+            rc = setNextHopFlag(nhop->first, NHFLAGS_IFDOWN);
+        }
+
+        if (rc == true) {
+            continue;
+        } else {
+            break;
+        }
+    }
+
+    return (rc);
 }
 
 bool NeighOrch::removeNextHop(IpAddress ipAddress, string alias)

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -88,13 +88,15 @@ bool NeighOrch::setNextHopFlag(const IpAddress &ipaddr, const uint32_t nh_flag)
 
     assert(nhop != m_syncdNextHops.end());
 
-    if (nhop->second.nh_flags & nh_flag) {
-        return (true);
+    if (nhop->second.nh_flags & nh_flag)
+    {
+        return true;
     }
 
     nhop->second.nh_flags |= nh_flag;
 
-    switch (nh_flag) {
+    switch (nh_flag)
+    {
         case NHFLAGS_IFDOWN:
             rc = gRouteOrch->invalidnexthopinNextHopGroup(ipaddr);
             break;
@@ -103,7 +105,7 @@ bool NeighOrch::setNextHopFlag(const IpAddress &ipaddr, const uint32_t nh_flag)
             break;
     }
 
-    return (rc);
+    return rc;
 }
 
 bool NeighOrch::clearNextHopFlag(const IpAddress &ipaddr, const uint32_t nh_flag)
@@ -115,13 +117,15 @@ bool NeighOrch::clearNextHopFlag(const IpAddress &ipaddr, const uint32_t nh_flag
 
     assert(nhop != m_syncdNextHops.end());
 
-    if (!(nhop->second.nh_flags & nh_flag)) {
-        return (true);
+    if (!(nhop->second.nh_flags & nh_flag))
+    {
+        return true;
     }
 
     nhop->second.nh_flags &= ~nh_flag;
 
-    switch (nh_flag) {
+    switch (nh_flag)
+    {
         case NHFLAGS_IFDOWN:
             rc = gRouteOrch->validnexthopinNextHopGroup(ipaddr);
             break;
@@ -130,7 +134,7 @@ bool NeighOrch::clearNextHopFlag(const IpAddress &ipaddr, const uint32_t nh_flag
             break;
     }
 
-    return (rc);
+    return rc;
 }
 
 bool NeighOrch::isNextHopFlagSet(const IpAddress &ipaddr, const uint32_t nh_flag)
@@ -141,11 +145,12 @@ bool NeighOrch::isNextHopFlagSet(const IpAddress &ipaddr, const uint32_t nh_flag
 
     assert(nhop != m_syncdNextHops.end());
 
-    if (nhop->second.nh_flags & nh_flag) {
-        return (true);
+    if (nhop->second.nh_flags & nh_flag)
+    {
+        return true;
     }
 
-    return (false);
+    return false;
 }
 
 bool NeighOrch::ifChangeInformNextHop(const string &alias, bool if_up)
@@ -153,25 +158,33 @@ bool NeighOrch::ifChangeInformNextHop(const string &alias, bool if_up)
     SWSS_LOG_ENTER();
     bool rc = true;
 
-    for (auto nhop = m_syncdNextHops.begin(); nhop != m_syncdNextHops.end(); ++nhop) {
-        if (nhop->second.if_alias != alias) {
+    for (auto nhop = m_syncdNextHops.begin(); nhop != m_syncdNextHops.end(); ++nhop)
+    {
+        if (nhop->second.if_alias != alias)
+        {
             continue;
         }
 
-        if (if_up) {
+        if (if_up)
+        {
             rc = clearNextHopFlag(nhop->first, NHFLAGS_IFDOWN);
-        } else {
+        }
+        else
+        {
             rc = setNextHopFlag(nhop->first, NHFLAGS_IFDOWN);
         }
 
-        if (rc == true) {
+        if (rc == true)
+        {
             continue;
-        } else {
+        }
+        else
+        {
             break;
         }
     }
 
-    return (rc);
+    return rc;
 }
 
 bool NeighOrch::removeNextHop(IpAddress ipAddress, string alias)

--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -8,6 +8,8 @@
 
 #include "ipaddress.h"
 
+#define NHFLAGS_IFDOWN                  0x1 // nexthop's outbound i/f is down
+
 struct NeighborEntry
 {
     IpAddress           ip_address;     // neighbor IP address
@@ -33,6 +35,8 @@ struct NextHopEntry
 {
     sai_object_id_t     next_hop_id;    // next hop id
     int                 ref_count;      // reference count
+    uint32_t            nh_flags;       // flags
+    string              if_alias;       // i/f name alias
 };
 
 /* NeighborTable: NeighborEntry, neighbor MAC address */
@@ -62,6 +66,9 @@ public:
 
     bool getNeighborEntry(const IpAddress&, NeighborEntry&, MacAddress&);
 
+    bool ifChangeInformNextHop(const string &, bool);
+    bool isNextHopFlagSet(const IpAddress &, const uint32_t);
+
 private:
     IntfsOrch *m_intfsOrch;
 
@@ -73,6 +80,9 @@ private:
 
     bool addNeighbor(NeighborEntry, MacAddress);
     bool removeNeighbor(NeighborEntry);
+
+    bool setNextHopFlag(const IpAddress &, const uint32_t);
+    bool clearNextHopFlag(const IpAddress &, const uint32_t);
 
     void doTask(Consumer &consumer);
 };

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1,4 +1,5 @@
 #include "portsorch.h"
+#include "neighorch.h"
 
 #include <cassert>
 #include <fstream>
@@ -27,6 +28,7 @@ extern sai_hostif_api_t* sai_hostif_api;
 extern sai_acl_api_t* sai_acl_api;
 extern sai_queue_api_t *sai_queue_api;
 extern sai_object_id_t gSwitchId;
+extern NeighOrch *gNeighOrch;
 extern CrmOrch *gCrmOrch;
 
 #define VLAN_PREFIX         "Vlan"
@@ -850,27 +852,30 @@ bool PortsOrch::setHostIntfsOperStatus(sai_object_id_t port_id, bool up)
 {
     SWSS_LOG_ENTER();
 
-    for (auto it = m_portList.begin(); it != m_portList.end(); it++)
-    {
-        if (it->second.m_port_id == port_id)
-        {
-            sai_attribute_t attr;
-            attr.id = SAI_HOSTIF_ATTR_OPER_STATUS;
-            attr.value.booldata = up;
-
-            sai_status_t status = sai_hostif_api->set_hostif_attribute(it->second.m_hif_id, &attr);
-            if (status != SAI_STATUS_SUCCESS)
-            {
-                SWSS_LOG_WARN("Failed to set operation status %s to host interface %s",
-                              up ? "UP" : "DOWN", it->second.m_alias.c_str());
-                return false;
-            }
-            SWSS_LOG_NOTICE("Set operation status %s to host interface %s",
-                            up ? "UP" : "DOWN", it->second.m_alias.c_str());
-            return true;
+    for (auto it = m_portList.begin(); it != m_portList.end(); it++) {
+        if (it->second.m_port_id != port_id) {
+            continue;
         }
+
+        sai_attribute_t attr;
+        attr.id = SAI_HOSTIF_ATTR_OPER_STATUS;
+        attr.value.booldata = up;
+
+        sai_status_t status = sai_hostif_api->set_hostif_attribute(it->second.m_hif_id, &attr);
+        if (status != SAI_STATUS_SUCCESS) {
+            SWSS_LOG_WARN("Failed to set operation status %s to host interface %s",
+                          up ? "UP" : "DOWN", it->second.m_alias.c_str());
+            return (false);
+        }
+        SWSS_LOG_NOTICE("Set operation status %s to host interface %s",
+                        up ? "UP" : "DOWN", it->second.m_alias.c_str());
+        if (gNeighOrch->ifChangeInformNextHop(it->second.m_alias, up) == false) {
+            SWSS_LOG_WARN("Inform nexthop operation failed for interface %s",
+                          it->second.m_alias.c_str());
+        }
+        return (true);
     }
-    return false;
+    return (false);
 }
 
 void PortsOrch::updateDbPortOperStatus(sai_object_id_t id, sai_port_oper_status_t status)

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -852,8 +852,10 @@ bool PortsOrch::setHostIntfsOperStatus(sai_object_id_t port_id, bool up)
 {
     SWSS_LOG_ENTER();
 
-    for (auto it = m_portList.begin(); it != m_portList.end(); it++) {
-        if (it->second.m_port_id != port_id) {
+    for (auto it = m_portList.begin(); it != m_portList.end(); it++)
+    {
+        if (it->second.m_port_id != port_id)
+        {
             continue;
         }
 
@@ -862,20 +864,22 @@ bool PortsOrch::setHostIntfsOperStatus(sai_object_id_t port_id, bool up)
         attr.value.booldata = up;
 
         sai_status_t status = sai_hostif_api->set_hostif_attribute(it->second.m_hif_id, &attr);
-        if (status != SAI_STATUS_SUCCESS) {
+        if (status != SAI_STATUS_SUCCESS)
+        {
             SWSS_LOG_WARN("Failed to set operation status %s to host interface %s",
                           up ? "UP" : "DOWN", it->second.m_alias.c_str());
-            return (false);
+            return false;
         }
         SWSS_LOG_NOTICE("Set operation status %s to host interface %s",
                         up ? "UP" : "DOWN", it->second.m_alias.c_str());
-        if (gNeighOrch->ifChangeInformNextHop(it->second.m_alias, up) == false) {
+        if (gNeighOrch->ifChangeInformNextHop(it->second.m_alias, up) == false)
+        {
             SWSS_LOG_WARN("Inform nexthop operation failed for interface %s",
                           it->second.m_alias.c_str());
         }
-        return (true);
+        return true;
     }
-    return (false);
+    return false;
 }
 
 void PortsOrch::updateDbPortOperStatus(sai_object_id_t id, sai_port_oper_status_t status)

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -523,6 +523,7 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
 
         sai_object_id_t next_hop_id = m_neighOrch->getNextHopId(it);
         next_hop_ids.push_back(next_hop_id);
+        nhopgroup_members_set[next_hop_id] = it;
     }
 
     sai_attribute_t nhg_attr;

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -200,6 +200,8 @@ bool RouteOrch::validnexthopinNextHopGroup(const IpAddress &ipaddr)
                            nhopgroup->second.next_hop_group_id, status);
             return (false);
         }
+
+        gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
         nhopgroup->second.nhopgroup_members[ipaddr] = nexthop_id;
     }
 
@@ -228,6 +230,8 @@ bool RouteOrch::invalidnexthopinNextHopGroup(const IpAddress &ipaddr)
                            nexthop_id, nhopgroup->second.next_hop_group_id, status);
             return (false);
         }
+
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
     }
 
     return (true);
@@ -607,6 +611,8 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
             SWSS_LOG_ERROR("Failed to remove next hop group member %lx: %d\n",
                            next_hop_id, status);
         }
+
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
     }
 
     return true;
@@ -640,7 +646,7 @@ bool RouteOrch::removeNextHopGroup(IpAddresses ipAddresses)
         if (status != SAI_STATUS_SUCCESS) {
             SWSS_LOG_ERROR("Failed to remove next hop group member %lx, rv:%d",
                            nhop->second, status);
-        return (false);
+            return (false);
         }
 
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -640,7 +640,7 @@ bool RouteOrch::removeNextHopGroup(IpAddresses ipAddresses)
          nhop != next_hop_group_entry->second.nhopgroup_members.end();) {
 
         if (m_neighOrch->isNextHopFlagSet(nhop->first, NHFLAGS_IFDOWN)) {
-	    nhop = next_hop_group_entry->second.nhopgroup_members.erase(nhop);
+            nhop = next_hop_group_entry->second.nhopgroup_members.erase(nhop);
             continue;
         }
         status = sai_next_hop_group_api->remove_next_hop_group_member(nhop->second);

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -166,6 +166,73 @@ void RouteOrch::detach(Observer *observer, const IpAddress& dstAddr)
     }
 }
 
+bool RouteOrch::validnexthopinNextHopGroup(const IpAddress &ipaddr)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t nexthop_id;
+    sai_status_t status;
+
+    for (auto nhopgroup = m_syncdNextHopGroups.begin();
+         nhopgroup != m_syncdNextHopGroups.end(); ++nhopgroup) {
+
+        if (!(nhopgroup->first.contains(ipaddr))) {
+            continue;
+        }
+
+        vector<sai_attribute_t> nhgm_attrs;
+        sai_attribute_t nhgm_attr;
+
+        nhgm_attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID;
+        nhgm_attr.value.oid = nhopgroup->second.next_hop_group_id;
+        nhgm_attrs.push_back(nhgm_attr);
+
+        nhgm_attr.id = SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_ID;
+        nhgm_attr.value.oid = m_neighOrch->getNextHopId(ipaddr);
+        nhgm_attrs.push_back(nhgm_attr);
+
+        status = sai_next_hop_group_api->create_next_hop_group_member(&nexthop_id, gSwitchId,
+                                                                      (uint32_t)nhgm_attrs.size(),
+                                                                      nhgm_attrs.data());
+
+        if (status != SAI_STATUS_SUCCESS) {
+            SWSS_LOG_ERROR("Failed to add next hop member to group %lx: %d\n",
+                           nhopgroup->second.next_hop_group_id, status);
+            return (false);
+        }
+        nhopgroup->second.nhopgroup_members[ipaddr] = nexthop_id;
+    }
+
+    return (true);
+}
+
+bool RouteOrch::invalidnexthopinNextHopGroup(const IpAddress &ipaddr)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t nexthop_id;
+    sai_status_t status;
+
+    for (auto nhopgroup = m_syncdNextHopGroups.begin();
+         nhopgroup != m_syncdNextHopGroups.end(); ++nhopgroup) {
+
+        if (!(nhopgroup->first.contains(ipaddr))) {
+            continue;
+        }
+
+        nexthop_id = nhopgroup->second.nhopgroup_members[ipaddr];
+        status = sai_next_hop_group_api->remove_next_hop_group_member(nexthop_id);
+
+        if (status != SAI_STATUS_SUCCESS) {
+            SWSS_LOG_ERROR("Failed to remove next hop member %lx from group %lx: %d\n",
+                           nexthop_id, nhopgroup->second.next_hop_group_id, status);
+            return (false);
+        }
+    }
+
+    return (true);
+}
+
 void RouteOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
@@ -436,6 +503,8 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
 
     vector<sai_object_id_t> next_hop_ids;
     set<IpAddress> next_hop_set = ipAddresses.getIpAddresses();
+    sai_object_id_t next_hop_id;
+    std::map<sai_object_id_t, IpAddress> nhopgroup_members_set;
 
     /* Assert each IP address exists in m_syncdNextHops table,
      * and add the corresponding next_hop_id to next_hop_ids. */
@@ -460,8 +529,10 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
     nhg_attrs.push_back(nhg_attr);
 
     sai_object_id_t next_hop_group_id;
-    sai_status_t status = sai_next_hop_group_api->
-            create_next_hop_group(&next_hop_group_id, gSwitchId, (uint32_t)nhg_attrs.size(), nhg_attrs.data());
+    sai_status_t status = sai_next_hop_group_api->create_next_hop_group(&next_hop_group_id,
+                                                                        gSwitchId,
+                                                                        (uint32_t)nhg_attrs.size(),
+                                                                        nhg_attrs.data());
 
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -493,8 +564,10 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
         nhgm_attrs.push_back(nhgm_attr);
 
         sai_object_id_t next_hop_group_member_id;
-        status = sai_next_hop_group_api->
-                create_next_hop_group_member(&next_hop_group_member_id, gSwitchId, (uint32_t)nhgm_attrs.size(), nhgm_attrs.data());
+        status = sai_next_hop_group_api->create_next_hop_group_member(&next_hop_group_member_id,
+                                                                      gSwitchId,
+                                                                      (uint32_t)nhgm_attrs.size(),
+                                                                      nhgm_attrs.data());
 
         if (status != SAI_STATUS_SUCCESS)
         {
@@ -507,10 +580,11 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
         gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
 
         // Save the membership into next hop structure
-        next_hop_group_entry.next_hop_group_members.insert(next_hop_group_member_id);
+        next_hop_group_entry.nhopgroup_members[nhopgroup_members_set.find(nhid)->second] =
+                                                                next_hop_group_member_id;
     }
 
-    /* Increate the ref_count for the next hops used by the next hop group. */
+    /* Increment the ref_count for the next hops used by the next hop group. */
     for (auto it : next_hop_set)
         m_neighOrch->increaseNextHopRefCount(it);
 
@@ -521,6 +595,20 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
     next_hop_group_entry.ref_count = 0;
     m_syncdNextHopGroups[ipAddresses] = next_hop_group_entry;
 
+    for (auto nhop : next_hop_set) {
+        if (!m_neighOrch->isNextHopFlagSet(nhop, NHFLAGS_IFDOWN)) {
+            continue;
+        }
+
+        next_hop_id = next_hop_group_entry.nhopgroup_members[nhop];
+        status = sai_next_hop_group_api->remove_next_hop_group_member(next_hop_id);
+
+        if (status != SAI_STATUS_SUCCESS) {
+            SWSS_LOG_ERROR("Failed to remove next hop group member %lx: %d\n",
+                           next_hop_id, status);
+        }
+    }
+
     return true;
 }
 
@@ -528,43 +616,51 @@ bool RouteOrch::removeNextHopGroup(IpAddresses ipAddresses)
 {
     SWSS_LOG_ENTER();
 
+    sai_object_id_t next_hop_group_id;
+    auto next_hop_group_entry = m_syncdNextHopGroups.find(ipAddresses);
     sai_status_t status;
-    assert(hasNextHopGroup(ipAddresses));
 
-    if (m_syncdNextHopGroups[ipAddresses].ref_count == 0)
-    {
-        auto next_hop_group_entry = m_syncdNextHopGroups[ipAddresses];
-        sai_object_id_t next_hop_group_id = next_hop_group_entry.next_hop_group_id;
+    assert(next_hop_group_entry != m_syncdNextHopGroups.end());
 
-        for (auto next_hop_group_member_id: next_hop_group_entry.next_hop_group_members)
-        {
-            status = sai_next_hop_group_api->remove_next_hop_group_member(next_hop_group_member_id);
-            if (status != SAI_STATUS_SUCCESS)
-            {
-                SWSS_LOG_ERROR("Failed to remove next hop group member %lx, rv:%d", next_hop_group_member_id, status);
-                return false;
-            }
-
-            gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
-        }
-
-        sai_status_t status = sai_next_hop_group_api->remove_next_hop_group(next_hop_group_id);
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to remove next hop group %lx, rv:%d", next_hop_group_id, status);
-            return false;
-        }
-
-        m_nextHopGroupCount --;
-
-        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
-
-        set<IpAddress> ip_address_set = ipAddresses.getIpAddresses();
-        for (auto it : ip_address_set)
-            m_neighOrch->decreaseNextHopRefCount(it);
-
-        m_syncdNextHopGroups.erase(ipAddresses);
+    if (next_hop_group_entry->second.ref_count != 0) {
+        return (true);
     }
+
+    next_hop_group_id = next_hop_group_entry->second.next_hop_group_id;
+    SWSS_LOG_NOTICE("Delete next hop group %s", ipAddresses.to_string().c_str());
+
+    for (auto nhop = next_hop_group_entry->second.nhopgroup_members.begin();
+         nhop != next_hop_group_entry->second.nhopgroup_members.end();) {
+
+        if (m_neighOrch->isNextHopFlagSet(nhop->first, NHFLAGS_IFDOWN)) {
+	    nhop = next_hop_group_entry->second.nhopgroup_members.erase(nhop);
+            continue;
+        }
+        status = sai_next_hop_group_api->remove_next_hop_group_member(nhop->second);
+        if (status != SAI_STATUS_SUCCESS) {
+            SWSS_LOG_ERROR("Failed to remove next hop group member %lx, rv:%d",
+                           nhop->second, status);
+        return (false);
+        }
+
+        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
+        nhop = next_hop_group_entry->second.nhopgroup_members.erase(nhop);
+    }
+
+    status = sai_next_hop_group_api->remove_next_hop_group(next_hop_group_id);
+    if (status != SAI_STATUS_SUCCESS) {
+        SWSS_LOG_ERROR("Failed to remove next hop group %lx, rv:%d", next_hop_group_id, status);
+        return (false);
+    }
+
+    m_nextHopGroupCount --;
+    gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
+
+    set<IpAddress> ip_address_set = ipAddresses.getIpAddresses();
+    for (auto it : ip_address_set) {
+        m_neighOrch->decreaseNextHopRefCount(it);
+    }
+    m_syncdNextHopGroups.erase(ipAddresses);
 
     return true;
 }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -174,9 +174,11 @@ bool RouteOrch::validnexthopinNextHopGroup(const IpAddress &ipaddr)
     sai_status_t status;
 
     for (auto nhopgroup = m_syncdNextHopGroups.begin();
-         nhopgroup != m_syncdNextHopGroups.end(); ++nhopgroup) {
+         nhopgroup != m_syncdNextHopGroups.end(); ++nhopgroup)
+    {
 
-        if (!(nhopgroup->first.contains(ipaddr))) {
+        if (!(nhopgroup->first.contains(ipaddr)))
+        {
             continue;
         }
 
@@ -195,17 +197,18 @@ bool RouteOrch::validnexthopinNextHopGroup(const IpAddress &ipaddr)
                                                                       (uint32_t)nhgm_attrs.size(),
                                                                       nhgm_attrs.data());
 
-        if (status != SAI_STATUS_SUCCESS) {
+        if (status != SAI_STATUS_SUCCESS)
+        {
             SWSS_LOG_ERROR("Failed to add next hop member to group %lx: %d\n",
                            nhopgroup->second.next_hop_group_id, status);
-            return (false);
+            return false;
         }
 
         gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
         nhopgroup->second.nhopgroup_members[ipaddr] = nexthop_id;
     }
 
-    return (true);
+    return true;
 }
 
 bool RouteOrch::invalidnexthopinNextHopGroup(const IpAddress &ipaddr)
@@ -216,25 +219,28 @@ bool RouteOrch::invalidnexthopinNextHopGroup(const IpAddress &ipaddr)
     sai_status_t status;
 
     for (auto nhopgroup = m_syncdNextHopGroups.begin();
-         nhopgroup != m_syncdNextHopGroups.end(); ++nhopgroup) {
+         nhopgroup != m_syncdNextHopGroups.end(); ++nhopgroup)
+    {
 
-        if (!(nhopgroup->first.contains(ipaddr))) {
+        if (!(nhopgroup->first.contains(ipaddr)))
+        {
             continue;
         }
 
         nexthop_id = nhopgroup->second.nhopgroup_members[ipaddr];
         status = sai_next_hop_group_api->remove_next_hop_group_member(nexthop_id);
 
-        if (status != SAI_STATUS_SUCCESS) {
+        if (status != SAI_STATUS_SUCCESS)
+        {
             SWSS_LOG_ERROR("Failed to remove next hop member %lx from group %lx: %d\n",
                            nexthop_id, nhopgroup->second.next_hop_group_id, status);
-            return (false);
+            return false;
         }
 
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
     }
 
-    return (true);
+    return true;
 }
 
 void RouteOrch::doTask(Consumer& consumer)
@@ -629,25 +635,29 @@ bool RouteOrch::removeNextHopGroup(IpAddresses ipAddresses)
 
     assert(next_hop_group_entry != m_syncdNextHopGroups.end());
 
-    if (next_hop_group_entry->second.ref_count != 0) {
-        return (true);
+    if (next_hop_group_entry->second.ref_count != 0)
+    {
+        return true;
     }
 
     next_hop_group_id = next_hop_group_entry->second.next_hop_group_id;
     SWSS_LOG_NOTICE("Delete next hop group %s", ipAddresses.to_string().c_str());
 
     for (auto nhop = next_hop_group_entry->second.nhopgroup_members.begin();
-         nhop != next_hop_group_entry->second.nhopgroup_members.end();) {
+         nhop != next_hop_group_entry->second.nhopgroup_members.end();)
+    {
 
-        if (m_neighOrch->isNextHopFlagSet(nhop->first, NHFLAGS_IFDOWN)) {
+        if (m_neighOrch->isNextHopFlagSet(nhop->first, NHFLAGS_IFDOWN))
+        {
             nhop = next_hop_group_entry->second.nhopgroup_members.erase(nhop);
             continue;
         }
         status = sai_next_hop_group_api->remove_next_hop_group_member(nhop->second);
-        if (status != SAI_STATUS_SUCCESS) {
+        if (status != SAI_STATUS_SUCCESS)
+        {
             SWSS_LOG_ERROR("Failed to remove next hop group member %lx, rv:%d",
                            nhop->second, status);
-            return (false);
+            return false;
         }
 
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
@@ -655,16 +665,18 @@ bool RouteOrch::removeNextHopGroup(IpAddresses ipAddresses)
     }
 
     status = sai_next_hop_group_api->remove_next_hop_group(next_hop_group_id);
-    if (status != SAI_STATUS_SUCCESS) {
+    if (status != SAI_STATUS_SUCCESS)
+    {
         SWSS_LOG_ERROR("Failed to remove next hop group %lx, rv:%d", next_hop_group_id, status);
-        return (false);
+        return false;
     }
 
     m_nextHopGroupCount --;
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
 
     set<IpAddress> ip_address_set = ipAddresses.getIpAddresses();
-    for (auto it : ip_address_set) {
+    for (auto it : ip_address_set)
+    {
         m_neighOrch->decreaseNextHopRefCount(it);
     }
     m_syncdNextHopGroups.erase(ipAddresses);

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -15,11 +15,13 @@
 /* Maximum next hop group number */
 #define NHGRP_MAX_SIZE 128
 
+typedef std::map<IpAddress, sai_object_id_t> NextHopGroupMembers;
+
 struct NextHopGroupEntry
 {
     sai_object_id_t         next_hop_group_id;      // next hop group id
-    std::set<sai_object_id_t>    next_hop_group_members; // next hop group member ids
     int                     ref_count;              // reference count
+    NextHopGroupMembers     nhopgroup_members;      // ids of members indexed by ip address
 };
 
 struct NextHopUpdate
@@ -60,6 +62,9 @@ public:
 
     bool addNextHopGroup(IpAddresses);
     bool removeNextHopGroup(IpAddresses);
+
+    bool validnexthopinNextHopGroup(const IpAddress &);
+    bool invalidnexthopinNextHopGroup(const IpAddress &);
 
 private:
     NeighOrch *m_neighOrch;

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -1,0 +1,128 @@
+from swsscommon import swsscommon
+import os
+import re
+import time
+import json
+
+def test_route_nhg(dvs):
+
+    dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
+    dvs.runcmd("ifconfig Ethernet4 10.0.0.2/31 up")
+    dvs.runcmd("ifconfig Ethernet8 10.0.0.4/31 up")
+
+    dvs.runcmd("arp -s 10.0.0.1 00:00:00:00:00:01") 
+    dvs.runcmd("arp -s 10.0.0.3 00:00:00:00:00:02") 
+    dvs.runcmd("arp -s 10.0.0.5 00:00:00:00:00:03") 
+
+    dvs.servers[0].runcmd("ip link set down dev eth0") == 0
+    dvs.servers[1].runcmd("ip link set down dev eth0") == 0
+    dvs.servers[2].runcmd("ip link set down dev eth0") == 0
+
+    dvs.servers[0].runcmd("ip link set up dev eth0") == 0
+    dvs.servers[1].runcmd("ip link set up dev eth0") == 0
+    dvs.servers[2].runcmd("ip link set up dev eth0") == 0
+
+    db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+    ps = swsscommon.ProducerStateTable(db, "ROUTE_TABLE")
+    fvs = swsscommon.FieldValuePairs([("nexthop","10.0.0.1,10.0.0.3,10.0.0.5"), ("ifname", "Ethernet0,Ethernet4,Ethernet8")])
+
+    ps.set("2.2.2.0/24", fvs)
+
+    time.sleep(1)
+
+    # check if route was propagated to ASIC DB
+
+    adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+
+    rtbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
+    nhgtbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP")
+    nhg_member_tbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER")
+
+    keys = rtbl.getKeys()
+
+    found_route = False
+    for k in keys:
+        rt_key = json.loads(k)
+
+        if rt_key['dest'] == "2.2.2.0/24":
+            found_route = True
+            break
+
+    assert found_route
+
+    # assert the route points to next hop group
+    (status, fvs) = rtbl.get(k)
+
+    for v in fvs:
+        if v[0] == "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID":
+            nhgid = v[1]
+
+    (status, fvs) = nhgtbl.get(nhgid)
+
+    assert status
+
+    keys = nhg_member_tbl.getKeys()
+
+    assert len(keys) == 3
+
+    for k in keys:
+        (status, fvs) = nhg_member_tbl.get(k)
+        
+        for v in fvs:
+            if v[0] == "SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID":
+                assert v[1] == nhgid
+
+    # bring links down one-by-one
+    for i in [0, 1, 2]:
+        dvs.servers[i].runcmd("ip link set down dev eth0") == 0
+
+        time.sleep(1)
+
+        tbl = swsscommon.Table(db, "PORT_TABLE")
+        (status, fvs) = tbl.get("Ethernet%d" % (i * 4))
+
+        assert status == True
+
+        oper_status = "unknown"
+
+        for v in fvs:
+            if v[0] == "oper_status":
+                oper_status = v[1]
+                break
+
+        assert oper_status == "down"
+
+        keys = nhg_member_tbl.getKeys()
+
+        assert len(keys) == 2 - i
+
+    # bring links up one-by-one
+    for i in [0, 1, 2]:
+        dvs.servers[i].runcmd("ip link set up dev eth0") == 0
+
+        time.sleep(1)
+
+        tbl = swsscommon.Table(db, "PORT_TABLE")
+        (status, fvs) = tbl.get("Ethernet0")
+
+        assert status == True
+
+        oper_status = "unknown"
+
+        for v in fvs:
+            if v[0] == "oper_status":
+                oper_status = v[1]
+                break
+
+        assert oper_status == "up"
+
+        keys = nhg_member_tbl.getKeys()
+
+        assert len(keys) == i + 1
+
+        for k in keys:
+            (status, fvs) = nhg_member_tbl.get(k)
+
+            for v in fvs:
+                if v[0] == "SAI_NEXT_HOP_GROUP_MEMBER_ATTR_NEXT_HOP_GROUP_ID":
+                    assert v[1] == nhgid


### PR DESCRIPTION
These changes introduce support for ecmp acceleration for physical i/f down events. The design document was reviewed a couple of months back and checked into the repo.

The functionality has been verified through manual testing in a physical topology having 2 T0 switches (asw01, asw02) connected 4-way to 4 T1 switches (csw01, csw02, csw03, csw04). IXIA was connected in the topology to both T0 switches. Prefixes were advertised to asw02 and traffic was towards asw01. The ecmp acceleration was tested by bring down the links in different combinations on the T1 devices and checking the membership through logs on asw01 as well as having IXIA measure the traffic loss duration.

Nikos.-