### PR TITLE
support to use python docker 3.5.0

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ SWSS Integration tests runs on docker-sonic-vs which runs on top of SAI virtual 
 
 - Install docker and pytest on your dev machine
     ```
-    sudo pip install --system docker==2.6.1
+    sudo pip install --system docker==3.5.0
     sudo pip install --system pytest==3.3.0
     ```
 - Compile and install swss common library. Follow instructions [here](https://github.com/Azure/sonic-swss-common/blob/master/README.md) to first install prerequisites to build swss common library. 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,7 +175,7 @@ class DockerVirtualSwitch(object):
             res = self.ctn.exec_run("supervisorctl status")
             try:
                 out = res.output
-            except:
+            except AttributeError:
                 out = res
             for l in out.split('\n'):
                 fds = re_space.split(l)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,7 +208,14 @@ class DockerVirtualSwitch(object):
         self.asicdb = AsicDbValidator(self)
 
     def runcmd(self, cmd):
-        return self.ctn.exec_run(cmd)
+        res = self.ctn.exec_run(cmd)
+        try:
+            exitcode = res.exit_code
+            out = res.output
+        except AttributeError:
+            exitcode = 0
+            out = res
+        return (exitcode, out)
 
 @pytest.yield_fixture(scope="module")
 def dvs(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,7 +172,11 @@ class DockerVirtualSwitch(object):
         started = 0
         while True:
             # get process status
-            out = self.ctn.exec_run("supervisorctl status")
+            res = self.ctn.exec_run("supervisorctl status")
+            try:
+                out = res.output
+            except:
+                out = res
             for l in out.split('\n'):
                 fds = re_space.split(l)
                 if len(fds) < 2:

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -169,7 +169,7 @@ def test_VlanMgrdWarmRestart(dvs):
     assert status == True
 
 
-    bv_before = dvs.runcmd("bridge vlan")
+    (exitcode, bv_before) = dvs.runcmd("bridge vlan")
     print(bv_before)
 
     restart_count = swss_get_RestartCount(state_db)
@@ -178,15 +178,15 @@ def test_VlanMgrdWarmRestart(dvs):
     dvs.runcmd(['sh', '-c', 'supervisorctl start vlanmgrd'])
     time.sleep(2)
 
-    bv_after = dvs.runcmd("bridge vlan")
+    (exitcode, bv_after) = dvs.runcmd("bridge vlan")
     assert bv_after == bv_before
 
      # No create/set/remove operations should be passed down to syncd for vlanmgr warm restart
-    num = dvs.runcmd(['sh', '-c', 'grep \|c\| /var/log/swss/sairedis.rec | wc -l'])
+    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|c\| /var/log/swss/sairedis.rec | wc -l'])
     assert num == '0\n'
-    num = dvs.runcmd(['sh', '-c', 'grep \|s\| /var/log/swss/sairedis.rec | wc -l'])
+    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|s\| /var/log/swss/sairedis.rec | wc -l'])
     assert num == '0\n'
-    num = dvs.runcmd(['sh', '-c', 'grep \|r\| /var/log/swss/sairedis.rec | wc -l'])
+    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|r\| /var/log/swss/sairedis.rec | wc -l'])
     assert num == '0\n'
 
     #new ip on server 5


### PR DESCRIPTION
start from docker 3.0.0, results from exec_run changed to
dict(outout, code)

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
allow test to use latest python docker 3.5.0

**Why I did it**
to use latest python docker 3.5.0

**How I verified it**
run test with both docker 3.5.0 and 2.6.1

**Details if related**
