### PR TITLE
[cfgmgr] Use sonic-swss-common instead of exec redis-cli

### DIFF
--- a/cfgmgr/shellcmd.h
+++ b/cfgmgr/shellcmd.h
@@ -4,7 +4,6 @@
 #define IP_CMD               "/sbin/ip"
 #define BRIDGE_CMD           "/sbin/bridge"
 #define ECHO_CMD             "/bin/echo"
-#define REDIS_CLI_CMD        "/usr/bin/redis-cli"
 #define XARGS_CMD            "/usr/bin/xargs"
 #define GREP_CMD             "/bin/grep"
 #define AWK_CMD              "/usr/bin/awk"


### PR DESCRIPTION
this enforces portablity of vlanmgrd

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Use `sonic-swss-common` instead of executing `redis-cli` to get MAC address of the device.

**Why I did it**

This is kinda refactoring but I'm actually facing a problem with current implementation.

I'm running `redis-server` in a diffrent docker container from a container which runs sonic's daemons.
Two containers shares a redis unix socket file and doesn't share a network namespace.
In this case, `vlanmgrd` crashes since current implementation executes `redis-cli` directly to get MAC address.

Since we are passing `DBConnector::DEFAULT_UNIXSOCKET` to `DBConnector `, using `sonic-swss-common` can solve this issue.
Also, we can easily add an option to `vlanmgrd` for choosing how to connect to the redis server in the future.

**How I verified it**

**Details if related**
