### PR TITLE
[vlanmgr]: Fix the incorrect ip link del command for vlan remove

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -97,7 +97,7 @@ bool VlanMgr::removeHostVlan(int vlan_id)
     //               /sbin/bridge vlan del vid {{vlan_id}} dev Bridge self"
     const std::string cmds = std::string("")
       + BASH_CMD + " -c \""
-      + IP_CMD + " link add del " + VLAN_PREFIX + std::to_string(vlan_id) + " && "
+      + IP_CMD + " link del " + VLAN_PREFIX + std::to_string(vlan_id) + " && "
       + BRIDGE_CMD + " vlan del vid " + std::to_string(vlan_id) + " dev " + DOT1Q_BRIDGE_NAME + " self\"";
 
     std::string res;


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Fix the incorrect ip link del command for vlan remove.
**Why I did it**
Incorrect IP link del command causes vlanmgr to exit.
**How I verified it**
vlan del command now works:

config vlan add 1200
config vlan del  1200
config vlan add 1200

**Details if related**
