### PR TITLE
Warm reboot: Add basic schema for warm start in configDB and stateDB.

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -622,15 +622,6 @@ Equivalent RedisDB entry:
     12) "0"
     127.0.0.1:6379>
 
----------------------------------------------
-### WARM\_RESTART\_TABLE
-    ;Stores application and orchdameon warm start status
-    ;Status: work in progress
-    key             = WARM_RESTART_TABLE:process_name         ; process_name is unique process identifier
-    restart_count   = 1*10DIGIT                               ; a number between 0 and 2147483647,
-                                                              ; count of warm start times.
-    state           = "init" / "restored" / "synced"
-
 
 ## Configuration DB schema
 
@@ -641,6 +632,23 @@ Equivalent RedisDB entry:
     key             = WARM_RESTART:name         ; name is the name of SONiC docker or "system" for global configuration
     enable          = "true" / "false"          ; default value as false
 
+
+## State DB schema
+
+### WARM\_RESTART\_TABLE
+    ;Stores application and orchdameon warm start status
+    ;Status: work in progress
+
+    key             = WARM_RESTART_TABLE:process_name         ; process_name is a unique process identifier.
+    restart_count   = 1*10DIGIT                               ; a number between 0 and 2147483647,
+                                                              ; count of warm start times.
+
+    state           = "init" / "restored" / "reconciled"      ; init: process init with warm start enabled.
+                                                              ; restored: process restored to the previous
+                                                              ; state using saved data.
+                                                              ; reconciled: process reconciled with up to date
+                                                              ; dynanic data like port state, neighbor, routes
+                                                              ; and so on.
 
 ## Configuration files
 What configuration files should we have?  Do apps, orch agent each need separate files?

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -635,10 +635,12 @@ Equivalent RedisDB entry:
                                                 ; If "system" warm start knob is true, docker level knob will be ignored.
                                                 ; If "system" warm start knob is false, docker level knob takes effect.
 
-    timer_name      = 1*255VCHAR                ; timer_name is the name of warm start timer for the whole system or the specific docker,
-                                                ; Ex. "neighbor_timer", "bgp_timer".
-                                                ; There could be more than one timer in a docker and the system.
-    timer_duration  = 1*4DIGIT                  ; timer duration, in seconds.
+    timer_name      = 1*255VCHAR,               ; timer_name is the name of warm start timer for the whole system or the specific docker,
+                                                ; Ex. "neighbor_timer", "bgp_timer". The name should not contain "," character.
+                                                ; There could be more than one timer in a docker or the system, separated by ",".
+
+    timer_duration  = 1*4DIGIT,                 ; timer duration, in seconds. Separated by "," if there are more than on timer.
+
 
 ## State DB schema
 

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -629,10 +629,16 @@ Equivalent RedisDB entry:
     ;Stores system warm start configuration
     ;Status: work in progress
 
-    key             = WARM_RESTART:name         ; name is the name of SONiC docker or "system" for global configuration
-    enable          = "true" / "false"          ; default value as false
-    timer           = 1*4DIGIT                  ; timer to determine when reconciliation is done, in seconds.
+    key             = WARM_RESTART:name         ; name is the name of SONiC docker or "system" for global configuration.
 
+    enable          = "true" / "false"          ; Default value as false.
+                                                ; If "system" warm start knob is true, docker level knob will be ignored.
+                                                ; If "system" warm start knob is false, docker level knob takes effect.
+
+    timer_name      = 1*255VCHAR                ; timer_name is the name of warm start timer for the whole system or the specific docker,
+                                                ; Ex. "neighbor_timer", "bgp_timer".
+                                                ; There could be more than one timer in a docker and the system.
+    timer_duration  = 1*4DIGIT                  ; timer duration, in seconds.
 
 ## State DB schema
 

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -1,10 +1,12 @@
 Schema data is defined in ABNF [RFC5234](https://tools.ietf.org/html/rfc5234) syntax.
 
-### Definitions of common tokens
+## Definitions of common tokens
     name                    = 1*DIGIT/1*ALPHA
     ref_hash_key_reference  = "[" hash_key "]" ;The token is a refernce to another valid DB key.
     hash_key                = name ; a valid key name (i.e. exists in DB)
 
+
+## Application DB schema
 
 ### PORT_TABLE
 Stores information for physical switch ports managed by the switch chip.  device_names are defined in [port_config.ini](../portsyncd/port_config.ini).  Ports to the CPU (ie: management port) and logical ports (loopback) are not declared in the PORT_TABLE.   See INTF_TABLE.
@@ -620,7 +622,27 @@ Equivalent RedisDB entry:
     12) "0"
     127.0.0.1:6379>
 
-### Configuration files
+---------------------------------------------
+### WARM\_RESTART\_TABLE
+    ;Stores application and orchdameon warm start status
+    ;Status: work in progress
+    key             = WARM_RESTART_TABLE:process_name         ; process_name is unique process identifier
+    restart_count   = 1*10DIGIT                               ; a number between 0 and 2147483647,
+                                                              ; count of warm start times.
+    state           = "init" / "restored" / "synced"
+
+
+## Configuration DB schema
+
+### WARM\_RESTART
+    ;Stores system warm start configuration
+    ;Status: work in progress
+
+    key             = WARM_RESTART:name         ; name is the name of SONiC docker or "system" for global configuration
+    enable          = "true" / "false"          ; default value as false
+
+
+## Configuration files
 What configuration files should we have?  Do apps, orch agent each need separate files?
 
 [port_config.ini](https://github.com/stcheng/swss/blob/mock/portsyncd/port_config.ini) - defines physical port information

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -631,6 +631,7 @@ Equivalent RedisDB entry:
 
     key             = WARM_RESTART:name         ; name is the name of SONiC docker or "system" for global configuration
     enable          = "true" / "false"          ; default value as false
+    timer           = 1*4DIGIT                  ; timer to determine when reconciliation is done, in seconds.
 
 
 ## State DB schema


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Basic schema for warm start 
Configuration:   Mainly to decide whether to flush the DB data and some timer setting for arp/route sync.

AppDB:   Store basic warm restore and sync up state and restart count for each process.

**Why I did it**

**How I verified it**

**Details if related**
