### PR TITLE
[crmorch]: neighbor used counter increased twice (#472) - Cherry-pick to 201803 branch

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -395,16 +395,16 @@ bool NeighOrch::addNeighbor(NeighborEntry neighborEntry, MacAddress macAddress)
             }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
 
-            return false;
-        }
+            if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
+            {
+                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEIGHBOR);
+            }
+            else
+            {
+                gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
+            }
 
-        if (neighbor_entry.ip_address.addr_family == SAI_IP_ADDR_FAMILY_IPV4)
-        {
-            gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV4_NEIGHBOR);
-        }
-        else
-        {
-            gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV6_NEIGHBOR);
+            return false;
         }
     }
     else


### PR DESCRIPTION
* [crmorch]: neighbor used counter increased twice

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Cherry-picked the https://github.com/Azure/sonic-swss/pull/472 PR
**Why I did it**
The bug with duplicate neighbor count is present in 201803 branch
**How I verified it**
1) `crm show resources ipv4 neighbor` shows 0
2) Adding 10 neighbors
3) `crm show resources ipv4 neighbor` shows 10
**Details if related**
