### PR TITLE
Warm reboot for PortsOrch

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -141,25 +141,21 @@ void Consumer::drain()
 }
 
 // TODO: Table should be const
-void Orch::addExistingData(Table *table)
+bool Orch::addExistingData(Table *table)
 {
     string tableName = table->getTableName();
-    Consumer* consumer;
-    auto it = m_consumerMap.begin();
-
-    while (it != m_consumerMap.end())
+    auto found = m_consumerMap.find(tableName);
+    if (found == m_consumerMap.end())
     {
-        consumer = (Consumer*)(it->second.get());
-        if (tableName == consumer->getTableName())
-        {
-            break;
-        }
-        it++;
+        SWSS_LOG_ERROR("No table %s in Orch", tableName.c_str());
+        return false;
     }
 
-    if (it == m_consumerMap.end())
+    Consumer* consumer = dynamic_cast<Consumer *>(found->second.get());
+    if (consumer == NULL)
     {
-        return;
+        SWSS_LOG_ERROR("Executor is not a Consumer: %s", tableName.c_str());
+        return false;
     }
 
     std::deque<KeyOpFieldsValuesTuple> entries;
@@ -180,6 +176,7 @@ void Orch::addExistingData(Table *table)
     }
 
     consumer->addToSync(entries);
+    return true;
 }
 
 /*

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -66,12 +66,9 @@ vector<Selectable *> Orch::getSelectables()
     return selectables;
 }
 
-void Consumer::execute()
+void Consumer::addToSync(std::deque<KeyOpFieldsValuesTuple> &entries)
 {
     SWSS_LOG_ENTER();
-
-    std::deque<KeyOpFieldsValuesTuple> entries;
-    getConsumerTable()->pops(entries);
 
     /* Nothing popped */
     if (entries.empty())
@@ -123,6 +120,16 @@ void Consumer::execute()
             m_toSync[key] = KeyOpFieldsValuesTuple(key, op, existing_values);
         }
     }
+}
+
+void Consumer::execute()
+{
+    SWSS_LOG_ENTER();
+
+    std::deque<KeyOpFieldsValuesTuple> entries;
+    getConsumerTable()->pops(entries);
+
+    addToSync(entries);
 
     drain();
 }
@@ -131,6 +138,48 @@ void Consumer::drain()
 {
     if (!m_toSync.empty())
         m_orch->doTask(*this);
+}
+
+// TODO: Table should be const
+void Orch::addExistingData(Table *table)
+{
+    string tableName = table->getTableName();
+    Consumer* consumer;
+    auto it = m_consumerMap.begin();
+
+    while (it != m_consumerMap.end())
+    {
+        consumer = (Consumer*)(it->second.get());
+        if (tableName == consumer->getTableName())
+        {
+            break;
+        }
+        it++;
+    }
+
+    if (it == m_consumerMap.end())
+    {
+        return;
+    }
+
+    std::deque<KeyOpFieldsValuesTuple> entries;
+    vector<string> keys;
+    table->getKeys(keys);
+    for (const auto &key: keys)
+    {
+        KeyOpFieldsValuesTuple kco;
+
+        kfvKey(kco) = key;
+        kfvOp(kco) = SET_COMMAND;
+
+        if (!table->get(key, kfvFieldsValues(kco)))
+        {
+            continue;
+        }
+        entries.push_back(kco);
+    }
+
+    consumer->addToSync(entries);
 }
 
 /*

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -150,7 +150,7 @@ public:
 
     vector<Selectable*> getSelectables();
 
-    // add the existing data to the consumer todo task list.
+    // add the existing table data (left by warm reboot) to the consumer todo task list.
     void addExistingData(Table *table);
 
     /* Iterate all consumers in m_consumerMap and run doTask(Consumer) */

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -101,14 +101,14 @@ protected:
 
 class Consumer : public Executor {
 public:
-    Consumer(TableConsumable *select, Orch *orch)
+    Consumer(ConsumerTableBase *select, Orch *orch)
         : Executor(select, orch)
     {
     }
 
-    TableConsumable *getConsumerTable() const
+    ConsumerTableBase *getConsumerTable() const
     {
-        return static_cast<TableConsumable *>(getSelectable());
+        return static_cast<ConsumerTableBase *>(getSelectable());
     }
 
     string getTableName() const
@@ -117,6 +117,8 @@ public:
     }
 
     void addToSync(std::deque<KeyOpFieldsValuesTuple> &entries);
+    void refillToSync();
+    void refillToSync(Table* table);
     void execute();
     void drain();
 
@@ -152,6 +154,7 @@ public:
 
     // add the existing table data (left by warm reboot) to the consumer todo task list.
     bool addExistingData(Table *table);
+    bool addExistingData(const string& tableName);
 
     /* Iterate all consumers in m_consumerMap and run doTask(Consumer) */
     void doTask();

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -151,7 +151,7 @@ public:
     vector<Selectable*> getSelectables();
 
     // add the existing table data (left by warm reboot) to the consumer todo task list.
-    void addExistingData(Table *table);
+    bool addExistingData(Table *table);
 
     /* Iterate all consumers in m_consumerMap and run doTask(Consumer) */
     void doTask();

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -116,6 +116,7 @@ public:
         return getConsumerTable()->getTableName();
     }
 
+    void addToSync(std::deque<KeyOpFieldsValuesTuple> &entries);
     void execute();
     void drain();
 
@@ -148,6 +149,9 @@ public:
     virtual ~Orch();
 
     vector<Selectable*> getSelectables();
+
+    // add the existing data to the consumer todo task list.
+    void addExistingData(Table *table);
 
     /* Iterate all consumers in m_consumerMap and run doTask(Consumer) */
     void doTask();

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -629,7 +629,7 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
         {
             // Bind this ACL group to LAG
             sai_attribute_t lag_attr;
-	        lag_attr.id = ingress ? SAI_LAG_ATTR_INGRESS_ACL : SAI_LAG_ATTR_EGRESS_ACL;
+            lag_attr.id = ingress ? SAI_LAG_ATTR_INGRESS_ACL : SAI_LAG_ATTR_EGRESS_ACL;
             lag_attr.value.oid = groupOid;
 
             status = sai_lag_api->set_lag_attribute(port.m_lag_id, &lag_attr);
@@ -1086,8 +1086,8 @@ bool PortsOrch::removePort(sai_object_id_t port_id)
     Port p;
     if (getPort(port_id, p))
     {
-    	PortUpdate update = {p, false };
-    	notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
+        PortUpdate update = {p, false };
+        notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
     }
 
     sai_status_t status = sai_port_api->remove_port(port_id);
@@ -1159,8 +1159,8 @@ bool PortsOrch::initPort(const string &alias, const set<int> &lane_set)
 
                 m_flexCounterTable->set(key, fields);
 
-    		PortUpdate update = {p, true };
-    		notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
+                PortUpdate update = {p, true };
+                notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
 
                 SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
             }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1213,6 +1213,11 @@ bool PortsOrch::bake()
     }
 
     addExistingData(m_portTable.get());
+    addExistingData(APP_LAG_TABLE_NAME);
+    addExistingData(APP_LAG_MEMBER_TABLE_NAME);
+    addExistingData(APP_VLAN_TABLE_NAME);
+    addExistingData(APP_VLAN_MEMBER_TABLE_NAME);
+
     return true;
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1203,7 +1203,6 @@ bool PortsOrch::bake()
         return false;
     }
 
-    doPortConfigDoneTask(tuples);
     if (m_portCount != keys.size() - 2)
     {
         // Invalid port table
@@ -1230,19 +1229,6 @@ void PortsOrch::cleanPortTable(const vector<string>& keys)
     }
 }
 
-void PortsOrch::doPortConfigDoneTask(const vector<FieldValueTuple>& tuples)
-{
-    m_portConfigDone = true;
-
-    for (auto i : tuples)
-    {
-        if (fvField(i) == "count")
-        {
-            m_portCount = to_uint<uint32_t>(fvValue(i));
-        }
-    }
-}
-
 void PortsOrch::doPortTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -1257,7 +1243,15 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
         if (alias == "PortConfigDone")
         {
-            doPortConfigDoneTask(kfvFieldsValues(t));
+            m_portConfigDone = true;
+
+            for (auto i : kfvFieldsValues(t))
+            {
+                if (fvField(i) == "count")
+                {
+                    m_portCount = to_uint<uint32_t>(fvValue(i));
+                }
+            }
         }
 
         /* Get notification from application */

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1331,6 +1331,12 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 m_lanesAliasSpeedMap[lane_set] = make_tuple(alias, speed, an, fec_mode);
             }
 
+            // TODO:
+            // Fix the issue below
+            // After PortConfigDone, while waiting for "PortInitDone" and the first gBufferOrch->isPortReady(alias),
+            // the complete m_lanesAliasSpeedMap may be populated again, so initPort() will be called more than once
+            // for the same port.
+
             /* Once all ports received, go through the each port and perform appropriate actions:
              * 1. Remove ports which don't exist anymore
              * 2. Create new ports

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -56,6 +56,9 @@ public:
     bool isInitDone();
 
     map<string, Port>& getAllPorts();
+    bool bake();
+    void cleanPortTable(const vector<string>& keys);
+    void doPortConfigDoneTask(const vector<FieldValueTuple>& tuples);
     bool getBridgePort(sai_object_id_t id, Port &port);
     bool getPort(string alias, Port &port);
     bool getPort(sai_object_id_t id, Port &port);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -58,7 +58,6 @@ public:
     map<string, Port>& getAllPorts();
     bool bake();
     void cleanPortTable(const vector<string>& keys);
-    void doPortConfigDoneTask(const vector<FieldValueTuple>& tuples);
     bool getBridgePort(sai_object_id_t id, Port &port);
     bool getPort(string alias, Port &port);
     bool getPort(sai_object_id_t id, Port &port);


### PR DESCRIPTION
The non-warm reboot behavior is backward compatible, and tested in lab.

The idea is best effort warm reboot based on left over entries in PORT_TABLE.
1. During a cold reboot, the whole table is empty, so keep original behavior
2. During a warm reboot, the previous port entries are left in the table, together with event entries such as PortConfigDone, PortInitDone. So PortsOrch will add them into PortsOrch's consumer queue to propagate to downstream syncd and ASIC.
3. During a warm reboot, if any corruption found in the table, clean up the table and fallback to cold reboot.

The warm reboot is not end-to-end tested.