### PR TITLE
[portmgrd]: Add portmgrd to monitor port MTU configurations

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -1,7 +1,7 @@
 INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/orchagent
 CFLAGS_SAI = -I /usr/include/sai
 
-bin_PROGRAMS = vlanmgrd intfmgrd buffermgrd
+bin_PROGRAMS = vlanmgrd portmgrd intfmgrd buffermgrd
 
 if DEBUG
 DBGFLAGS = -ggdb -DDEBUG
@@ -13,6 +13,11 @@ vlanmgrd_SOURCES = vlanmgrd.cpp vlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(t
 vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vlanmgrd_LDADD = -lswsscommon
+
+portmgrd_SOURCES = portmgrd.cpp portmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
+portmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
+portmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
+portmgrd_LDADD = -lswsscommon
 
 intfmgrd_SOURCES = intfmgrd.cpp intfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)

--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -1,0 +1,109 @@
+#include <string>
+#include "logger.h"
+#include "dbconnector.h"
+#include "producerstatetable.h"
+#include "tokenize.h"
+#include "ipprefix.h"
+#include "portmgr.h"
+#include "exec.h"
+#include "shellcmd.h"
+
+using namespace std;
+using namespace swss;
+
+PortMgr::PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
+        Orch(cfgDb, tableNames),
+        m_cfgPortTable(cfgDb, CFG_PORT_TABLE_NAME),
+        m_cfgLagTable(cfgDb, CFG_LAG_TABLE_NAME),
+        m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
+        m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME)
+{
+}
+
+bool PortMgr::setPortMtu(const string &alias, const string &mtu)
+{
+    stringstream cmd;
+    string res;
+
+    cmd << IP_CMD << " link set dev " << alias << " mtu " << mtu;
+    return exec(cmd.str(), res) == 0;
+}
+
+bool PortMgr::setPortAdminStatus(const string &alias, const bool up)
+{
+    stringstream cmd;
+    string res;
+
+    cmd << IP_CMD << " link set dev " << alias << (up ? " up" : " down");
+    return exec(cmd.str(), res) == 0;
+}
+
+bool PortMgr::isPortStateOk(const string &table, const string &alias)
+{
+    vector<FieldValueTuple> temp;
+
+    if (table == CFG_PORT_TABLE_NAME)
+    {
+        if (m_statePortTable.get(alias, temp))
+        {
+            SWSS_LOG_INFO("Port %s is ready", alias.c_str());
+            return true;
+        }
+    }
+    else if (table == CFG_LAG_TABLE_NAME)
+    {
+        if (m_stateLagTable.get(alias, temp))
+        {
+            SWSS_LOG_INFO("Lag %s is ready", alias.c_str());
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void PortMgr::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    auto table = consumer.getTableName();
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+
+        string alias = kfvKey(t);
+        string op = kfvOp(t);
+
+        if (op == SET_COMMAND)
+        {
+            if (!isPortStateOk(table, alias))
+            {
+                SWSS_LOG_INFO("Port %s is not ready, pending", alias.c_str());
+                it++;
+                continue;
+            }
+
+            for (auto i : kfvFieldsValues(t))
+            {
+                if (fvField(i) == "mtu")
+                {
+                    auto mtu = fvValue(i);
+                    setPortMtu(alias, mtu);
+                    SWSS_LOG_NOTICE("Configure %s MTU to %s",
+                                    alias.c_str(), mtu.c_str());
+                }
+                else if (fvField(i) == "admin_status")
+                {
+                    auto status = fvValue(i);
+                    setPortAdminStatus(alias, status == "up");
+                    SWSS_LOG_NOTICE("Configure %s %s",
+                            alias.c_str(), status.c_str());
+                }
+            }
+        }
+
+        it = consumer.m_toSync.erase(it);
+    }
+}

--- a/cfgmgr/portmgr.h
+++ b/cfgmgr/portmgr.h
@@ -1,0 +1,33 @@
+#ifndef __INTFMGR__
+#define __INTFMGR__
+
+#include "dbconnector.h"
+#include "producerstatetable.h"
+#include "orch.h"
+
+#include <map>
+#include <string>
+
+namespace swss {
+
+class PortMgr : public Orch
+{
+public:
+    PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames);
+    using Orch::doTask;
+
+private:
+    Table m_cfgPortTable;
+    Table m_cfgLagTable;
+    Table m_statePortTable;
+    Table m_stateLagTable;
+
+    void doTask(Consumer &consumer);
+    bool setPortMtu(const string &alias, const string &mtu);
+    bool setPortAdminStatus(const string &alias, const bool up);
+    bool isPortStateOk(const string &table, const string &alias);
+};
+
+}
+
+#endif

--- a/cfgmgr/portmgrd.cpp
+++ b/cfgmgr/portmgrd.cpp
@@ -1,0 +1,89 @@
+#include <unistd.h>
+#include <vector>
+#include <mutex>
+#include "dbconnector.h"
+#include "select.h"
+#include "exec.h"
+#include "schema.h"
+#include "portmgr.h"
+#include <fstream>
+#include <iostream>
+
+using namespace std;
+using namespace swss;
+
+/* select() function timeout retry time, in millisecond */
+#define SELECT_TIMEOUT 1000
+
+/*
+ * Following global variables are defined here for the purpose of
+ * using existing Orch class which is to be refactored soon to
+ * eliminate the direct exposure of the global variables.
+ *
+ * Once Orch class refactoring is done, these global variables
+ * should be removed from here.
+ */
+int gBatchSize = 0;
+bool gSwssRecord = false;
+bool gLogRotate = false;
+ofstream gRecordOfs;
+string gRecordFile;
+/* Global database mutex */
+mutex gDbMutex;
+
+int main(int argc, char **argv)
+{
+    Logger::linkToDbNative("portmgrd");
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("--- Starting portmgrd ---");
+
+    try
+    {
+        vector<string> cfg_port_tables = {
+            CFG_PORT_TABLE_NAME,
+            CFG_LAG_TABLE_NAME,
+        };
+
+        DBConnector cfgDb(CONFIG_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+        DBConnector appDb(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+        DBConnector stateDb(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+
+        PortMgr portmgr(&cfgDb, &appDb, &stateDb, cfg_port_tables);
+
+        // TODO: add tables in stateDB which interface depends on to monitor list
+        std::vector<Orch *> cfgOrchList = {&portmgr};
+
+        swss::Select s;
+        for (Orch *o : cfgOrchList)
+        {
+            s.addSelectables(o->getSelectables());
+        }
+
+        while (true)
+        {
+            Selectable *sel;
+            int ret;
+
+            ret = s.select(&sel, SELECT_TIMEOUT);
+            if (ret == Select::ERROR)
+            {
+                SWSS_LOG_NOTICE("Error: %s!", strerror(errno));
+                continue;
+            }
+            if (ret == Select::TIMEOUT)
+            {
+                portmgr.doTask();
+                continue;
+            }
+
+            auto *c = (Executor *)sel;
+            c->execute();
+        }
+    }
+    catch(const std::exception &e)
+    {
+        SWSS_LOG_ERROR("Runtime error: %s", e.what());
+    }
+    return -1;
+}

--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -110,7 +110,6 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
     unsigned int flags = rtnl_link_get_flags(link);
     bool admin = flags & IFF_UP;
     bool oper = flags & IFF_LOWER_UP;
-    unsigned int mtu = rtnl_link_get_mtu(link);
 
     char addrStr[MAX_ADDR_SIZE+1] = {0};
     nl_addr2str(rtnl_link_get_addr(link), addrStr, MAX_ADDR_SIZE);
@@ -155,9 +154,7 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
 
     vector<FieldValueTuple> fvVector;
     FieldValueTuple a("admin_status", admin ? "up" : "down");
-    FieldValueTuple m("mtu", to_string(mtu));
     fvVector.push_back(a);
-    fvVector.push_back(m);
 
     /* front panel interfaces: Check if the port is in the PORT_TABLE
      * non-front panel interfaces such as eth0, lo which are not in the

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -291,19 +291,6 @@ void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple>
             if (op == SET_COMMAND)
             {
                 p.set(key, values);
-                for (auto fv : values)
-                {
-                    string field = fvField(fv);
-                    string value = fvValue(fv);
-
-                    /* Update the mtu field on host interface */
-                    if (field == "mtu")
-                    {
-                        string cmd, res;
-                        cmd = "ip link set " + key + " mtu " + value;
-                        swss::exec(cmd, res);
-                     }
-                }
             }
 
             it = port_cfg_map.erase(it);

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,6 +1,27 @@
 from swsscommon import swsscommon
+
 import time
 import os
+
+class TestPort(object):
+    def test_PortMtu(self, dvs):
+        pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+        # set MTU to port
+        tbl = swsscommon.Table(cdb, "PORT")
+        fvs = swsscommon.FieldValuePairs([("MTU", "9100")])
+        tbl.set("Ethernet8", fvs)
+        time.sleep(1)
+
+        # check application database
+        tbl = swsscommon.Table(pdb, "PORT_TABLE")
+        (status, fvs) = tbl.get("Ethernet8")
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "mtu":
+                assert fv[1] == "9100"
 
 def test_PortNotification(dvs):
 


### PR DESCRIPTION
In order to get rid of /etc/network/interfaces file and move
all the configurations to the configuration database, MTU configurations
are required to be put into the database and monitored by a specific
daemon. This daemon is right now to achieve this goal.

Currently, this daemon will only listen to the port MTU configurations
if existed in the database and then call the 'ip link' command to
configure the kernel netdevs. Then, portsyncd will catch the messages
via libnl and send the message to orchagent.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>