### PR TITLE
Improve PortsOrch::doPortTask()

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1177,96 +1177,6 @@ bool PortsOrch::initPort(const string &alias, const set<int> &lane_set)
     return true;
 }
 
-void PortsOrch::doPortConfigDoneTask(const vector<FieldValueTuple>& tuples)
-{
-    SWSS_LOG_ENTER();
-
-    m_portConfigDone = true;
-
-    for (auto i : tuples)
-    {
-        if (fvField(i) == "count")
-        {
-            m_portCount = to_uint<uint32_t>(fvValue(i));
-        }
-    }
-
-    if (m_lanesAliasSpeedMap.size() != m_portCount)
-    {
-        SWSS_LOG_ERROR("Unexpected number of PORTs received before PortConfigDone: %zu != %u", m_lanesAliasSpeedMap.size(), m_portCount);
-        return;
-    }
-
-    /* Once all ports received, go through the each port and perform appropriate actions:
-     * 1. Remove ports which don't exist anymore
-     * 2. Create new ports
-     * 3. Initialize all ports
-     */
-    for (auto it = m_portListLaneMap.begin(); it != m_portListLaneMap.end();)
-    {
-        if (m_lanesAliasSpeedMap.find(it->first) == m_lanesAliasSpeedMap.end())
-        {
-            char *platform = getenv("platform");
-            if (platform && (strstr(platform, BFN_PLATFORM_SUBSTRING) || strstr(platform, MLNX_PLATFORM_SUBSTRING)))
-            {
-                if (!removePort(it->second))
-                {
-                    throw runtime_error("PortsOrch initialization failure.");
-                }
-            }
-            else
-            {
-                SWSS_LOG_NOTICE("Failed to remove Port %lx due to missing SAI remove_port API.", it->second);
-            }
-
-            it = m_portListLaneMap.erase(it);
-        }
-        else
-        {
-            it++;
-        }
-    }
-
-    for (auto it = m_lanesAliasSpeedMap.begin(); it != m_lanesAliasSpeedMap.end();)
-    {
-        bool port_created = false;
-
-        if (m_portListLaneMap.find(it->first) == m_portListLaneMap.end())
-        {
-            // work around to avoid syncd termination on SAI error due missing create_port SAI API
-            // can be removed when SAI redis return NotImplemented error
-            char *platform = getenv("platform");
-            if (platform && (strstr(platform, BFN_PLATFORM_SUBSTRING) || strstr(platform, MLNX_PLATFORM_SUBSTRING)))
-            {
-                if (!addPort(it->first, get<1>(it->second), get<2>(it->second), get<3>(it->second)))
-                {
-                    throw runtime_error("PortsOrch initialization failure.");
-                }
-
-                port_created = true;
-            }
-            else
-            {
-                SWSS_LOG_NOTICE("Failed to create Port %s due to missing SAI create_port API.", get<0>(it->second).c_str());
-            }
-        }
-        else
-        {
-            port_created = true;
-        }
-
-        if (port_created)
-        {
-            if (!initPort(get<0>(it->second), it->first))
-            {
-                throw runtime_error("PortsOrch initialization failure.");
-            }
-        }
-
-        it = m_lanesAliasSpeedMap.erase(it);
-    }
-}
-
 void PortsOrch::doPortTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -1281,10 +1191,15 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
         if (alias == "PortConfigDone")
         {
-            doPortConfigDoneTask(kfvFieldsValues(t));
+            m_portConfigDone = true;
 
-            it = consumer.m_toSync.erase(it);
-            continue;
+            for (auto i : kfvFieldsValues(t))
+            {
+                if (fvField(i) == "count")
+                {
+                    m_portCount = to_uint<uint32_t>(fvValue(i));
+                }
+            }
         }
 
         /* Get notification from application */
@@ -1362,6 +1277,90 @@ void PortsOrch::doPortTask(Consumer &consumer)
             if (lane_set.size())
             {
                 m_lanesAliasSpeedMap[lane_set] = make_tuple(alias, speed, an, fec_mode);
+            }
+
+            /* Once all ports received, go through the each port and perform appropriate actions:
+             * 1. Remove ports which don't exist anymore
+             * 2. Create new ports
+             * 3. Initialize all ports
+             */
+            if (m_portConfigDone && (m_lanesAliasSpeedMap.size() == m_portCount))
+            {
+                for (auto it = m_portListLaneMap.begin(); it != m_portListLaneMap.end();)
+                {
+                    if (m_lanesAliasSpeedMap.find(it->first) == m_lanesAliasSpeedMap.end())
+                    {
+                        char *platform = getenv("platform");
+                        if (platform && (strstr(platform, BFN_PLATFORM_SUBSTRING) || strstr(platform, MLNX_PLATFORM_SUBSTRING)))
+                        {
+                            if (!removePort(it->second))
+                            {
+                                throw runtime_error("PortsOrch initialization failure.");
+                            }
+                        }
+                        else
+                        {
+                            SWSS_LOG_NOTICE("Failed to remove Port %lx due to missing SAI remove_port API.", it->second);
+                        }
+
+                        it = m_portListLaneMap.erase(it);
+                    }
+                    else
+                    {
+                        it++;
+                    }
+                }
+
+                for (auto it = m_lanesAliasSpeedMap.begin(); it != m_lanesAliasSpeedMap.end();)
+                {
+                    bool port_created = false;
+
+                    if (m_portListLaneMap.find(it->first) == m_portListLaneMap.end())
+                    {
+                        // work around to avoid syncd termination on SAI error due missing create_port SAI API
+                        // can be removed when SAI redis return NotImplemented error
+                        char *platform = getenv("platform");
+                        if (platform && (strstr(platform, BFN_PLATFORM_SUBSTRING) || strstr(platform, MLNX_PLATFORM_SUBSTRING)))
+                        {
+                            if (!addPort(it->first, get<1>(it->second), get<2>(it->second), get<3>(it->second)))
+                            {
+                                throw runtime_error("PortsOrch initialization failure.");
+                            }
+
+                            port_created = true;
+                        }
+                        else
+                        {
+                            SWSS_LOG_NOTICE("Failed to create Port %s due to missing SAI create_port API.", get<0>(it->second).c_str());
+                        }
+                    }
+                    else
+                    {
+                        port_created = true;
+                    }
+
+                    if (port_created)
+                    {
+                        if (!initPort(get<0>(it->second), it->first))
+                        {
+                            throw runtime_error("PortsOrch initialization failure.");
+                        }
+                    }
+
+                    it = m_lanesAliasSpeedMap.erase(it);
+                }
+            }
+
+            if (!m_portConfigDone)
+            {
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            if (alias == "PortConfigDone")
+            {
+                it = consumer.m_toSync.erase(it);
+                continue;
             }
 
             if (!gBufferOrch->isPortReady(alias))
@@ -1496,6 +1495,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         continue;
                     }
                 }
+
 
                 if (!fec_mode.empty())
                 {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1353,7 +1353,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
             if (!m_portConfigDone)
             {
-                it = consumer.m_toSync.erase(it);
+                // Not yet receive PortConfigDone. Save it for future retry
+                it++;
                 continue;
             }
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -56,6 +56,7 @@ public:
     bool isInitDone();
 
     map<string, Port>& getAllPorts();
+    void doPortConfigDoneTask(const vector<FieldValueTuple>& tuples);
     bool getBridgePort(sai_object_id_t id, Port &port);
     bool getPort(string alias, Port &port);
     bool getPort(sai_object_id_t id, Port &port);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -56,7 +56,6 @@ public:
     bool isInitDone();
 
     map<string, Port>& getAllPorts();
-    void doPortConfigDoneTask(const vector<FieldValueTuple>& tuples);
     bool getBridgePort(sai_object_id_t id, Port &port);
     bool getPort(string alias, Port &port);
     bool getPort(sai_object_id_t id, Port &port);

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -44,3 +44,63 @@ def test_PortNotification(dvs):
             break
 
     assert oper_status == "up"
+
+def test_PortFec(dvs):
+
+    dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up") == 0
+    dvs.runcmd("ifconfig Ethernet4 10.0.0.2/31 up") == 0
+
+    dvs.servers[0].runcmd("ip link set down dev eth0") == 0
+
+    time.sleep(1)
+
+    db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+    adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+
+    tbl = swsscommon.Table(db, "PORT_TABLE")
+    ptbl = swsscommon.ProducerTable(db, "PORT_TABLE")
+    atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+
+    (status, fvs) = tbl.get("Ethernet0")
+
+    assert status == True
+
+    oper_status = "unknown"
+
+    for v in fvs:
+        if v[0] == "oper_status":
+            oper_status = v[1]
+            break
+
+    assert oper_status == "down"
+
+    dvs.servers[0].runcmd("ip link set up dev eth0") == 0
+
+    time.sleep(1)
+
+    (status, fvs) = tbl.get("Ethernet0")
+
+    assert status == True
+
+    oper_status = "unknown"
+
+    for v in fvs:
+        if v[0] == "oper_status":
+            oper_status = v[1]
+            break
+
+    assert oper_status == "up"
+
+    # set fec
+    fvs = swsscommon.FieldValuePairs([("fec","rs"), ("speed", "1000")])
+    ptbl.set("Ethernet0", fvs)
+
+    time.sleep(1)
+
+    # get fec
+    (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+    assert status == True
+
+    for fv in fvs:
+        if fv[0] == "SAI_PORT_ATTR_FEC_MODE":
+            assert fv[1] == "SAI_PORT_FEC_MODE_RS"

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -58,7 +58,7 @@ def test_PortFec(dvs):
     adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
 
     tbl = swsscommon.Table(db, "PORT_TABLE")
-    ptbl = swsscommon.ProducerTable(db, "PORT_TABLE")
+    ptbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
     atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
 
     (status, fvs) = tbl.get("Ethernet0")


### PR DESCRIPTION
(Reduce the scope of this PR, please check the updated comment below)

I tested with virtual switch (vs) and Mellanox platform. The initial config of 'fec' is added in ```/usr/share/sonic/device/*/*/port_config.ini```. However this manual test is not materialized as a unit test because of some difficulty.

Original implementation of PortsOrch::doPortTask() has some issues:

1. ~~It was using a ConsumerStateTable, which makes the message coming out of order. The complex logic was used to handle the order. After replace ConsumerStateTable by ConsumerTable, we can simplify the logic.~~

2. The original ConsumerStateTable implementation will always pop all entry attributes even there is one attribute coming. This behavior is not by design and was changed after https://github.com/Azure/sonic-swss-common/pull/204 merged. The  PortsOrch::doPortTask() takes advantage of this specific behavior and doesn't handle some port attributes correctly, if they come before PortConfigDone. These attributes are m_autoneg, speed, mtu, admin_status, fec_mode.

This PR solve these issues, and add vs test case.
