### PR TITLE
[crmorch]: neighbor used counter increased twice

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -168,6 +168,7 @@ bool FdbOrch::getPort(const MacAddress& mac, uint16_t vlan, Port& port)
     }
 
     sai_fdb_entry_t entry;
+    entry.switch_id = gSwitchId;
     memcpy(entry.mac_address, mac.getMac(), sizeof(sai_mac_t));
     entry.bv_id = port.m_vlan_info.vlan_oid;
 
@@ -423,6 +424,7 @@ bool FdbOrch::removeFdbEntry(const FdbEntry& entry)
 
     sai_status_t status;
     sai_fdb_entry_t fdb_entry;
+    fdb_entry.switch_id = gSwitchId;
     memcpy(fdb_entry.mac_address, entry.mac.getMac(), sizeof(sai_mac_t));
     fdb_entry.bv_id = entry.bv_id;
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -395,16 +395,16 @@ bool NeighOrch::addNeighbor(NeighborEntry neighborEntry, MacAddress macAddress)
             }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
 
-            return false;
-        }
+            if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
+            {
+                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEIGHBOR);
+            }
+            else
+            {
+                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
+            }
 
-        if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
-        {
-            gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEIGHBOR);
-        }
-        else
-        {
-            gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
+            return false;
         }
     }
     else


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Modified crmorch stats for neighbor used counter. Increase it just after create neighbor entry success. Decrease it when remove neighbor entry success in case of add nexthop failure.

**Why I did it**
Test found bug.

**How I verified it**
By code walkthrough I found neighbor used counter increased both before and after add nexthop.

**Details if related**
before add ipv4 neighbor,the value of crm_stats_ipv4_neighbor_used is 8
3) "crm_stats_ipv4_neighbor_used" 
4) "8"
after add one ipv4 neighbor,the value of crm_stats_ipv4_neighbor_used is 10
3) "crm_stats_ipv4_neighbor_used" 
4) "10"