### PR TITLE
[pfcwd]: rename FLEX_COUNTER_POLL_MSECS  and move define in swss common

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -12,7 +12,6 @@ using namespace swss;
 
 /* select() function timeout retry time */
 #define SELECT_TIMEOUT 1000
-#define FLEX_COUNTER_POLL_MSECS 100
 
 extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
@@ -143,7 +142,7 @@ bool OrchDaemon::init()
                     portStatIds,
                     queueStatIds,
                     queueAttrIds,
-                    FLEX_COUNTER_POLL_MSECS));
+                    PFC_WD_POLL_MSECS));
     }
     else if (platform == BRCM_PLATFORM_SUBSTRING)
     {
@@ -184,7 +183,7 @@ bool OrchDaemon::init()
                     portStatIds,
                     queueStatIds,
                     queueAttrIds,
-                    FLEX_COUNTER_POLL_MSECS));
+                    PFC_WD_POLL_MSECS));
     }
 
     return true;


### PR DESCRIPTION

Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Rename FLEX_COUNTER_POLL_MSECS to PFC_WD_POLL_MSECS  and move definition to swss common repo.
**Why I did it**
As this variable is specific to PFCWD, rename it to better match its function. sairedis also need this variable, so move to swss-common.
**How I verified it**
Test on DUT

**Details if related**
