### PR TITLE
fix SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH value type mismatch bug on 201803 branch

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -245,7 +245,7 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
                 attribs.push_back(attr);
 
                 attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH;
-                attr.value.u32 = (uint32_t)stoul(value);
+                attr.value.s8 = (sai_int8_t)stol(value);
                 attribs.push_back(attr);
             }
             else if (field == buffer_static_th_field_name)

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -593,7 +593,7 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ing
     attribs.push_back(attr);
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH;
-    attr.value.u32 = -8; // ALPHA_0
+    attr.value.s8 = -8; // ALPHA_0
     attribs.push_back(attr);
 
     status = sai_buffer_api->create_buffer_profile(


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
fix SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH value type mismatch bug
**Why I did it**
according to SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH defination in saibuffer.h:
/**
* @brief Dynamic threshold for the shared usage
*
* The threshold is set to the 2^n of available buffer of the pool.
*
* @type sai_int8_t
* @flags MANDATORY_ON_CREATE | CREATE_AND_SET
* @condition SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE == SAI_BUFFER_PROFILE_THRESHOLD_MODE_DYNAMIC
*/
SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH,

the value type is a sai_int8_t, support negative value

on centec goldengate chip platform, we support range [-7, 3],
but currnetly in swss, uint32 type value is used, have to fix it
**How I verified it**

    build success
    startup and init success
    set a negative value to SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH

**Details if related**
same as https://github.com/Azure/sonic-swss/pull/495
merge to branch 201803