### PR TITLE
[portsorch]: Only add port stat IDs that are needed to query

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -39,7 +39,7 @@ static map<string, sai_port_fec_mode_t> fec_mode_map =
     { "fc", SAI_PORT_FEC_MODE_FC }
 };
 
-static const vector<sai_port_stat_t> portStatIds =
+const vector<sai_port_stat_t> portStatIds =
 {
     SAI_PORT_STAT_IF_IN_OCTETS,
     SAI_PORT_STAT_IF_IN_UCAST_PKTS,
@@ -68,7 +68,6 @@ static const vector<sai_port_stat_t> portStatIds =
     SAI_PORT_STAT_PFC_6_RX_PKTS,
     SAI_PORT_STAT_PFC_7_RX_PKTS
 };
-
 
 static const vector<sai_queue_stat_t> queueStatIds =
 {
@@ -959,9 +958,9 @@ bool PortsOrch::initPort(const string &alias, const set<int> &lane_set)
 
                 std::string delimiter = "";
                 std::ostringstream counters_stream;
-                for (auto it = portStatIds.begin(); it !=  portStatIds.end(); it++)
+                for (const auto &id: portStatIds)
                 {
-                    counters_stream << delimiter << sai_serialize_port_stat(*it);
+                    counters_stream << delimiter << sai_serialize_port_stat(id);
                     delimiter = ",";
                 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -39,6 +39,37 @@ static map<string, sai_port_fec_mode_t> fec_mode_map =
     { "fc", SAI_PORT_FEC_MODE_FC }
 };
 
+static const vector<sai_port_stat_t> portStatIds =
+{
+    SAI_PORT_STAT_IF_IN_OCTETS,
+    SAI_PORT_STAT_IF_IN_UCAST_PKTS,
+    SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS,
+    SAI_PORT_STAT_IF_IN_DISCARDS,
+    SAI_PORT_STAT_IF_IN_ERRORS,
+    SAI_PORT_STAT_IF_IN_UNKNOWN_PROTOS,
+    SAI_PORT_STAT_IF_OUT_OCTETS,
+    SAI_PORT_STAT_IF_OUT_UCAST_PKTS,
+    SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS,
+    SAI_PORT_STAT_IF_OUT_DISCARDS,
+    SAI_PORT_STAT_IF_OUT_ERRORS,
+    SAI_PORT_STAT_IF_OUT_QLEN,
+    SAI_PORT_STAT_IF_IN_MULTICAST_PKTS,
+    SAI_PORT_STAT_IF_IN_BROADCAST_PKTS,
+    SAI_PORT_STAT_IF_OUT_MULTICAST_PKTS,
+    SAI_PORT_STAT_IF_OUT_BROADCAST_PKTS,
+    SAI_PORT_STAT_ETHER_RX_OVERSIZE_PKTS,
+    SAI_PORT_STAT_ETHER_TX_OVERSIZE_PKTS,
+    SAI_PORT_STAT_PFC_0_RX_PKTS,
+    SAI_PORT_STAT_PFC_1_RX_PKTS,
+    SAI_PORT_STAT_PFC_2_RX_PKTS,
+    SAI_PORT_STAT_PFC_3_RX_PKTS,
+    SAI_PORT_STAT_PFC_4_RX_PKTS,
+    SAI_PORT_STAT_PFC_5_RX_PKTS,
+    SAI_PORT_STAT_PFC_6_RX_PKTS,
+    SAI_PORT_STAT_PFC_7_RX_PKTS
+};
+
+
 static const vector<sai_queue_stat_t> queueStatIds =
 {
     SAI_QUEUE_STAT_PACKETS,
@@ -928,9 +959,9 @@ bool PortsOrch::initPort(const string &alias, const set<int> &lane_set)
 
                 std::string delimiter = "";
                 std::ostringstream counters_stream;
-                for (int cntr = SAI_PORT_STAT_IF_IN_OCTETS; cntr <= SAI_PORT_STAT_PFC_7_ON2OFF_RX_PKTS; ++cntr)
+                for (auto it = portStatIds.begin(); it !=  portStatIds.end(); it++)
                 {
-                    counters_stream << delimiter << sai_serialize_port_stat(static_cast<sai_port_stat_t>(cntr));
+                    counters_stream << delimiter << sai_serialize_port_stat(*it);
                     delimiter = ",";
                 }
 


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Only query needed port stat sai attributes.
**Why I did it**
The hardcoded for loop was not the good option to query all
IDs defined in the SAI header. While only limited partial of
the counters are needed, we don't need to query each of them
**How I verified it**
Verified on DUT
**Details if related**
