### PR TITLE
[intfmgr]: Support configuring IPs for all regular interfaces

### DIFF
--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -21,7 +21,7 @@ private:
     Table m_cfgIntfTable, m_cfgVlanIntfTable;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable;
 
-    bool setIntfIp(const string &alias, const string &opCmd, const string &ipPrefixStr);
+    bool setIntfIp(const string &alias, const string &opCmd, const string &ipPrefixStr, const bool ipv4 = true);
     void doTask(Consumer &consumer);
     bool isIntfStateOk(const string &alias);
 };


### PR DESCRIPTION
Enable configuring IPv4 and IPv6 addresses on regular ports
Add tests to test IPv4 add/remove to regular ports

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

NOTE:
1. LAG IP configuration test will be added later once the support of LAG creation/removal feature is added.
2. IPv6 tests will be added later once the docker vs supports IPv6 after some docker configuration changes.