### PR TITLE
Warm reboot: Fix race condition and avoid unnecessary create/delete nexthop_group_…

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -80,6 +80,7 @@ public:
     sai_object_id_t     m_ingress_acl_table_group_id = 0;
     sai_object_id_t     m_egress_acl_table_group_id = 0;
     vlan_members_t      m_vlan_members;
+    sai_port_oper_status_t m_oper_status;
     std::set<std::string> m_members;
     std::vector<sai_object_id_t> m_queue_ids;
     std::vector<sai_object_id_t> m_priority_group_ids;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1027,6 +1027,7 @@ void PortsOrch::updateDbPortOperStatus(sai_object_id_t id, sai_port_oper_status_
             FieldValueTuple tuple("oper_status", oper_status_strings.at(status));
             tuples.push_back(tuple);
             m_portTable->set(it->first, tuples);
+            it->second.m_oper_status = status;
         }
     }
 }
@@ -2098,6 +2099,11 @@ bool PortsOrch::initializePort(Port &p)
         FieldValueTuple tuple("oper_status", "down");
         vector.push_back(tuple);
         m_portTable->set(p.m_alias, vector);
+        p.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
+    }
+    else
+    {
+        p.m_oper_status = SAI_PORT_OPER_STATUS_UP;
     }
 
     return true;

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -515,7 +515,6 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
 
     vector<sai_object_id_t> next_hop_ids;
     set<IpAddress> next_hop_set = ipAddresses.getIpAddresses();
-    sai_object_id_t next_hop_id;
     std::map<sai_object_id_t, IpAddress> nhopgroup_members_set;
 
     /* Assert each IP address exists in m_syncdNextHops table,
@@ -564,6 +563,11 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
 
     for (auto nhid: next_hop_ids)
     {
+        // skip next hop group member create for neighbor from down port
+        if (m_neighOrch->isNextHopFlagSet(nhopgroup_members_set[nhid], NHFLAGS_IFDOWN)) {
+            continue;
+        }
+
         // Create a next hop group member
         vector<sai_attribute_t> nhgm_attrs;
 
@@ -608,21 +612,6 @@ bool RouteOrch::addNextHopGroup(IpAddresses ipAddresses)
     next_hop_group_entry.ref_count = 0;
     m_syncdNextHopGroups[ipAddresses] = next_hop_group_entry;
 
-    for (auto nhop : next_hop_set) {
-        if (!m_neighOrch->isNextHopFlagSet(nhop, NHFLAGS_IFDOWN)) {
-            continue;
-        }
-
-        next_hop_id = next_hop_group_entry.nhopgroup_members[nhop];
-        status = sai_next_hop_group_api->remove_next_hop_group_member(next_hop_id);
-
-        if (status != SAI_STATUS_SUCCESS) {
-            SWSS_LOG_ERROR("Failed to remove next hop group member %lx: %d\n",
-                           next_hop_id, status);
-        }
-
-        gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
-    }
 
     return true;
 }
@@ -651,6 +640,8 @@ bool RouteOrch::removeNextHopGroup(IpAddresses ipAddresses)
 
         if (m_neighOrch->isNextHopFlagSet(nhop->first, NHFLAGS_IFDOWN))
         {
+            SWSS_LOG_WARN("NHFLAGS_IFDOWN set for next hop group member %s with next_hop_id %lx",
+                           nhop->first.to_string().c_str(), nhop->second);
             nhop = next_hop_group_entry->second.nhopgroup_members.erase(nhop);
             continue;
         }

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -423,6 +423,12 @@ def test_CrmNexthopGroup(dvs):
 
 def test_CrmNexthopGroupMember(dvs):
 
+    # down, then up to generate port up signal
+    dvs.servers[0].runcmd("ip link set down dev eth0") == 0
+    dvs.servers[1].runcmd("ip link set down dev eth0") == 0
+    dvs.servers[0].runcmd("ip link set up dev eth0") == 0
+    dvs.servers[1].runcmd("ip link set up dev eth0") == 0
+
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
     dvs.runcmd("ifconfig Ethernet4 10.0.0.2/31 up")
 


### PR DESCRIPTION
…member

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**

**Why I did it**
<1> Fix the possible race condition when port is down, but previously buffered neigbor and next hop group events are processed later.

<2> Remove the unnecessary create_next_hop_group_member()/remove_next_hop_group_member() operations for nexthop on down port which may cause traffic interruption.

<3> The change also happens to fix the state restore for ecmp acceleration during warm reboot.
The scenario:
   -  Port is down,  NHFLAGS_IFDOWN is set on the next hop and the next_hop_group_member_id has been removed from the next hop group.    
   - system/orchagent shutdown for warm start.
   - orchagent state restore with certain port oper status down, nexthop(neighbor), nexthop group will be restored from appDB.

**How I verified it**
VS test.
**Details if related**
