### PR TITLE
[swss - buffer manager] set xon_offset when available in lookup table

### DIFF
--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -16,6 +16,7 @@ namespace swss {
 typedef struct{
     string size;
     string xon;
+    string xon_offset;
     string xoff;
     string threshold;
 } pg_profile_t;

--- a/cfgmgr/buffermgrd.cpp
+++ b/cfgmgr/buffermgrd.cpp
@@ -37,7 +37,7 @@ void usage()
     cout << "Usage: buffermgrd -l pg_lookup.ini" << endl;
     cout << "       -l pg_lookup.ini: PG profile look up table file (mandatory)" << endl;
     cout << "       format: csv" << endl;
-    cout << "       values: 'speed, cable, size, xon,  xoff, dynamic_threshold'" << endl;
+    cout << "       values: 'speed, cable, size, xon,  xoff, dynamic_threshold, xon_offset'" << endl;
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
**What I did**
Add xon_offset support to buffer manager.

**Why I did it**
We will set xon_offset in production. The orchagent support has been checked in. This PR adds the matching buffer manager support.

**How I verified it**
1. Tested with a pg_profile_lookup.ini without xon_offset column, the profiles were applied with xon_offset set to 0xffff (SAI default).
2. Tested with a pg_profile_lookup.ini with xon_offset column, the profiles were applied with xon_offset set to the expected value.
3. Changed xon_offset values and rebooted dut, new values were applied.
4. A test will come to test the profile generation, making sure the profile contains the correct values.