### PR TITLE
Tune consumer order in BufferOrch::doTask() based on dependency for warm start

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -643,7 +643,7 @@ void BufferOrch::doTask()
     //      3.1	    Ingress priority group (PG) configuration
     //      3.2.1	Buffer profile configuration
     //
-    // buffer poll
+    // buffer pool
     // └── buffer profile
     //     ├── buffer port ingress profile list
     //     ├── buffer port egress profile list

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -637,6 +637,19 @@ task_process_status BufferOrch::processEgressBufferProfileList(Consumer &consume
 
 void BufferOrch::doTask()
 {
+    // The hidden dependency tree:
+    // ref: https://github.com/opencomputeproject/SAI/blob/master/doc/QOS/SAI-Proposal-buffers-Ver4.docx
+    //      2	    SAI model
+    //      3.1	    Ingress priority group (PG) configuration
+    //      3.2.1	Buffer profile configuration
+    //
+    // buffer poll
+    // └── buffer profile
+    //     ├── buffer port ingress profile list
+    //     ├── buffer port egress profile list
+    //     ├── buffer queue
+    //     └── buffer pq table
+
     auto pool_consumer = getExecutor((CFG_BUFFER_POOL_TABLE_NAME));
     pool_consumer->drain();
 

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -38,8 +38,8 @@ private:
     virtual void doTask() override;
     virtual void doTask(Consumer& consumer);
     void initTableHandlers();
-    void initBufferReadyLists();
-    void initBufferReadyList(std::deque<KeyOpFieldsValuesTuple>& entries);
+    void initBufferReadyLists(DBConnector *db);
+    void initBufferReadyList(Table& table);
     task_process_status processBufferPool(Consumer &consumer);
     task_process_status processBufferProfile(Consumer &consumer);
     task_process_status processQueue(Consumer &consumer);

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -35,10 +35,11 @@ private:
     typedef map<string, buffer_table_handler> buffer_table_handler_map;
     typedef pair<string, buffer_table_handler> buffer_handler_pair;
 
+    virtual void doTask() override;
     virtual void doTask(Consumer& consumer);
     void initTableHandlers();
-    void initBufferReadyLists(DBConnector *db);
-    void initBufferReadyList(Table& table);
+    void initBufferReadyLists();
+    void initBufferReadyList(std::deque<KeyOpFieldsValuesTuple>& entries);
     task_process_status processBufferPool(Consumer &consumer);
     task_process_status processBufferProfile(Consumer &consumer);
     task_process_status processQueue(Consumer &consumer);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -182,7 +182,7 @@ public:
     virtual bool bake();
 
     /* Iterate all consumers in m_consumerMap and run doTask(Consumer) */
-    void doTask();
+    virtual void doTask();
 
     /* Run doTask against a specific executor */
     virtual void doTask(Consumer &consumer) = 0;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -264,7 +264,11 @@ bool OrchDaemon::init()
 
     if (WarmStart::isWarmStart())
     {
-        warmRestoreAndSyncUp();
+        bool suc = warmRestoreAndSyncUp();
+        if (!suc)
+        {
+            return false;
+        }
     }
 
     return true;
@@ -336,7 +340,7 @@ void OrchDaemon::start()
  * Try to perform orchagent state restore and dynamic states sync up if
  * warm start reqeust is detected.
  */
-void OrchDaemon::warmRestoreAndSyncUp()
+bool OrchDaemon::warmRestoreAndSyncUp()
 {
     WarmStart::setWarmStartState("orchagent", WarmStart::INIT);
 
@@ -366,7 +370,12 @@ void OrchDaemon::warmRestoreAndSyncUp()
      * orchagent should be in exact same state of pre-shutdown.
      * Perform restore validation as needed.
      */
-    warmRestoreValidation();
+    bool suc = warmRestoreValidation();
+    if (!suc)
+    {
+        SWSS_LOG_ERROR("Orchagent state restore failed");
+        return false;
+    }
 
     SWSS_LOG_NOTICE("Orchagent state restore done");
 
@@ -377,6 +386,7 @@ void OrchDaemon::warmRestoreAndSyncUp()
      * The "RECONCILED" state of orchagent doesn't mean the state related to neighbor is up to date.
      */
     WarmStart::setWarmStartState("orchagent", WarmStart::RECONCILED);
+    return true;
 }
 
 /*

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -34,7 +34,7 @@ public:
 
     bool init();
     void start();
-    void warmRestoreAndSyncUp();
+    bool warmRestoreAndSyncUp();
     void getTaskToSync(vector<string> &ts);
     bool warmRestoreValidation();
 private:


### PR DESCRIPTION
Tested in VS:
1. cold start
2. change config DB
```
127.0.0.1:6379[4]> hset WARM_RESTART|swss enable true
```
3. restart orchagent process only
4. observe syslog about "There are pending consumer tasks after restore". There will be no buffer related tasks.