### PR TITLE
[orchagent] Add PFC shared headroom support

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -114,6 +114,12 @@ task_process_status BufferOrch::processBufferPool(Consumer &consumer)
                 attr.id = SAI_BUFFER_POOL_ATTR_THRESHOLD_MODE;
                 attribs.push_back(attr);
             }
+            else if (field == buffer_pool_xoff_field_name)
+            {
+                attr.value.u32 = (uint32_t)stoul(value);
+                attr.id = SAI_BUFFER_POOL_ATTR_XOFF_SIZE;
+                attribs.push_back(attr);
+            }
             else
             {
                 SWSS_LOG_ERROR("Unknown pool field specified:%s, ignoring", field.c_str());

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -11,6 +11,7 @@ const string buffer_pool_mode_field_name    = "mode";
 const string buffer_pool_field_name         = "pool";
 const string buffer_pool_mode_dynamic_value = "dynamic";
 const string buffer_pool_mode_static_value  = "static";
+const string buffer_pool_xoff_field_name    = "xoff";
 const string buffer_xon_field_name          = "xon";
 const string buffer_xoff_field_name         = "xoff";
 const string buffer_dynamic_th_field_name   = "dynamic_th";


### PR DESCRIPTION
This commit adds new code to support PFC shared headroom pool size
(Ingress) for lossless traffic feature.  This is one of the requirement
for PFC support on SONiC.

Verified by using a JSON configuration file to push the XOFF parameter
to program in Hardware.  XOFF parameter in JSON file translates to
SAI_BUFFER_POOL_ATTR_XOFF_SIZE which gets programmed in register
THDI_HDRM_BUFFER_CELL_LIMIT_HP. The register was programmed with correct
values.

Signed-off-by: Harish Venkatraman <Harish_Venkatraman@dell.com>