### PR TITLE
[portsyncd]: Skip empty lines

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -205,6 +205,11 @@ void handlePortConfigFile(ProducerTable &p, string file)
     string line;
     while (getline(infile, line))
     {
+        if (line.size() == 0)
+        {
+            continue;
+        }
+
         if (line.at(0) == '#')
         {
             // Take this line as column header line


### PR DESCRIPTION
If the length of the line is 0, skip parsing this line.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>