### PR TITLE
Fixed ACL IP type parser.

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -132,13 +132,11 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
         }
         else if(attr_name == MATCH_IP_TYPE)
         {
-            if (!processIpType(attr_value, value.aclfield.data.u32))
+            if (!processIpType(attr_value, value.aclfield.data.s32))
             {
                 SWSS_LOG_ERROR("Invalid IP type %s", attr_value.c_str());
                 return false;
             }
-
-            value.aclfield.mask.u32 = 0xFFFFFFFF;
         }
         else if(attr_name == MATCH_TCP_FLAGS)
         {
@@ -241,7 +239,7 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
     return true;
 }
 
-bool AclRule::processIpType(string type, sai_uint32_t &ip_type)
+bool AclRule::processIpType(string type, sai_int32_t &ip_type)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -129,7 +129,7 @@ public:
     virtual bool validateAddMatch(string attr_name, string attr_value);
     virtual bool validateAddAction(string attr_name, string attr_value) = 0;
     virtual bool validate() = 0;
-    bool processIpType(string type, sai_uint32_t &ip_type);
+    bool processIpType(string type, sai_int32_t &ip_type);
     inline static void setRulePriorities(sai_uint32_t min, sai_uint32_t max)
     {
         m_minPriority = min;


### PR DESCRIPTION
**What I did**
Fixed ACL IP type parser logic.

**Why I did it**
Because of SAI headers documentation:
/** Ip Type [sai_acl_ip_type_t] (field mask is not needed) */
SAI_ACL_ENTRY_ATTR_FIELD_IP_TYPE