### PR TITLE
[Portsorch]: The mtu configuration on the port cannot be updated if the fec configuration is blank

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1274,6 +1274,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     if (setPortMtu(p.m_port_id, mtu))
                     {
                         p.m_mtu = mtu;
+                        m_portList[alias] = p;
                         SWSS_LOG_NOTICE("Set port %s MTU to %u", alias.c_str(), mtu);
                     }
                     else

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1294,6 +1294,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             p.m_fec_mode = fec_mode_map[fec_mode];
                             if (setPortFec(p.m_port_id, p.m_fec_mode))
                             {
+                                m_portList[alias] = p;
                                 SWSS_LOG_NOTICE("Set port %s fec to %s", alias.c_str(), fec_mode.c_str());
                             }
                             else
@@ -1308,8 +1309,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     {
                         SWSS_LOG_ERROR("Unknown fec mode %s", fec_mode.c_str());
                     }
+
                 }
-                m_portList[alias] = p;
             }
         }
         else

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1294,7 +1294,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             p.m_fec_mode = fec_mode_map[fec_mode];
                             if (setPortFec(p.m_port_id, p.m_fec_mode))
                             {
-                                m_portList[alias] = p;
                                 SWSS_LOG_NOTICE("Set port %s fec to %s", alias.c_str(), fec_mode.c_str());
                             }
                             else
@@ -1309,8 +1308,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     {
                         SWSS_LOG_ERROR("Unknown fec mode %s", fec_mode.c_str());
                     }
-
                 }
+                m_portList[alias] = p;
             }
         }
         else


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Save the value once the mtu configuration of the port is set successfully.
**Why I did it**
Based on the current logic, if the fec configuration is empty or the fec configuration setting fails, the mtu configuration cannot be saved.
**How I verified it**
Through the code logic.
**Details if related**
