### PR TITLE
[portsyncd] support read port configuration from configDB

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -15,8 +15,6 @@
 #include "subscriberstatetable.h"
 #include "exec.h"
 
-#define DEFAULT_PORT_CONFIG_FILE     "port_config.ini"
-
 using namespace std;
 using namespace swss;
 
@@ -36,11 +34,12 @@ bool g_init = false;
 void usage()
 {
     cout << "Usage: portsyncd [-p port_config.ini]" << endl;
-    cout << "       -p port_config.ini: MANDATORY import port lane mapping" << endl;
-    cout << "                           default: port_config.ini" << endl;
+    cout << "       -p port_config.ini: import port lane mapping" << endl;
+    cout << "                           use configDB data if not specified" << endl;
 }
 
 void handlePortConfigFile(ProducerStateTable &p, string file);
+void handlePortConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb);
 void handleVlanIntfFile(string file);
 void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple> &port_cfg_map);
 
@@ -48,7 +47,7 @@ int main(int argc, char **argv)
 {
     Logger::linkToDbNative("portsyncd");
     int opt;
-    string port_config_file = DEFAULT_PORT_CONFIG_FILE;
+    string port_config_file;
     map<string, KeyOpFieldsValuesTuple> port_cfg_map;
 
     while ((opt = getopt(argc, argv, "p:v:h")) != -1 )
@@ -85,7 +84,12 @@ int main(int argc, char **argv)
         netlink.registerGroup(RTNLGRP_LINK);
         cout << "Listen to link messages..." << endl;
 
-        handlePortConfigFile(p, port_config_file);
+        if (!port_config_file.empty())
+        {
+            handlePortConfigFile(p, port_config_file);
+        } else {
+            handlePortConfigFromConfigDB(p, cfgDb);
+        }
 
         s.addSelectable(&netlink);
         s.addSelectable(&portCfg);
@@ -151,6 +155,37 @@ int main(int argc, char **argv)
     }
 
     return 1;
+}
+
+static void notifyPortConfigDone(ProducerStateTable &p)
+{
+    /* Notify that all ports added */
+    FieldValueTuple finish_notice("count", to_string(g_portSet.size()));
+    vector<FieldValueTuple> attrs = { finish_notice };
+    p.set("PortConfigDone", attrs);
+}
+
+void handlePortConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb)
+{
+    cout << "Get port configuration from ConfigDB..." << endl;
+
+    Table table(&cfgDb, CFG_PORT_TABLE_NAME, CONFIGDB_TABLE_NAME_SEPARATOR);
+    std::vector<FieldValueTuple> ovalues;
+    std::vector<string> keys;
+    table.getKeys(keys);
+    for ( auto &k : keys )
+    {
+        table.get(k, ovalues);
+        vector<FieldValueTuple> attrs;
+        for ( auto &v : ovalues )
+        {
+            FieldValueTuple attr(v.first, v.second);
+            attrs.push_back(attr);
+        }
+        p.set(k, attrs);
+        g_portSet.insert(k);
+    }
+    notifyPortConfigDone(p);
 }
 
 void handlePortConfigFile(ProducerStateTable &p, string file)
@@ -225,11 +260,7 @@ void handlePortConfigFile(ProducerStateTable &p, string file)
     }
 
     infile.close();
-
-    /* Notify that all ports added */
-    FieldValueTuple finish_notice("count", to_string(g_portSet.size()));
-    vector<FieldValueTuple> attrs = { finish_notice };
-    p.set("PortConfigDone", attrs);
+    notifyPortConfigDone(p);
 }
 
 void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple> &port_cfg_map)


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

read port configuration from configDB when `-p` is not specified.

**Why I did it**

configDB is the master data of port configuration.
We can simply use it instead of passing dedicated configuration file for `portsyncd`

**How I verified it**

Run `portsyncd` without `-p` option.

**Details if related**
