### PR TITLE
[pfcwd]: Log port name and queue index during storm detect/restore

### DIFF
--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -38,10 +38,20 @@ PfcWdActionHandler::PfcWdActionHandler(sai_object_id_t port, sai_object_id_t que
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_NOTICE(
-            "PFC Watchdog detected PFC storm on queue 0x%lx port 0x%lx",
-            m_queue,
-            m_port);
+    Port p;
+    if (!gPortsOrch->getPort(port, p))
+    {
+        SWSS_LOG_ERROR("Unknown port id 0x%lx", port);
+    }
+    else
+    {
+        SWSS_LOG_NOTICE(
+                "PFC Watchdog detected PFC storm on port %s, queue index %d, queue id 0x%lx and port id 0x%lx.",
+                m_portAlias.c_str(),
+                m_queueId,
+                m_queue,
+                m_port);
+    }
 }
 
 PfcWdActionHandler::~PfcWdActionHandler(void)
@@ -49,7 +59,9 @@ PfcWdActionHandler::~PfcWdActionHandler(void)
     SWSS_LOG_ENTER();
 
     SWSS_LOG_NOTICE(
-            "Queue 0x%lx port 0x%lx restored from PFC storm.",
+            "PFC Watchdog strom restored on  port %s, queue index %d, queue id 0x%lx and port id 0x%lx.",
+            m_portAlias.c_str(),
+            m_queueId,
             m_queue,
             m_port);
 }

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -79,6 +79,7 @@ class PfcWdActionHandler
         sai_object_id_t m_port = SAI_NULL_OBJECT_ID;
         sai_object_id_t m_queue = SAI_NULL_OBJECT_ID;
         uint8_t m_queueId = 0;
+        string m_portAlias;
         shared_ptr<Table> m_countersTable = nullptr;
         PfcWdHwStats m_hwStats;
 };


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add port name and queue index in the syslog message when pfc storm is detected or restored.
**Why I did it**
It's more user-friendly, and normal user can have straightforward Ethernet port name from syslog instead of only sai_stat_t ids.
**How I verified it**
Verified on DUT.
**Details if related**
