### PR TITLE
Populate existing interface cache, bring down before configDone

### DIFF
--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -179,6 +179,7 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
             vector<FieldValueTuple> vector;
             vector.push_back(tuple);
             m_statePortTable.set(key, vector);
+            SWSS_LOG_INFO("Publish %s(ok) to state db", key.c_str());
         }
 
         m_portTableProducer.set(key, fvVector);

--- a/portsyncd/linksync.h
+++ b/portsyncd/linksync.h
@@ -23,6 +23,7 @@ private:
     Table m_portTable, m_statePortTable;
 
     std::map<unsigned int, std::string> m_ifindexNameMap;
+    std::map<unsigned int, std::string> m_ifindexOldNameMap;
 };
 
 }


### PR DESCRIPTION
**What I did**
During swss initialization, iterate through the existing kernel interfaces and populate cache. Also bring down the _old_ interfaces during initialization 

**Why I did it**
During swss initialization (swss restart, load minigraph), it was observed that sometimes Netlink messages are generated for _old_ kernel interfaces which incorrectly results in populating the state_db and notifying subscribers as interface create. By having the old interface cache, this Netlink messages could be ignored. 

**How I verified it**
Do config load_minigraph, service swss restart and verify logs

**Details if related**
The following logs are meant to show the `ifindexes ` and `timestamps `on when it is added to `state_db`
```
May  1 01:07:44.661599 str-s6100-acs-5 INFO supervisord: portsyncd Existing ifname Ethernet52 index 95
May  1 01:07:44.661651 str-s6100-acs-5 INFO supervisord: portsyncd Executing ip link set Ethernet52 down - ifindex 95
May  1 01:07:44.672936 str-s6100-acs-5 INFO supervisord: portsyncd Existing ifname Ethernet53 index 96
May  1 01:07:44.672936 str-s6100-acs-5 INFO supervisord: portsyncd Executing ip link set Ethernet53 down - ifindex 96
May  1 01:07:44.680075 str-s6100-acs-5 INFO supervisord: portsyncd Existing ifname Ethernet54 index 97
May  1 01:07:44.680075 str-s6100-acs-5 INFO supervisord: portsyncd Executing ip link set Ethernet54 down - ifindex 97
May  1 01:07:44.686330 str-s6100-acs-5 INFO supervisord: portsyncd Existing ifname Ethernet55 index 98
May  1 01:07:44.687798 str-s6100-acs-5 INFO supervisord: portsyncd Executing ip link set Ethernet55 down - ifindex 98
May  1 01:07:44.692745 str-s6100-acs-5 INFO supervisord: portsyncd Existing ifname Ethernet34 index 99
May  1 01:07:44.692745 str-s6100-acs-5 INFO supervisord: portsyncd Executing ip link set Ethernet34 down - ifindex 99
..
May  1 01:07:44.956949 str-s6100-acs-5 INFO supervisord: portsyncd Existing ifname Ethernet36 index 157
May  1 01:07:44.957011 str-s6100-acs-5 INFO supervisord: portsyncd Executing ip link set Ethernet36 down - ifindex 157
May  1 01:07:44.960543 str-s6100-acs-5 INFO supervisord: portsyncd Existing ifname Ethernet37 index 158
May  1 01:07:44.960602 str-s6100-acs-5 INFO supervisord: portsyncd Executing ip link set Ethernet37 down - ifindex 158


May  1 01:09:35.404282 str-s6100-acs-5 NOTICE portsyncd: :- onMsg: Adding to state db Ethernet52, 184
May  1 01:09:35.490402 str-s6100-acs-5 NOTICE portsyncd: :- onMsg: Adding to state db Ethernet53, 185
May  1 01:09:35.577087 str-s6100-acs-5 NOTICE portsyncd: :- onMsg: Adding to state db Ethernet54, 186
..
May  1 01:09:45.309125 str-s6100-acs-5 NOTICE portsyncd: :- onMsg: Adding to state db Ethernet39, 245
May  1 01:09:45.671632 str-s6100-acs-5 NOTICE portsyncd: :- onMsg: Adding to state db Ethernet36, 246
May  1 01:09:45.843315 str-s6100-acs-5 NOTICE portsyncd: :- onMsg: Adding to state db Ethernet37, 247
```
