### PR TITLE
Fix bug: NeighOrch waits for router interface ready

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -293,7 +293,7 @@ void NeighOrch::doTask(Consumer &consumer)
         if (!p.m_rif_id)
         {
             SWSS_LOG_INFO("Router interface doesn't exist on %s", alias.c_str());
-            it = consumer.m_toSync.erase(it);
+            it++;
             continue;
         }
 


### PR DESCRIPTION
The router interface creation may be delayed, so neighorch should leave task in m_toSync instead of erasing. Tested in both cold start and warm start.