### PR TITLE
[qosorch]: Optimizations of qosorch

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -621,16 +621,6 @@ QosOrch::QosOrch(DBConnector *db, vector<string> &tableNames) : Orch(db, tableNa
     }
 
     initTableHandlers();
-
-    /* Get max child groups count */
-    sai_attribute_t attr;
-    attr.id = SAI_SWITCH_ATTR_QOS_MAX_NUMBER_OF_CHILDS_PER_SCHEDULER_GROUP;
-    sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
-    if (SAI_STATUS_SUCCESS != status)
-    {
-        throw runtime_error("Failed to get number of childs per scheduler group");
-    }
-    m_max_number_of_childs_per_scheduler_group = attr.value.u32;
 };
 
 type_map& QosOrch::getTypeMap()
@@ -885,96 +875,128 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
     return task_process_status::task_success;
 }
 
+sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id_t queue_id)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t            attr;
+    sai_status_t               sai_status;
+
+    const auto it = m_scheduler_group_port_info.find(port.m_port_id);
+    if (it == m_scheduler_group_port_info.end())
+    {
+        /* Get max sched groups count */
+        attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_SCHEDULER_GROUPS;
+        sai_status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
+        if (SAI_STATUS_SUCCESS != sai_status)
+        {
+            SWSS_LOG_ERROR("Failed to get number of scheduler groups for port:%s", port.m_alias.c_str());
+            return SAI_NULL_OBJECT_ID;
+        }
+
+        /* Get total groups list on the port */
+        uint32_t groups_count = attr.value.u32;
+        std::vector<sai_object_id_t> groups(groups_count);
+
+        attr.id = SAI_PORT_ATTR_QOS_SCHEDULER_GROUP_LIST;
+        attr.value.objlist.list = groups.data();
+        attr.value.objlist.count = groups_count;
+        sai_status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
+        if (SAI_STATUS_SUCCESS != sai_status)
+        {
+            SWSS_LOG_ERROR("Failed to get scheduler group list for port:%s", port.m_alias.c_str());
+            return SAI_NULL_OBJECT_ID;
+        }
+
+        m_scheduler_group_port_info[port.m_port_id] = {
+            .groups = std::move(groups),
+            .child_groups = std::vector<std::vector<sai_object_id_t>>(groups_count)
+        };
+     }
+
+    /* Lookup groups to which queue belongs */
+    for (uint32_t ii = 0; ii < m_scheduler_group_port_info[port.m_port_id].groups.size() ; ii++)
+    {
+        const auto& group_id = m_scheduler_group_port_info[port.m_port_id].groups[ii];
+        const auto& child_groups = m_scheduler_group_port_info[port.m_port_id].child_groups[ii];
+        if (child_groups.empty())
+        {
+            attr.id = SAI_SCHEDULER_GROUP_ATTR_CHILD_COUNT;//Number of queues/groups childs added to scheduler group
+            sai_status = sai_scheduler_group_api->get_scheduler_group_attribute(group_id, 1, &attr);
+            if (SAI_STATUS_SUCCESS != sai_status)
+            {
+                SWSS_LOG_ERROR("Failed to get child count for scheduler group:0x%lx of port:%s", group_id, port.m_alias.c_str());
+                return SAI_NULL_OBJECT_ID;
+            }
+
+            uint32_t child_count = attr.value.u32;
+            vector<sai_object_id_t> child_groups(child_count);
+
+            // skip this iteration if there're no children in this group
+            if (child_count == 0)
+            {
+                continue;
+            }
+
+            attr.id = SAI_SCHEDULER_GROUP_ATTR_CHILD_LIST;
+            attr.value.objlist.list = child_groups.data();
+            attr.value.objlist.count = child_count;
+            sai_status = sai_scheduler_group_api->get_scheduler_group_attribute(group_id, 1, &attr);
+            if (SAI_STATUS_SUCCESS != sai_status)
+            {
+                SWSS_LOG_ERROR("Failed to get child list for scheduler group:0x%lx of port:%s", group_id, port.m_alias.c_str());
+                return SAI_NULL_OBJECT_ID;
+            }
+            m_scheduler_group_port_info[port.m_port_id].child_groups[ii] = std::move(child_groups);
+        }
+
+        for (uint32_t jj = 0; jj < m_scheduler_group_port_info[port.m_port_id].child_groups[ii].size(); jj++)
+        {
+            if (m_scheduler_group_port_info[port.m_port_id].child_groups[ii][jj] == queue_id)
+            {
+                return group_id;
+            }
+        }
+    }
+
+    return SAI_NULL_OBJECT_ID;
+}
+
 bool QosOrch::applySchedulerToQueueSchedulerGroup(Port &port, size_t queue_ind, sai_object_id_t scheduler_profile_id)
 {
     SWSS_LOG_ENTER();
-    sai_attribute_t            attr;
-    sai_status_t               sai_status;
-    sai_object_id_t            queue_id;
-    vector<sai_object_id_t>    groups;
-    vector<sai_object_id_t>    child_groups(m_max_number_of_childs_per_scheduler_group);
-    uint32_t                   groups_count     = 0;
 
     if (port.m_queue_ids.size() <= queue_ind)
     {
         SWSS_LOG_ERROR("Invalid queue index specified:%zd", queue_ind);
         return false;
     }
-    queue_id = port.m_queue_ids[queue_ind];
 
-    /* Get max sched groups count */
-    attr.id = SAI_PORT_ATTR_QOS_NUMBER_OF_SCHEDULER_GROUPS;
-    sai_status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
-    if (SAI_STATUS_SUCCESS != sai_status)
+    const sai_object_id_t queue_id = port.m_queue_ids[queue_ind];
+
+    const sai_object_id_t group_id = getSchedulerGroup(port, queue_id);
+    if(group_id == SAI_NULL_OBJECT_ID)
     {
-        SWSS_LOG_ERROR("Failed to get number of scheduler groups for port:%s", port.m_alias.c_str());
         return false;
     }
 
-    /* Get total groups list on the port */
-    groups_count = attr.value.u32;
-    groups.resize(groups_count);
+    /* Apply scheduler profile to all port groups  */
+    sai_attribute_t attr;
+    sai_status_t    sai_status;
 
-    attr.id = SAI_PORT_ATTR_QOS_SCHEDULER_GROUP_LIST;
-    attr.value.objlist.list = groups.data();
-    attr.value.objlist.count = groups_count;
-    sai_status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
+    attr.id = SAI_SCHEDULER_GROUP_ATTR_SCHEDULER_PROFILE_ID;
+    attr.value.oid = scheduler_profile_id;
+
+    sai_status = sai_scheduler_group_api->set_scheduler_group_attribute(group_id, &attr);
     if (SAI_STATUS_SUCCESS != sai_status)
     {
-        SWSS_LOG_ERROR("Failed to get scheduler group list for port:%s", port.m_alias.c_str());
+        SWSS_LOG_ERROR("Failed applying scheduler profile:0x%lx to scheduler group:0x%lx, port:%s", scheduler_profile_id, group_id, port.m_alias.c_str());
         return false;
     }
 
-    /* Lookup groups to which queue belongs */
-    for (uint32_t ii = 0; ii < groups_count ; ii++)
-    {
-        uint32_t child_count = 0;
+    SWSS_LOG_DEBUG("port:%s, scheduler_profile_id:0x%lx applied to scheduler group:0x%lx", port.m_alias.c_str(), scheduler_profile_id, group_id);
 
-        attr.id = SAI_SCHEDULER_GROUP_ATTR_CHILD_COUNT;//Number of queues/groups childs added to scheduler group
-        sai_status = sai_scheduler_group_api->get_scheduler_group_attribute(groups[ii], 1, &attr);
-        child_count = attr.value.u32;
-        if (SAI_STATUS_SUCCESS != sai_status)
-        {
-            SWSS_LOG_ERROR("Failed to get child count for scheduler group:0x%lx of port:%s", groups[ii], port.m_alias.c_str());
-            return false;
-        }
-
-        // skip this iteration if there're no children in this group
-        if (child_count == 0)
-        {
-            continue;
-        }
-
-        attr.id = SAI_SCHEDULER_GROUP_ATTR_CHILD_LIST;
-        attr.value.objlist.list = child_groups.data();
-        attr.value.objlist.count = child_count;
-        sai_status = sai_scheduler_group_api->get_scheduler_group_attribute(groups[ii], 1, &attr);
-        if (SAI_STATUS_SUCCESS != sai_status)
-        {
-            SWSS_LOG_ERROR("Failed to get child list for scheduler group:0x%lx of port:%s", groups[ii], port.m_alias.c_str());
-            return false;
-        }
-
-        for (uint32_t jj = 0; jj < child_count; jj++)
-        {
-            if (child_groups[jj] != queue_id)
-            {
-                continue;
-            }
-
-            attr.id = SAI_SCHEDULER_GROUP_ATTR_SCHEDULER_PROFILE_ID;
-            attr.value.oid = scheduler_profile_id;
-            sai_status = sai_scheduler_group_api->set_scheduler_group_attribute(groups[ii], &attr);
-            if (SAI_STATUS_SUCCESS != sai_status)
-            {
-                SWSS_LOG_ERROR("Failed applying scheduler profile:0x%lx to scheduler group:0x%lx, port:%s", scheduler_profile_id, groups[ii], port.m_alias.c_str());
-                return false;
-            }
-            SWSS_LOG_DEBUG("port:%s, scheduler_profile_id:0x%lx applied to scheduler group:0x%lx", port.m_alias.c_str(), scheduler_profile_id, groups[ii]);
-            return true;
-        }
-    }
-    return false;
+    return true;
 }
 
 bool QosOrch::applyWredProfileToQueue(Port &port, size_t queue_ind, sai_object_id_t sai_wred_profile)

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -2,6 +2,8 @@
 #define SWSS_QOSORCH_H
 
 #include <map>
+#include <unordered_map>
+#include <unordered_set>
 #include "orch.h"
 #include "portsorch.h"
 
@@ -132,6 +134,8 @@ private:
     task_process_status handleQueueTable(Consumer& consumer);
     task_process_status handleWredProfileTable(Consumer& consumer);
 
+    sai_object_id_t getSchedulerGroup(const Port &port, const sai_object_id_t queue_id);
+
     bool applyMapToPort(Port &port, sai_attr_id_t attr_id, sai_object_id_t sai_dscp_to_tc_map);
     bool applySchedulerToQueueSchedulerGroup(Port &port, size_t queue_ind, sai_object_id_t scheduler_profile_id);
     bool applyWredProfileToQueue(Port &port, size_t queue_ind, sai_object_id_t sai_wred_profile);
@@ -140,6 +144,13 @@ private:
 
 private:
     qos_table_handler_map m_qos_handler_map;
-    sai_uint32_t m_max_number_of_childs_per_scheduler_group;
+
+    struct SchedulerGroupPortInfo_t
+    {
+        std::vector<sai_object_id_t> groups;
+        std::vector<std::vector<sai_object_id_t>> child_groups;
+    };
+
+    std::unordered_map<sai_object_id_t, SchedulerGroupPortInfo_t> m_scheduler_group_port_info;
 };
 #endif /* SWSS_QOSORCH_H */

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -140,5 +140,6 @@ private:
 
 private:
     qos_table_handler_map m_qos_handler_map;
+    sai_uint32_t m_max_number_of_childs_per_scheduler_group;
 };
 #endif /* SWSS_QOSORCH_H */


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Optimized qosorch to make it run faster. I'm caching intermediate results, to avoid re-request the information which was already requested from ASIC.

**Why I did it**
It reduces qosorch working time significantly. For example on the target platform it was reduced by 4 secs.
Here the statistics of SAI requests before and after the change:
Before:
```
    128 SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP - 128 set
    832 SAI_OBJECT_TYPE_PORT                   - 512 get, 320 set
    128 SAI_OBJECT_TYPE_QUEUE                  - 128 set 
   2304 SAI_OBJECT_TYPE_SCHEDULER_GROUP        - 256 set, 2048 get
    256 SAI_OBJECT_TYPE_SWITCH                 - 256 get
   2816 SAI_STATUS_SUCCESS                     - results of get
```

After:
```
    128 SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP - 128 set
    448 SAI_OBJECT_TYPE_PORT                   - 128 get, 320 set
    128 SAI_OBJECT_TYPE_QUEUE                  - 128 set 
   1024 SAI_OBJECT_TYPE_SCHEDULER_GROUP        - 256 set, 768 get
      0 SAI_OBJECT_TYPE_SWITCH                 - 0 get
    896 SAI_STATUS_SUCCESS                     - results of get
```

**How I verified it**
Build and check sairedis.rec. You should see only one get of this attribute from the switch.

**Details if related**
