### PR TITLE
[test]: Add test_InterfaceAddRemoveSecondIpv4Address

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -47,7 +47,7 @@ class TestInterfaceIpv4Addresses(object):
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_TYPE":
                         assert fv[1] == "SAI_ROUTER_INTERFACE_TYPE_PORT"
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_MTU":
-                        assert fv[1] == "1500"
+                        assert fv[1] == "9100"
 
         # check ASIC route database
         tbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
@@ -63,12 +63,10 @@ class TestInterfaceIpv4Addresses(object):
     def test_InterfaceChangeMtu(self, dvs):
         pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
-        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
 
         tbl = swsscommon.ProducerStateTable(pdb, "PORT_TABLE")
         fvs = swsscommon.FieldValuePairs([("mtu", "8888")])
         tbl.set("Ethernet8", fvs)
-
         time.sleep(1)
 
         # check ASIC router interface database
@@ -87,6 +85,51 @@ class TestInterfaceIpv4Addresses(object):
                         assert fv[1] == "SAI_ROUTER_INTERFACE_TYPE_PORT"
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_MTU":
                         assert fv[1] == "8888"
+
+    def test_InterfaceAddRemoveSecondIpv4Address(self, dvs):
+        pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+        # assign second IP to interface
+        tbl = swsscommon.Table(cdb, "INTERFACE")
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set("Ethernet8|20.0.0.4/31", fvs)
+        time.sleep(1)
+
+        # check application database
+        tbl = swsscommon.Table(pdb, "INTF_TABLE:Ethernet8")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 2
+        assert "10.0.0.4/31" in intf_entries
+        assert "20.0.0.4/31" in intf_entries
+
+        for key in intf_entries:
+            (status, fvs) = tbl.get(key)
+            assert status == True
+            assert len(fvs) == 2
+            for fv in fvs:
+                if fv[0] == "scope":
+                    assert fv[1] == "global"
+                elif fv[0] == "family":
+                    assert fv[1] == "IPv4"
+                else:
+                    assert False
+
+        # check ASIC route database
+        tbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
+        for key in tbl.getKeys():
+            route = json.loads(key)
+            if route["dest"] == "20.0.0.4/31":
+                subnet_found = True
+            if route["dest"] == "20.0.0.4/32":
+                ip2me_found = True
+
+        assert subnet_found and ip2me_found
+
+        tbl = swsscommon.Table(cdb, "INTERFACE")
+        tbl._del("Ethernet8|20.0.0.4/31")
+        time.sleep(1)
 
     def test_InterfaceRemoveIpv4Address(self, dvs):
         pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)


### PR DESCRIPTION
This test is to cover cases where one router interface
has two IPs assigned to it.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>