### PR TITLE
[portsorch]: Support LAG MTU configuration

### DIFF
--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -1,4 +1,5 @@
 #include <string>
+
 #include "logger.h"
 #include "dbconnector.h"
 #include "producerstatetable.h"
@@ -16,17 +17,57 @@ PortMgr::PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_cfgPortTable(cfgDb, CFG_PORT_TABLE_NAME),
         m_cfgLagTable(cfgDb, CFG_LAG_TABLE_NAME),
         m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
-        m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME)
+        m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME),
+        m_appPortTable(appDb, APP_PORT_TABLE_NAME),
+        m_appLagTable(appDb, APP_LAG_TABLE_NAME)
 {
 }
 
-bool PortMgr::setPortMtu(const string &alias, const string &mtu)
+bool PortMgr::setPortMtu(const string &table, const string &alias, const string &mtu)
 {
     stringstream cmd;
     string res;
 
     cmd << IP_CMD << " link set dev " << alias << " mtu " << mtu;
-    return exec(cmd.str(), res) == 0;
+    EXEC_WITH_ERROR_THROW(cmd.str(), res);
+
+    if (table == CFG_PORT_TABLE_NAME)
+    {
+        // Set the port MTU in application database to update both
+        // the port MTU and possibly the port based router interface MTU
+        vector<FieldValueTuple> fvs;
+        FieldValueTuple fv("mtu", mtu);
+        fvs.push_back(fv);
+        m_appPortTable.set(alias, fvs);
+    }
+    else if (table == CFG_LAG_TABLE_NAME)
+    {
+        // Set the port channel MTU in application database to update
+        // the LAG based router interface MTU in orchagent
+        vector<FieldValueTuple> fvs;
+        FieldValueTuple fv("mtu", mtu);
+        fvs.push_back(fv);
+        m_appLagTable.set(alias, fvs);
+
+        m_cfgLagTable.get(alias, fvs);
+        for (auto fv: fvs)
+        {
+            // Set the port channel members MTU in application database
+            // to update the port MTU in orchagent
+            if (fvField(fv) == "members")
+            {
+                for (auto member : tokenize(fvValue(fv), ','))
+                {
+                    vector<FieldValueTuple> member_fvs;
+                    FieldValueTuple member_fv("mtu", mtu);
+                    member_fvs.push_back(member_fv);
+                    m_appPortTable.set(member, member_fvs);
+                }
+            }
+        }
+    }
+
+    return true;
 }
 
 bool PortMgr::setPortAdminStatus(const string &alias, const bool up)
@@ -35,7 +76,9 @@ bool PortMgr::setPortAdminStatus(const string &alias, const bool up)
     string res;
 
     cmd << IP_CMD << " link set dev " << alias << (up ? " up" : " down");
-    return exec(cmd.str(), res) == 0;
+    EXEC_WITH_ERROR_THROW(cmd.str(), res);
+
+    return true;
 }
 
 bool PortMgr::isPortStateOk(const string &table, const string &alias)
@@ -80,7 +123,7 @@ void PortMgr::doTask(Consumer &consumer)
         {
             if (!isPortStateOk(table, alias))
             {
-                SWSS_LOG_INFO("Port %s is not ready, pending", alias.c_str());
+                SWSS_LOG_INFO("Port %s is not ready, pending...", alias.c_str());
                 it++;
                 continue;
             }
@@ -90,7 +133,7 @@ void PortMgr::doTask(Consumer &consumer)
                 if (fvField(i) == "mtu")
                 {
                     auto mtu = fvValue(i);
-                    setPortMtu(alias, mtu);
+                    setPortMtu(table, alias, mtu);
                     SWSS_LOG_NOTICE("Configure %s MTU to %s",
                                     alias.c_str(), mtu.c_str());
                 }

--- a/cfgmgr/portmgr.h
+++ b/cfgmgr/portmgr.h
@@ -21,9 +21,11 @@ private:
     Table m_cfgLagTable;
     Table m_statePortTable;
     Table m_stateLagTable;
+    ProducerStateTable m_appPortTable;
+    ProducerStateTable m_appLagTable;
 
     void doTask(Consumer &consumer);
-    bool setPortMtu(const string &alias, const string &mtu);
+    bool setPortMtu(const string &table, const string &alias, const string &mtu);
     bool setPortAdminStatus(const string &alias, const bool up);
     bool isPortStateOk(const string &table, const string &alias);
 };

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -310,13 +310,14 @@ bool IntfsOrch::addRouterIntfs(Port &port)
     sai_status_t status = sai_router_intfs_api->create_router_interface(&port.m_rif_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to create router interface for port %s, rv:%d", port.m_alias.c_str(), status);
+        SWSS_LOG_ERROR("Failed to create router interface %s, rv:%d",
+                port.m_alias.c_str(), status);
         throw runtime_error("Failed to create router interface.");
     }
 
     gPortsOrch->setPort(port.m_alias, port);
 
-    SWSS_LOG_NOTICE("Create router interface for port %s mtu %u", port.m_alias.c_str(), port.m_mtu);
+    SWSS_LOG_NOTICE("Create router interface %s MTU %u", port.m_alias.c_str(), port.m_mtu);
 
     return true;
 }

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -45,25 +45,22 @@ void TeamSync::onMsg(int nlmsg_type, struct nl_object *obj)
 
     addLag(lagName, rtnl_link_get_ifindex(link),
            rtnl_link_get_flags(link) & IFF_UP,
-           rtnl_link_get_flags(link) & IFF_LOWER_UP,
-           rtnl_link_get_mtu(link));
+           rtnl_link_get_flags(link) & IFF_LOWER_UP);
 }
 
 void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
-                      bool oper_state, unsigned int mtu)
+                      bool oper_state)
 {
     /* Set the LAG */
     std::vector<FieldValueTuple> fvVector;
     FieldValueTuple a("admin_status", admin_state ? "up" : "down");
     FieldValueTuple o("oper_status", oper_state ? "up" : "down");
-    FieldValueTuple m("mtu", to_string(mtu));
     fvVector.push_back(a);
     fvVector.push_back(o);
-    fvVector.push_back(m);
     m_lagTable.set(lagName, fvVector);
 
-    SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s mtu:%d",
-                   lagName.c_str(), admin_state ? "up" : "down", oper_state ? "up" : "down", mtu);
+    SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s",
+                   lagName.c_str(), admin_state ? "up" : "down", oper_state ? "up" : "down");
 
     /* Return when the team instance has already been tracked */
     if (m_teamPorts.find(lagName) != m_teamPorts.end())

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -50,7 +50,7 @@ public:
 
 protected:
     void addLag(const std::string &lagName, int ifindex, bool admin_state,
-                bool oper_state, unsigned int mtu);
+                bool oper_state);
     void removeLag(const std::string &lagName);
 
 private:


### PR DESCRIPTION
- LAG MTU configuration is now on stage

- By default, the MTU of port channel based router interface is 9100.

- If a new MTU is applied to the port channel via configuration
  database, this new MTU will be used 1) to the netdev in the kernel
  via ip command; 2) to all the member netdevs in the kernel via teamd;
  3) to the port channel based router interface MTU; 4) to all the
  member port MTU.

- Remove the libnl MTU from teamsyncd

- Refactor test_interface.py tests. Each one test is independent from
  the other test. The switch will be cleaned up at the end of the test.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>