### PR TITLE
[teamsyncd]: Add team_ifindex2ifname return value check

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -160,11 +160,19 @@ int TeamSync::TeamPortSync::onChange()
         bool enabled;
 
         ifindex = team_get_port_ifindex(port);
-        team_ifindex2ifname(m_team, ifindex, ifname, MAX_IFNAME);
+
+        /* Skip if interface is not found */
+        if (!team_ifindex2ifname(m_team, ifindex, ifname, MAX_IFNAME))
+        {
+            SWSS_LOG_INFO("Interface ifindex(%u) is not found", ifindex);
+            continue;
+        }
 
         /* Skip the member that is removed from the LAG */
         if (team_is_port_removed(port))
+        {
             continue;
+        }
 
         team_get_port_enabled(m_team, ifindex, &enabled);
         tmp_lag_members[string(ifname)] = enabled;


### PR DESCRIPTION
Without the return value check, it is possible that ifname is
empty due to interface not found.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
