### PR TITLE
[pfcwd]: only init counter when creating action handler

### DIFF
--- a/orchagent/pfc_restore.lua
+++ b/orchagent/pfc_restore.lua
@@ -20,7 +20,7 @@ for i = n, 1, -1 do
     local pfc_wd_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_STATUS')
     local restoration_time = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME')
     local pfc_wd_action = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_ACTION')
-    if pfc_wd_status ~= 'operational'  and pfc_wd_action ~= 'alert' and restoration_time then
+    if pfc_wd_status ~= 'operational'  and pfc_wd_action ~= 'alert' and restoration_time and restoration_time ~= '' then
         restoration_time = tonumber(restoration_time)
         local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME_LEFT')
         if time_left == nil then

--- a/orchagent/pfcwdorch.h
+++ b/orchagent/pfcwdorch.h
@@ -105,9 +105,6 @@ private:
     shared_ptr<ProducerTable> m_flexCounterTable = nullptr;
     shared_ptr<ProducerTable> m_flexCounterGroupTable = nullptr;
 
-    atomic_bool m_runPfcWdSwOrchThread = { false };
-    shared_ptr<thread> m_pfcWatchdogThread = nullptr;
-
     int m_pollInterval;
 };
 


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Only init counter when handler is created
2. Update lua script to support infinite restoration time
3. Clean up no need code
**Why I did it**

**How I verified it**
Tested on DUT
**Details if related**
