### PR TITLE
read switch mac from DEVICE_METADATA|localhost:mac

### DIFF
--- a/cfgmgr/vlanmgrd.cpp
+++ b/cfgmgr/vlanmgrd.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
          */
         string switch_mac_str;
         stringstream cmd;
-        cmd << REDIS_CLI_CMD << " -n " << CONFIG_DB << " hget " << " \"SWITCH|SWITCH_ATTR\" " << " switch_mac";
+        cmd << REDIS_CLI_CMD << " -n " << CONFIG_DB << " hget " << " \"DEVICE_METADATA|localhost\" " << " mac";
         EXEC_WITH_ERROR_THROW(cmd.str(), switch_mac_str);
         gMacAddress = MacAddress(switch_mac_str);
 


### PR DESCRIPTION
**What I did**
change vlanmgrd to read switch mac from DEVICE_METADATA|localhost entry

**Why I did it**
unify the switch level attribute to DEVICE_METADATA field. 
Check the wiki. https://github.com/Azure/SONiC/wiki/Configuration

**How I verified it**
```
admin@str-s6000-on-1:~$ redis-cli -n 4 hget "DEVICE_METADATA|localhost" "mac"                    
"00:00:11:11:11:11"
```

**Details if related**
