### PR TITLE
[aclorch]: remove SAI_ACL_TABLE_ATTR_FIELD_TC from data/mirror acl type

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1058,10 +1058,6 @@ bool AclTable::create()
     attr.value.booldata = true;
     table_attrs.push_back(attr);
 
-    attr.id = SAI_ACL_TABLE_ATTR_FIELD_TC;
-    attr.value.booldata = true;
-    table_attrs.push_back(attr);
-
     if(stage == ACL_STAGE_INGRESS)
     {
         attr.id = SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE;


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove SAI_ACL_TABLE_ATTR_FIELD_TC from data/mirror acl type
**Why I did it**
SAI_ACL_TABLE_ATTR_FIELD_TC is a qualifier specific for ACL_PFC_WD type. So remove it for other L3/mirror ACL type.
**How I verified it**

**Details if related**
