### PR TITLE
Raise the priority of LAG_TABLE to 44 so it has precedence over VLAN_…

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -56,7 +56,7 @@ bool OrchDaemon::init()
         { APP_PORT_TABLE_NAME,        portsorch_base_pri + 5 },
         { APP_VLAN_TABLE_NAME,        portsorch_base_pri + 2 },
         { APP_VLAN_MEMBER_TABLE_NAME, portsorch_base_pri     },
-        { APP_LAG_TABLE_NAME,         portsorch_base_pri + 2 },
+        { APP_LAG_TABLE_NAME,         portsorch_base_pri + 4 },
         { APP_LAG_MEMBER_TABLE_NAME,  portsorch_base_pri     }
     };
 


### PR DESCRIPTION
…TABLE in orchagent processing

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Raise the priority of LAG_TABLE to 44 so it has precedence over VLAN_TABLE in orchagent processing
**Why I did it**
LAG could be member of VLAN,  lag table should have higher priority than vlan table.

**How I verified it**

**Details if related**
