### PR TITLE
Updated CRM test case to check for exact used counter

### DIFF
--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -307,7 +307,7 @@ def test_CrmIpv4Neighbor(dvs):
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_neighbor_used')
     new_avail_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_neighbor_available')
 
-    assert new_used_counter - used_counter >= 1
+    assert new_used_counter - used_counter == 1
     assert avail_counter - new_avail_counter == 1
 
     # remove neighbor and update available counter
@@ -320,7 +320,7 @@ def test_CrmIpv4Neighbor(dvs):
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_neighbor_used')
     new_avail_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv4_neighbor_available')
 
-    assert new_used_counter >= used_counter
+    assert new_used_counter == used_counter
     assert new_avail_counter == avail_counter
 
 
@@ -352,7 +352,7 @@ def test_CrmIpv6Neighbor(dvs):
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_neighbor_used')
     new_avail_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_neighbor_available')
 
-    assert new_used_counter - used_counter >= 1
+    assert new_used_counter - used_counter == 1
     assert avail_counter - new_avail_counter == 1
 
     # remove neighbor and update available counter
@@ -365,7 +365,7 @@ def test_CrmIpv6Neighbor(dvs):
     new_used_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_neighbor_used')
     new_avail_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_ipv6_neighbor_available')
 
-    assert new_used_counter >= used_counter
+    assert new_used_counter == used_counter
     assert new_avail_counter == avail_counter
 
 


### PR DESCRIPTION
**What I did**
Updated CRM test case to check for exact used counter for IPv4/v6 neighbor tables

**Why I did it**
https://github.com/Azure/sonic-swss/pull/472 fixed the double increment for neighbor counters.
This PR is to check for the usage based on exact used counter.

**How I verified it**
Run CRM VS test case (In-progress)

**Details if related**
N/A