### PR TITLE
[pfcwd]: update counters of queues associated with handler when pfcwd stops

### DIFF
--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -432,6 +432,17 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::unregisterFromWdDb(const Port& po
 
         // Unregister in syncd
         m_flexCounterTable->del(key);
+
+        auto entry = m_entryMap.find(queueId);
+        if (entry != m_entryMap.end())
+        {
+            if (entry->second.handler != nullptr)
+            {
+                entry->second.handler->commitCounters();
+                entry->second.handler = nullptr;
+            }
+        }
+
         m_entryMap.erase(queueId);
 
         // Clean up


### PR DESCRIPTION

Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Update counters of queues associated with handler when pfcwd stops
**Why I did it**
If the queue is in drop mode and pfcwd stops, queue are restored and the counters should be updated as well.
**How I verified it**
Tested on DUT.
**Details if related**
