### PR TITLE
Support ecn on/off on a queue

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -290,7 +290,7 @@ bool Orch::parseReference(type_map &type_maps, string &ref_in, string &type_name
                 if (type_it != type_maps.end())
                 {
                     type_name = tokens[0];
-                    SWSS_LOG_ERROR("Orch::parseReference: type_name:%s, object_name: missing\n", tokens[0].c_str());
+                    SWSS_LOG_INFO("Incomplete reference received: type_name:%s, object_name: missing\n", tokens[0].c_str());
                     return false;
                 }
             }

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -285,7 +285,7 @@ bool Orch::parseReference(type_map &type_maps, string &ref_in, string &type_name
     {
         // value set by user is "[]"
         // Deem it as a valid format
-        // clear both type_name  and object_name
+        // clear both type_name and object_name
         // as an indication to the caller that
         // such a case has been encountered
         SWSS_LOG_INFO("special reference:%s.", ref_in.c_str());

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -288,7 +288,6 @@ bool Orch::parseReference(type_map &type_maps, string &ref_in, string &type_name
         // clear both type_name and object_name
         // as an indication to the caller that
         // such a case has been encountered
-        SWSS_LOG_INFO("special reference:%s.", ref_in.c_str());
         type_name.clear();
         object_name.clear();
         return true;
@@ -348,24 +347,17 @@ ref_resolve_status Orch::resolveFieldRefValue(
             {
                 return ref_resolve_status::not_resolved;
             }
-            if (ref_type_name.empty() && object_name.empty())
+            else if (ref_type_name.empty() && object_name.empty())
             {
-                sai_object = SAI_NULL_OBJECT_ID;
+                return ref_resolve_status::empty;
             }
-            else
-            {
-                sai_object = (*(type_maps[ref_type_name]))[object_name];
-            }
+            sai_object = (*(type_maps[ref_type_name]))[object_name];
             hit = true;
         }
     }
     if (!hit)
     {
         return ref_resolve_status::field_not_found;
-    }
-    if (SAI_NULL_OBJECT_ID == sai_object)
-    {
-        return ref_resolve_status::empty;
     }
     return ref_resolve_status::success;
 }

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -155,6 +155,7 @@ typedef enum
     field_not_found,
     multiple_instances,
     not_resolved,
+    object_name_empty,
     failure
 } ref_resolve_status;
 

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -155,7 +155,7 @@ typedef enum
     field_not_found,
     multiple_instances,
     not_resolved,
-    object_name_empty,
+    empty,
     failure
 } ref_resolve_status;
 

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1155,7 +1155,6 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
                 return task_process_status::task_failed;
             }
 
-
             sai_object_id_t sai_wred_profile;
             resolve_result = resolveFieldRefValue(m_qos_maps, wred_profile_field_name, tuple, sai_wred_profile);
             if (ref_resolve_status::success == resolve_result)

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1182,13 +1182,28 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
             }
             else if (resolve_result != ref_resolve_status::field_not_found)
             {
-                if(ref_resolve_status::not_resolved == resolve_result)
+                if (ref_resolve_status::object_name_empty == resolve_result)
                 {
-                    SWSS_LOG_INFO("Missing or invalid wred reference");
+                    SWSS_LOG_ERROR("Missing wred reference. Unbind wred profile from queue");
+                    // NOTE: The wred profile is un-bound from the port. But the wred profile itself still exists
+                    // and stays untouched.
+                    result = applyWredProfileToQueue(port, queue_ind, SAI_NULL_OBJECT_ID);
+                    if (!result)
+                    {
+                        SWSS_LOG_ERROR("Failed unbinding field:%s from port:%s, queue:%zd, line:%d", wred_profile_field_name.c_str(), port.m_alias.c_str(), queue_ind, __LINE__);
+                        return task_process_status::task_failed;
+                    }
+                }
+                else if (ref_resolve_status::not_resolved == resolve_result)
+                {
+                    SWSS_LOG_ERROR("Invalid wred reference");
                     return task_process_status::task_need_retry;
                 }
-                SWSS_LOG_ERROR("Resolving wred reference failed");
-                return task_process_status::task_failed;
+                else
+                {
+                    SWSS_LOG_ERROR("Resolving wred reference failed");
+                    return task_process_status::task_failed;
+                }
             }
         }
     }

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1189,7 +1189,7 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
             }
             else if (resolve_result != ref_resolve_status::field_not_found)
             {
-                if (ref_resolve_status::object_name_empty == resolve_result)
+                if (ref_resolve_status::empty == resolve_result)
                 {
                     SWSS_LOG_INFO("Missing wred reference. Unbind wred profile from queue");
                     // NOTE: The wred profile is un-bound from the port. But the wred profile itself still exists

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -103,7 +103,6 @@ task_process_status QosMapHandler::processWorkItem(Consumer& consumer)
             }
             (*(QosOrch::getTypeMap()[qos_map_type_name]))[qos_object_name] = sai_object;
             SWSS_LOG_NOTICE("Created [%s:%s]", qos_map_type_name.c_str(), qos_object_name.c_str());
-            SWSS_LOG_ERROR("QosMapHandler::processWorkItem: Created object_map: %s: %lu", qos_object_name.c_str(), sai_object);
         }
         freeAttribResources(attributes);
     }
@@ -1086,7 +1085,6 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
     bool result;
     string key = kfvKey(tuple);
     string op = kfvOp(tuple);
-    vector<FieldValueTuple> &fvVec = kfvFieldsValues(tuple);
     size_t queue_ind = 0;
     vector<string> tokens;
 
@@ -1095,7 +1093,6 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
 
     ref_resolve_status  resolve_result;
     // sample "QUEUE: {Ethernet4|0-1}"
-    SWSS_LOG_ERROR("handleQueueTable: key: %s", key.c_str());
     tokens = tokenize(key, config_db_key_delimiter);
     if (tokens.size() != 2)
     {
@@ -1126,7 +1123,6 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
             resolve_result = resolveFieldRefValue(m_qos_maps, scheduler_field_name, tuple, sai_scheduler_profile);
             if (ref_resolve_status::success == resolve_result)
             {
-                SWSS_LOG_ERROR("handleQueueTable: resolved field: scheduler");
                 if (op == SET_COMMAND)
                 {
                     result = applySchedulerToQueueSchedulerGroup(port, queue_ind, sai_scheduler_profile);
@@ -1160,12 +1156,10 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
             }
 
 
-            SWSS_LOG_ERROR("handleQueueTable: size of FieldValueTuple vector: %lu", fvVec.size());
             sai_object_id_t sai_wred_profile;
             resolve_result = resolveFieldRefValue(m_qos_maps, wred_profile_field_name, tuple, sai_wred_profile);
             if (ref_resolve_status::success == resolve_result)
             {
-                SWSS_LOG_ERROR("handleQueueTable: resolved field: wred");
                 if (op == SET_COMMAND)
                 {
                     result = applyWredProfileToQueue(port, queue_ind, sai_wred_profile);

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -103,6 +103,7 @@ task_process_status QosMapHandler::processWorkItem(Consumer& consumer)
             }
             (*(QosOrch::getTypeMap()[qos_map_type_name]))[qos_object_name] = sai_object;
             SWSS_LOG_NOTICE("Created [%s:%s]", qos_map_type_name.c_str(), qos_object_name.c_str());
+            SWSS_LOG_ERROR("QosMapHandler::processWorkItem: Created object_map: %s: %lu", qos_object_name.c_str(), sai_object);
         }
         freeAttribResources(attributes);
     }
@@ -1085,6 +1086,7 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
     bool result;
     string key = kfvKey(tuple);
     string op = kfvOp(tuple);
+    vector<FieldValueTuple> &fvVec = kfvFieldsValues(tuple);
     size_t queue_ind = 0;
     vector<string> tokens;
 
@@ -1093,6 +1095,7 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
 
     ref_resolve_status  resolve_result;
     // sample "QUEUE: {Ethernet4|0-1}"
+    SWSS_LOG_ERROR("handleQueueTable: key: %s", key.c_str());
     tokens = tokenize(key, config_db_key_delimiter);
     if (tokens.size() != 2)
     {
@@ -1123,6 +1126,7 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
             resolve_result = resolveFieldRefValue(m_qos_maps, scheduler_field_name, tuple, sai_scheduler_profile);
             if (ref_resolve_status::success == resolve_result)
             {
+                SWSS_LOG_ERROR("handleQueueTable: resolved field: scheduler");
                 if (op == SET_COMMAND)
                 {
                     result = applySchedulerToQueueSchedulerGroup(port, queue_ind, sai_scheduler_profile);
@@ -1155,10 +1159,13 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
                 return task_process_status::task_failed;
             }
 
+
+            SWSS_LOG_ERROR("handleQueueTable: size of FieldValueTuple vector: %lu", fvVec.size());
             sai_object_id_t sai_wred_profile;
             resolve_result = resolveFieldRefValue(m_qos_maps, wred_profile_field_name, tuple, sai_wred_profile);
             if (ref_resolve_status::success == resolve_result)
             {
+                SWSS_LOG_ERROR("handleQueueTable: resolved field: wred");
                 if (op == SET_COMMAND)
                 {
                     result = applyWredProfileToQueue(port, queue_ind, sai_wred_profile);

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1191,7 +1191,7 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
             {
                 if (ref_resolve_status::object_name_empty == resolve_result)
                 {
-                    SWSS_LOG_ERROR("Missing wred reference. Unbind wred profile from queue");
+                    SWSS_LOG_INFO("Missing wred reference. Unbind wred profile from queue");
                     // NOTE: The wred profile is un-bound from the port. But the wred profile itself still exists
                     // and stays untouched.
                     result = applyWredProfileToQueue(port, queue_ind, SAI_NULL_OBJECT_ID);
@@ -1203,7 +1203,7 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
                 }
                 else if (ref_resolve_status::not_resolved == resolve_result)
                 {
-                    SWSS_LOG_ERROR("Invalid wred reference");
+                    SWSS_LOG_INFO("Invalid wred reference");
                     return task_process_status::task_need_retry;
                 }
                 else


### PR DESCRIPTION
The approach is to use "[]" as a CLI signal to unbind wred profile from a queue or a list of queues; Add the parsing and processing logic in qosorch to support such an operation. 

With the correct SAI support, we can see asic_db is correctly set to "SAI_QUEUE_ATTR_WRED_PROFILE_ID":"oid:0x0"

"ASIC_STATE:SAI_OBJECT_TYPE_QUEUE:oid:0x15000000000285":{"type":"hash","value":
{"SAI_QUEUE_ATTR_BUFFER_PROFILE_ID":"oid:0x190000000005d6","SAI_QUEUE_ATTR_WRED_PROFILE_ID":"oid:0x0","NULL":"NULL","SAI_QUEUE_ATTR_TYPE":"SAI_QUEUE_TYPE_UNICAST"}}



<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**
Tested on dut

**Details if related**
