### PR TITLE
[orchagent]: Add internal loopback port logic

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -158,6 +158,10 @@ PortsOrch::PortsOrch(DBConnector *db, vector<string> tableNames) :
     m_cpuPort.m_port_id = attr.value.oid;
     m_portList[m_cpuPort.m_alias] = m_cpuPort;
 
+    /* Create loopback port */
+    m_loopbackPort = Port("lo", Port::LOOPBACK);
+    m_portList[m_loopbackPort.m_alias] = m_loopbackPort;
+
     /* Get port number */
     attr.id = SAI_SWITCH_ATTR_PORT_NUMBER;
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -75,6 +75,7 @@ private:
 
     bool m_initDone = false;
     Port m_cpuPort;
+    Port m_loopbackPort;
     // TODO: Add Bridge/Vlan class
     sai_object_id_t m_default1QBridge;
     sai_object_id_t m_defaultVlan;


### PR DESCRIPTION
While doing service interfaces-config restart, we notice that
loopback interface tear down message won't be generated. Thus,
orchagent will receive duplicate loopback interface generation
messages, which will cause crash.

This commit reuses the logic for regular interfaces to ignore
duplicate messages so that orchagent won't crash when multiple
loopback interface bring up messages are received.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>