### PR TITLE
 Fix issue with update ACL TABLE CRM error

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1085,7 +1085,8 @@ bool AclTable::create()
 
     if (status == SAI_STATUS_SUCCESS)
     {
-        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, (sai_acl_stage_t) attr.value.s32, SAI_ACL_BIND_POINT_TYPE_PORT);
+        sai_acl_stage_t acl_stage = (stage == ACL_STAGE_INGRESS) ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS;
+        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, acl_stage, SAI_ACL_BIND_POINT_TYPE_PORT);
     }
 
     return status == SAI_STATUS_SUCCESS;

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1042,8 +1042,7 @@ bool AclTable::create()
 
     if (status == SAI_STATUS_SUCCESS)
     {
-        sai_acl_stage_t acl_stage = (stage == ACL_STAGE_INGRESS) ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS;
-        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, acl_stage, SAI_ACL_BIND_POINT_TYPE_PORT);
+        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, (sai_acl_stage_t) attr.value.s32, SAI_ACL_BIND_POINT_TYPE_PORT);
     }
 
     return status == SAI_STATUS_SUCCESS;

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1042,7 +1042,8 @@ bool AclTable::create()
 
     if (status == SAI_STATUS_SUCCESS)
     {
-        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, (sai_acl_stage_t) attr.value.s32, SAI_ACL_BIND_POINT_TYPE_PORT);
+        sai_acl_stage_t acl_stage = (stage == ACL_STAGE_INGRESS) ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS;
+        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, acl_stage, SAI_ACL_BIND_POINT_TYPE_PORT);
     }
 
     return status == SAI_STATUS_SUCCESS;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -553,7 +553,9 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
             port.m_egress_acl_table_group_id = groupOid;
         }
 
-        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP, (sai_acl_stage_t) group_attr.value.s32, SAI_ACL_BIND_POINT_TYPE_PORT);
+        sai_acl_stage_t acl_stage = ingress ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS;
+		
+        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP, acl_stage, SAI_ACL_BIND_POINT_TYPE_PORT);
 
         switch (port.m_type)
         {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2209,6 +2209,12 @@ bool PortsOrch::addLag(string lag_alias)
     lag.m_members = set<string>();
     m_portList[lag_alias] = lag;
 
+    /* Add lag name map to counter table */
+    FieldValueTuple tuple(lag_alias, sai_serialize_object_id(lag_id));
+    vector<FieldValueTuple> fields;
+    fields.push_back(tuple);
+    m_counterTable->set("", fields);
+
     return true;
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -553,9 +553,7 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
             port.m_egress_acl_table_group_id = groupOid;
         }
 
-        sai_acl_stage_t acl_stage = ingress ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS;
-		
-        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP, acl_stage, SAI_ACL_BIND_POINT_TYPE_PORT);
+        gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP, (sai_acl_stage_t) group_attr.value.s32, SAI_ACL_BIND_POINT_TYPE_PORT);
 
         switch (port.m_type)
         {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1274,6 +1274,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     if (setPortMtu(p.m_port_id, mtu))
                     {
                         p.m_mtu = mtu;
+                        m_portList[alias] = p;
                         SWSS_LOG_NOTICE("Set port %s MTU to %u", alias.c_str(), mtu);
                     }
                     else

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2209,12 +2209,6 @@ bool PortsOrch::addLag(string lag_alias)
     lag.m_members = set<string>();
     m_portList[lag_alias] = lag;
 
-    /* Add lag name map to counter table */
-    FieldValueTuple tuple(lag_alias, sai_serialize_object_id(lag_id));
-    vector<FieldValueTuple> fields;
-    fields.push_back(tuple);
-    m_counterTable->set("", fields);
-
     return true;
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1294,6 +1294,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             p.m_fec_mode = fec_mode_map[fec_mode];
                             if (setPortFec(p.m_port_id, p.m_fec_mode))
                             {
+                                m_portList[alias] = p;
                                 SWSS_LOG_NOTICE("Set port %s fec to %s", alias.c_str(), fec_mode.c_str());
                             }
                             else
@@ -1308,8 +1309,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     {
                         SWSS_LOG_ERROR("Unknown fec mode %s", fec_mode.c_str());
                     }
+
                 }
-                m_portList[alias] = p;
             }
         }
         else

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1294,7 +1294,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             p.m_fec_mode = fec_mode_map[fec_mode];
                             if (setPortFec(p.m_port_id, p.m_fec_mode))
                             {
-                                m_portList[alias] = p;
                                 SWSS_LOG_NOTICE("Set port %s fec to %s", alias.c_str(), fec_mode.c_str());
                             }
                             else
@@ -1309,8 +1308,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     {
                         SWSS_LOG_ERROR("Unknown fec mode %s", fec_mode.c_str());
                     }
-
                 }
+                m_portList[alias] = p;
             }
         }
         else

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -679,7 +679,7 @@ sai_object_id_t QosOrch::initSystemAclTable()
     }
     SWSS_LOG_NOTICE("Create a system ACL table for ECN coloring");
 
-    gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, (sai_acl_stage_t) attr.value.s32, SAI_ACL_BIND_POINT_TYPE_PORT);
+    gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, SAI_ACL_STAGE_INGRESS, SAI_ACL_BIND_POINT_TYPE_PORT);
 
     for (auto& pair: gPortsOrch->getAllPorts())
     {

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -679,7 +679,7 @@ sai_object_id_t QosOrch::initSystemAclTable()
     }
     SWSS_LOG_NOTICE("Create a system ACL table for ECN coloring");
 
-    gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, SAI_ACL_STAGE_INGRESS, SAI_ACL_BIND_POINT_TYPE_PORT);
+    gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, (sai_acl_stage_t) attr.value.s32, SAI_ACL_BIND_POINT_TYPE_PORT);
 
     for (auto& pair: gPortsOrch->getAllPorts())
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
 Fix issue with update ACL TABLE CRM error

**Why I did it**
when execute command "crm show resource all", it display wrong used count on acl_table. the ingress used acl_table was counted to egress used. from the code, when it call function gCrmOrch->incCrmAclUsedCounter, the second parameter is the acl stage, but the code use a variable attr.value.s32 which has been modified, it is not equal to acl stage any more.

**How I verified it**
I make a new swss_1.0.0_amd64.deb, and update it to switch. after reboot, when execute "crm show resource all", it can display the acl_table used count correctly.

**Details if related**
