### PR TITLE
[orchagent]: Remove the global variable gPortsOrch in orch.cpp file

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -605,7 +605,7 @@ sai_object_id_t AclRuleL3::getRedirectObjectId(const string& redirect_value)
 
     // Try to parse physical port and LAG first
     Port port;
-    if(m_pAclOrch->m_portOrch->getPort(target, port))
+    if (gPortsOrch->getPort(target, port))
     {
         if (port.m_type == Port::PHY)
         {
@@ -1211,7 +1211,6 @@ bool AclRange::remove()
 
 AclOrch::AclOrch(DBConnector *db, vector<string> tableNames, PortsOrch *portOrch, MirrorOrch *mirrorOrch, NeighOrch *neighOrch, RouteOrch *routeOrch) :
         Orch(db, tableNames),
-        m_portOrch(portOrch),
         m_mirrorOrch(mirrorOrch),
         m_neighOrch(neighOrch),
         m_routeOrch(routeOrch)
@@ -1275,9 +1274,8 @@ void AclOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!m_portOrch->isInitDone())
+    if (!gPortsOrch->isInitDone())
     {
-        /* Wait for ports initialization */
         return;
     }
 
@@ -1586,7 +1584,7 @@ bool AclOrch::processPorts(string portsList, std::function<void (sai_object_id_t
     for (const auto& alias : strList)
     {
         Port port;
-        if (!m_portOrch->getPort(alias, port))
+        if (!gPortsOrch->getPort(alias, port))
         {
             SWSS_LOG_ERROR("Failed to process port. Port %s doesn't exist", alias.c_str());
             return false;

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -280,7 +280,6 @@ public:
     }
 
     // FIXME: Add getters for them? I'd better to add a common directory of orch objects and use it everywhere
-    PortsOrch *m_portOrch;
     MirrorOrch *m_mirrorOrch;
     NeighOrch *m_neighOrch;
     RouteOrch *m_routeOrch;

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -538,6 +538,12 @@ task_process_status BufferOrch::processEgressBufferProfileList(Consumer &consume
 void BufferOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
+
+    if (!gPortsOrch->isInitDone())
+    {
+        return;
+    }
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -1,6 +1,7 @@
 #include "sai.h"
-#include "tokenize.h"
 #include "copporch.h"
+#include "portsorch.h"
+#include "tokenize.h"
 #include "logger.h"
 
 #include <sstream>
@@ -12,7 +13,9 @@ using namespace std;
 extern sai_hostif_api_t*    sai_hostif_api;
 extern sai_policer_api_t*   sai_policer_api;
 extern sai_switch_api_t*    sai_switch_api;
+
 extern sai_object_id_t      gSwitchId;
+extern PortsOrch*           gPortsOrch;
 
 map<string, sai_meter_type_t> policer_meter_map = {
     {"packets", SAI_METER_TYPE_PACKETS},
@@ -584,6 +587,11 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
 void CoppOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
+
+    if (gPortsOrch->isInitDone())
+    {
+        return;
+    }
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -6,9 +6,10 @@
 #include "tokenize.h"
 #include "fdborch.h"
 
-extern sai_object_id_t gSwitchId;
+extern sai_fdb_api_t    *sai_fdb_api;
 
-extern sai_fdb_api_t *sai_fdb_api;
+extern sai_object_id_t  gSwitchId;
+extern PortsOrch*       gPortsOrch;
 
 void FdbOrch::update(sai_fdb_event_t type, const sai_fdb_entry_t* entry, sai_object_id_t bridge_port_id)
 {
@@ -79,6 +80,11 @@ bool FdbOrch::getPort(const MacAddress& mac, uint16_t vlan, Port& port)
 void FdbOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
+
+    if (gPortsOrch->isInitDone())
+    {
+        return;
+    }
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -54,6 +54,11 @@ void IntfsOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
+    if (!gPortsOrch->isInitDone())
+    {
+        return;
+    }
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -28,7 +28,9 @@
 #define MLNX_PLATFORM       "mlnx"
 
 extern sai_mirror_api_t *sai_mirror_api;
-extern sai_object_id_t gSwitchId;
+
+extern sai_object_id_t  gSwitchId;
+extern PortsOrch*       gPortsOrch;
 
 using namespace std::rel_ops;
 
@@ -865,6 +867,11 @@ void MirrorOrch::updateVlanMember(const VlanMemberUpdate& update)
 void MirrorOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
+
+    if (!gPortsOrch->isInitDone())
+    {
+        return;
+    }
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -130,6 +130,11 @@ void NeighOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
+    if (!gPortsOrch->isInitDone())
+    {
+        return;
+    }
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -233,9 +233,6 @@ ref_resolve_status Orch::resolveFieldRefValue(
 
 void Orch::doTask()
 {
-    if (!gPortsOrch->isInitDone())
-        return;
-
     for(auto &it : m_consumerMap)
     {
         if (!it.second.m_toSync.empty())

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -18,6 +18,7 @@
 
 extern sai_port_api_t *sai_port_api;
 extern sai_queue_api_t *sai_queue_api;
+
 extern PortsOrch *gPortsOrch;
 
 template <typename DropHandler, typename ForwardHandler>
@@ -39,6 +40,11 @@ template <typename DropHandler, typename ForwardHandler>
 void PfcWdOrch<DropHandler, ForwardHandler>::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
+
+    if (!gPortsOrch->isInitDone())
+    {
+        return;
+    }
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -894,8 +894,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
 void PortsOrch::doVlanTask(Consumer &consumer)
 {
-    if (!isInitDone())
-        return;
+    SWSS_LOG_ENTER();
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
@@ -957,8 +956,7 @@ void PortsOrch::doVlanTask(Consumer &consumer)
 
 void PortsOrch::doVlanMemberTask(Consumer &consumer)
 {
-    if (!isInitDone())
-        return;
+    SWSS_LOG_ENTER();
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
@@ -1075,8 +1073,7 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
 
 void PortsOrch::doLagTask(Consumer &consumer)
 {
-    if (!isInitDone())
-        return;
+    SWSS_LOG_ENTER();
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
@@ -1125,8 +1122,7 @@ void PortsOrch::doLagTask(Consumer &consumer)
 
 void PortsOrch::doLagMemberTask(Consumer &consumer)
 {
-    if (!isInitDone())
-        return;
+    SWSS_LOG_ENTER();
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
@@ -1241,15 +1237,34 @@ void PortsOrch::doTask(Consumer &consumer)
     string table_name = consumer.m_consumer->getTableName();
 
     if (table_name == APP_PORT_TABLE_NAME)
+    {
         doPortTask(consumer);
-    else if (table_name == APP_VLAN_TABLE_NAME)
-        doVlanTask(consumer);
-    else if (table_name == APP_VLAN_MEMBER_TABLE_NAME)
-        doVlanMemberTask(consumer);
-    else if (table_name == APP_LAG_TABLE_NAME)
-        doLagTask(consumer);
-    else if (table_name == APP_LAG_MEMBER_TABLE_NAME)
-        doLagMemberTask(consumer);
+    }
+    else
+    {
+        /* Wait for all ports to be initialized */
+        if (!isInitDone())
+        {
+            return;
+        }
+
+        if (table_name == APP_VLAN_TABLE_NAME)
+        {
+            doVlanTask(consumer);
+        }
+        else if (table_name == APP_VLAN_MEMBER_TABLE_NAME)
+        {
+            doVlanMemberTask(consumer);
+        }
+        else if (table_name == APP_LAG_TABLE_NAME)
+        {
+            doLagTask(consumer);
+        }
+        else if (table_name == APP_LAG_MEMBER_TABLE_NAME)
+        {
+            doLagMemberTask(consumer);
+        }
+    }
 }
 
 void PortsOrch::initializeQueues(Port &port)

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1275,6 +1275,12 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
 void QosOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
+
+    if (!gPortsOrch->isInitDone())
+    {
+        return;
+    }
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -164,6 +164,11 @@ void RouteOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
 
+    if (!gPortsOrch->isInitDone())
+    {
+        return;
+    }
+
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -38,7 +38,6 @@ void SwitchOrch::doTask(Consumer &consumer)
     while (it != consumer.m_toSync.end())
     {
         auto t = it->second;
-
         auto op = kfvOp(t);
 
         if (op == SET_COMMAND)

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -1,27 +1,30 @@
 #include <string.h>
 #include "tunneldecaporch.h"
+#include "portsorch.h"
 #include "logger.h"
 #include "swssnet.h"
 
 extern sai_tunnel_api_t* sai_tunnel_api;
 extern sai_router_interface_api_t* sai_router_intfs_api;
 
-extern sai_object_id_t gVirtualRouterId;
-extern sai_object_id_t gUnderlayIfId;
-extern sai_object_id_t gSwitchId;
+extern sai_object_id_t  gVirtualRouterId;
+extern sai_object_id_t  gUnderlayIfId;
+extern sai_object_id_t  gSwitchId;
+extern PortsOrch*       gPortsOrch;
 
 TunnelDecapOrch::TunnelDecapOrch(DBConnector *db, string tableName) : Orch(db, tableName)
 {
     SWSS_LOG_ENTER();
 }
 
-/**
- * Function Description:
- *    @brief reads from APP_DB and creates tunnel
- */
 void TunnelDecapOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
+
+    if (!gPortsOrch->isInitDone())
+    {
+        return;
+    }
 
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())


### PR DESCRIPTION
This change is the first step of refactoring Orch class.
The global variable gPortsOrch is removed from that orch.cpp file
and this class no longer requires such external variable.

The current solution is to move the global variable into each different
places that need this variable. Later, a better design could be
introduced to further remove all the global variables from the whole
project.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove the gPortsOrch from the orch.cpp file.

**Why I did it**
Free the orch.cpp file.

**How I verified it**
Compile and run the code.
