### PR TITLE
Port table should be ProducerTable

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -364,6 +364,10 @@ void Orch::addConsumer(DBConnector *db, string tableName, int pri)
     {
         addExecutor(tableName, new Consumer(new SubscriberStateTable(db, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, pri), this));
     }
+    else if (tableName == APP_PORT_TABLE_NAME)
+    {
+        addExecutor(tableName, new Consumer(new ConsumerTable(db, tableName, gBatchSize, pri), this));
+    }
     else
     {
         addExecutor(tableName, new Consumer(new ConsumerStateTable(db, tableName, gBatchSize, pri), this));

--- a/portsyncd/linksync.h
+++ b/portsyncd/linksync.h
@@ -2,7 +2,7 @@
 #define __LINKSYNC__
 
 #include "dbconnector.h"
-#include "producerstatetable.h"
+#include "producertable.h"
 #include "netmsg.h"
 
 #include <map>
@@ -19,7 +19,7 @@ public:
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);
 
 private:
-    ProducerStateTable m_portTableProducer;
+    ProducerTable m_portTableProducer;
     Table m_portTable, m_statePortTable;
 
     std::map<unsigned int, std::string> m_ifindexNameMap;

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -11,6 +11,7 @@
 #include "netdispatcher.h"
 #include "netlink.h"
 #include "producerstatetable.h"
+#include "producertable.h"
 #include "portsyncd/linksync.h"
 #include "subscriberstatetable.h"
 #include "exec.h"
@@ -38,10 +39,11 @@ void usage()
     cout << "                           use configDB data if not specified" << endl;
 }
 
-void handlePortConfigFile(ProducerStateTable &p, string file);
-void handlePortConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb);
+// TODO: find a common base class for ProducerTable and ProducerStateTable
+void handlePortConfigFile(ProducerTable &p, string file);
+void handlePortConfigFromConfigDB(ProducerTable &p, DBConnector &cfgDb);
 void handleVlanIntfFile(string file);
-void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple> &port_cfg_map);
+void handlePortConfig(ProducerTable &p, map<string, KeyOpFieldsValuesTuple> &port_cfg_map);
 
 int main(int argc, char **argv)
 {
@@ -69,7 +71,7 @@ int main(int argc, char **argv)
     DBConnector cfgDb(CONFIG_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     DBConnector appl_db(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     DBConnector state_db(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
-    ProducerStateTable p(&appl_db, APP_PORT_TABLE_NAME);
+    ProducerTable p(&appl_db, APP_PORT_TABLE_NAME);
     SubscriberStateTable portCfg(&cfgDb, CFG_PORT_TABLE_NAME);
 
     LinkSync sync(&appl_db, &state_db);
@@ -157,7 +159,7 @@ int main(int argc, char **argv)
     return 1;
 }
 
-static void notifyPortConfigDone(ProducerStateTable &p)
+static void notifyPortConfigDone(ProducerTable &p)
 {
     /* Notify that all ports added */
     FieldValueTuple finish_notice("count", to_string(g_portSet.size()));
@@ -165,7 +167,7 @@ static void notifyPortConfigDone(ProducerStateTable &p)
     p.set("PortConfigDone", attrs);
 }
 
-void handlePortConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb)
+void handlePortConfigFromConfigDB(ProducerTable &p, DBConnector &cfgDb)
 {
     cout << "Get port configuration from ConfigDB..." << endl;
 
@@ -188,7 +190,7 @@ void handlePortConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb)
     notifyPortConfigDone(p);
 }
 
-void handlePortConfigFile(ProducerStateTable &p, string file)
+void handlePortConfigFile(ProducerTable &p, string file)
 {
     cout << "Read port configuration file..." << endl;
 
@@ -273,7 +275,7 @@ void handlePortConfigFile(ProducerStateTable &p, string file)
     notifyPortConfigDone(p);
 }
 
-void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple> &port_cfg_map)
+void handlePortConfig(ProducerTable &p, map<string, KeyOpFieldsValuesTuple> &port_cfg_map)
 {
 
     auto it = port_cfg_map.begin();

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -6,7 +6,7 @@ def test_PortAutoNeg(dvs):
 
     db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
 
-    tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+    tbl = swsscommon.ProducerTable(db, "PORT_TABLE")
 
     # set autoneg = false and speed = 1000
     fvs = swsscommon.FieldValuePairs([("autoneg","1"), ("speed", "1000")])
@@ -31,7 +31,7 @@ def test_PortAutoNeg(dvs):
 
     # set speed = 100
     fvs = swsscommon.FieldValuePairs([("speed", "100")])
- 
+
     tbl.set("Ethernet0", fvs)
 
     time.sleep(1)


### PR DESCRIPTION
The entries in APP_PORT_TABLE_NAME are sequence sensitive because there are event entries (PortConfigDone, PortInitDone). Change it back to ProducerTable.