### PR TITLE
[test]: Change the default router interface MTU to 9100

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -47,7 +47,7 @@ class TestInterfaceIpv4Addresses(object):
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_TYPE":
                         assert fv[1] == "SAI_ROUTER_INTERFACE_TYPE_PORT"
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_MTU":
-                        assert fv[1] == "1500"
+                        assert fv[1] == "9100"
 
         # check ASIC route database
         tbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")


### PR DESCRIPTION
With the recent pull requests, if the router interface is created
without specifying the MTU in the configuration database, the
default MTU would be 9100 instead of 1500.

Note:
9100 comes from the orchagent/port.h; 1500 comes from the kernel.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>