### PR TITLE
Fix to prevent OA crashes when configuring interfaces with overlapping subnets

### DIFF
--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -45,6 +45,8 @@ private:
 
     void addIp2MeRoute(const IpPrefix &ip_prefix);
     void removeIp2MeRoute(const IpPrefix &ip_prefix);
+
+    bool validIntfAddress(const IpPrefix &ip_prefix, const string &alias);
 };
 
 #endif /* SWSS_INTFSORCH_H */


### PR DESCRIPTION

To prevent orchagent from crashing with a simple ifconfig/ip command, i added some sanity-checking logic to verify that the new ip/mask being associated with an interface, does not overlap with any of the existing interfaces in the system. If an overlap is detected, the corresponding netlink message is discarded while an error log is dumped in syslog to alert user of their mistake.

When facing a subnet's overlapping scenario, OA will identify the offending prefix (meta_sai_validate_route_entry) and will throw an exception that will eventually terminate OA. See an example below...

Original interfaces -- Ethernet112 = 10.1.2.2/24, Ethernet116 = 10.2.2.2/24

I go ahead and configure an overlapping subnet by doing:

admin@lnos-x1-a-asw02:~$ sudo ifconfig Ethernet112 10.2.2.3 netmask 255.255.255.0

Nov 27 21:44:32.0 lnos-x1-a-asw02 NOTICE orchagent: :- removeSubnetRoute: Remove subnet route to 10.1.2.2/24 from Ethernet112
Nov 27 21:44:32.0 lnos-x1-a-asw02 NOTICE orchagent: :- removeIp2MeRoute: Remove packet action trap route ip:10.1.2.2
Nov 27 21:44:32.0 lnos-x1-a-asw02 ERR orchagent: :- meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"10.2.2.0/24","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000072"} already exists
Nov 27 21:44:32.0 lnos-x1-a-asw02 ERR orchagent: :- addSubnetRoute: Failed to create subnet route to 10.2.2.3/24 from Ethernet112, rv:-6
Nov 27 21:44:32.0 lnos-x1-a-asw02 ERR orchagent: :- main: Failed due to exception: Failed to create subnet route.
Nov 27 21:44:32.0 lnos-x1-a-asw02 INFO supervisord: orchagent terminate called without an active exception
Nov 27 21:44:33.170506 lnos-x1-a-asw02 INFO swss.sh[29508]: 2017-11-27
21:44:33,169 INFO exited: orchagent (terminated by SIGABRT (core dumped); not expected)
Nov 27 21:44:33.0 lnos-x1-a-asw02 INFO supervisord 2017-11-27 21:44:33,169 INFO exited: orchagent (terminated by SIGABRT (core
dumped); not expected)

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
