### PR TITLE
Update FDB CRM counters based on return value

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -46,10 +46,21 @@ void FdbOrch::update(sai_fdb_event_t type, const sai_fdb_entry_t* entry, sai_obj
 
         update.add = true;
 
-        (void)m_entries.insert(update.entry);
-        SWSS_LOG_DEBUG("FdbOrch notification: mac %s was inserted into bv_id 0x%lx", update.entry.mac.to_string().c_str(), entry->bv_id);
+        {
+            auto ret = m_entries.insert(update.entry);
 
-        gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_FDB_ENTRY);
+            SWSS_LOG_DEBUG("FdbOrch notification: mac %s was inserted into bv_id 0x%lx",
+                            update.entry.mac.to_string().c_str(), entry->bv_id);
+
+            if (ret.second)
+            {
+                gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_FDB_ENTRY);
+            }
+            else
+            {
+                SWSS_LOG_INFO("FdbOrch notification: mac %s is duplicate", update.entry.mac.to_string().c_str());
+            }
+        }
 
         for (auto observer: m_observers)
         {
@@ -62,10 +73,15 @@ void FdbOrch::update(sai_fdb_event_t type, const sai_fdb_entry_t* entry, sai_obj
     case SAI_FDB_EVENT_MOVE:
         update.add = false;
 
-        (void)m_entries.erase(update.entry);
-        SWSS_LOG_DEBUG("FdbOrch notification: mac %s was removed from bv_id 0x%lx", update.entry.mac.to_string().c_str(), entry->bv_id);
+        {
+            auto ret = m_entries.erase(update.entry);
+            SWSS_LOG_DEBUG("FdbOrch notification: mac %s was removed from bv_id 0x%lx", update.entry.mac.to_string().c_str(), entry->bv_id);
 
-        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_FDB_ENTRY);
+            if (ret)
+            {
+                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_FDB_ENTRY);
+            }
+        }
 
         for (auto observer: m_observers)
         {


### PR DESCRIPTION
**What I did**
CRM FDB _used_ counters are incremented/decremented based on STL return values

**Why I did it**
With some SAI vendors, the FDB entries that are programmed via application, is also notified back by the SAI. This resulted in double increment of _used_ counter for the same FDB entry.  In another case, observed some notifications for _AGE_ out FDB entries that are not originally added. This resulted in incorrect decrement of CRM counters. 

**How I verified it**
Check CRM counters after adding FDB entry and _used_ counter must be same as the number of entries _added_

**Details if related**

**Duplicate add case:**

```
NOTICE orchagent: :- addFdbEntry: Create dynamic FDB 52:54:00:25:07:e9 on Ethernet0
INFO orchagent: :- update: FdbOrch notification: mac 52:54:00:25:07:e9 is duplicate
```

**Delete case: (FDB ageout notifications for Vlan 1)**
```
WARNING orchagent: :- meta_sai_on_fdb_event_single: object key SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x26000000000030","mac":"52:54:00:FD:CA:C6","switch_id":"oid:0x21000000000000"} doesn't exist but received AGED event
INFO orchagent: :- update: FdbOrch notification: mac 52:54:00:45:87:81 removed.. event 1.. ret 0
```

```
crm show resources fdb


Resource Name      Used Count    Available Count
---------------  ------------  -----------------
fdb_entry          4294967288               8189

```
