### PR TITLE
Don't generate an error message when alias == 'ConfigPortDone'

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1159,6 +1159,12 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 continue;
             }
 
+            if (alias == "PortConfigDone")
+            {
+                // the alias is a fake here, move to the next request
+                continue;
+            }
+
             Port p;
             if (!getPort(alias, p))
             {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add a code to avoid not informational error message
"ERR orchagent: :- doPortTask: Failed to get port id by alias:PortConfigDone"

**Why I did it**
Because log supposed to be clean and easy to read

**How I verified it**
Run on a DUT

**Details if related**
