### PR TITLE
FdbOrch getPort failed because fdb_entry have no switch_id

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -168,6 +168,7 @@ bool FdbOrch::getPort(const MacAddress& mac, uint16_t vlan, Port& port)
     }
 
     sai_fdb_entry_t entry;
+    entry.switch_id = gSwitchId;
     memcpy(entry.mac_address, mac.getMac(), sizeof(sai_mac_t));
     entry.bv_id = port.m_vlan_info.vlan_oid;
 
@@ -423,6 +424,7 @@ bool FdbOrch::removeFdbEntry(const FdbEntry& entry)
 
     sai_status_t status;
     sai_fdb_entry_t fdb_entry;
+    fdb_entry.switch_id = gSwitchId;
     memcpy(fdb_entry.mac_address, entry.mac.getMac(), sizeof(sai_mac_t));
     fdb_entry.bv_id = entry.bv_id;
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I modified getPort function in FdbOrch, where the key for get_attribute hadn't set switch_id. It was the same for  removeFdbEntry. I just added it like addFdbEntry.
**Why I did it**
I found a bug that mirror didn't work when mirrored to an vlan interface, while ok for port interface.
**How I verified it**
After checking the syslog, I found ERR that said failed to get bridge port ID, while the entry can be found in DB. Then read the source code and I found that meta_key for fdb_entry was serialized as a whole, so the key string included switch_id, so in our case it failed in checking object_exists.
**Details if related**
ERR orchagent: :- getPort: Failed to get bridge port ID for FDB entry 00:1b:21:bb:2f:de, rv:-5