### PR TITLE
Fix skipping vlan memeber if not yet created

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1643,8 +1643,8 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
 
         if (!getPort(port_alias, port))
         {
-            SWSS_LOG_ERROR("Failed to locate port %s", port_alias.c_str());
-            it = consumer.m_toSync.erase(it);
+            SWSS_LOG_DEBUG("%s is not not yet created, delaying", port_alias.c_str());
+            it++;
             continue;
         }
 


### PR DESCRIPTION
Signed-off-by: Andriy Moroz <c_andriym@mellanox.com>

**What I did**
Replaced skipping add port to VLAN if not yet created with the postponing
This happened to PortChannels quite often because creation of PortChannel is delayed due to long path: teamd->netlink->teamsync->APPL_DB

**Why I did it**
Fixed bug reported by the verification team

**How I verified it**
Tested and checked using SDK dump that PortChannel is added to the VLAN

**Details if related**
