### PR TITLE
[portsyncd] allow port syncd to parse port_config.ini in random column order

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -205,17 +205,15 @@ void handlePortConfigFile(ProducerStateTable &p, string file)
     {
         if (line.at(0) == '#')
         {
-            /* Find out what info is specified in the configuration file */
-            for (auto it = header.begin(); it != header.end();)
-            {
-                if (line.find(*it) == string::npos)
-                {
-                    it = header.erase(it);
-                }
-                else
-                {
-                    ++it;
-                }
+            // Take this line as column header line
+            istringstream iss_hdr(line.substr(1));
+            string hdr;
+
+            header.clear();
+            while (! iss_hdr.eof()) {
+                iss_hdr >> hdr;
+                cout << "Adding column header '" << hdr << "'" << endl;
+                header.push_back(hdr);
             }
 
             continue;


### PR DESCRIPTION
**What I did**
- Parse the column header to decide column ordering.
- Extra column(s) will be ignored.

**How I verified it**
When processing a port_config.ini with columns name, lanes, alias, index, speed. Though portsyncd ignores the index column, it didn't skip the values in the column, the values were read as speed. Later causing orchagent to crash after setting values in index column as port speed.

With the change, orchagent stayed up, the values were process correctly, and all ports went online.
