### PR TITLE
IntfsOrch uses ConsumerTable instead of ConsumerStateTable

### DIFF
--- a/intfsyncd/intfsync.cpp
+++ b/intfsyncd/intfsync.cpp
@@ -6,7 +6,6 @@
 #include "logger.h"
 #include "netmsg.h"
 #include "dbconnector.h"
-#include "producerstatetable.h"
 #include "linkcache.h"
 #include "intfsyncd/intfsync.h"
 

--- a/intfsyncd/intfsync.h
+++ b/intfsyncd/intfsync.h
@@ -2,7 +2,7 @@
 #define __INTFSYNC__
 
 #include "dbconnector.h"
-#include "producerstatetable.h"
+#include "producertable.h"
 #include "netmsg.h"
 
 namespace swss {
@@ -17,7 +17,7 @@ public:
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);
 
 private:
-    ProducerStateTable m_intfTable;
+    ProducerTable m_intfTable;
 };
 
 }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -113,9 +113,8 @@ void IntfsOrch::doTask(Consumer &consumer)
             /* NOTE: Overlap checking is required to handle ifconfig weird behavior.
              * When set IP address using ifconfig command it applies it in two stages.
              * On stage one it sets IP address with netmask /8. On stage two it
-             * changes netmask to specified in command. As DB is async event to
-             * add IP address with original netmask may come before event to
-             * delete IP with netmask /8. To handle this we in case of overlap
+             * changes netmask to specified in command.
+             * To handle this we in case of overlap
              * we should wait until entry with /8 netmask will be removed.
              * Time frame between those event is quite small.*/
             bool overlaps = false;

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -368,7 +368,14 @@ void Orch::addConsumer(DBConnector *db, string tableName)
     {
         Consumer consumer(new SubscriberStateTable(db, tableName));
         m_consumerMap.insert(ConsumerMapPair(tableName, consumer));
-    } else {
+    }
+    else if (tableName == APP_INTF_TABLE_NAME)
+    {
+        Consumer consumer(new ConsumerTable(db, tableName, gBatchSize));
+        m_consumerMap.insert(ConsumerMapPair(tableName, consumer));
+    }
+    else
+    {
         Consumer consumer(new ConsumerStateTable(db, tableName, gBatchSize));
         m_consumerMap.insert(ConsumerMapPair(tableName, consumer));
     }


### PR DESCRIPTION
Signed-off-by: Qi Luo <qiluo-msft@users.noreply.github.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
IntfsOrch uses ConsumerTable instead of ConsumerStateTable

**Why I did it**
Sample Intfs events:
```
Nov  4 18:53:52.393657 str-msn2700-03 WARNING orchagent: :- doTask: IntfsOrch::doTask receives Ethernet96:10.0.0.48/31 DEL
Nov  4 18:53:52.403133 str-msn2700-03 WARNING orchagent: :- doTask: IntfsOrch::doTask receives Ethernet96:10.0.1.48/8 SET
Nov  4 18:53:52.407662 str-msn2700-03 WARNING orchagent: :- doTask: IntfsOrch::doTask receives Ethernet96:10.0.1.48/24 SET
Nov  4 18:53:52.407999 str-msn2700-03 WARNING orchagent: :- doTask: IntfsOrch::doTask receives Ethernet96:10.0.1.48/8 DEL
```
The order of events are important here, so use original ConsumerTable to keep the event order. ConsumerStateTable will not keep the order.

**How I verified it**
Test it on DUT, use 'sudo ifconfig Ethernet96 10.0.1.48/24‘ to change interface IP address

**Details if related**
