### PR TITLE
[lua]: Only set the entry values when they are not nil

### DIFF
--- a/orchagent/pfc_detect_broadcom.lua
+++ b/orchagent/pfc_detect_broadcom.lua
@@ -22,74 +22,77 @@ for i = n, 1, -1 do
     local pfc_wd_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_STATUS')
     local pfc_wd_action = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_ACTION')
     if pfc_wd_status == 'operational' or pfc_wd_action == 'alert' then
-        local detection_time = tonumber(redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME'))
-        local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT')
-        if not time_left  then
-            time_left = detection_time
-        else
-            time_left = tonumber(time_left)
-        end
-
-        local queue_index = redis.call('HGET', 'COUNTERS_QUEUE_INDEX_MAP', KEYS[i])
-        local port_id = redis.call('HGET', 'COUNTERS_QUEUE_PORT_MAP', KEYS[i])
-        local pfc_rx_pkt_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_RX_PKTS'
-        local pfc_on2off_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_ON2OFF_RX_PKTS'
-
-        -- Get all counters
-        local occupancy_bytes = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES')
-        local packets = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS')
-        local pfc_rx_packets = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key)
-        local pfc_on2off = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_on2off_key)
-        local queue_pause_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS')
-
-        if occupancy_bytes and packets and pfc_rx_packets and pfc_on2off and queue_pause_status then
-            occupancy_bytes = tonumber(occupancy_bytes)
-            packets = tonumber(packets)
-            pfc_rx_packets = tonumber(pfc_rx_packets)
-            pfc_on2off = tonumber(pfc_on2off)
-
-            local packets_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last')
-            local pfc_rx_packets_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
-            local pfc_on2off_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last')
-            local queue_pause_status_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last')
-
-            -- DEBUG CODE START. Uncomment to enable
-            local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
-            -- DEBUG CODE END.
-
-            -- If this is not a first run, then we have last values available
-            if packets_last and pfc_rx_packets_last and pfc_on2off_last and queue_pause_status_last then
-                packets_last = tonumber(packets_last)
-                pfc_rx_packets_last = tonumber(pfc_rx_packets_last)
-                pfc_on2off_last = tonumber(pfc_on2off_last)
-
-                -- Check actual condition of queue being in PFC storm
-                if (occupancy_bytes > 0 and packets - packets_last == 0 and pfc_rx_packets - pfc_rx_packets_last > 0) or
-                    -- DEBUG CODE START. Uncomment to enable
-                    (debug_storm == "enabled") or
-                    -- DEBUG CODE END.
-                    (occupancy_bytes == 0 and pfc_rx_packets - pfc_rx_packets_last > 0 and pfc_on2off - pfc_on2off_last == 0 and queue_pause_status_last == 'true' and queue_pause_status == 'true') then
-                    if time_left <= poll_time then
-                        redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","storm"]')
-                        is_deadlock = true
-                        time_left = detection_time
-                    else
-                        time_left = time_left - poll_time
-                    end
-                else
-                    if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
-                        redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","restore"]')
-                    end
-                    time_left = detection_time
-                end
+        local detection_time = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME')
+        if detection_time then
+            detection_time = tonumber(detection_time)
+            local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT')
+            if not time_left  then
+                time_left = detection_time
+            else
+                time_left = tonumber(time_left)
             end
 
-        -- Save values for next run
-            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last', queue_pause_status)
-            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
-            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
-            redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
-            redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last', pfc_on2off)
+            local queue_index = redis.call('HGET', 'COUNTERS_QUEUE_INDEX_MAP', KEYS[i])
+            local port_id = redis.call('HGET', 'COUNTERS_QUEUE_PORT_MAP', KEYS[i])
+            local pfc_rx_pkt_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_RX_PKTS'
+            local pfc_on2off_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_ON2OFF_RX_PKTS'
+
+            -- Get all counters
+            local occupancy_bytes = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES')
+            local packets = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS')
+            local pfc_rx_packets = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key)
+            local pfc_on2off = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_on2off_key)
+            local queue_pause_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS')
+
+            if occupancy_bytes and packets and pfc_rx_packets and pfc_on2off and queue_pause_status then
+                occupancy_bytes = tonumber(occupancy_bytes)
+                packets = tonumber(packets)
+                pfc_rx_packets = tonumber(pfc_rx_packets)
+                pfc_on2off = tonumber(pfc_on2off)
+
+                local packets_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last')
+                local pfc_rx_packets_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
+                local pfc_on2off_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last')
+                local queue_pause_status_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last')
+
+                -- DEBUG CODE START. Uncomment to enable
+                local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
+                -- DEBUG CODE END.
+
+                -- If this is not a first run, then we have last values available
+                if packets_last and pfc_rx_packets_last and pfc_on2off_last and queue_pause_status_last then
+                    packets_last = tonumber(packets_last)
+                    pfc_rx_packets_last = tonumber(pfc_rx_packets_last)
+                    pfc_on2off_last = tonumber(pfc_on2off_last)
+
+                    -- Check actual condition of queue being in PFC storm
+                    if (occupancy_bytes > 0 and packets - packets_last == 0 and pfc_rx_packets - pfc_rx_packets_last > 0) or
+                        -- DEBUG CODE START. Uncomment to enable
+                        (debug_storm == "enabled") or
+                        -- DEBUG CODE END.
+                        (occupancy_bytes == 0 and pfc_rx_packets - pfc_rx_packets_last > 0 and pfc_on2off - pfc_on2off_last == 0 and queue_pause_status_last == 'true' and queue_pause_status == 'true') then
+                        if time_left <= poll_time then
+                            redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","storm"]')
+                            is_deadlock = true
+                            time_left = detection_time
+                        else
+                            time_left = time_left - poll_time
+                        end
+                    else
+                        if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
+                            redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","restore"]')
+                        end
+                        time_left = detection_time
+                    end
+                end
+
+            -- Save values for next run
+                redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last', queue_pause_status)
+                redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
+                redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
+                redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
+                redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last', pfc_on2off)
+            end
         end
     end
 end

--- a/orchagent/pfc_detect_broadcom.lua
+++ b/orchagent/pfc_detect_broadcom.lua
@@ -34,61 +34,63 @@ for i = n, 1, -1 do
         local port_id = redis.call('HGET', 'COUNTERS_QUEUE_PORT_MAP', KEYS[i])
         local pfc_rx_pkt_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_RX_PKTS'
         local pfc_on2off_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_ON2OFF_RX_PKTS'
-        
 
         -- Get all counters
-        local occupancy_bytes = tonumber(redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES'))
-        local packets = tonumber(redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS'))
-        local pfc_rx_packets = tonumber(redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key))
-        local pfc_on2off = tonumber(redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_on2off_key))
+        local occupancy_bytes = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES')
+        local packets = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS')
+        local pfc_rx_packets = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key)
+        local pfc_on2off = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_on2off_key)
         local queue_pause_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS')
-        
-        local packets_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last')
-        local pfc_rx_packets_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
-        local pfc_on2off_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last')
-        local queue_pause_status_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last')
 
-        -- DEBUG CODE START. Uncomment to enable
-        local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
-        -- DEBUG CODE END.
+        if occupancy_bytes and packets and pfc_rx_packets and pfc_on2off and queue_pause_status then
+            occupancy_bytes = tonumber(occupancy_bytes)
+            packets = tonumber(packets)
+            pfc_rx_packets = tonumber(pfc_rx_packets)
+            pfc_on2off = tonumber(pfc_on2off)
 
-        -- If this is not a first run, then we have last values available
-        if packets_last and pfc_rx_packets_last and pfc_on2off_last and queue_pause_status_last then
-            packets_last = tonumber(packets_last)
-            pfc_rx_packets_last = tonumber(pfc_rx_packets_last)
-            pfc_on2off_last = tonumber(pfc_on2off_last)
+            local packets_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last')
+            local pfc_rx_packets_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
+            local pfc_on2off_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last')
+            local queue_pause_status_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last')
 
-            -- Check actual condition of queue being in PFC storm
-            if (occupancy_bytes > 0 and packets - packets_last == 0 and pfc_rx_packets - pfc_rx_packets_last > 0) or
-                -- DEBUG CODE START. Uncomment to enable
-                (debug_storm == "enabled") or
-                -- DEBUG CODE END.
-                (occupancy_bytes == 0 and pfc_rx_packets - pfc_rx_packets_last > 0 and pfc_on2off - pfc_on2off_last == 0 and queue_pause_status_last == 'true' and queue_pause_status == 'true') then
-                if time_left <= poll_time then
-                    redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","storm"]')
-                    is_deadlock = true
-                    time_left = detection_time
+            -- DEBUG CODE START. Uncomment to enable
+            local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
+            -- DEBUG CODE END.
+
+            -- If this is not a first run, then we have last values available
+            if packets_last and pfc_rx_packets_last and pfc_on2off_last and queue_pause_status_last then
+                packets_last = tonumber(packets_last)
+                pfc_rx_packets_last = tonumber(pfc_rx_packets_last)
+                pfc_on2off_last = tonumber(pfc_on2off_last)
+
+                -- Check actual condition of queue being in PFC storm
+                if (occupancy_bytes > 0 and packets - packets_last == 0 and pfc_rx_packets - pfc_rx_packets_last > 0) or
+                    -- DEBUG CODE START. Uncomment to enable
+                    (debug_storm == "enabled") or
+                    -- DEBUG CODE END.
+                    (occupancy_bytes == 0 and pfc_rx_packets - pfc_rx_packets_last > 0 and pfc_on2off - pfc_on2off_last == 0 and queue_pause_status_last == 'true' and queue_pause_status == 'true') then
+                    if time_left <= poll_time then
+                        redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","storm"]')
+                        is_deadlock = true
+                        time_left = detection_time
+                    else
+                        time_left = time_left - poll_time
+                    end
                 else
-                    time_left = time_left - poll_time
+                    if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
+                        redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","restore"]')
+                    end
+                    time_left = detection_time
                 end
-            else
-                if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
-                    redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","restore"]')
-                end
-                time_left = detection_time
             end
-        end
 
         -- Save values for next run
-        if queue_pause_status then
             redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last', queue_pause_status)
-        end
-        redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
-        if time_left then
+            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
             redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
+            redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
+            redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last', pfc_on2off)
         end
-        redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
-        redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last', pfc_on2off)
     end
 end
 

--- a/orchagent/pfc_detect_broadcom.lua
+++ b/orchagent/pfc_detect_broadcom.lua
@@ -80,9 +80,13 @@ for i = n, 1, -1 do
         end
 
         -- Save values for next run
-        redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last', queue_pause_status)
+        if queue_pause_status then
+            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS_last', queue_pause_status)
+        end
         redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
-	redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
+        if time_left then
+            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
+        end
         redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
         redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_on2off_key .. '_last', pfc_on2off)
     end

--- a/orchagent/pfc_detect_mellanox.lua
+++ b/orchagent/pfc_detect_mellanox.lua
@@ -22,71 +22,74 @@ for i = n, 1, -1 do
     local pfc_wd_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_STATUS')
     local pfc_wd_action = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_ACTION')
     if pfc_wd_status == 'operational' or pfc_wd_action == 'alert' then
-        local detection_time = tonumber(redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME'))
-        local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT')
-        if not time_left  then
-            time_left = detection_time
-        else
-            time_left = tonumber(time_left)
-        end
-
-        local queue_index = redis.call('HGET', 'COUNTERS_QUEUE_INDEX_MAP', KEYS[i])
-        local port_id = redis.call('HGET', 'COUNTERS_QUEUE_PORT_MAP', KEYS[i])
-        local pfc_rx_pkt_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_RX_PKTS'
-        local pfc_duration_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_RX_PAUSE_DURATION'
-
-        -- Get all counters
-        local occupancy_bytes = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES')
-        local packets = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS')
-        local pfc_rx_packets = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key)
-        local pfc_duration = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_duration_key)
-
-        if occupancy_bytes and packets and pfc_rx_packets and pfc_duration then
-            occupancy_bytes = tonumber(occupancy_bytes)
-            packets = tonumber(packets)
-            pfc_rx_packets = tonumber(pfc_rx_packets)
-            pfc_duration =  tonumber(pfc_duration)
-
-            local packets_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last')
-            local pfc_rx_packets_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
-            local pfc_duration_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
-            -- DEBUG CODE START. Uncomment to enable
-            local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
-            -- DEBUG CODE END.
-
-            -- If this is not a first run, then we have last values available
-            if packets_last and pfc_rx_packets_last and pfc_duration_last then
-                packets_last = tonumber(packets_last)
-                pfc_rx_packets_last = tonumber(pfc_rx_packets_last)
-                pfc_duration_last = tonumber(pfc_duration_last)
-
-                -- Check actual condition of queue being in PFC storm
-                if (occupancy_bytes > 0 and packets - packets_last == 0 and pfc_rx_packets - pfc_rx_packets_last > 0) or
-                    -- DEBUG CODE START. Uncomment to enable
-                    (debug_storm == "enabled") or
-                    -- DEBUG CODE END.
-                    (occupancy_bytes == 0 and packets - packets_last == 0 and (pfc_duration - pfc_duration_last) > poll_time * 0.8) then
-                    if time_left <= poll_time then
-                        redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","storm"]')
-                        is_deadlock = true
-                        time_left = detection_time
-                    else
-                        time_left = time_left - poll_time
-                    end
-                else
-                    if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
-                        redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","restore"]')
-                    end
-                    time_left = detection_time
-                end
+        local detection_time = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME')
+        if detection_time then
+            detection_time = tonumber(detection_time)
+            local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT')
+            if not time_left  then
+                time_left = detection_time
+            else
+                time_left = tonumber(time_left)
             end
 
-        -- Save values for next run
-            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
-            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
-            redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
-            redis.call('HDEL', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
-            redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last', pfc_duration)
+            local queue_index = redis.call('HGET', 'COUNTERS_QUEUE_INDEX_MAP', KEYS[i])
+            local port_id = redis.call('HGET', 'COUNTERS_QUEUE_PORT_MAP', KEYS[i])
+            local pfc_rx_pkt_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_RX_PKTS'
+            local pfc_duration_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_RX_PAUSE_DURATION'
+
+            -- Get all counters
+            local occupancy_bytes = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES')
+            local packets = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS')
+            local pfc_rx_packets = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key)
+            local pfc_duration = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_duration_key)
+
+            if occupancy_bytes and packets and pfc_rx_packets and pfc_duration then
+                occupancy_bytes = tonumber(occupancy_bytes)
+                packets = tonumber(packets)
+                pfc_rx_packets = tonumber(pfc_rx_packets)
+                pfc_duration =  tonumber(pfc_duration)
+
+                local packets_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last')
+                local pfc_rx_packets_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
+                local pfc_duration_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
+                -- DEBUG CODE START. Uncomment to enable
+                local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
+                -- DEBUG CODE END.
+
+                -- If this is not a first run, then we have last values available
+                if packets_last and pfc_rx_packets_last and pfc_duration_last then
+                    packets_last = tonumber(packets_last)
+                    pfc_rx_packets_last = tonumber(pfc_rx_packets_last)
+                    pfc_duration_last = tonumber(pfc_duration_last)
+
+                    -- Check actual condition of queue being in PFC storm
+                    if (occupancy_bytes > 0 and packets - packets_last == 0 and pfc_rx_packets - pfc_rx_packets_last > 0) or
+                        -- DEBUG CODE START. Uncomment to enable
+                        (debug_storm == "enabled") or
+                        -- DEBUG CODE END.
+                        (occupancy_bytes == 0 and packets - packets_last == 0 and (pfc_duration - pfc_duration_last) > poll_time * 0.8) then
+                        if time_left <= poll_time then
+                            redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","storm"]')
+                            is_deadlock = true
+                            time_left = detection_time
+                        else
+                            time_left = time_left - poll_time
+                        end
+                    else
+                        if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
+                            redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","restore"]')
+                        end
+                        time_left = detection_time
+                    end
+                end
+
+            -- Save values for next run
+                redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
+                redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
+                redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
+                redis.call('HDEL', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
+                redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last', pfc_duration)
+            end
         end
     end
 end

--- a/orchagent/pfc_detect_mellanox.lua
+++ b/orchagent/pfc_detect_mellanox.lua
@@ -77,7 +77,9 @@ for i = n, 1, -1 do
 
         -- Save values for next run
         redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
-        redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
+        if time_left then
+            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
+        end
         redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
         if is_deadlock then
             redis.call('HDEL', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')

--- a/orchagent/pfc_detect_mellanox.lua
+++ b/orchagent/pfc_detect_mellanox.lua
@@ -36,54 +36,56 @@ for i = n, 1, -1 do
         local pfc_duration_key = 'SAI_PORT_STAT_PFC_' .. queue_index .. '_RX_PAUSE_DURATION'
 
         -- Get all counters
-        local occupancy_bytes = tonumber(redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES'))
-        local packets = tonumber(redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS'))
-        local pfc_rx_packets = tonumber(redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key))
-        local pfc_duration = tonumber(redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_duration_key))
+        local occupancy_bytes = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES')
+        local packets = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS')
+        local pfc_rx_packets = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key)
+        local pfc_duration = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_duration_key)
 
-        local packets_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last')
-        local pfc_rx_packets_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
-        local pfc_duration_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
-        -- DEBUG CODE START. Uncomment to enable
-        local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
-        -- DEBUG CODE END.
+        if occupancy_bytes and packets and pfc_rx_packets and pfc_duration then
+            occupancy_bytes = tonumber(occupancy_bytes)
+            packets = tonumber(packets)
+            pfc_rx_packets = tonumber(pfc_rx_packets)
+            pfc_duration =  tonumber(pfc_duration)
 
-        -- If this is not a first run, then we have last values available
-        if packets_last and pfc_rx_packets_last and pfc_duration_last then
-            packets_last = tonumber(packets_last)
-            pfc_rx_packets_last = tonumber(pfc_rx_packets_last)
-            pfc_duration_last = tonumber(pfc_duration_last)
+            local packets_last = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last')
+            local pfc_rx_packets_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last')
+            local pfc_duration_last = redis.call('HGET', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
+            -- DEBUG CODE START. Uncomment to enable
+            local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
+            -- DEBUG CODE END.
 
-            -- Check actual condition of queue being in PFC storm
-            if (occupancy_bytes > 0 and packets - packets_last == 0 and pfc_rx_packets - pfc_rx_packets_last > 0) or
-                -- DEBUG CODE START. Uncomment to enable
-                (debug_storm == "enabled") or
-                -- DEBUG CODE END.
-                (occupancy_bytes == 0 and packets - packets_last == 0 and (pfc_duration - pfc_duration_last) > poll_time * 0.8) then
-                if time_left <= poll_time then
-                    redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","storm"]')
-                    is_deadlock = true
-                    time_left = detection_time
+            -- If this is not a first run, then we have last values available
+            if packets_last and pfc_rx_packets_last and pfc_duration_last then
+                packets_last = tonumber(packets_last)
+                pfc_rx_packets_last = tonumber(pfc_rx_packets_last)
+                pfc_duration_last = tonumber(pfc_duration_last)
+
+                -- Check actual condition of queue being in PFC storm
+                if (occupancy_bytes > 0 and packets - packets_last == 0 and pfc_rx_packets - pfc_rx_packets_last > 0) or
+                    -- DEBUG CODE START. Uncomment to enable
+                    (debug_storm == "enabled") or
+                    -- DEBUG CODE END.
+                    (occupancy_bytes == 0 and packets - packets_last == 0 and (pfc_duration - pfc_duration_last) > poll_time * 0.8) then
+                    if time_left <= poll_time then
+                        redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","storm"]')
+                        is_deadlock = true
+                        time_left = detection_time
+                    else
+                        time_left = time_left - poll_time
+                    end
                 else
-                    time_left = time_left - poll_time
+                    if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
+                        redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","restore"]')
+                    end
+                    time_left = detection_time
                 end
-            else
-                if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
-                    redis.call('PUBLISH', 'PFC_WD', '["' .. KEYS[i] .. '","restore"]')
-                end 
-                time_left = detection_time
             end
-        end
 
         -- Save values for next run
-        redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
-        if time_left then
+            redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_STAT_PACKETS_last', packets)
             redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
-        end
-        redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
-        if is_deadlock then
+            redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_rx_pkt_key .. '_last', pfc_rx_packets)
             redis.call('HDEL', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last')
-        else
             redis.call('HSET', counters_table_name .. ':' .. port_id, pfc_duration_key .. '_last', pfc_duration)
         end
     end

--- a/orchagent/pfc_restore.lua
+++ b/orchagent/pfc_restore.lua
@@ -20,7 +20,7 @@ for i = n, 1, -1 do
     local pfc_wd_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_STATUS')
     local restoration_time = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME')
     local pfc_wd_action = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_ACTION')
-    if pfc_wd_status ~= 'operational'  and pfc_wd_action ~= 'alert' and restoration_time ~= '' then
+    if pfc_wd_status ~= 'operational'  and pfc_wd_action ~= 'alert' and restoration_time then
         restoration_time = tonumber(restoration_time)
         local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME_LEFT')
         if time_left == nil then

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -45,6 +45,7 @@ PfcWdActionHandler::PfcWdActionHandler(sai_object_id_t port, sai_object_id_t que
     }
     else
     {
+        m_portAlias = p.m_alias;
         SWSS_LOG_NOTICE(
                 "PFC Watchdog detected PFC storm on port %s, queue index %d, queue id 0x%lx and port id 0x%lx.",
                 m_portAlias.c_str(),


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Check whether the value is nil before redis set
**Why I did it**
During pfcwd start/stop, occasionally have the following error if orchagent removes the entry before lua script runs.

ERR syncd: :- runRedisScript: Caught exception while running Redis lua sc
ipt: ERR Error running script (call to f_ac71cbd58a59a2d9e49ff896ab51b8d189d4acd2): @user_script:83: @user_script: 83: Lua r
dis() command arguments must be strings or integers : Input/output error\n\n[LogAnalyzer][diagnostic]:matching line: Feb 23 
0:07:48.075531 str-s6000-acs-13 ERR syncd: :- guard: RedisReply catches system_error: command: *63#015#012$7#015#012EVALSHA#

**How I verified it**
Run on DUT
**Details if related**
