### PR TITLE
[portsorch]: Don't print error when alias equal to PortConfigDone

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1220,7 +1220,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
             }
 
             Port p;
-            if (!getPort(alias, p))
+            if (!getPort(alias, p) && alias != "PortConfigDone")
             {
                 SWSS_LOG_ERROR("Failed to get port id by alias:%s", alias.c_str());
             }
@@ -1332,7 +1332,9 @@ void PortsOrch::doPortTask(Consumer &consumer)
             }
         }
         else
+        {
             SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+        }
 
         it = consumer.m_toSync.erase(it);
     }


### PR DESCRIPTION
Don't print 'orchagent: :- doPortTask: Failed to get port id by alias PortConfigDone error'

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Don't print 'orchagent: :- doPortTask: Failed to get port id by alias PortConfigDone error'

**Why I did it**
Because this error message was an error

**How I verified it**
Build swss and run it

**Details if related**
