### PR TITLE
Revert "Update port and queue stat counters by Flex counter (#358)"

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -11,7 +11,6 @@ using namespace swss;
 
 /* select() function timeout retry time */
 #define SELECT_TIMEOUT 1000
-#define FLEX_COUNTER_POLL_MSECS 100
 
 extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
@@ -141,8 +140,7 @@ bool OrchDaemon::init()
                     pfc_wd_tables,
                     portStatIds,
                     queueStatIds,
-                    queueAttrIds,
-                    FLEX_COUNTER_POLL_MSECS));
+                    queueAttrIds));
     }
     else if (platform == BRCM_PLATFORM_SUBSTRING)
     {
@@ -182,8 +180,7 @@ bool OrchDaemon::init()
                     pfc_wd_tables,
                     portStatIds,
                     queueStatIds,
-                    queueAttrIds,
-                    FLEX_COUNTER_POLL_MSECS));
+                    queueAttrIds));
     }
 
     return true;

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -62,8 +62,7 @@ public:
             vector<string> &tableNames,
             const vector<sai_port_stat_t> &portStatIds,
             const vector<sai_queue_stat_t> &queueStatIds,
-            const vector<sai_queue_attr_t> &queueAttrIds,
-            int pollInterval);
+            const vector<sai_queue_attr_t> &queueAttrIds);
     virtual ~PfcWdSwOrch(void);
 
     virtual bool startWdOnPort(const Port& port,
@@ -107,8 +106,6 @@ private:
 
     atomic_bool m_runPfcWdSwOrchThread = { false };
     shared_ptr<thread> m_pfcWatchdogThread = nullptr;
-
-    int m_pollInterval;
 };
 
 #endif

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -6,7 +6,6 @@
 #include <set>
 #include <algorithm>
 #include <tuple>
-#include <sstream>
 
 #include <netinet/if_ether.h>
 #include "net/if.h"
@@ -30,7 +29,6 @@ extern sai_object_id_t gSwitchId;
 
 #define VLAN_PREFIX         "Vlan"
 #define DEFAULT_VLAN_ID     1
-#define FLEX_STAT_COUNTER_POLL_MSECS "1000"
 
 static map<string, sai_port_fec_mode_t> fec_mode_map =
 {
@@ -58,19 +56,16 @@ PortsOrch::PortsOrch(DBConnector *db, vector<string> tableNames) :
     SWSS_LOG_ENTER();
 
     /* Initialize counter table */
-    m_counter_db = shared_ptr<DBConnector>(new DBConnector(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0));
-    m_counterTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_PORT_NAME_MAP));
+    DBConnector *counter_db(new DBConnector(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0));
+    m_counterTable = unique_ptr<Table>(new Table(counter_db, COUNTERS_PORT_NAME_MAP));
 
     /* Initialize port table */
     m_portTable = unique_ptr<Table>(new Table(db, APP_PORT_TABLE_NAME));
 
     /* Initialize queue tables */
-    m_queueTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_QUEUE_NAME_MAP));
-    m_queuePortTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_QUEUE_PORT_MAP));
-    m_queueIndexTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_QUEUE_INDEX_MAP));
-
-    m_flex_db = shared_ptr<DBConnector>(new DBConnector(PFC_WD_DB, DBConnector::DEFAULT_UNIXSOCKET, 0));
-    m_flexCounterTable = unique_ptr<ProducerStateTable>(new ProducerStateTable(m_flex_db.get(), PFC_WD_STATE_TABLE));
+    m_queueTable = unique_ptr<Table>(new Table(counter_db, COUNTERS_QUEUE_NAME_MAP));
+    m_queuePortTable = unique_ptr<Table>(new Table(counter_db, COUNTERS_QUEUE_PORT_MAP));
+    m_queueIndexTable = unique_ptr<Table>(new Table(counter_db, COUNTERS_QUEUE_INDEX_MAP));
 
     uint32_t i, j;
     sai_status_t status;
@@ -648,25 +643,9 @@ bool PortsOrch::initPort(const string &alias, const set<int> &lane_set)
                 m_portList[alias] = p;
                 /* Add port name map to counter table */
                 FieldValueTuple tuple(p.m_alias, sai_serialize_object_id(p.m_port_id));
-                vector<FieldValueTuple> fields;
-                fields.push_back(tuple);
-                m_counterTable->set("", fields);
-
-                /* Add port to flex_counter for updating stat counters  */
-                string key = sai_serialize_object_id(p.m_port_id) + ":" + FLEX_STAT_COUNTER_POLL_MSECS;
-
-                std::string delimiter = "";
-                std::ostringstream counters_stream;
-                for (int cntr = SAI_PORT_STAT_IF_IN_OCTETS; cntr <= SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS; ++cntr)
-                {
-                    counters_stream << delimiter << sai_serialize_port_stat(static_cast<sai_port_stat_t>(cntr));
-                    delimiter = ",";
-                }
-
-                fields.clear();
-                fields.emplace_back(PFC_WD_PORT_COUNTER_ID_LIST, counters_stream.str());
-
-                m_flexCounterTable->set(key, fields);
+                vector<FieldValueTuple> vector;
+                vector.push_back(tuple);
+                m_counterTable->set("", vector);
 
                 SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
             }
@@ -1383,7 +1362,6 @@ void PortsOrch::initializeQueues(Port &port)
     SWSS_LOG_INFO("Get queues for port %s", port.m_alias.c_str());
 
     /* Create the Queue map in the Counter DB */
-    /* Add stat counters to flex_counter */
     vector<FieldValueTuple> queueVector;
     vector<FieldValueTuple> queuePortVector;
     vector<FieldValueTuple> queueIndexVector;
@@ -1404,21 +1382,6 @@ void PortsOrch::initializeQueues(Port &port)
                 sai_serialize_object_id(port.m_queue_ids[queueIndex]),
                 to_string(queueIndex));
         queueIndexVector.push_back(queueIndexTuple);
-
-        string key = sai_serialize_object_id(port.m_queue_ids[queueIndex]) + ":" + FLEX_STAT_COUNTER_POLL_MSECS;
-
-        std::string delimiter = "";
-        std::ostringstream counters_stream;
-        for (int cntr = SAI_QUEUE_STAT_PACKETS; cntr <= SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES ; ++cntr)
-        {
-            counters_stream << delimiter << sai_serialize_queue_stat(static_cast<sai_queue_stat_t>(cntr));
-            delimiter = ",";
-        }
-
-        vector<FieldValueTuple> fieldValues;
-        fieldValues.emplace_back(PFC_WD_QUEUE_COUNTER_ID_LIST, counters_stream.str());
-
-        m_flexCounterTable->set(key, fieldValues);
     }
 
     m_queueTable->set("", queueVector);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -7,7 +7,6 @@
 #include "port.h"
 #include "observer.h"
 #include "macaddress.h"
-#include "producerstatetable.h"
 
 #include <map>
 
@@ -62,10 +61,6 @@ private:
     unique_ptr<Table> m_queueTable;
     unique_ptr<Table> m_queuePortTable;
     unique_ptr<Table> m_queueIndexTable;
-    unique_ptr<ProducerStateTable> m_flexCounterTable;
-
-    shared_ptr<DBConnector> m_counter_db;
-    shared_ptr<DBConnector> m_flex_db;
 
     std::map<sai_object_id_t, PortSupportedSpeeds> m_portSupportedSpeeds;
 


### PR DESCRIPTION
This reverts commit 87649024c03fd0a2233628a4be586ae672de5697.

**What I did**
revert commit 8764902

Update port and queue stat counters by Flex counter (#358) [AndriiS]

**Why I did it**
The commit needs https://github.com/Azure/sonic-sairedis/pull/230 to be merged first.

**How I verified it**
Revert it and tested with the latest sonic buildimage.

**Details if related**
