### PR TITLE
[swssconfig/sample]: Add buffer&QoS json files for TH

### DIFF
--- a/debian/swss.install
+++ b/debian/swss.install
@@ -2,6 +2,8 @@ swssconfig/sample/netbouncer.json etc/swss/config.d
 swssconfig/sample/00-copp.config.json etc/swss/config.d
 swssconfig/sample/td2.32ports.buffers.json etc/swss/config.d
 swssconfig/sample/td2.32ports.qos.json etc/swss/config.d
+swssconfig/sample/th.32ports.buffers.json etc/swss/config.d
+swssconfig/sample/th.32ports.qos.json etc/swss/config.d
 swssconfig/sample/th.64ports.buffers.json etc/swss/config.d
 swssconfig/sample/th.64ports.qos.json etc/swss/config.d
 swssconfig/sample/th2.118ports.buffers.json etc/swss/config.d

--- a/swssconfig/sample/th.32ports.buffers.json
+++ b/swssconfig/sample/th.32ports.buffers.json
@@ -1,0 +1,85 @@
+[
+    {
+        "BUFFER_POOL_TABLE:ingress_lossless_lossy_pool": {
+            "size": "10443264",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "4625920"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_POOL_TABLE:egress_lossy_pool": {
+            "size": "8877440",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_POOL_TABLE:egress_lossless_pool": {
+            "size": "15982592",
+            "type": "egress",
+            "mode": "static"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:ingress_lossless_profile": {
+            "pool": "[BUFFER_POOL_TABLE:ingress_lossless_lossy_pool]",
+            "xon": "4096",
+            "xoff": "58448",
+            "size": "1248",
+            "dynamic_th": "-4"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:ingress_lossy_profile": {
+            "pool":"[BUFFER_POOL_TABLE:ingress_lossless_lossy_pool]",
+            "size":"0",
+            "dynamic_th":"3"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:egress_lossless_profile": {
+            "pool":"[BUFFER_POOL_TABLE:egress_lossless_pool]",
+            "size":"1518",
+            "static_th":"3995648"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PROFILE_TABLE:egress_lossy_profile": {
+            "pool":"[BUFFER_POOL_TABLE:egress_lossy_pool]",
+            "size":"1518",
+            "dynamic_th":"3"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PG_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124:3-4": {
+            "profile" : "[BUFFER_PROFILE_TABLE:ingress_lossless_profile]"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_PG_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124:0-1": {
+            "profile" : "[BUFFER_PROFILE_TABLE:ingress_lossy_profile]"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_QUEUE_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124:3-4": {
+            "profile" : "[BUFFER_PROFILE_TABLE:egress_lossless_profile]"
+        },
+        "OP": "SET"
+    },
+    {
+        "BUFFER_QUEUE_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124:0-1": {
+            "profile" : "[BUFFER_PROFILE_TABLE:egress_lossy_profile]"
+        },
+        "OP": "SET"
+    }
+]

--- a/swssconfig/sample/th.32ports.qos.json
+++ b/swssconfig/sample/th.32ports.qos.json
@@ -1,0 +1,167 @@
+[
+    {
+        "TC_TO_PRIORITY_GROUP_MAP_TABLE:AZURE": {
+            "0": "0",
+            "1": "1",
+            "3": "3",
+            "4": "4"
+        },
+        "OP": "SET"
+    },
+    {
+        "MAP_PFC_PRIORITY_TO_QUEUE:AZURE": {
+            "0": "0",
+            "1": "1",
+            "3": "3",
+            "4": "4"
+        },
+        "OP": "SET"
+    },
+    {
+        "TC_TO_QUEUE_MAP_TABLE:AZURE": {
+            "0": "0",
+            "1": "1",
+            "3": "3",
+            "4": "4"
+        },
+        "OP": "SET"
+    },
+    {
+        "DSCP_TO_TC_MAP_TABLE:AZURE": {
+            "0":"0",
+            "1":"0",
+            "2":"0",
+            "3":"3",
+            "4":"4",
+            "5":"0",
+            "6":"0",
+            "7":"0",
+            "8":"1",
+            "9":"0",
+            "10":"0",
+            "11":"0",
+            "12":"0",
+            "13":"0",
+            "14":"0",
+            "15":"0",
+            "16":"0",
+            "17":"0",
+            "18":"0",
+            "19":"0",
+            "20":"0",
+            "21":"0",
+            "22":"0",
+            "23":"0",
+            "24":"0",
+            "25":"0",
+            "26":"0",
+            "27":"0",
+            "28":"0",
+            "29":"0",
+            "30":"0",
+            "31":"0",
+            "32":"0",
+            "33":"0",
+            "34":"0",
+            "35":"0",
+            "36":"0",
+            "37":"0",
+            "38":"0",
+            "39":"0",
+            "40":"0",
+            "41":"0",
+            "42":"0",
+            "43":"0",
+            "44":"0",
+            "45":"0",
+            "46":"0",
+            "47":"0",
+            "48":"0",
+            "49":"0",
+            "50":"0",
+            "51":"0",
+            "52":"0",
+            "53":"0",
+            "54":"0",
+            "55":"0",
+            "56":"0",
+            "57":"0",
+            "58":"0",
+            "59":"0",
+            "60":"0",
+            "61":"0",
+            "62":"0",
+            "63":"0"
+        },
+        "OP": "SET"
+    },
+    {
+        "SCHEDULER_TABLE:scheduler.0" : {
+            "type":"DWRR",
+            "weight": "25"
+        },
+        "OP": "SET"
+    },
+    {
+        "SCHEDULER_TABLE:scheduler.1" : {
+            "type":"DWRR",
+            "weight": "30"
+        },
+        "OP": "SET"
+    },
+    {
+        "SCHEDULER_TABLE:scheduler.2" : {
+            "type":"DWRR",
+            "weight": "20"
+        },
+        "OP": "SET"
+    },
+    {
+        "PORT_QOS_MAP_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124": {
+            "dscp_to_tc_map"  : "[DSCP_TO_TC_MAP_TABLE:AZURE]",
+            "tc_to_queue_map" : "[TC_TO_QUEUE_MAP_TABLE:AZURE]",
+            "tc_to_pg_map"    : "[TC_TO_PRIORITY_GROUP_MAP_TABLE:AZURE]",
+            "pfc_to_queue_map": "[MAP_PFC_PRIORITY_TO_QUEUE:AZURE]",
+            "pfc_enable": "3,4"
+        },
+        "OP": "SET"
+    },
+    {
+        "WRED_PROFILE_TABLE:AZURE" : {
+            "wred_green_enable":"true",
+            "wred_yellow_enable":"true",
+            "ecn":"ecn_all",
+            "red_max_threshold":"512000",
+            "red_min_threshold":"512000",
+            "yellow_max_threshold":"512000",
+            "yellow_min_threshold":"512000",
+            "green_max_threshold": "184320",
+            "green_min_threshold": "184320"
+        },
+        "OP": "SET"
+    },
+    {
+        "QUEUE_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124:0-1" : {
+            "wred_profile"  :   "[WRED_PROFILE_TABLE:AZURE]"
+        },
+        "OP": "SET"
+    },
+    {
+        "QUEUE_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124:3-4" : {
+            "scheduler"     :   "[SCHEDULER_TABLE:scheduler.0]"
+        },
+        "OP": "SET"
+    },
+    {
+        "QUEUE_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124:0" : {
+            "scheduler"     :   "[SCHEDULER_TABLE:scheduler.1]"
+        },
+        "OP": "SET"
+    },
+    {
+        "QUEUE_TABLE:Ethernet0,Ethernet4,Ethernet8,Ethernet12,Ethernet16,Ethernet20,Ethernet24,Ethernet28,Ethernet32,Ethernet36,Ethernet40,Ethernet44,Ethernet48,Ethernet52,Ethernet56,Ethernet60,Ethernet64,Ethernet68,Ethernet72,Ethernet76,Ethernet80,Ethernet84,Ethernet88,Ethernet92,Ethernet96,Ethernet100,Ethernet104,Ethernet108,Ethernet112,Ethernet116,Ethernet120,Ethernet124:1" : {
+            "scheduler"     :   "[SCHEDULER_TABLE:scheduler.2]"
+        },
+        "OP": "SET"
+    }
+]


### PR DESCRIPTION
* Add JSON files includes th.32ports.{buffer, qos}.json for 32 port configuration of BRCM Tomahawk

Signed-off-by: Phil Huang <phil_huang@edge-core.com>

**What I did**
Add buffer and QoS JSON files for 32 ports on BRCM Tomahawk

**Why I did it**
sonic-swss doesn't have these files for 32 ports configuration on BRCM TH

**How I verified it**
* Recommend to verified by running the JSON files and checking hardware registers

**Details if related**