### PR TITLE
Suppress Cable length errors in case pg profile lookup file is not provided

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -34,6 +34,8 @@ void BufferMgr::readPgProfileLookupFile(string file)
     ifstream infile(file);
     if (!infile.is_open())
     {
+        m_pgfile_readable = false;
+        SWSS_LOG_WARN("PG profile lookup file: %s is not readable", file.c_str());
         return;
     }
 
@@ -211,7 +213,7 @@ void BufferMgr::doTask(Consumer &consumer)
                     task_status = doCableTask(fvField(i), fvValue(i));
                 }
                 // In case of PORT table update, Buffer Manager is interested in speed update only
-                if (table_name == CFG_PORT_TABLE_NAME && fvField(i) == "speed")
+                if (m_pgfile_readable && table_name == CFG_PORT_TABLE_NAME && fvField(i) == "speed")
                 {
                     // create/update profile for port
                     task_status = doSpeedUpdateTask(port, fvValue(i));

--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -31,10 +31,11 @@ void BufferMgr::readPgProfileLookupFile(string file)
 {
     SWSS_LOG_NOTICE("Read lookup configuration file...");
 
+    m_pgfile_processed = false;
+
     ifstream infile(file);
     if (!infile.is_open())
     {
-        m_pgfile_readable = false;
         SWSS_LOG_WARN("PG profile lookup file: %s is not readable", file.c_str());
         return;
     }
@@ -71,6 +72,7 @@ void BufferMgr::readPgProfileLookupFile(string file)
                        );
     }
 
+    m_pgfile_processed = true;
     infile.close();
 }
 
@@ -213,7 +215,7 @@ void BufferMgr::doTask(Consumer &consumer)
                     task_status = doCableTask(fvField(i), fvValue(i));
                 }
                 // In case of PORT table update, Buffer Manager is interested in speed update only
-                if (m_pgfile_readable && table_name == CFG_PORT_TABLE_NAME && fvField(i) == "speed")
+                if (m_pgfile_processed && table_name == CFG_PORT_TABLE_NAME && fvField(i) == "speed")
                 {
                     // create/update profile for port
                     task_status = doSpeedUpdateTask(port, fvValue(i));

--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -39,7 +39,7 @@ private:
     Table m_cfgBufferProfileTable;
     Table m_cfgBufferPgTable;
     Table m_cfgLosslessPgPoolTable;
-    bool m_pgfile_readable = true;
+    bool m_pgfile_processed;
 
     pg_profile_lookup_t m_pgProfileLookup;
     port_cable_length_t m_cableLenLookup;

--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -39,6 +39,7 @@ private:
     Table m_cfgBufferProfileTable;
     Table m_cfgBufferPgTable;
     Table m_cfgLosslessPgPoolTable;
+    bool m_pgfile_readable = true;
 
     pg_profile_lookup_t m_pgProfileLookup;
     port_cable_length_t m_cableLenLookup;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Suppress the error messages like below
May 19 07:39:02.473125 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet0. Cable length is not set
If we don't have pg_profile_lookup.ini file provided.

**Why I did it**
In some platform, pg_profile_lookup.ini is not provided and we don't need this buffer management feature. 

Today the code is repeating these messages:
May 19 07:39:02.473125 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet0. Cable length is not set
May 19 07:39:02.473362 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet1. Cable length is not set
May 19 07:39:02.473558 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet10. Cable length is not set
May 19 07:39:02.473717 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet100. Cable length is not set
May 19 07:39:02.473872 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet102. Cable length is not set
May 19 07:39:02.474061 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet104. Cable length is not set
May 19 07:39:02.474248 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet106. Cable length is not set
May 19 07:39:02.474404 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet108. Cable length is not set
May 19 07:39:02.474557 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet11. Cable length is not set
May 19 07:39:02.474710 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet110. Cable length is not set
May 19 07:39:02.474864 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet112. Cable length is not set
May 19 07:39:02.475018 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet114. Cable length is not set
May 19 07:39:02.475171 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet116. Cable length is not set
May 19 07:39:02.475325 sonic NOTICE buffermgrd: :- doSpeedUpdateTask: Unable to create/update PG profile for port Ethernet118. Cable length is not set
We should disable this error messages.

**How I verified it**
With the fix, no error messages were seen.

**Details if related**
