### PR TITLE
[aclorch]: only bind to port for ACL_TABLE_PFCWD type

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1022,7 +1022,12 @@ bool AclTable::create()
 
     sai_attribute_t attr;
     vector<sai_attribute_t> table_attrs;
-    vector<int32_t> bpoint_list = type == ACL_TABLE_PFCWD ? { SAI_ACL_BIND_POINT_TYPE_PORT} : { SAI_ACL_BIND_POINT_TYPE_PORT, SAI_ACL_BIND_POINT_TYPE_LAG };
+    vector<int32_t> bpoint_list = { SAI_ACL_BIND_POINT_TYPE_PORT, SAI_ACL_BIND_POINT_TYPE_LAG };
+    if (type == ACL_TABLE_PFCWD)
+    {
+        bpoint_list = { SAI_ACL_BIND_POINT_TYPE_PORT };
+    }
+
     attr.id = SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST;
     attr.value.s32list.count = static_cast<uint32_t>(bpoint_list.size());
     attr.value.s32list.list = bpoint_list.data();

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1022,7 +1022,7 @@ bool AclTable::create()
 
     sai_attribute_t attr;
     vector<sai_attribute_t> table_attrs;
-    vector<int32_t> bpoint_list = { SAI_ACL_BIND_POINT_TYPE_PORT, SAI_ACL_BIND_POINT_TYPE_LAG };
+    vector<int32_t> bpoint_list = type == ACL_TABLE_PFCWD ? { SAI_ACL_BIND_POINT_TYPE_PORT} : { SAI_ACL_BIND_POINT_TYPE_PORT, SAI_ACL_BIND_POINT_TYPE_LAG };
     attr.id = SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST;
     attr.value.s32list.count = static_cast<uint32_t>(bpoint_list.size());
     attr.value.s32list.list = bpoint_list.data();


### PR DESCRIPTION
Signed-off-by: Sihui Han <sihan@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Only bind to port for ACL_TABLE_PFCWD type
**Why I did it**
PFCWD only requires to bind to port regardless if port is a LAG member. And LAG binding is not supported for egress acl table which will be used for PFCWD.
**How I verified it**

**Details if related**
