### PR TITLE
[lua]: use not command to check whether the field exists

### DIFF
--- a/orchagent/pfc_restore.lua
+++ b/orchagent/pfc_restore.lua
@@ -24,7 +24,7 @@ for i = n, 1, -1 do
     if not big_red_switch_mode and pfc_wd_status ~= 'operational'  and pfc_wd_action ~= 'alert' and restoration_time and restoration_time ~= '' then
         restoration_time = tonumber(restoration_time)
         local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME_LEFT')
-        if time_left == nil then
+        if not time_left then
             time_left = restoration_time
         else
             time_left = tonumber(time_left)


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Use not command to check whether the field exists
**Why I did it**
Redis will convert nil to false in lua script. Need to use "not a" instead of "a==nil"

Redis to Lua conversion table.
Redis integer reply -> Lua number
Redis bulk reply -> Lua string
Redis multi bulk reply -> Lua table (may have other Redis data types nested)
Redis status reply -> Lua table with a single ok field containing the status
Redis error reply -> Lua table with a single err field containing the error
**Redis Nil bulk reply and Nil multi bulk reply -> Lua false boolean type**

**How I verified it**

**Details if related**
