### PR TITLE
Expose the capability to config wred drop probability 

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -329,6 +329,24 @@ bool WredMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tupl
             attr.value.s32 = stoi(fvValue(*i));
             attribs.push_back(attr);
         }
+        else if (fvField(*i) == green_drop_probability_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_GREEN_DROP_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == yellow_drop_probability_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_YELLOW_DROP_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
+        else if (fvField(*i) == red_drop_probability_field_name)
+        {
+            attr.id = SAI_WRED_ATTR_RED_DROP_PROBABILITY;
+            attr.value.s32 = stoi(fvValue(*i));
+            attribs.push_back(attr);
+        }
         else if (fvField(*i) == wred_green_enable_field_name)
         {
             attr.id = SAI_WRED_ATTR_GREEN_ENABLE;
@@ -394,14 +412,6 @@ sai_object_id_t WredMapHandler::addQosItem(const vector<sai_attribute_t> &attrib
     sai_object_id_t sai_object;
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
-
-    attr.id = SAI_WRED_ATTR_GREEN_DROP_PROBABILITY;
-    attr.value.s32 = 100;
-    attrs.push_back(attr);
-
-    attr.id = SAI_WRED_ATTR_YELLOW_DROP_PROBABILITY;
-    attr.value.s32 = 100;
-    attrs.push_back(attr);
 
     attr.id = SAI_WRED_ATTR_WEIGHT;
     attr.value.s32 = 0;

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -7,41 +7,44 @@
 #include "orch.h"
 #include "portsorch.h"
 
-const string dscp_to_tc_field_name             = "dscp_to_tc_map";
-const string pfc_to_pg_map_name                = "pfc_to_pg_map";
-const string pfc_to_queue_map_name             = "pfc_to_queue_map";
-const string pfc_enable_name                   = "pfc_enable";
-const string tc_to_pg_map_field_name           = "tc_to_pg_map";
-const string tc_to_queue_field_name            = "tc_to_queue_map";
-const string scheduler_field_name              = "scheduler";
-const string red_max_threshold_field_name      = "red_max_threshold";
-const string red_min_threshold_field_name      = "red_min_threshold";
-const string yellow_max_threshold_field_name   = "yellow_max_threshold";
-const string yellow_min_threshold_field_name   = "yellow_min_threshold";
-const string green_max_threshold_field_name    = "green_max_threshold";
-const string green_min_threshold_field_name    = "green_min_threshold";
+const string dscp_to_tc_field_name              = "dscp_to_tc_map";
+const string pfc_to_pg_map_name                 = "pfc_to_pg_map";
+const string pfc_to_queue_map_name              = "pfc_to_queue_map";
+const string pfc_enable_name                    = "pfc_enable";
+const string tc_to_pg_map_field_name            = "tc_to_pg_map";
+const string tc_to_queue_field_name             = "tc_to_queue_map";
+const string scheduler_field_name               = "scheduler";
+const string red_max_threshold_field_name       = "red_max_threshold";
+const string red_min_threshold_field_name       = "red_min_threshold";
+const string yellow_max_threshold_field_name    = "yellow_max_threshold";
+const string yellow_min_threshold_field_name    = "yellow_min_threshold";
+const string green_max_threshold_field_name     = "green_max_threshold";
+const string green_min_threshold_field_name     = "green_min_threshold";
+const string red_drop_probability_field_name    = "red_drop_probability";
+const string yellow_drop_probability_field_name = "yellow_drop_probability";
+const string green_drop_probability_field_name  = "green_drop_probability";
 
-const string wred_profile_field_name           = "wred_profile";
-const string wred_red_enable_field_name        = "wred_red_enable";
-const string wred_yellow_enable_field_name     = "wred_yellow_enable";
-const string wred_green_enable_field_name      = "wred_green_enable";
+const string wred_profile_field_name            = "wred_profile";
+const string wred_red_enable_field_name         = "wred_red_enable";
+const string wred_yellow_enable_field_name      = "wred_yellow_enable";
+const string wred_green_enable_field_name       = "wred_green_enable";
 
-const string scheduler_algo_type_field_name    = "type";
-const string scheduler_algo_DWRR               = "DWRR";
-const string scheduler_algo_WRR                = "WRR";
-const string scheduler_algo_STRICT             = "STRICT";
-const string scheduler_weight_field_name       = "weight";
-const string scheduler_priority_field_name     = "priority";
+const string scheduler_algo_type_field_name     = "type";
+const string scheduler_algo_DWRR                = "DWRR";
+const string scheduler_algo_WRR                 = "WRR";
+const string scheduler_algo_STRICT              = "STRICT";
+const string scheduler_weight_field_name        = "weight";
+const string scheduler_priority_field_name      = "priority";
 
-const string ecn_field_name                    = "ecn";
-const string ecn_none                          = "ecn_none";
-const string ecn_red                           = "ecn_red";
-const string ecn_yellow                        = "ecn_yellow";
-const string ecn_yellow_red                    = "ecn_yellow_red";
-const string ecn_green                         = "ecn_green";
-const string ecn_green_red                     = "ecn_green_red";
-const string ecn_green_yellow                  = "ecn_green_yellow";
-const string ecn_all                           = "ecn_all";
+const string ecn_field_name                     = "ecn";
+const string ecn_none                           = "ecn_none";
+const string ecn_red                            = "ecn_red";
+const string ecn_yellow                         = "ecn_yellow";
+const string ecn_yellow_red                     = "ecn_yellow_red";
+const string ecn_green                          = "ecn_green";
+const string ecn_green_red                      = "ecn_green_red";
+const string ecn_green_yellow                   = "ecn_green_yellow";
+const string ecn_all                            = "ecn_all";
 
 class QosMapHandler
 {


### PR DESCRIPTION
Expose the capability to config wred drop probability of all packet colors (green, yellow, and red)

Signed-off-by: Wenda <wenni@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**
Tested on a7050

**Details if related**
