### PR TITLE
Postpone intf task after buffer configuration applied on the port.

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -10,6 +10,7 @@
 #include "swssnet.h"
 #include "tokenize.h"
 #include "crmorch.h"
+#include "bufferorch.h"
 
 extern sai_object_id_t gVirtualRouterId;
 
@@ -20,6 +21,7 @@ extern sai_neighbor_api_t*          sai_neighbor_api;
 extern PortsOrch *gPortsOrch;
 extern sai_object_id_t gSwitchId;
 extern CrmOrch *gCrmOrch;
+extern BufferOrch *gBufferOrch;
 
 const int intfsorch_pri = 35;
 
@@ -93,6 +95,13 @@ void IntfsOrch::doTask(Consumer &consumer)
             if (!gPortsOrch->getPort(alias, port))
             {
                 /* TODO: Resolve the dependency relationship and add ref_count to port */
+                it++;
+                continue;
+            }
+
+            // buffer configuration hasn't been applied yet, hold from intf config.
+            if (!gBufferOrch->isPortReady(alias))
+            {
                 it++;
                 continue;
             }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -116,7 +116,7 @@ bool OrchDaemon::init()
         CFG_DTEL_EVENT_TABLE_NAME
     };
 
-    m_orchList = { switch_orch, gCrmOrch, gPortsOrch, intfs_orch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, gBufferOrch, mirror_orch };
+    m_orchList = { switch_orch, gCrmOrch, gBufferOrch, gPortsOrch, intfs_orch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, mirror_orch };
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)
@@ -155,7 +155,7 @@ bool OrchDaemon::init()
     m_orchList.push_back(gAclOrch);
     m_orchList.push_back(gFdbOrch);
     m_orchList.push_back(vrf_orch);
-    
+
     m_select = new Select();
 
 


### PR DESCRIPTION
This also ensures all port setting applied before intf setting.

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Don't apply intf setting on a port before buffer applied on the port.
The order of orches in  m_orchList guaranteed that for pending tasks, buffer is processed before port, port before intf.

**Why I did it**
There is racing condition that, even when "PortInitDone" has been received and m_initDone set  true,  buffer configuration hasn't been applied.  

https://github.com/Azure/sonic-swss/blob/dcf6c905410f08b004e880dbed56823d29e7bd5e/orchagent/portsorch.cpp#L1360

mtu setting for port will be postponed, while IntfsOrch::doTask() only checks gPortsOrch->isInitDone().  For router interface creation,  it uses default port mtu which may be different from the one to be configured.

Seen with VS, potentially also may happen on hardware box.

swss.rec, check Ethernet4
```
2018-07-19.03:38:11.402835|PORT_TABLE:Ethernet4|SET|admin_status:up|mtu:1500
2018-07-19.03:38:11.402840|PORT_TABLE:Ethernet112|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402851|PORT_TABLE:Ethernet100|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402857|PORT_TABLE:Ethernet124|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402862|PORT_TABLE:Ethernet88|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402867|PORT_TABLE:Ethernet76|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402872|PORT_TABLE:Ethernet84|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402877|PORT_TABLE:Ethernet8|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402882|PORT_TABLE:Ethernet96|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402887|PORT_TABLE:Ethernet68|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402892|PORT_TABLE:Ethernet44|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402897|PORT_TABLE:Ethernet48|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402902|PORT_TABLE:Ethernet24|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402907|PORT_TABLE:Ethernet12|SET|admin_status:down|mtu:1500
2018-07-19.03:38:11.402912|PORT_TABLE:Ethernet16|SET|admin_status:down|mtu:1500

2018-07-19.03:38:11.402916|PORT_TABLE:PortInitDone|SET|lanes:0

2018-07-19.03:38:12.450151|INTF_TABLE:Ethernet4:10.0.0.2/31|SET|scope:global|family:IPv4
```

Also syslog:

```
....

Jul 19 03:38:11.402958 91fd31fb460f INFO /orchagent: :- doPortTask: Get PortInitDone notification from portsyncd.


Jul 19 03:38:11.403686 91fd31fb460f NOTICE /orchagent: :- addIp2MeRoute: Create IP2me route ip:10.0.0.0
Jul 19 03:38:11.403979 91fd31fb460f NOTICE /orchagent: :- addRouterIntfs: Create router interface for port Ethernet4 mtu 9100          <----- default MTU
....


Jul 19 03:38:11.416971 91fd31fb460f NOTICE /orchagent: :- doPortTask: Set port Ethernet4 MTU to 1500           <---- configured MTU
```

**How I verified it**
VS testing.

**Details if related**
