### PR TITLE
[portsorch]: Rewrite validatePortSpeed() method. Use true lazy approach

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1238,7 +1238,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                     if (!validatePortSpeed(p.m_port_id, speed))
                     {
-                        SWSS_LOG_ERROR("Failed to set speed %u for port %s. The value is not supported", speed, alias.c_str());
                         it++;
                         continue;
                     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -771,10 +771,11 @@ bool PortsOrch::validatePortSpeed(const std::string& alias, sai_object_id_t port
         std::vector<sai_uint32_t> speeds(size_guess);
 
         for (int attempt = 0; attempt < 2; ++attempt) // two attempts to get our value
-        {                                             // first with the guess, 
+        {                                             // first with the guess,
                                                       // other with the returned value
+            attr.id = SAI_PORT_ATTR_SUPPORTED_SPEED;
             attr.value.u32list.count = static_cast<uint32_t>(speeds.size());
-            attr.value.u32list.list  = speeds.data();
+            attr.value.u32list.list = speeds.data();
 
             status = sai_port_api->get_port_attribute(port_id, 1, &attr);
             if (status != SAI_STATUS_BUFFER_OVERFLOW)

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -134,7 +134,7 @@ private:
 
     bool setBridgePortAdminStatus(sai_object_id_t id, bool up);
 
-    bool validatePortSpeed(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
+    bool isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
     bool setPortSpeed(sai_object_id_t port_id, sai_uint32_t speed);
     bool getPortSpeed(sai_object_id_t port_id, sai_uint32_t &speed);
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -134,7 +134,7 @@ private:
 
     bool setBridgePortAdminStatus(sai_object_id_t id, bool up);
 
-    bool validatePortSpeed(sai_object_id_t port_id, sai_uint32_t speed);
+    bool validatePortSpeed(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
     bool setPortSpeed(sai_object_id_t port_id, sai_uint32_t speed);
     bool getPortSpeed(sai_object_id_t port_id, sai_uint32_t &speed);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I've overwritten validatePortSpeed() method of PortsOrch class. Also I've rename it to more suitable `isSpeedSupported`.
 Previously:
1. The method tried to get the speed list many times if this operation is not supported by platform
2. The method use two get operations to get the list, currently it should be one in the most cases.
3. The method returns false if:
    1. internally it gets any error except NOT_SUPPORTED and NOT_IMPLEMENTED
    2. the `speed` is not found in the list of speeds.
Now:
1. the number of SAI GET operations are minimized.
2. the function return false only if we get a list of speeds and the requested `speed` not in the list of successfully returned supported speeds. Otherwise it's always true.

**Why I did it**
Because this method slowed fast-reboot operations down (multiple get operations). 
Also this method gave a noise with false ERRORs in the syslog.

**How I verified it**
Build and run on my DUT

**Details if related**
