### PR TITLE
[swssconfig/sample]: Add the speed configuration JASON file

### DIFF
--- a/swssconfig/sample/th.32ports.speed.json
+++ b/swssconfig/sample/th.32ports.speed.json
@@ -1,0 +1,194 @@
+[
+    {
+        "PORT_TABLE:Ethernet0": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet4": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet8": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet12": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet16": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet20": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet24": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet28": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet32": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet36": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet40": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet44": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet48": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet52": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet56": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet60": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet64": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet68": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet72": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet76": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet80": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet84": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet88": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet92": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet96": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet100": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet104": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet108": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet112": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet116": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet120": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_TABLE:Ethernet124": {
+            "speed": "40000"
+        },
+        "OP": "SET"
+    }
+]


### PR DESCRIPTION
[swssconfig/sample]: Add the speed configuration JASON file

* Add the speed configuration JASON file, th.32ports.speed.json

Signed-off-by: polly_hsu@edge-core.com

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add the speed configuration JASON file, th.32ports.speed.json

**Why I did it**
We have a customer who consulted us how to configure the port speed as 40G on our device, AS7712-32X

**How I verified it**
1. Copy the configuration JASON file to the docker, swss
2. Configure the speed via the configuration JASON file under swss
3. Check whether the lower layer SDK port speed changed as configured
4. Check whether the upper layer interface speed changed as configured

**Details if related**
