### PR TITLE
[swss] a couple non-functional code cleanup changes

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -65,17 +65,20 @@ task_process_status BufferOrch::processBufferPool(Consumer &consumer)
         vector<sai_attribute_t> attribs;
         for (auto i = kfvFieldsValues(tuple).begin(); i != kfvFieldsValues(tuple).end(); i++)
         {
-            SWSS_LOG_DEBUG("field:%s, value:%s", fvField(*i).c_str(), fvValue(*i).c_str());
+            string field = fvField(*i);
+            string value = fvValue(*i);
+
+            SWSS_LOG_DEBUG("field:%s, value:%s", field.c_str(), value.c_str());
             sai_attribute_t attr;
-            if (fvField(*i) == buffer_size_field_name)
+            if (field == buffer_size_field_name)
             {
                 attr.id = SAI_BUFFER_POOL_ATTR_SIZE;
-                attr.value.u32 = (uint32_t)stoul(fvValue(*i));
+                attr.value.u32 = (uint32_t)stoul(value);
                 attribs.push_back(attr);
             }
-            else if (fvField(*i) == buffer_pool_type_field_name)
+            else if (field == buffer_pool_type_field_name)
             {
-                string type = fvValue(*i);
+                string type = value;
                 if (type == buffer_value_ingress)
                 {
                     attr.value.u32 = SAI_BUFFER_POOL_TYPE_INGRESS;
@@ -92,9 +95,9 @@ task_process_status BufferOrch::processBufferPool(Consumer &consumer)
                 attr.id = SAI_BUFFER_POOL_ATTR_TYPE;
                 attribs.push_back(attr);
             }
-            else if (fvField(*i) == buffer_pool_mode_field_name)
+            else if (field == buffer_pool_mode_field_name)
             {
-                string mode = fvValue(*i);
+                string mode = value;
                 if (mode == buffer_pool_mode_dynamic_value)
                 {
                     attr.value.u32 = SAI_BUFFER_POOL_THRESHOLD_MODE_DYNAMIC;
@@ -113,7 +116,7 @@ task_process_status BufferOrch::processBufferPool(Consumer &consumer)
             }
             else
             {
-                SWSS_LOG_ERROR("Unknown pool field specified:%s, ignoring", fvField(*i).c_str());
+                SWSS_LOG_ERROR("Unknown pool field specified:%s, ignoring", field.c_str());
                 continue;
             }
         }
@@ -182,9 +185,12 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
         vector<sai_attribute_t> attribs;
         for (auto i = kfvFieldsValues(tuple).begin(); i != kfvFieldsValues(tuple).end(); i++)
         {
-            SWSS_LOG_DEBUG("field:%s, value:%s", fvField(*i).c_str(), fvValue(*i).c_str());
+            string field = fvField(*i);
+            string value = fvValue(*i);
+
+            SWSS_LOG_DEBUG("field:%s, value:%s", field.c_str(), value.c_str());
             sai_attribute_t attr;
-            if (fvField(*i) == buffer_pool_field_name)
+            if (field == buffer_pool_field_name)
             {
                 sai_object_id_t sai_pool;
                 ref_resolve_status resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_pool_field_name, tuple, sai_pool);
@@ -202,47 +208,47 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
                 attr.value.oid = sai_pool;
                 attribs.push_back(attr);
             }
-            else if (fvField(*i) == buffer_xon_field_name)
+            else if (field == buffer_xon_field_name)
             {
-                attr.value.u32 = (uint32_t)stoul(fvValue(*i));
+                attr.value.u32 = (uint32_t)stoul(value);
                 attr.id = SAI_BUFFER_PROFILE_ATTR_XON_TH;
                 attribs.push_back(attr);
             }
-            else if (fvField(*i) == buffer_xoff_field_name)
+            else if (field == buffer_xoff_field_name)
             {
-                attr.value.u32 = (uint32_t)stoul(fvValue(*i));
+                attr.value.u32 = (uint32_t)stoul(value);
                 attr.id = SAI_BUFFER_PROFILE_ATTR_XOFF_TH;
                 attribs.push_back(attr);
             }
-            else if (fvField(*i) == buffer_size_field_name)
+            else if (field == buffer_size_field_name)
             {
                 attr.id = SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE;
-                attr.value.u32 = (uint32_t)stoul(fvValue(*i));
+                attr.value.u32 = (uint32_t)stoul(value);
                 attribs.push_back(attr);
             }
-            else if (fvField(*i) == buffer_dynamic_th_field_name)
+            else if (field == buffer_dynamic_th_field_name)
             {
                 attr.id = SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE;
                 attr.value.s32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_DYNAMIC;
                 attribs.push_back(attr);
 
                 attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH;
-                attr.value.u32 = (uint32_t)stoul(fvValue(*i));
+                attr.value.u32 = (uint32_t)stoul(value);
                 attribs.push_back(attr);
             }
-            else if (fvField(*i) == buffer_static_th_field_name)
+            else if (field == buffer_static_th_field_name)
             {
                 attr.id = SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE;
                 attr.value.s32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_STATIC;
                 attribs.push_back(attr);
 
                 attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_STATIC_TH;
-                attr.value.u32 = (uint32_t)stoul(fvValue(*i));
+                attr.value.u32 = (uint32_t)stoul(value);
                 attribs.push_back(attr);
             }
             else
             {
-                SWSS_LOG_ERROR("Unknown buffer profile field specified:%s, ignoring", fvField(*i).c_str());
+                SWSS_LOG_ERROR("Unknown buffer profile field specified:%s, ignoring", field.c_str());
                 continue;
             }
         }

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -9,6 +9,8 @@ const string buffer_size_field_name         = "size";
 const string buffer_pool_type_field_name    = "type";
 const string buffer_pool_mode_field_name    = "mode";
 const string buffer_pool_field_name         = "pool";
+const string buffer_pool_mode_dynamic_value = "dynamic";
+const string buffer_pool_mode_static_value  = "static";
 const string buffer_xon_field_name          = "xon";
 const string buffer_xoff_field_name         = "xoff";
 const string buffer_dynamic_th_field_name   = "dynamic_th";
@@ -16,8 +18,6 @@ const string buffer_static_th_field_name    = "static_th";
 const string buffer_profile_field_name      = "profile";
 const string buffer_value_ingress           = "ingress";
 const string buffer_value_egress            = "egress";
-const string buffer_pool_mode_dynamic_value = "dynamic";
-const string buffer_pool_mode_static_value  = "static";
 const string buffer_profile_list_field_name = "profile_list";
 
 class BufferOrch : public Orch


### PR DESCRIPTION
**What I did**
1. Cleaned up function BufferOrch::processBufferPool and BufferOrch::processBufferPRofile, cache the repeated used attributes in local variables. And use local variable in function.
2. Re-organized some buffer related definitions to place related definitions close to each other.

**Why I did it**
1. Minor performance optimization.
2. Code readability.

**How I verified it**
This is non-functional change. It passed nightly tests on 2 duts.
