### PR TITLE
Split Orch class into two classes: OrchBase and Orch

### DIFF
--- a/fpmsyncd/fpmlink.cpp
+++ b/fpmsyncd/fpmlink.cpp
@@ -40,7 +40,7 @@ FpmLink::FpmLink(int port) :
 
     memset (&addr, 0, sizeof (addr));
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(port);
+    addr.sin_port = htons((uint16_t)port);
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 
     if (bind(m_server_socket, (struct sockaddr *)&addr, sizeof(addr)) < 0)

--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -21,6 +21,7 @@ orchagent_SOURCES = \
 		    main.cpp \
 		    port.cpp \
 		    orchdaemon.cpp \
+		    orchbase.cpp \
 		    orch.cpp \
 		    notifications.cpp \
 		    routeorch.cpp \
@@ -47,6 +48,7 @@ orchagent_SOURCES = \
 		    neighorch.h \
 		    notifications.h \
 		    observer.h \
+		    orchbase.h \
 		    orch.h \
 		    orchdaemon.h \
 		    pfcactionhandler.h \

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -34,7 +34,6 @@ sai_object_id_t gUnderlayIfId;
 sai_object_id_t gSwitchId = SAI_NULL_OBJECT_ID;
 MacAddress gMacAddress;
 
-#define DEFAULT_BATCH_SIZE  128
 int gBatchSize = DEFAULT_BATCH_SIZE;
 
 bool gSairedisRecord = true;

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -1,18 +1,12 @@
 #ifndef SWSS_ORCH_H
 #define SWSS_ORCH_H
 
-#include <map>
-#include <memory>
-
 extern "C" {
 #include "sai.h"
 #include "saistatus.h"
 }
 
-#include "dbconnector.h"
-#include "table.h"
-#include "consumertable.h"
-#include "consumerstatetable.h"
+#include "orchbase.h"
 
 using namespace std;
 using namespace swss;
@@ -42,16 +36,6 @@ typedef pair<string, sai_object_id_t> object_map_pair;
 typedef map<string, object_map*> type_map;
 typedef pair<string, object_map*> type_map_pair;
 
-typedef map<string, KeyOpFieldsValuesTuple> SyncMap;
-struct Consumer {
-    Consumer(TableConsumable* consumer) : m_consumer(consumer)  { }
-    TableConsumable* m_consumer;
-    /* Store the latest 'golden' status */
-    SyncMap m_toSync;
-};
-typedef pair<string, Consumer> ConsumerMapPair;
-typedef map<string, Consumer> ConsumerMap;
-
 typedef enum
 {
     success,
@@ -61,20 +45,13 @@ typedef enum
     failure
 } ref_resolve_status;
 
-typedef pair<DBConnector *, string> TableConnector;
-typedef pair<DBConnector *, vector<string>> TablesConnector;
-
-class Orch
+class Orch : public OrchBase
 {
 public:
     Orch(DBConnector *db, string tableName);
     Orch(DBConnector *db, vector<string> &tableNames);
     Orch(const vector<TableConnector>& tables);
     virtual ~Orch();
-
-    vector<Selectable*> getSelectables();
-    bool hasSelectable(TableConsumable* s) const;
-
     bool execute(string tableName);
     /* Iterate all consumers in m_consumerMap and run doTask(Consumer) */
     void doTask();

--- a/orchagent/orchbase.cpp
+++ b/orchagent/orchbase.cpp
@@ -1,0 +1,202 @@
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <sys/time.h>
+
+#include "orchbase.h"
+#include "subscriberstatetable.h"
+#include "tokenize.h"
+#include "logger.h"
+#include "consumerstatetable.h"
+
+using namespace swss;
+
+OrchBase::OrchBase(DBConnector *db, string tableName)
+{
+    addConsumer(db, tableName);
+}
+
+OrchBase::OrchBase(DBConnector *db, vector<string> &tableNames)
+{
+    for(auto it : tableNames)
+    {
+        addConsumer(db, it);
+    }
+}
+
+OrchBase::OrchBase(const vector<TableConnector>& tables)
+{
+    for (auto it : tables)
+    {
+        addConsumer(it.first, it.second);
+    }
+}
+
+OrchBase::~OrchBase()
+{
+    for(auto &it : m_consumerMap)
+        delete it.second.m_consumer;
+}
+
+vector<Selectable *> OrchBase::getSelectables()
+{
+    vector<Selectable *> selectables;
+    for(auto it : m_consumerMap) {
+        selectables.push_back(it.second.m_consumer);
+    }
+    return selectables;
+}
+
+bool OrchBase::hasSelectable(TableConsumable *selectable) const
+{
+    for(auto it : m_consumerMap) {
+        if (it.second.m_consumer == selectable) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool OrchBase::syncDB(string tableName, Table &tableConsumer)
+{
+    SWSS_LOG_ENTER();
+
+    auto consumer_it = m_consumerMap.find(tableName);
+    if (consumer_it == m_consumerMap.end())
+    {
+        SWSS_LOG_ERROR("Unrecognized tableName:%s\n", tableName.c_str());
+        return false;
+    }
+    Consumer& consumer = consumer_it->second;
+
+    vector<KeyOpFieldsValuesTuple> tuples;
+
+    tableConsumer.getTableContent(tuples);
+    for (auto tuple : tuples)
+    {
+        string key = kfvKey(tuple);
+        /* Directly put it into consumer.m_toSync map */
+        if (consumer.m_toSync.find(key) == consumer.m_toSync.end())
+        {
+           consumer.m_toSync[key] = make_tuple(key, SET_COMMAND, kfvFieldsValues(tuple));
+        }
+        /*
+         * Syncing from DB directly, don't expect duplicate keys.
+         * Or there is pending task from consumber state pipe, in this case just skip it.
+         */
+        else
+        {
+            SWSS_LOG_WARN("Duplicate key %s found in tableName:%s\n", key.c_str(), tableName.c_str());
+            continue;
+        }
+        SWSS_LOG_DEBUG("%s", (dumpTuple(consumer, tuple)).c_str());
+        doTask(consumer);
+    }
+    return true;
+}
+
+bool OrchBase::execute(string tableName)
+{
+    SWSS_LOG_ENTER();
+
+    auto consumer_it = m_consumerMap.find(tableName);
+    if (consumer_it == m_consumerMap.end())
+    {
+        SWSS_LOG_ERROR("Unrecognized tableName:%s\n", tableName.c_str());
+        return false;
+    }
+    Consumer& consumer = consumer_it->second;
+
+    std::deque<KeyOpFieldsValuesTuple> entries;
+    consumer.m_consumer->pops(entries);
+
+    /* Nothing popped */
+    if (entries.empty())
+    {
+        return true;
+    }
+
+    for (auto entry: entries)
+    {
+        string key = kfvKey(entry);
+        string op  = kfvOp(entry);
+
+        recordTuple(consumer, entry);
+
+        /* If a new task comes or if a DEL task comes, we directly put it into consumer.m_toSync map */
+        if (consumer.m_toSync.find(key) == consumer.m_toSync.end() || op == DEL_COMMAND)
+        {
+           consumer.m_toSync[key] = entry;
+        }
+        /* If an old task is still there, we combine the old task with new task */
+        else
+        {
+            KeyOpFieldsValuesTuple existing_data = consumer.m_toSync[key];
+
+            auto new_values = kfvFieldsValues(entry);
+            auto existing_values = kfvFieldsValues(existing_data);
+
+
+            for (auto it : new_values)
+            {
+                string field = fvField(it);
+                string value = fvValue(it);
+
+                auto iu = existing_values.begin();
+                while (iu != existing_values.end())
+                {
+                    string ofield = fvField(*iu);
+                    if (field == ofield)
+                        iu = existing_values.erase(iu);
+                    else
+                        iu++;
+                }
+                existing_values.push_back(FieldValueTuple(field, value));
+            }
+            consumer.m_toSync[key] = KeyOpFieldsValuesTuple(key, op, existing_values);
+        }
+    }
+
+    if (!consumer.m_toSync.empty())
+        doTask(consumer);
+
+    return true;
+}
+
+void OrchBase::recordTuple(Consumer &consumer, KeyOpFieldsValuesTuple &tuple)
+{
+    return;
+}
+
+void OrchBase::doTask()
+{
+    for(auto &it : m_consumerMap)
+    {
+        if (!it.second.m_toSync.empty())
+            doTask(it.second);
+    }
+}
+
+string OrchBase::dumpTuple(Consumer &consumer, KeyOpFieldsValuesTuple &tuple)
+{
+    string s = consumer.m_consumer->getTableName() + ":" + kfvKey(tuple)
+               + "|" + kfvOp(tuple);
+    for (auto i = kfvFieldsValues(tuple).begin(); i != kfvFieldsValues(tuple).end(); i++)
+    {
+        s += "|" + fvField(*i) + ":" + fvValue(*i);
+    }
+
+    return s;
+}
+
+void OrchBase::addConsumer(DBConnector *db, string tableName, int batchSize)
+{
+    if (db->getDB() == CONFIG_DB)
+    {
+        Consumer consumer(new SubscriberStateTable(db, tableName));
+        m_consumerMap.insert(ConsumerMapPair(tableName, consumer));
+    } else {
+        Consumer consumer(new ConsumerStateTable(db, tableName, batchSize));
+        m_consumerMap.insert(ConsumerMapPair(tableName, consumer));
+    }
+}

--- a/orchagent/orchbase.cpp
+++ b/orchagent/orchbase.cpp
@@ -16,7 +16,7 @@ OrchBase::OrchBase(DBConnector *db, string tableName)
     addConsumer(db, tableName);
 }
 
-OrchBase::OrchBase(DBConnector *db, vector<string> &tableNames)
+OrchBase::OrchBase(DBConnector *db, const vector<string> &tableNames)
 {
     for(auto it : tableNames)
     {

--- a/orchagent/orchbase.h
+++ b/orchagent/orchbase.h
@@ -4,11 +4,6 @@
 #include <map>
 #include <memory>
 
-extern "C" {
-#include "sai.h"
-#include "saistatus.h"
-}
-
 #include "dbconnector.h"
 #include "table.h"
 #include "consumertable.h"
@@ -38,7 +33,7 @@ class OrchBase
 {
 public:
     OrchBase(DBConnector *db, string tableName);
-    OrchBase(DBConnector *db, vector<string> &tableNames);
+    OrchBase(DBConnector *db, const vector<string> &tableNames);
     OrchBase(const vector<TableConnector>& tables);
     virtual ~OrchBase();
 

--- a/orchagent/orchbase.h
+++ b/orchagent/orchbase.h
@@ -1,0 +1,63 @@
+#ifndef SWSS_ORCH_BASE_H
+#define SWSS_ORCH_BASE_H
+
+#include <map>
+#include <memory>
+
+extern "C" {
+#include "sai.h"
+#include "saistatus.h"
+}
+
+#include "dbconnector.h"
+#include "table.h"
+#include "consumertable.h"
+#include "consumerstatetable.h"
+
+using namespace std;
+using namespace swss;
+
+#define DEFAULT_BATCH_SIZE        128
+#define DEFAULT_KEY_SEPARATOR     ":"
+#define CONFIGDB_KEY_SEPARATOR    "|"
+
+typedef map<string, KeyOpFieldsValuesTuple> SyncMap;
+struct Consumer {
+    Consumer(TableConsumable* consumer) : m_consumer(consumer)  { }
+    TableConsumable* m_consumer;
+    /* Store the latest 'golden' status */
+    SyncMap m_toSync;
+};
+typedef pair<string, Consumer> ConsumerMapPair;
+typedef map<string, Consumer> ConsumerMap;
+
+typedef pair<DBConnector *, string> TableConnector;
+typedef pair<DBConnector *, vector<string>> TablesConnector;
+
+class OrchBase
+{
+public:
+    OrchBase(DBConnector *db, string tableName);
+    OrchBase(DBConnector *db, vector<string> &tableNames);
+    OrchBase(const vector<TableConnector>& tables);
+    virtual ~OrchBase();
+
+    vector<Selectable*> getSelectables();
+    bool hasSelectable(TableConsumable* s) const;
+
+    virtual bool execute(string tableName);
+    /* Iterate all consumers in m_consumerMap and run doTask(Consumer) */
+    virtual void doTask();
+
+protected:
+    ConsumerMap m_consumerMap;
+
+    /* Run doTask against a specific consumer */
+    virtual void doTask(Consumer &consumer) = 0;
+    virtual void recordTuple(Consumer &consumer, KeyOpFieldsValuesTuple &tuple);
+    string dumpTuple(Consumer &consumer, KeyOpFieldsValuesTuple &tuple);
+    void addConsumer(DBConnector *db, string tableName, int batchSize = DEFAULT_BATCH_SIZE);
+    bool syncDB(string tableName, Table &tableConsumer);
+};
+
+#endif /* SWSS_ORCH_BASE_H */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,7 +12,7 @@ endif
 CFLAGS_GTEST =
 LDADD_GTEST =
 
-tests_SOURCES = swssnet_ut.cpp
+tests_SOURCES = swssnet_ut.cpp orchbase_ut.cpp $(top_srcdir)/orchagent/orchbase.cpp
 
 tests_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)
 tests_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_GTEST) $(CFLAGS_SAI)

--- a/tests/orchbase_ut.cpp
+++ b/tests/orchbase_ut.cpp
@@ -1,0 +1,387 @@
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <iostream>
+#include <vector>
+#include "dbconnector.h"
+#include "select.h"
+#include "schema.h"
+#include "exec.h"
+#include "orchbase.h"
+#include "producerstatetable.h"
+
+using namespace std;
+using namespace swss;
+
+/*
+ * In the following unit test:
+ * OrchBase supports orchestrating notifications from three tables in TEST_CONFIG_DB,
+ * CFGTABLE_A_1, CFGTABLE_A_2 & CFGTABLE_B with client type of keyspace SubscriberStateTable,
+ * and one table in TEST_APP_DB,  APPTABLE_C with client type of ConsumerStateTable,
+ * and directs the notification to each result table in TEST_RESULT_DB
+ */
+#define TEST_CONFIG_DB        (CONFIG_DB)
+#define TEST_APP_DB              (7)
+#define TEST_RESULT_DB           (8)
+
+#define SELECT_TIMEOUT 1000
+
+const string cfgTableNameA1 = "CFGTABLE_A_1";
+const string cfgTableNameA2 = "CFGTABLE_A_2";
+const string cfgTableNameB = "CFGTABLE_B";
+const string appTableNameC = "APPTABLE_C";
+
+const string keySuffix = "_Key";
+const string keyA1 = cfgTableNameA1 + keySuffix;
+const string keyA2 = cfgTableNameA2 + keySuffix;
+const string keyB = cfgTableNameB + keySuffix;
+const string keyC = appTableNameC + keySuffix;
+
+static inline void clearDB(int db)
+{
+    DBConnector dbc(db, "localhost", 6379, 0);
+    RedisReply r(&dbc, "FLUSHDB", REDIS_REPLY_STATUS);
+    r.checkStatusOK();
+}
+
+class CfgAgentA : public OrchBase
+{
+public:
+    CfgAgentA(DBConnector *cfgDb, DBConnector *resultDb, vector<string> tableNames):
+        OrchBase(cfgDb, tableNames),
+        m_cfgTableA1(cfgDb, cfgTableNameA1, CONFIGDB_TABLE_NAME_SEPARATOR),
+        m_cfgTableA2(cfgDb, cfgTableNameA2, CONFIGDB_TABLE_NAME_SEPARATOR),
+        m_resultTableA1(resultDb, cfgTableNameA1),
+        m_resultTableA2(resultDb, cfgTableNameA2)
+    {
+    }
+
+    void syncCfgDB()
+    {
+        OrchBase::syncDB(cfgTableNameA1, m_cfgTableA1);
+        OrchBase::syncDB(cfgTableNameA2, m_cfgTableA2);
+    }
+
+private:
+    Table m_cfgTableA1, m_cfgTableA2;
+    Table m_resultTableA1, m_resultTableA2;
+
+    void doTask(Consumer &consumer)
+    {
+        string table_name = consumer.m_consumer->getTableName();
+        string key_expected = table_name + keySuffix;
+
+        EXPECT_TRUE(table_name == cfgTableNameA1 || table_name == cfgTableNameA2);
+
+        auto it = consumer.m_toSync.begin();
+        while (it != consumer.m_toSync.end())
+        {
+            KeyOpFieldsValuesTuple t = it->second;
+
+            string key = kfvKey(t);
+            ASSERT_STREQ(key.c_str(), key_expected.c_str());
+
+            string op = kfvOp(t);
+            if (op == SET_COMMAND)
+            {
+                if (table_name == cfgTableNameA1)
+                {
+                    m_resultTableA1.set(kfvKey(t), kfvFieldsValues(t));
+                }
+                else
+                {
+                    m_resultTableA2.set(kfvKey(t), kfvFieldsValues(t));
+                }
+            }
+            else if (op == DEL_COMMAND)
+            {
+                if (table_name == cfgTableNameA1)
+                {
+                    m_resultTableA1.del(kfvKey(t));
+                }
+                else
+                {
+                    m_resultTableA2.del(kfvKey(t));
+                }
+            }
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+    }
+};
+
+class CfgAgentB : public OrchBase
+{
+public:
+    CfgAgentB(DBConnector *cfgDb, DBConnector *resultDb, vector<string> tableNames):
+        OrchBase(cfgDb, tableNames),
+        m_cfgTableB(cfgDb, cfgTableNameB, CONFIGDB_TABLE_NAME_SEPARATOR),
+        m_resultTableB(resultDb, cfgTableNameB)
+    {
+
+    }
+
+    void syncCfgDB()
+    {
+        OrchBase::syncDB(cfgTableNameB, m_cfgTableB);
+    }
+
+private:
+    Table m_cfgTableB;
+    Table m_resultTableB;
+
+    void doTask(Consumer &consumer)
+    {
+        string table_name = consumer.m_consumer->getTableName();
+        string key_expected = table_name + keySuffix;
+
+        EXPECT_TRUE(table_name == cfgTableNameB);
+
+        auto it = consumer.m_toSync.begin();
+        while (it != consumer.m_toSync.end())
+        {
+            KeyOpFieldsValuesTuple t = it->second;
+
+            string key = kfvKey(t);
+            ASSERT_STREQ(key.c_str(), key_expected.c_str());
+
+            string op = kfvOp(t);
+            if (op == SET_COMMAND)
+            {
+                m_resultTableB.set(kfvKey(t), kfvFieldsValues(t));
+            }
+            else if (op == DEL_COMMAND)
+            {
+                m_resultTableB.del(kfvKey(t));
+            }
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+    }
+};
+
+class AppAgentC : public OrchBase
+{
+public:
+    AppAgentC(DBConnector *appDb, DBConnector *resultDb, vector<string> tableNames):
+        OrchBase(appDb, tableNames),
+        m_appTableC(appDb, appTableNameC),
+        m_resultTableC(resultDb, appTableNameC)
+    {
+
+    }
+
+    void syncAppDB()
+    {
+        OrchBase::syncDB(appTableNameC, m_appTableC);
+    }
+
+private:
+    Table m_appTableC;
+    Table m_resultTableC;
+
+    void doTask(Consumer &consumer)
+    {
+        string table_name = consumer.m_consumer->getTableName();
+        string key_expected = table_name + keySuffix;
+
+        EXPECT_TRUE(table_name == appTableNameC);
+
+        auto it = consumer.m_toSync.begin();
+        while (it != consumer.m_toSync.end())
+        {
+            KeyOpFieldsValuesTuple t = it->second;
+
+            string key = kfvKey(t);
+            ASSERT_STREQ(key.c_str(), key_expected.c_str());
+
+            string op = kfvOp(t);
+            if (op == SET_COMMAND)
+            {
+                m_resultTableC.set(kfvKey(t), kfvFieldsValues(t));
+            }
+            else if (op == DEL_COMMAND)
+            {
+                m_resultTableC.del(kfvKey(t));
+            }
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+    }
+};
+
+// Thread for both publisher and producer
+static void publisherProducerWorkerSet()
+{
+    // To trigger keyspace notification
+    DBConnector cfgDb(TEST_CONFIG_DB, "localhost", 6379, 0);
+    Table tableA1(&cfgDb, cfgTableNameA1, CONFIGDB_TABLE_NAME_SEPARATOR);
+    Table tableA2(&cfgDb, cfgTableNameA2, CONFIGDB_TABLE_NAME_SEPARATOR);
+    Table tableB(&cfgDb, cfgTableNameB, CONFIGDB_TABLE_NAME_SEPARATOR);
+
+    // TO trigger producer state notifiation
+    DBConnector appDb(TEST_APP_DB, "localhost", 6379, 0);
+    ProducerStateTable tableC(&appDb, appTableNameC);
+
+    vector<FieldValueTuple> fields;
+    FieldValueTuple t("field", "value");
+    fields.push_back(t);
+
+    tableA1.set(keyA1, fields);
+    tableA2.set(keyA2, fields);
+    tableB.set(keyB, fields);
+    tableC.set(keyC, fields);
+}
+
+static void publisherProducerWorkerDel()
+{
+    DBConnector cfgDb(TEST_CONFIG_DB, "localhost", 6379, 0);
+    Table tableA1(&cfgDb, cfgTableNameA1, CONFIGDB_TABLE_NAME_SEPARATOR);
+    Table tableA2(&cfgDb, cfgTableNameA2, CONFIGDB_TABLE_NAME_SEPARATOR);
+    Table tableB(&cfgDb, cfgTableNameB, CONFIGDB_TABLE_NAME_SEPARATOR);
+
+    DBConnector appDb(TEST_APP_DB, "localhost", 6379, 0);
+    ProducerStateTable tableC(&appDb, appTableNameC);
+
+    tableA1.del(keyA1);
+    tableA2.del(keyA2);
+    tableB.del(keyB);
+    tableC.del(keyC);
+}
+
+// worker thread for both keyspace subscriber and state consumer
+static void subscriberConsumerWorker(std::vector<OrchBase *> cfgOrchList)
+{
+    swss::Select s;
+    for (OrchBase *o : cfgOrchList)
+    {
+        s.addSelectables(o->getSelectables());
+    }
+
+    while (true)
+    {
+        Selectable *sel;
+        int fd, ret;
+
+        ret = s.select(&sel, &fd, SELECT_TIMEOUT);
+        if (ret == Select::TIMEOUT)
+        {
+            static int maxWait = 10;
+            maxWait--;
+            if (maxWait < 0)
+            {
+                // This unit testing should finish in 10 seconds!
+                break;;
+            }
+            continue;
+        }
+        EXPECT_EQ(ret, Select::OBJECT);
+
+        for (OrchBase *o : cfgOrchList)
+        {
+            TableConsumable *c = (TableConsumable *)sel;
+            if (o->hasSelectable(c))
+            {
+                o->execute(c->getTableName());
+            }
+        }
+    }
+}
+
+TEST(OrchBase, test)
+{
+    thread *publisherThread;
+    thread *subscriberThread;
+    vector<FieldValueTuple> values;
+
+    vector<string> agent_a_tables = {
+        cfgTableNameA1,
+        cfgTableNameA2,
+    };
+    vector<string> agent_b_tables = {
+        cfgTableNameB,
+    };
+
+    vector<string> agent_c_tables = {
+        appTableNameC,
+    };
+
+    cout << "Starting OrchBase testing" << endl;
+    clearDB(TEST_CONFIG_DB);
+    clearDB(TEST_APP_DB);
+    clearDB(TEST_RESULT_DB);
+
+    string result;
+    string kea_cmd = "redis-cli config set notify-keyspace-events KEA";
+    int ret = exec(kea_cmd, result);
+    EXPECT_TRUE(ret == 0);
+
+    // Connection to configDB will work as keysapce SubscriberStateTable client in OrchBase.
+    // Note that TEST_CONFIG_DB must be defined as CONFIG_DB
+    DBConnector cfgDb(TEST_CONFIG_DB, "localhost", 6379, 0);
+
+    // Connection to other DB will work as ConsumerStateTable client in OrchBase.
+    DBConnector appDb(TEST_APP_DB, "localhost", 6379, 0);
+
+    // connection to result DB is just for checking the processing result.
+    DBConnector resultDb(TEST_RESULT_DB, "localhost", 6379, 0);
+
+    CfgAgentA agent_a(&cfgDb, &resultDb, agent_a_tables);
+    CfgAgentB agent_b(&cfgDb, &resultDb, agent_b_tables);
+    AppAgentC agent_c(&appDb, &resultDb, agent_c_tables);
+
+    std::vector<OrchBase *> cfgOrchList = {&agent_a, &agent_b, &agent_c};
+
+    cout << "- Step 1. Provision TEST_CONFIG_DB and TEST_APP_DB" << endl;
+
+    subscriberThread = new thread(subscriberConsumerWorker, cfgOrchList);
+
+    publisherThread = new thread(publisherProducerWorkerSet);
+    publisherThread->join();
+    delete publisherThread;
+
+    sleep(1);
+
+    cout << "- Step 2. Verify TEST_RESULT_DB content" << endl;
+    Table resultTableA1(&resultDb, cfgTableNameA1);
+    Table resultTableA2(&resultDb, cfgTableNameA2);
+    Table resultTableB(&resultDb, cfgTableNameB);
+    Table resultTableC(&resultDb, appTableNameC);
+    ASSERT_EQ(resultTableA1.get(keyA1, values), true);
+    EXPECT_EQ(resultTableA2.get(keyA2, values), true);
+    EXPECT_EQ(resultTableB.get(keyB, values), true);
+    EXPECT_EQ(resultTableC.get(keyC, values), true);
+
+    cout << "- Step 3. Flush TEST_RESULT_DB" << endl;
+    clearDB(TEST_RESULT_DB);
+    EXPECT_EQ(resultTableA1.get(keyA1, values), false);
+    EXPECT_EQ(resultTableA2.get(keyA2, values), false);
+    EXPECT_EQ(resultTableB.get(keyB, values), false);
+    EXPECT_EQ(resultTableC.get(keyC, values), false);
+
+    cout << "- Step 4. Sync from TEST_CONFIG_DB and TEST_APP_DB" << endl;
+    agent_a.syncCfgDB();
+    agent_b.syncCfgDB();
+    agent_c.syncAppDB();
+
+    cout << "- Step 5. Verify TEST_RESULT_DB content" << endl;
+    EXPECT_EQ(resultTableA1.get(keyA1, values), true);
+    EXPECT_EQ(resultTableA2.get(keyA2, values), true);
+    EXPECT_EQ(resultTableB.get(keyB, values), true);
+    EXPECT_EQ(resultTableC.get(keyC, values), true);
+
+    cout << "- Step 6. Clean TEST_CONFIG_DB and TEST_APP_DB" << endl;
+    publisherThread = new thread(publisherProducerWorkerDel);
+    publisherThread->join();
+    delete publisherThread;
+    sleep(1);
+    cout << "- Step 7. Verify TEST_RESULT_DB content is empty" << endl;
+    EXPECT_EQ(resultTableA1.get(keyA1, values), false);
+    EXPECT_EQ(resultTableA2.get(keyA2, values), false);
+    EXPECT_EQ(resultTableB.get(keyB, values), false);
+    EXPECT_EQ(resultTableC.get(keyC, values), false);
+
+    subscriberThread->join();
+    delete subscriberThread;
+    cout << "Done." << endl;
+}


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**

Split Orch class into two classes: Orch and OrchBase

**Why I did it**
OrchBase is to be used by both orchagent and configDB enforcers in cfgagent
**How I verified it**
jipan@0cc3061a68e8:/sonic/src/sonic-swss$ tests/tests 
Running main() from gtest_main.cc
[==========] Running 9 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 8 tests from swssnet
[ RUN      ] swssnet.copy1_v6
[       OK ] swssnet.copy1_v6 (0 ms)
[ RUN      ] swssnet.copy1_v4
[       OK ] swssnet.copy1_v4 (0 ms)
[ RUN      ] swssnet.copy2_v6
[       OK ] swssnet.copy2_v6 (0 ms)
[ RUN      ] swssnet.copy2_v4
[       OK ] swssnet.copy2_v4 (0 ms)
[ RUN      ] swssnet.copy3_v6
[       OK ] swssnet.copy3_v6 (0 ms)
[ RUN      ] swssnet.copy3_v4
[       OK ] swssnet.copy3_v4 (0 ms)
[ RUN      ] swssnet.subnet_v6
[       OK ] swssnet.subnet_v6 (0 ms)
[ RUN      ] swssnet.subnet_v4
[       OK ] swssnet.subnet_v4 (0 ms)
[----------] 8 tests from swssnet (0 ms total)

[----------] 1 test from OrchBase
[ RUN      ] OrchBase.test
Starting OrchBase testing
- Step 1. Provision TEST_CONFIG_DB and TEST_APP_DB
- Step 2. Verify TEST_RESULT_DB content
- Step 3. Flush TEST_RESULT_DB
- Step 4. Sync from TEST_CONFIG_DB and TEST_APP_DB
- Step 5. Verify TEST_RESULT_DB content
- Step 6. Clean TEST_CONFIG_DB and TEST_APP_DB
- Step 7. Verify TEST_RESULT_DB content is empty
Done.
[       OK ] OrchBase.test (11024 ms)
[----------] 1 test from OrchBase (11024 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 2 test cases ran. (11024 ms total)
[  PASSED  ] 9 tests.


**Details if related**
