### PR TITLE
[counters]: separate query of port/queue counters

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -67,7 +67,9 @@ private:
     unique_ptr<ProducerTable> m_flexCounterTable;
     unique_ptr<ProducerTable> m_flexCounterGroupTable;
 
-    std:: string getFlexCounterTableKey(std::string s);
+    std::string getQueueFlexCounterTableKey(std::string s);
+    std::string getPortFlexCounterTableKey(std::string s);
+
     shared_ptr<DBConnector> m_counter_db;
     shared_ptr<DBConnector> m_flex_db;
 


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Separate port and queue query. By default query port counters every 1s, and queue counters every 10s
**Why I did it**
Querying all queue counters every 1s is cpu consuming. Reducing queue counter query rate helps to reduce cpu overhead. 
**How I verified it**
Tested on DUT.
**Details if related**
