### PR TITLE
[mtu] Update the mtu on host interfaces if config DB changes

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -13,6 +13,7 @@
 #include "producerstatetable.h"
 #include "portsyncd/linksync.h"
 #include "subscriberstatetable.h"
+#include "exec.h"
 
 #define DEFAULT_PORT_CONFIG_FILE     "port_config.ini"
 
@@ -250,6 +251,19 @@ void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple>
             if (op == SET_COMMAND)
             {
                 p.set(key, values);
+                for (auto fv : values)
+                {
+                    string field = fvField(fv);
+                    string value = fvValue(fv);
+
+                    /* Update the mtu field on host interface */
+                    if (field == "mtu")
+                    {
+                        string cmd, res;
+                        cmd = "ip link set " + key + " mtu " + value;
+                        swss::exec(cmd, res);
+                     }
+                }
             }
 
             it = port_cfg_map.erase(it);


### PR DESCRIPTION
Signed-off-by: Haiyang Zheng <haiyang.z@alibaba-inc.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Now, portsyncd is subscribed to config DB, and use handlePortConfig to copy port config from config DB to APP DB. Here, we also need to update the host interfaces MTU in linux kernel if the port config changes.

**Why I did it**

Otherwise, there will be discrepancy between linux kernel MTU and port MTU in config DB/app DB. 

**How I verified it**

Update the port inside config_db.json file with new mtu field, and verify both kernel MTU and ASIC port MTU has been updated properly.

**Details if related**

This pull request require the following pull request
https://github.com/Azure/sonic-buildimage/pull/1128

With both changes, the MTU from config DB will be the only source for Kernel MTU and port MTU on ASIC.