### PR TITLE
[bug]: do not enumerate all ports in portsyncd init

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -84,7 +84,6 @@ int main(int argc, char **argv)
 
         netlink.registerGroup(RTNLGRP_LINK);
         cout << "Listen to link messages..." << endl;
-        netlink.dumpRequest(RTM_GETLINK);
 
         handlePortConfigFile(p, port_config_file);
 


### PR DESCRIPTION
**What I did**
remove ports enumerating in portsyncd init

**Why I did it**
portsyncd enumerate all ports in initialization phase via netlink.
which is not neccessary by design. portsyncd is supposed to read
the port_config.ini and translate them into appdb, and then once
all ports are created, it sets PortInitDone.

enumerating all ports in the initialization causes issue in swss
restart. When swss restarts, the old ports are still here which
triggers portsyncd to set PortInitDone falsely.

**How I verified it**
manually restart swss.service and also reboot the box.
verify vlan and vlan member are created correctly

**Details if related**
