### PR TITLE
[pfcwd]: Inherit PfcAclHandler from PfcLossyHandler

### DIFF
--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -194,7 +194,7 @@ void PfcWdActionHandler::updateWdCounters(const string& queueIdStr, const PfcWdQ
 
 PfcWdAclHandler::PfcWdAclHandler(sai_object_id_t port, sai_object_id_t queue,
         uint8_t queueId, shared_ptr<Table> countersTable):
-    PfcWdActionHandler(port, queue, queueId, countersTable)
+    PfcWdLossyHandler(port, queue, queueId, countersTable)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -83,7 +83,17 @@ class PfcWdActionHandler
         PfcWdHwStats m_hwStats;
 };
 
-class PfcWdAclHandler: public PfcWdActionHandler
+// Pfc queue that implements forward action by disabling PFC on queue
+class PfcWdLossyHandler: public PfcWdActionHandler
+{
+    public:
+        PfcWdLossyHandler(sai_object_id_t port, sai_object_id_t queue,
+                uint8_t queueId, shared_ptr<Table> countersTable);
+        virtual ~PfcWdLossyHandler(void);
+        virtual bool getHwCounters(PfcWdHwStats& counters);
+};
+
+class PfcWdAclHandler: public PfcWdLossyHandler
 {
     public:
         PfcWdAclHandler(sai_object_id_t port, sai_object_id_t queue,
@@ -101,16 +111,6 @@ class PfcWdAclHandler: public PfcWdActionHandler
         string m_strRule;
         void createPfcAclTable(sai_object_id_t port, string strTable, bool ingress);
         void createPfcAclRule(shared_ptr<AclRuleL3> rule, uint8_t queueId, string strTable);
-};
-
-// Pfc queue that implements forward action by disabling PFC on queue
-class PfcWdLossyHandler: public PfcWdActionHandler
-{
-    public:
-        PfcWdLossyHandler(sai_object_id_t port, sai_object_id_t queue,
-                uint8_t queueId, shared_ptr<Table> countersTable);
-        virtual ~PfcWdLossyHandler(void);
-        virtual bool getHwCounters(PfcWdHwStats& counters);
 };
 
 // PFC queue that implements drop action by draining queue with buffer of zero size


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Inherit PfcAclHandler from PfcLossyHandler instead of PfcActionHandler
**Why I did it**
PfcActionHandler is the base class. And in PfcLossyHandler (inherits from PfcActionHandler), it adds support to disable PFC once storm is detected. Since this function is also needed for PfcAclHandler. We need to let PfcAclHandler inherit from PfcLossyHandler instead of the base class.
**How I verified it**
Test on DUT
**Details if related**

  