### PR TITLE
swss: flush g_asicState after each event is done

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -313,5 +313,6 @@ void OrchDaemon::start()
         for (Orch *o : m_orchList)
             o->doTask();
 
+        flush(); //flush after each event is handled, don't wait
     }
 }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -313,6 +313,7 @@ void OrchDaemon::start()
         for (Orch *o : m_orchList)
             o->doTask();
 
-        flush(); //flush after each event is handled, don't wait
+        //flush after each event is handled, don't wait timeout
+        flush();
     }
 }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -294,12 +294,6 @@ void OrchDaemon::start()
 
         if (ret == Select::TIMEOUT)
         {
-            /* Let sairedis to flush all SAI function call to ASIC DB.
-             * Normally the redis pipeline will flush when enough request
-             * accumulated. Still it is possible that small amount of
-             * requests live in it. When the daemon has nothing to do, it
-             * is a good chance to flush the pipeline  */
-            flush();
             continue;
         }
 
@@ -313,7 +307,12 @@ void OrchDaemon::start()
         for (Orch *o : m_orchList)
             o->doTask();
 
-        //flush after each event is handled, don't wait timeout
+        /* Let sairedis to flush all SAI function call to ASIC DB.
+         * Normally the redis pipeline will flush when enough request
+         * accumulated. Still it is possible that small amount of
+         * requests live in it. When the daemon has finished events/tasks, it
+         * is a good chance to flush the pipeline before next select happened.
+         */
         flush();
     }
 }


### PR DESCRIPTION
* add flush() after event is handled in case some entries are still in buffer, don't wait
* with the changes in sairedis and swss-common, route performance improved by 200~300 routes/sec

  Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
