### PR TITLE
make reset crm polling interval effective immediately

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -236,6 +236,10 @@ void CrmOrch::handleSetCommand(const string& key, const vector<FieldValueTuple>&
             if (field == CRM_POLLING_INTERVAL)
             {
                 m_pollingInterval = chrono::seconds(to_uint<uint32_t>(value));
+                auto timer = static_cast<ExecutableTimer *>(Orch::getExecutor("CRM_COUNTERS_POLL"))->getSelectableTimer();
+                auto interv = timespec { .tv_sec = m_pollingInterval.count(), .tv_nsec = 0 };
+                timer->setInterval(interv);
+                timer->reset();
             }
             else if (crmThreshTypeResMap.find(field) != crmThreshTypeResMap.end())
             {

--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -149,7 +149,8 @@ const map<string, CrmResourceType> crmUsedCntsTableMap =
 CrmOrch::CrmOrch(DBConnector *db, string tableName):
     Orch(db, tableName),
     m_countersDb(new DBConnector(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0)),
-    m_countersCrmTable(new Table(m_countersDb.get(), COUNTERS_CRM_TABLE))
+    m_countersCrmTable(new Table(m_countersDb.get(), COUNTERS_CRM_TABLE)),
+    m_timer(new SelectableTimer(timespec { .tv_sec = CRM_POLLING_INTERVAL_DEFAULT, .tv_nsec = 0 }))
 {
     SWSS_LOG_ENTER();
 
@@ -160,11 +161,9 @@ CrmOrch::CrmOrch(DBConnector *db, string tableName):
         m_resourcesMap.emplace(res.first, CrmResourceEntry(res.second, CRM_THRESHOLD_TYPE_DEFAULT, CRM_THRESHOLD_LOW_DEFAULT, CRM_THRESHOLD_HIGH_DEFAULT));
     }
 
-    auto interv = timespec { .tv_sec = CRM_POLLING_INTERVAL_DEFAULT, .tv_nsec = 0 };
-    auto timer = new SelectableTimer(interv);
-    auto executor = new ExecutableTimer(timer, this);
+    auto executor = new ExecutableTimer(m_timer.get(), this);
     Orch::addExecutor("CRM_COUNTERS_POLL", executor);
-    timer->start();
+    m_timer->start();
 }
 
 CrmOrch::CrmResourceEntry::CrmResourceEntry(string name, CrmThresholdType thresholdType, uint32_t lowThreshold, uint32_t highThreshold):
@@ -236,10 +235,9 @@ void CrmOrch::handleSetCommand(const string& key, const vector<FieldValueTuple>&
             if (field == CRM_POLLING_INTERVAL)
             {
                 m_pollingInterval = chrono::seconds(to_uint<uint32_t>(value));
-                auto timer = static_cast<ExecutableTimer *>(Orch::getExecutor("CRM_COUNTERS_POLL"))->getSelectableTimer();
                 auto interv = timespec { .tv_sec = m_pollingInterval.count(), .tv_nsec = 0 };
-                timer->setInterval(interv);
-                timer->reset();
+                m_timer->setInterval(interv);
+                m_timer->reset();
             }
             else if (crmThreshTypeResMap.find(field) != crmThreshTypeResMap.end())
             {

--- a/orchagent/crmorch.h
+++ b/orchagent/crmorch.h
@@ -52,6 +52,7 @@ public:
 private:
     shared_ptr<DBConnector> m_countersDb = nullptr;
     shared_ptr<Table> m_countersCrmTable = nullptr;
+    shared_ptr<SelectableTimer> m_timer = nullptr;
 
     struct CrmResourceCounter
     {

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -375,6 +375,17 @@ void Orch::addExecutor(string executorName, Executor* executor)
             std::forward_as_tuple(executor));
 }
 
+Executor *Orch::getExecutor(string executorName)
+{
+    auto it = m_consumerMap.find(executorName);
+    if (it != m_consumerMap.end())
+    {
+        return it->second.get();
+    }
+
+    return NULL;
+}
+
 void Orch2::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -162,6 +162,7 @@ protected:
 
     /* Note: consumer will be owned by this class */
     void addExecutor(string executorName, Executor* executor);
+    Executor *getExecutor(string executorName);
 private:
     void addConsumer(DBConnector *db, string tableName);
 };

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -45,7 +45,7 @@ def test_CrmFdbEntry(dvs):
 
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_FDB_ENTRY', '1000')
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_fdb_entry_used')
@@ -107,7 +107,7 @@ def test_CrmIpv4Route(dvs):
     ps = swsscommon.ProducerStateTable(db, "ROUTE_TABLE")
     fvs = swsscommon.FieldValuePairs([("nexthop","10.0.0.1"), ("ifname", "Ethernet0")])
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_route_used')
@@ -163,7 +163,7 @@ def test_CrmIpv6Route(dvs):
     ps = swsscommon.ProducerStateTable(db, "ROUTE_TABLE")
     fvs = swsscommon.FieldValuePairs([("nexthop","fc00::2"), ("ifname", "Ethernet0")])
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_route_used')
@@ -205,7 +205,7 @@ def test_CrmIpv4Nexthop(dvs):
 
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEXTHOP_ENTRY', '1000')
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_nexthop_used')
@@ -250,7 +250,7 @@ def test_CrmIpv6Nexthop(dvs):
 
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEXTHOP_ENTRY', '1000')
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_nexthop_used')
@@ -291,7 +291,7 @@ def test_CrmIpv4Neighbor(dvs):
 
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEIGHBOR_ENTRY', '1000')
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_neighbor_used')
@@ -336,7 +336,7 @@ def test_CrmIpv6Neighbor(dvs):
 
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEIGHBOR_ENTRY', '1000')
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_neighbor_used')
@@ -386,7 +386,7 @@ def test_CrmNexthopGroup(dvs):
     ps = swsscommon.ProducerStateTable(db, "ROUTE_TABLE")
     fvs = swsscommon.FieldValuePairs([("nexthop","10.0.0.1,10.0.0.3"), ("ifname", "Ethernet0,Ethernet4")])
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_nexthop_group_used')
@@ -438,7 +438,7 @@ def test_CrmNexthopGroupMember(dvs):
     ps = swsscommon.ProducerStateTable(db, "ROUTE_TABLE")
     fvs = swsscommon.FieldValuePairs([("nexthop","10.0.0.1,10.0.0.3"), ("ifname", "Ethernet0,Ethernet4")])
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     # get counters
     used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_nexthop_group_member_used')
@@ -492,7 +492,7 @@ def test_CrmAcl(dvs):
     fvs = swsscommon.FieldValuePairs([("priority", "55"), ("PACKET_ACTION", "FORWARD"), ("L4_SRC_PORT", "65000")])
     rtbl.set("test|acl_test_rule", fvs)
 
-    time.sleep(5*60)
+    time.sleep(2)
 
     table_used_counter = getCrmCounterValue(dvs, 'ACL_STATS:INGRESS:PORT', 'crm_stats_acl_table_used')
     assert table_used_counter == 1

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -72,7 +72,7 @@ def test_CrmFdbEntry(dvs):
     # update available counter
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_FDB_ENTRY', '999')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_fdb_entry_used')
@@ -84,7 +84,7 @@ def test_CrmFdbEntry(dvs):
     # update available counter
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_FDB_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_avail_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_fdb_entry_available')
@@ -117,7 +117,7 @@ def test_CrmIpv4Route(dvs):
     ps.set("2.2.2.0/24", fvs)
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV4_ROUTE_ENTRY', '999')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_route_used')
@@ -131,7 +131,7 @@ def test_CrmIpv4Route(dvs):
     dvs.runcmd("ip neigh del 10.0.0.1 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV4_ROUTE_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_route_used')
@@ -173,7 +173,7 @@ def test_CrmIpv6Route(dvs):
     ps.set("2001::/64", fvs)
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV6_ROUTE_ENTRY', '999')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_route_used')
@@ -187,7 +187,7 @@ def test_CrmIpv6Route(dvs):
     dvs.runcmd("ip -6 neigh del fc00::2 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV6_ROUTE_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_route_used')
@@ -215,7 +215,7 @@ def test_CrmIpv4Nexthop(dvs):
     dvs.runcmd("ip neigh replace 10.0.0.1 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEXTHOP_ENTRY', '999')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_nexthop_used')
@@ -228,7 +228,7 @@ def test_CrmIpv4Nexthop(dvs):
     dvs.runcmd("ip neigh del 10.0.0.1 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEXTHOP_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_nexthop_used')
@@ -260,7 +260,7 @@ def test_CrmIpv6Nexthop(dvs):
     dvs.runcmd("ip -6 neigh replace fc00::2 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEXTHOP_ENTRY', '999')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_nexthop_used')
@@ -273,7 +273,7 @@ def test_CrmIpv6Nexthop(dvs):
     dvs.runcmd("ip -6 neigh del fc00::2 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEXTHOP_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_nexthop_used')
@@ -301,7 +301,7 @@ def test_CrmIpv4Neighbor(dvs):
     dvs.runcmd("ip neigh replace 10.0.0.1 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEIGHBOR_ENTRY', '999')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_neighbor_used')
@@ -314,7 +314,7 @@ def test_CrmIpv4Neighbor(dvs):
     dvs.runcmd("ip neigh del 10.0.0.1 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEIGHBOR_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_neighbor_used')
@@ -346,7 +346,7 @@ def test_CrmIpv6Neighbor(dvs):
     dvs.runcmd("ip -6 neigh replace fc00::2 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEIGHBOR_ENTRY', '999')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_neighbor_used')
@@ -359,7 +359,7 @@ def test_CrmIpv6Neighbor(dvs):
     dvs.runcmd("ip -6 neigh del fc00::2 lladdr 11:22:33:44:55:66 dev Ethernet0")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEIGHBOR_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_neighbor_used')
@@ -396,7 +396,7 @@ def test_CrmNexthopGroup(dvs):
     ps.set("2.2.2.0/24", fvs)
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_ENTRY', '999')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_nexthop_group_used')
@@ -411,7 +411,7 @@ def test_CrmNexthopGroup(dvs):
     dvs.runcmd("ip neigh del 10.0.0.3 lladdr 11:22:33:44:55:66 dev Ethernet4")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_nexthop_group_used')
@@ -448,7 +448,7 @@ def test_CrmNexthopGroupMember(dvs):
     ps.set("2.2.2.0/24", fvs)
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_MEMBER_ENTRY', '998')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_nexthop_group_member_used')
@@ -463,7 +463,7 @@ def test_CrmNexthopGroupMember(dvs):
     dvs.runcmd("ip neigh del 10.0.0.3 lladdr 11:22:33:44:55:66 dev Ethernet4")
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_MEMBER_ENTRY', '1000')
 
-    time.sleep(1)
+    time.sleep(2)
 
     # get counters
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_nexthop_group_member_used')
@@ -511,7 +511,7 @@ def test_CrmAcl(dvs):
     # remove ACL rule
     rtbl._del("test|acl_test_rule")
 
-    time.sleep(1)
+    time.sleep(2)
 
     entry_used_counter = getCrmCounterValue(dvs, key, 'crm_stats_acl_entry_used')
     assert entry_used_counter == 0
@@ -522,7 +522,7 @@ def test_CrmAcl(dvs):
     # remove ACL table
     ttbl._del("test")
 
-    time.sleep(1)
+    time.sleep(2)
 
     table_used_counter = getCrmCounterValue(dvs, 'ACL_STATS:INGRESS:PORT', 'crm_stats_acl_table_used')
     assert table_used_counter == 0


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
make reset crm polling interval effective immediately

**Why I did it**
it takes too long to run the crm test

**How I verified it**
passing swss integration test

**Details if related**
```
lgh@gulv-vm1:/data/sonic/sonic-swss/tests$ sudo pytest -v --dvsname=vs test_crm.py 
======================================================== test session starts ========================================================
platform linux2 -- Python 2.7.12, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /data/sonic/sonic-swss/tests, inifile:
collected 10 items                                                                                                                  

test_crm.py::test_CrmFdbEntry PASSED                                                                                          [ 10%]
test_crm.py::test_CrmIpv4Route PASSED                                                                                         [ 20%]
test_crm.py::test_CrmIpv6Route PASSED                                                                                         [ 30%]
test_crm.py::test_CrmIpv4Nexthop PASSED                                                                                       [ 40%]
test_crm.py::test_CrmIpv6Nexthop PASSED                                                                                       [ 50%]
test_crm.py::test_CrmIpv4Neighbor PASSED                                                                                      [ 60%]
test_crm.py::test_CrmIpv6Neighbor PASSED                                                                                      [ 70%]
test_crm.py::test_CrmNexthopGroup PASSED                                                                                      [ 80%]
test_crm.py::test_CrmNexthopGroupMember PASSED                                                                                [ 90%]
test_crm.py::test_CrmAcl PASSED                                                                                               [100%]

==================================================== 10 passed in 92.19 seconds =====================================================
```