### PR TITLE
WarmRestart class changes

### DIFF
--- a/cfgmgr/vlanmgrd.cpp
+++ b/cfgmgr/vlanmgrd.cpp
@@ -57,6 +57,7 @@ int main(int argc, char **argv)
         DBConnector appDb(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
         DBConnector stateDb(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
 
+        WarmStart::initialize("vlanmgrd");
         WarmStart::checkWarmStart("vlanmgrd");
 
         /*

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -734,15 +734,14 @@ Stores information for physical switch ports managed by the switch chip. Ports t
                                                               ; of times an application has iterated through
                                                               ; a warm-restart cycle.
 
-    state           = "initialized" / "restored" / "reconciled"  ; initialized: default/initial state for processes
-                                                                 ; with warm-restart capabilities turned on. This
-                                                                 ; state will be applied permanently for processes
-                                                                 ; with warm-restart feature being turned off.
+    state           = "initialized" / "restored" / "reconciled"  ; initialized: initial FSM state for processes
+                                                                 ; with warm-restart capabilities turned on.
                                                                  ;
-                                                                 ; restored: process restored to the previous
-                                                                 ; state using saved data.
+                                                                 ; restored: process restored the state previously
+                                                                 ; uploaded to redis data-stores.
                                                                  ;
-                                                                 ; reconciled: process reconciled with updated
+                                                                 ; reconciled: process reconciled 'old' and 'new'
+                                                                 ; state collected in 'restored' phase. Examples:
                                                                  ; dynanic data like port state, neighbor, routes
                                                                  ; and so on.
 

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -677,6 +677,15 @@ Stores information for physical switch ports managed by the switch chip. Ports t
                                             ; and push the delta to appDB
                                             ; Valid value is 1-9999. 0 is invalid.
 
+    bgp_timer           = 1*4DIGIT          ; bgp_timer holds the time interval utilized by fpmsyncd during warm-restart episodes.
+                                            ; During this interval fpmsyncd will recover all the routing state previously pushed to
+                                            ; AppDB, as well as all the new state coming from zebra/bgpd. Upon expiration of this
+                                            ; timer, fpmsyncd will execute the reconciliation logic to eliminate all the staled
+                                            ; state from AppDB. This timer should match the BGP-GR restart-timer configured within
+                                            ; the elected routing-stack.
+                                            ; Supported range: 1-9999.
+
+
 ### VXLAN\_TUNNEL
 Stores vxlan tunnels configuration
 Status: ready
@@ -717,15 +726,25 @@ Stores information for physical switch ports managed by the switch chip. Ports t
     ;Status: work in progress
 
     key             = WARM_RESTART_TABLE:process_name         ; process_name is a unique process identifier.
-    restart_count   = 1*10DIGIT                               ; a number between 0 and 2147483647,
-                                                              ; count of warm start times.
 
-    state           = "init" / "restored" / "reconciled"      ; init: process init with warm start enabled.
-                                                              ; restored: process restored to the previous
-                                                              ; state using saved data.
-                                                              ; reconciled: process reconciled with up to date
-                                                              ; dynanic data like port state, neighbor, routes
-                                                              ; and so on.
+    restore_count   = 1*10DIGIT                               ; a value between 0 and 2147483647 to keep track
+                                                              ; of the number of times that an application has
+                                                              ; 'restored' its state from its associated redis
+                                                              ; data-store; which is equivalent to the number
+                                                              ; of times an application has iterated through
+                                                              ; a warm-restart cycle.
+
+    state           = "initialized" / "restored" / "reconciled"  ; initialized: default/initial state for processes
+                                                                 ; with warm-restart capabilities turned on. This
+                                                                 ; state will be applied permanently for processes
+                                                                 ; with warm-restart feature being turned off.
+                                                                 ;
+                                                                 ; restored: process restored to the previous
+                                                                 ; state using saved data.
+                                                                 ;
+                                                                 ; reconciled: process reconciled with updated
+                                                                 ; dynanic data like port state, neighbor, routes
+                                                                 ; and so on.
 
 ## Configuration files
 What configuration files should we have?  Do apps, orch agent each need separate files?
@@ -735,4 +754,3 @@ What configuration files should we have?  Do apps, orch agent each need separate
 portsyncd reads from port_config.ini and updates PORT_TABLE in APP_DB
 
 All other apps (intfsyncd) read from PORT_TABLE in APP_DB
-

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -101,6 +101,8 @@ int main(int argc, char **argv)
     swss::Logger::linkToDbNative("orchagent");
 
     SWSS_LOG_ENTER();
+
+    WarmStart::initialize("orchagent");
     WarmStart::checkWarmStart("orchagent");
 
     if (signal(SIGHUP, sighup_handler) == SIG_ERR)

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -377,7 +377,7 @@ void OrchDaemon::start()
  */
 bool OrchDaemon::warmRestoreAndSyncUp()
 {
-    WarmStart::setWarmStartState("orchagent", WarmStart::INIT);
+    WarmStart::setWarmStartState("orchagent", WarmStart::INITIALIZED);
 
     for (Orch *o : m_orchList)
     {

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -75,6 +75,7 @@ int main(int argc, char **argv)
     ProducerStateTable p(&appl_db, APP_PORT_TABLE_NAME);
     SubscriberStateTable portCfg(&cfgDb, CFG_PORT_TABLE_NAME);
 
+    WarmStart::initialize("portsyncd");
     WarmStart::checkWarmStart("portsyncd");
     if (WarmStart::isWarmStart())
     {

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -312,7 +312,7 @@ def test_VlanMgrdWarmRestart(dvs):
     (status, fvs) = tbl.get("Vlan20:11.0.0.11")
     assert status == True
 
-    swss_app_check_RestartCount_single(state_db, restart_count, "vlanmgrd")
+    swss_app_check_RestoreCount_single(state_db, restore_count, "vlanmgrd")
 
 # function to stop neighsyncd service and clear syslog and sairedis records
 def stop_neighsyncd_clear_syslog_sairedis(dvs, save_number):
@@ -436,8 +436,8 @@ def test_swss_neighbor_syncup(dvs):
     # appDB should be kept the same.
     #
 
-    # get restart_count
-    restart_count = swss_get_RestartCount(state_db)
+    # get restore_count
+    restore_count = swss_get_RestoreCount(state_db)
 
     # stop neighsyncd and clear syslog and sairedis.rec
     stop_neighsyncd_clear_syslog_sairedis(dvs, 1)
@@ -471,8 +471,8 @@ def test_swss_neighbor_syncup(dvs):
     check_syslog_for_neighbor_entry(dvs, 0, 0, "ipv6")
     check_sairedis_for_neighbor_entry(dvs, 0, 0, 0)
 
-    # check restart Count
-    swss_app_check_RestartCount_single(state_db, restart_count, "neighsyncd")
+    # check restore Count
+    swss_app_check_RestoreCount_single(state_db, restore_count, "neighsyncd")
 
     #
     # Testcase 3:
@@ -482,8 +482,8 @@ def test_swss_neighbor_syncup(dvs):
     #       but it will send netlink message to be removed from appDB, so it works ok here,
     #       just that if we want to add the same neighbor again, use "change" instead of "add"
 
-    # get restart_count
-    restart_count = swss_get_RestartCount(state_db)
+    # get restore_count
+    restore_count = swss_get_RestoreCount(state_db)
 
     # stop neighsyncd and clear syslog and sairedis.rec
     stop_neighsyncd_clear_syslog_sairedis(dvs, 2)
@@ -538,8 +538,8 @@ def test_swss_neighbor_syncup(dvs):
     check_syslog_for_neighbor_entry(dvs, 0, 2, "ipv4")
     check_syslog_for_neighbor_entry(dvs, 0, 2, "ipv6")
     check_sairedis_for_neighbor_entry(dvs, 0, 0, 4)
-    # check restart Count
-    swss_app_check_RestartCount_single(state_db, restart_count, "neighsyncd")
+    # check restore Count
+    swss_app_check_RestoreCount_single(state_db, restore_count, "neighsyncd")
 
 
     #
@@ -549,8 +549,8 @@ def test_swss_neighbor_syncup(dvs):
     # The neighsyncd is supposed to sync up the entries from kernel after warm restart
     # Check the timer is not retrieved from configDB since it is not configured
 
-    # get restart_count
-    restart_count = swss_get_RestartCount(state_db)
+    # get restore_count
+    restore_count = swss_get_RestoreCount(state_db)
 
     # stop neighsyncd and clear syslog and sairedis.rec
     stop_neighsyncd_clear_syslog_sairedis(dvs, 3)
@@ -594,8 +594,8 @@ def test_swss_neighbor_syncup(dvs):
     check_syslog_for_neighbor_entry(dvs, 2, 0, "ipv4")
     check_syslog_for_neighbor_entry(dvs, 2, 0, "ipv6")
     check_sairedis_for_neighbor_entry(dvs, 4, 0, 0)
-    # check restart Count
-    swss_app_check_RestartCount_single(state_db, restart_count, "neighsyncd")
+    # check restore Count
+    swss_app_check_RestoreCount_single(state_db, restore_count, "neighsyncd")
 
     #
     # Testcase 5:
@@ -615,8 +615,8 @@ def test_swss_neighbor_syncup(dvs):
         ]
     )
 
-    # get restart_count
-    restart_count = swss_get_RestartCount(state_db)
+    # get restore_count
+    restore_count = swss_get_RestoreCount(state_db)
 
     # stop neighsyncd and clear syslog and sairedis.rec
     stop_neighsyncd_clear_syslog_sairedis(dvs, 4)
@@ -693,8 +693,9 @@ def test_swss_neighbor_syncup(dvs):
     check_syslog_for_neighbor_entry(dvs, 4, 2, "ipv4")
     check_syslog_for_neighbor_entry(dvs, 4, 2, "ipv6")
     check_sairedis_for_neighbor_entry(dvs, 4, 4, 4)
-    # check restart Count
-    swss_app_check_RestartCount_single(state_db, restart_count, "neighsyncd")
+
+    # check restore Count
+    swss_app_check_RestoreCount_single(state_db, restore_count, "neighsyncd")
 
 
 # TODO: The condition of warm restart readiness check is still under discussion.
@@ -768,7 +769,7 @@ def test_swss_port_state_syncup(dvs):
 
     tbl = swsscommon.Table(appl_db, swsscommon.APP_PORT_TABLE_NAME)
 
-    restart_count = swss_get_RestartCount(state_db)
+    restore_count = swss_get_RestoreCount(state_db)
 
     # update port admin state
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
@@ -815,7 +816,7 @@ def test_swss_port_state_syncup(dvs):
     start_swss(dvs)
     time.sleep(10)
 
-    swss_check_RestartCount(state_db, restart_count)
+    swss_check_RestoreCount(state_db, restore_count)
 
     for i in [0, 1, 2]:
         (status, fvs) = tbl.get("Ethernet%d" % (i * 4))

--- a/warmrestart/warmRestartAssist.cpp
+++ b/warmrestart/warmRestartAssist.cpp
@@ -24,6 +24,7 @@ AppRestartAssist::AppRestartAssist(RedisPipeline *pipeline,
     m_psTable(psTable),
     m_warmStartTimer(timespec{0, 0})
 {
+    WarmStart::initialize(m_appName, m_dockerName);
     WarmStart::checkWarmStart(m_appName, m_dockerName);
 
     m_appTableName = m_appTable.getTableName();
@@ -60,7 +61,7 @@ AppRestartAssist::AppRestartAssist(RedisPipeline *pipeline,
         // Clear the producerstate table to make sure no pending data for the AppTable
         m_psTable->clear();
 
-        WarmStart::setWarmStartState(m_appName, WarmStart::INIT);
+        WarmStart::setWarmStartState(m_appName, WarmStart::INITIALIZED);
     }
 }
 
@@ -266,4 +267,3 @@ bool AppRestartAssist::checkReconcileTimer(Selectable *s)
     }
     return false;
 }
-

--- a/warmrestart/warm_restart.cpp
+++ b/warmrestart/warm_restart.cpp
@@ -55,13 +55,14 @@ void WarmStart::initialize(const std::string &app_name,
  * No need to check docker level knobs in this case since the whole system is being rebooted .
 
  * <2> Upon docker service start, first to check system knob.
- * if enabled, docker warm start should be performed, otherwise system warm reboot will be ruined.
- * If system knob disabled, while docker knob enabled, this is likely an individual docker warm restart request.
+ * if enabled, docker warm-start should be performed, otherwise system warm-reboot will be ruined.
+ * If system knob disabled, while docker knob enabled, this is likely an individual docker
+ * warm-restart request.
 
  * Within each application which should take care warm start case,
  * when the system knob or docker knob enabled, we do further check on the
- * actual warm start state ( restart_count), if no warm start state data available,
- * the database has been flushed, do cold start. Otherwise warm start.
+ * actual warm-start state ( restore_count), if no warm-start state data available,
+ * the database has been flushed, do cold start. Otherwise warm-start.
  */
 
 /*
@@ -95,31 +96,31 @@ bool WarmStart::checkWarmStart(const std::string &app_name,
     // Create the entry for this app here.
     if (!warmStart.m_enabled)
     {
-        warmStart.m_stateWarmRestartTable->hset(app_name, "restart_count", "0");
+        warmStart.m_stateWarmRestartTable->hset(app_name, "restore_count", "0");
         return false;
     }
 
-    uint32_t restart_count = 0;
-    warmStart.m_stateWarmRestartTable->hget(app_name, "restart_count", value);
+    uint32_t restore_count = 0;
+    warmStart.m_stateWarmRestartTable->hget(app_name, "restore_count", value);
     if (value == "")
     {
-        SWSS_LOG_WARN("%s doing warm start, but restart_count not found in stateDB %s table, fall back to cold start",
+        SWSS_LOG_WARN("%s doing warm start, but restore_count not found in stateDB %s table, fall back to cold start",
                 app_name.c_str(), STATE_WARM_RESTART_TABLE_NAME);
         warmStart.m_enabled = false;
-        warmStart.m_stateWarmRestartTable->hset(app_name, "restart_count", "0");
+        warmStart.m_stateWarmRestartTable->hset(app_name, "restore_count", "0");
         return false;
     }
     else
     {
-        restart_count = (uint32_t)stoul(value);
+        restore_count = (uint32_t)stoul(value);
     }
 
-    restart_count++;
-    warmStart.m_stateWarmRestartTable->hset(app_name, "restart_count",
-                                            std::to_string(restart_count));
+    restore_count++;
+    warmStart.m_stateWarmRestartTable->hset(app_name, "restore_count",
+                                            std::to_string(restore_count));
 
-    SWSS_LOG_NOTICE("%s doing warm start, restart count %d", app_name.c_str(),
-                    restart_count);
+    SWSS_LOG_NOTICE("%s doing warm start, restore count %d", app_name.c_str(),
+                    restore_count);
 
     return true;
 }

--- a/warmrestart/warm_restart.cpp
+++ b/warmrestart/warm_restart.cpp
@@ -1,22 +1,52 @@
 #include <string>
+#include <climits>
 #include "logger.h"
 #include "schema.h"
-#include <climits>
 #include "warm_restart.h"
 
 namespace swss {
 
 const WarmStart::WarmStartStateNameMap WarmStart::warmStartStateNameMap =
 {
-    {INIT,          "init"},
+    {INITIALIZED,   "initialized"},
     {RESTORED,      "restored"},
     {RECONCILED,    "reconciled"}
 };
 
-WarmStart &WarmStart::getInstance()
+WarmStart &WarmStart::getInstance(void)
 {
     static WarmStart m_warmStart;
     return m_warmStart;
+}
+
+/*
+ * WarmStart's initialization method -- to be invoked once per application.
+ */
+void WarmStart::initialize(const std::string &app_name,
+                           const std::string &docker_name)
+{
+    auto& warmStart = getInstance();
+
+    if (warmStart.m_initialized)
+    {
+        return;
+    }
+
+    warmStart.m_stateDb =
+        std::make_shared<swss::DBConnector>(STATE_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
+
+    warmStart.m_stateWarmRestartTable =
+        std::unique_ptr<Table>(new Table(warmStart.m_stateDb.get(), STATE_WARM_RESTART_TABLE_NAME));
+
+    warmStart.m_cfgDb =
+        std::make_shared<swss::DBConnector>(CONFIG_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
+
+    warmStart.m_cfgWarmRestartTable =
+        std::unique_ptr<Table>(new Table(warmStart.m_cfgDb.get(), CFG_WARM_RESTART_TABLE_NAME));
+
+    setWarmStartState(app_name, WarmStart::INITIALIZED);
+
+    warmStart.m_initialized = true;
 }
 
 /*
@@ -34,45 +64,39 @@ WarmStart &WarmStart::getInstance()
  * the database has been flushed, do cold start. Otherwise warm start.
  */
 
-// Check warm start flag at the very begining of application, do it once for each process.
-bool WarmStart::checkWarmStart(const std::string &app_name, const std::string &docker_name)
+/*
+ * Method to verify/obtain the state of Warm-Restart feature for any warm-reboot
+ * capable component. Typically, this function will be called during initialization of
+ * SONiC modules; however, method could be invoked at any given point to verify the
+ * latest state of Warm-Restart functionality.
+ */
+bool WarmStart::checkWarmStart(const std::string &app_name,
+                               const std::string &docker_name)
 {
+    std::string value;
+
     auto& warmStart = getInstance();
 
-    if (warmStart.m_stateDb)
-    {
-        return true;
-    }
-
-    warmStart.m_stateDb     = std::make_shared<swss::DBConnector>(STATE_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
-    warmStart.m_stateWarmRestartTable = std::unique_ptr<Table>(new Table(warmStart.m_stateDb.get(), STATE_WARM_RESTART_TABLE_NAME));
-
-    warmStart.m_cfgDb       = std::make_shared<swss::DBConnector>(CONFIG_DB, swss::DBConnector::DEFAULT_UNIXSOCKET, 0);
-    warmStart.m_cfgWarmRestartTable   = std::unique_ptr<Table>(new Table(warmStart.m_cfgDb.get(), CFG_WARM_RESTART_TABLE_NAME));
-
-    warmStart.enabled = false;
-
-    std::string value;
-    // Check system level warm restart config first
+    // Check system level warm-restart config first
     warmStart.m_cfgWarmRestartTable->hget("system", "enable", value);
     if (value == "true")
     {
-        warmStart.enabled = true;
+        warmStart.m_enabled = true;
     }
 
-    // docker level warm restart configuration
+    // Check docker level warm-restart configuration
     warmStart.m_cfgWarmRestartTable->hget(docker_name, "enable", value);
     if (value == "true")
     {
-        warmStart.enabled = true;
+        warmStart.m_enabled = true;
     }
 
     // For cold start, the whole state db will be flushed including warm start table.
     // Create the entry for this app here.
-    if (!warmStart.enabled)
+    if (!warmStart.m_enabled)
     {
         warmStart.m_stateWarmRestartTable->hset(app_name, "restart_count", "0");
-        return true;
+        return false;
     }
 
     uint32_t restart_count = 0;
@@ -81,9 +105,9 @@ bool WarmStart::checkWarmStart(const std::string &app_name, const std::string &d
     {
         SWSS_LOG_WARN("%s doing warm start, but restart_count not found in stateDB %s table, fall back to cold start",
                 app_name.c_str(), STATE_WARM_RESTART_TABLE_NAME);
-        warmStart.enabled = false;
+        warmStart.m_enabled = false;
         warmStart.m_stateWarmRestartTable->hset(app_name, "restart_count", "0");
-        return true;
+        return false;
     }
     else
     {
@@ -91,18 +115,24 @@ bool WarmStart::checkWarmStart(const std::string &app_name, const std::string &d
     }
 
     restart_count++;
-    warmStart.m_stateWarmRestartTable->hset(app_name, "restart_count", std::to_string(restart_count));
-    SWSS_LOG_NOTICE("%s doing warm start, restart count %d", app_name.c_str(), restart_count);
+    warmStart.m_stateWarmRestartTable->hset(app_name, "restart_count",
+                                            std::to_string(restart_count));
+
+    SWSS_LOG_NOTICE("%s doing warm start, restart count %d", app_name.c_str(),
+                    restart_count);
 
     return true;
 }
 
 /*
- * Get warmStartTimer for an application in a docker (default to be swss)
- * return timer value. Value 0 means invalid.
+ * Obtain the time-interval defined by a warm-restart-capable application
+ * corresponding to the amount of time required to complete a full-restart cycle.
+ * This time-duration (warmStartTimer) will be taken into account by the
+ * warm-restart logic to kick-off the reconciliation process of this application.
+ * A returned value of '0' implies that no valid interval was found.
  */
 uint32_t WarmStart::getWarmStartTimer(const std::string &app_name,
-    const std::string &docker_name)
+                                      const std::string &docker_name)
 {
     auto& warmStart = getInstance();
     std::string timer_name = app_name + "_timer";
@@ -111,34 +141,41 @@ uint32_t WarmStart::getWarmStartTimer(const std::string &app_name,
     warmStart.m_cfgWarmRestartTable->hget(docker_name, timer_name, timer_value_str);
 
     unsigned long int temp_value = strtoul(timer_value_str.c_str(), NULL, 0);
-    if (temp_value != 0 && temp_value != ULONG_MAX && temp_value <= MAXIMUM_WARMRESTART_TIMER_VALUE)
+
+    if (temp_value != 0 && temp_value != ULONG_MAX &&
+        temp_value <= MAXIMUN_WARMRESTART_TIMER_VALUE)
     {
         SWSS_LOG_NOTICE("Getting warmStartTimer for docker: %s, app: %s, value: %lu",
-                docker_name.c_str(), app_name.c_str(), temp_value);
+                        docker_name.c_str(), app_name.c_str(), temp_value);
         return (uint32_t)temp_value;
     }
     else
     {
         SWSS_LOG_NOTICE("warmStartTimer is not configured or invalid for docker: %s, app: %s",
-                docker_name.c_str(), app_name.c_str());
+                        docker_name.c_str(), app_name.c_str());
         return 0;
     }
 }
 
-bool WarmStart::isWarmStart()
+bool WarmStart::isWarmStart(void)
 {
     auto& warmStart = getInstance();
 
-    return warmStart.enabled;
+    return warmStart.m_enabled;
 }
 
-// Set the state restored flag
+// Set the WarmStart FSM state for a particular application.
 void WarmStart::setWarmStartState(const std::string &app_name, WarmStartState state)
 {
     auto& warmStart = getInstance();
 
-    warmStart.m_stateWarmRestartTable->hset(app_name, "state", warmStartStateNameMap.at(state).c_str());
-    SWSS_LOG_NOTICE("%s warm start state changed to %s", app_name.c_str(), warmStartStateNameMap.at(state).c_str());
+    warmStart.m_stateWarmRestartTable->hset(app_name,
+                                            "state",
+                                            warmStartStateNameMap.at(state).c_str());
+
+    SWSS_LOG_NOTICE("%s warm start state changed to %s",
+                    app_name.c_str(),
+                    warmStartStateNameMap.at(state).c_str());
 }
 
 }

--- a/warmrestart/warm_restart.cpp
+++ b/warmrestart/warm_restart.cpp
@@ -69,7 +69,7 @@ void WarmStart::initialize(const std::string &app_name,
  * Method to verify/obtain the state of Warm-Restart feature for any warm-reboot
  * capable component. Typically, this function will be called during initialization of
  * SONiC modules; however, method could be invoked at any given point to verify the
- * latest state of Warm-Restart functionality.
+ * latest state of Warm-Restart functionality and to update the restore_count value.
  */
 bool WarmStart::checkWarmStart(const std::string &app_name,
                                const std::string &docker_name)

--- a/warmrestart/warm_restart.cpp
+++ b/warmrestart/warm_restart.cpp
@@ -44,8 +44,6 @@ void WarmStart::initialize(const std::string &app_name,
     warmStart.m_cfgWarmRestartTable =
         std::unique_ptr<Table>(new Table(warmStart.m_cfgDb.get(), CFG_WARM_RESTART_TABLE_NAME));
 
-    setWarmStartState(app_name, WarmStart::INITIALIZED);
-
     warmStart.m_initialized = true;
 }
 

--- a/warmrestart/warm_restart.cpp
+++ b/warmrestart/warm_restart.cpp
@@ -142,18 +142,16 @@ uint32_t WarmStart::getWarmStartTimer(const std::string &app_name,
     unsigned long int temp_value = strtoul(timer_value_str.c_str(), NULL, 0);
 
     if (temp_value != 0 && temp_value != ULONG_MAX &&
-        temp_value <= MAXIMUN_WARMRESTART_TIMER_VALUE)
+        temp_value <= MAXIMUM_WARMRESTART_TIMER_VALUE)
     {
         SWSS_LOG_NOTICE("Getting warmStartTimer for docker: %s, app: %s, value: %lu",
                         docker_name.c_str(), app_name.c_str(), temp_value);
         return (uint32_t)temp_value;
     }
-    else
-    {
-        SWSS_LOG_NOTICE("warmStartTimer is not configured or invalid for docker: %s, app: %s",
-                        docker_name.c_str(), app_name.c_str());
-        return 0;
-    }
+
+    SWSS_LOG_NOTICE("warmStartTimer is not configured or invalid for docker: %s, app: %s",
+                    docker_name.c_str(), app_name.c_str());
+    return 0;
 }
 
 bool WarmStart::isWarmStart(void)

--- a/warmrestart/warm_restart.h
+++ b/warmrestart/warm_restart.h
@@ -14,7 +14,7 @@ class WarmStart
 public:
 	enum WarmStartState
 	{
-	    INIT,
+	    INITIALIZED,
 	    RESTORED,
 	    RECONCILED,
 	};
@@ -22,19 +22,29 @@ public:
     typedef std::map<WarmStartState, std::string>  WarmStartStateNameMap;
     static const WarmStartStateNameMap warmStartStateNameMap;
 
-    static WarmStart &getInstance();
+    static WarmStart &getInstance(void);
 
-    static bool checkWarmStart(const std::string &app_name, const std::string &docker_name = "swss");
+    static void initialize(const std::string &app_name,
+                           const std::string &docker_name = "swss");
+
+    static bool checkWarmStart(const std::string &app_name,
+                               const std::string &docker_name = "swss");
+
+    static bool isWarmStart(void);
+
+    static void setWarmStartState(const std::string &app_name,
+                                  WarmStartState     state);
+
     static uint32_t getWarmStartTimer(const std::string &app_name,
-        const std::string &docker_name ="swss");
-    static bool isWarmStart();
-    static void setWarmStartState(const std::string &app_name, WarmStartState state);
+                                      const std::string &docker_name ="swss");
+
 private:
-	std::shared_ptr<swss::DBConnector>          m_stateDb;
-	std::shared_ptr<swss::DBConnector>          m_cfgDb;
-	std::unique_ptr<Table>         m_stateWarmRestartTable;
-	std::unique_ptr<Table>         m_cfgWarmRestartTable;
-	bool enabled;
+    std::shared_ptr<swss::DBConnector>   m_stateDb;
+    std::shared_ptr<swss::DBConnector>   m_cfgDb;
+    std::unique_ptr<Table>               m_stateWarmRestartTable;
+    std::unique_ptr<Table>               m_cfgWarmRestartTable;
+    bool                                 m_initialized;
+    bool                                 m_enabled;
 };
 
 }


### PR DESCRIPTION
The current WarmStart class assumes that restarting applications will invoke checkWarmStart() method during initialization. Currently, this method serves two main purposes: 1) a static-constructor and 2) checks if WarmRestart feature has been enabled for a given application.

In this PR i'm proposing to split these different logics in two separated methods. The main goal here is to allow applications such as fpmSyncd to call checkWarmStart whenever it please (i.e. fpmSyncd restart event or zebra<->fpmSyncd tcp re-establishment). There could be other applications in the future interested in this differentiated approach.

Other than that i'm making small adjustments in the code to enhance readibility.

Signed-off-by: Rodny Molina <rmolina@linkedin.com>
