### PR TITLE
[pfcwd]: create queue pfcwd handler only when it doesn't exist

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -177,7 +177,7 @@ bool OrchDaemon::init()
             SAI_QUEUE_ATTR_PAUSE_STATUS,
         };
 
-        m_orchList.push_back(new PfcWdSwOrch<PfcWdActionHandler, PfcWdActionHandler>(
+        m_orchList.push_back(new PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>(
                     m_configDb,
                     pfc_wd_tables,
                     portStatIds,

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -481,19 +481,25 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::doTask(swss::NotificationConsumer
         }
         else if (entry->second.action == PfcWdAction::PFC_WD_ACTION_DROP)
         {
-            entry->second.handler = make_shared<DropHandler>(
-                    entry->second.portId,
-                    entry->first,
-                    entry->second.index,
-                    PfcWdOrch<DropHandler, ForwardHandler>::getCountersTable());
+            if (entry->second.handler == nullptr)
+            {
+                entry->second.handler = make_shared<DropHandler>(
+                        entry->second.portId,
+                        entry->first,
+                        entry->second.index,
+                        PfcWdOrch<DropHandler, ForwardHandler>::getCountersTable());
+            }
         }
         else if (entry->second.action == PfcWdAction::PFC_WD_ACTION_FORWARD)
         {
-            entry->second.handler = make_shared<ForwardHandler>(
-                    entry->second.portId,
-                    entry->first,
-                    entry->second.index,
-                    PfcWdOrch<DropHandler, ForwardHandler>::getCountersTable());
+            if (entry->second.handler == nullptr)
+            {
+                entry->second.handler = make_shared<ForwardHandler>(
+                        entry->second.portId,
+                        entry->first,
+                        entry->second.index,
+                        PfcWdOrch<DropHandler, ForwardHandler>::getCountersTable());
+            }
         }
         else
         {
@@ -512,4 +518,4 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::doTask(swss::NotificationConsumer
 
 // Trick to keep member functions in a separate file
 template class PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>;
-template class PfcWdSwOrch<PfcWdActionHandler, PfcWdActionHandler>;
+template class PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>;


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Create queue pfcwd handler only when it doesn't exist.
**Why I did it**
Redis pub/sub might have latency and it's possible that orchagent receives multiple storm/restore notification continuously. This PR is to prevent orchagent keeps creating new handler smart pointer and removing existing one in such case. Instead, it will only honor the first notification and do the corresponding operation.
**How I verified it**
Verified on DUT
**Details if related**
