### PR TITLE
[fdborch]: Fix 'double free' bug in fdb event handler

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -352,9 +352,9 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
             }
 
             this->update(fdbevent[i].event_type, &fdbevent[i].fdb_entry, oid);
-
-            sai_deserialize_free_fdb_event_ntf(count, fdbevent);
         }
+
+        sai_deserialize_free_fdb_event_ntf(count, fdbevent);
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix a bug which could cause to free the same memory twice.

**Why I did it**
To fix a segmentation fault in case we got 'count' variable greater than 1.

**How I verified it**
Build and run on DUT.

**Details if related**
