### PR TITLE
[Aclorch] hard code table name separator to make it compatible with 201803 branch

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -12,6 +12,8 @@
 using namespace std;
 using namespace swss;
 
+#define DB_TABLE_NAME_SEPARATOR_VBAR '|'
+
 mutex AclOrch::m_countersMutex;
 map<acl_range_properties_t, AclRange*> AclRange::m_ranges;
 condition_variable AclOrch::m_sleepGuard;
@@ -1550,7 +1552,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
     {
         KeyOpFieldsValuesTuple t = it->second;
         string key = kfvKey(t);
-        size_t found = key.find(consumer.getConsumerTable()->getTableNameSeparator().c_str());
+        size_t found = key.find(DB_TABLE_NAME_SEPARATOR_VBAR);
         string table_id = key.substr(0, found);
         string op = kfvOp(t);
 
@@ -1650,7 +1652,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
     {
         KeyOpFieldsValuesTuple t = it->second;
         string key = kfvKey(t);
-        size_t found = key.find(consumer.getConsumerTable()->getTableNameSeparator().c_str());
+        size_t found = key.find(DB_TABLE_NAME_SEPARATOR_VBAR);
         string table_id = key.substr(0, found);
         string rule_id = key.substr(found + 1);
         string op = kfvOp(t);
@@ -1739,7 +1741,7 @@ void AclOrch::doAclTablePortUpdateTask(Consumer &consumer)
     {
         KeyOpFieldsValuesTuple t = it->second;
         string key = kfvKey(t);
-        size_t found = key.find(consumer.getConsumerTable()->getTableNameSeparator().c_str());
+        size_t found = key.find(DB_TABLE_NAME_SEPARATOR_VBAR);
         string port_alias = key.substr(0, found);
         string op = kfvOp(t);
 


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Hard code the table name separator with a Macro instead of getting it by calling swss-common functions.

**Why I did it**
On the 201803 branch, the swss-common submodule have an issue when the table obeject constructed without a table separator, to make the fix  #https://github.com/Azure/sonic-buildimage/pull/1712 also work on the branch, so make this change.

**How I verified it**
Run ACL/Everflow/CRM test.

**Details if related**
If decided to update the swss-common submodule on the branch, then this PR not needed anymore.
