### PR TITLE
Routing-stack warm-reboot feature.

### DIFF
--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -8,7 +8,7 @@ else
 DBGFLAGS = -g
 endif
 
-fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrestart/warmRestartHelper.cpp $(top_srcdir)/warmrestart/warmRestartHelper.h $(top_srcdir)/warmrestart/warm_restart.cpp $(top_srcdir)/warmrestart/warm_restart.h
+fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrestart/warmRestartHelper.cpp $(top_srcdir)/warmrestart/warmRestartHelper.h
 
 fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = -I $(top_srcdir) -I $(FPM_PATH)
+INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/warmrestart -I $(FPM_PATH)
 
 bin_PROGRAMS = fpmsyncd
 
@@ -8,9 +8,8 @@ else
 DBGFLAGS = -g
 endif
 
-fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp
+fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrestart/warmRestartHelper.cpp $(top_srcdir)/warmrestart/warmRestartHelper.h $(top_srcdir)/warmrestart/warm_restart.cpp $(top_srcdir)/warmrestart/warm_restart.h
 
 fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 fpmsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
-

--- a/fpmsyncd/fpmlink.cpp
+++ b/fpmsyncd/fpmlink.cpp
@@ -61,7 +61,6 @@ FpmLink::FpmLink(int port) :
 
 FpmLink::~FpmLink()
 {
-    SWSS_LOG_INFO("Calling fpmlink destructor");
     delete m_messageBuffer;
     if (m_connected)
         close(m_connection_socket);

--- a/fpmsyncd/fpmlink.cpp
+++ b/fpmsyncd/fpmlink.cpp
@@ -61,6 +61,7 @@ FpmLink::FpmLink(int port) :
 
 FpmLink::~FpmLink()
 {
+    SWSS_LOG_INFO("Calling fpmlink destructor");
     delete m_messageBuffer;
     if (m_connected)
         close(m_connection_socket);

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -1,12 +1,23 @@
 #include <iostream>
 #include "logger.h"
 #include "select.h"
+#include "selectabletimer.h"
 #include "netdispatcher.h"
+#include "warmRestartHelper.h"
 #include "fpmsyncd/fpmlink.h"
 #include "fpmsyncd/routesync.h"
 
+
 using namespace std;
 using namespace swss;
+
+
+/*
+ * Default warm-restart timer interval for routing-stack app. To be used only if
+ * no explicit value has been defined in configuration.
+ */
+const uint32_t DEFAULT_ROUTING_RESTART_INTERVAL = 120;
+
 
 int main(int argc, char **argv)
 {
@@ -18,25 +29,70 @@ int main(int argc, char **argv)
     NetDispatcher::getInstance().registerMessageHandler(RTM_NEWROUTE, &sync);
     NetDispatcher::getInstance().registerMessageHandler(RTM_DELROUTE, &sync);
 
-    while (1)
+    while (true)
     {
         try
         {
             FpmLink fpm;
             Select s;
 
-            cout << "Waiting for connection..." << endl;
+            SelectableTimer warmStartTimer(timespec{0, 0});
+
+            cout << "Waiting for fpm-client connection..." << endl;
             fpm.accept();
             cout << "Connected!" << endl;
 
             s.addSelectable(&fpm);
+
+            /* Initialize warm-restart logic if this one is enabled */
+            bool warmStartEnabled = sync.m_warmStartHelper.isEnabled();
+            if (warmStartEnabled)
+            {
+                /* Obtain warm-restart timer defined for routing application */
+                uint32_t warmRestartIval = sync.m_warmStartHelper.getRestartTimer();
+                if (!warmRestartIval)
+                {
+                    warmStartTimer.setInterval(timespec{DEFAULT_ROUTING_RESTART_INTERVAL, 0});
+                }
+                else
+                {
+                    warmStartTimer.setInterval(timespec{warmRestartIval, 0});
+                }
+
+                /* Execute recovery instruction and kick off warm-restart timer */
+                if (sync.m_warmStartHelper.runRecovery())
+                {
+                    warmStartTimer.start();
+                    s.addSelectable(&warmStartTimer);
+                }
+            }
+
             while (true)
             {
                 Selectable *temps;
-                /* Reading FPM messages forever (and calling "readData" to read them) */
+
+                /* Reading FPM messages forever (and calling "readMe" to read them) */
                 s.select(&temps);
-                pipeline.flush();
-                SWSS_LOG_DEBUG("Pipeline flushed");
+
+                /*
+                 * Upon expiration of the warm-restart timer, proceed to run the
+                 * reconciliation process and remove warm-restart timer from
+                 * select() loop.
+                 */
+                if (warmStartEnabled && temps == &warmStartTimer)
+                {
+                    SWSS_LOG_NOTICE("Warm-Restart timer expired.");
+                    sync.m_warmStartHelper.reconciliate();
+                    s.removeSelectable(&warmStartTimer);
+
+                    pipeline.flush();
+                    SWSS_LOG_NOTICE("Pipeline flushed");
+                }
+                else if (!warmStartEnabled || sync.m_warmStartHelper.isReconciled())
+                {
+                    pipeline.flush();
+                    SWSS_LOG_NOTICE("Pipeline flushed");
+                }
             }
         }
         catch (FpmLink::FpmConnectionClosedException &e)

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
             s.addSelectable(&fpm);
 
             /* If warm-restart feature is enabled, execute 'restoration' logic */
-            bool warmStartEnabled = sync.m_warmStartHelper.isEnabled();
+            bool warmStartEnabled = sync.m_warmStartHelper.checkAndStart();
             if (warmStartEnabled)
             {
                 /* Obtain warm-restart timer defined for routing application */

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -54,11 +54,14 @@ void RouteSync::onMsg(int nlmsg_type, struct nl_object *obj)
         }
         else
         {
-            SWSS_LOG_INFO("Warm-Restart mode: Receiving delete msg: %s\n", destipprefix);
+            SWSS_LOG_INFO("Warm-Restart mode: Receiving delete msg: %s\n",
+                          destipprefix);
 
             vector<FieldValueTuple> fvVector;
-            const KeyOpFieldsValuesTuple kfv = std::make_tuple(destipprefix, "", fvVector);
-            m_warmStartHelper.removeRestorationMap(kfv, WarmStartHelper::DELETE);
+            const KeyOpFieldsValuesTuple kfv = std::make_tuple(destipprefix,
+                                                               DEL_COMMAND,
+                                                               fvVector);
+            m_warmStartHelper.insertRefreshMap(kfv);
             return;
         }
     }
@@ -157,7 +160,9 @@ void RouteSync::onMsg(int nlmsg_type, struct nl_object *obj)
         SWSS_LOG_INFO("Warm-Restart mode: RouteTable set msg: %s %s %s\n",
                       destipprefix, nexthops.c_str(), ifnames.c_str());
 
-        const KeyOpFieldsValuesTuple kfv = std::make_tuple(destipprefix, "", fvVector);
-        m_warmStartHelper.insertRestorationMap(kfv, WarmStartHelper::CLEAN);
+        const KeyOpFieldsValuesTuple kfv = std::make_tuple(destipprefix,
+                                                           SET_COMMAND,
+                                                           fvVector);
+        m_warmStartHelper.insertRefreshMap(kfv);
     }
 }

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -4,6 +4,8 @@
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "netmsg.h"
+#include "warmRestartHelper.h"
+
 
 namespace swss {
 
@@ -16,10 +18,12 @@ public:
 
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);
 
+    WarmStartHelper  m_warmStartHelper;
+
 private:
-    ProducerStateTable m_routeTable;
-    struct nl_cache *m_link_cache;
-    struct nl_sock *m_nl_sock;
+    ProducerStateTable  m_routeTable;
+    struct nl_cache    *m_link_cache;
+    struct nl_sock     *m_nl_sock;
 };
 
 }

--- a/warmrestart/warmRestartHelper.cpp
+++ b/warmrestart/warmRestartHelper.cpp
@@ -1,0 +1,472 @@
+#include <cassert>
+#include <sstream>
+
+#include "warmRestartHelper.h"
+
+
+using namespace swss;
+
+
+WarmStartHelper::WarmStartHelper(RedisPipeline      *pipeline,
+                                 ProducerStateTable *syncTable,
+                                 const std::string  &dockerName,
+                                 const std::string  &appName) :
+    m_recoveryTable(pipeline, APP_ROUTE_TABLE_NAME, false),
+    m_syncTable(syncTable),
+    m_dockName(dockerName),
+    m_appName(appName)
+{
+    WarmStart::initialize(appName, dockerName);
+}
+
+
+WarmStartHelper::~WarmStartHelper()
+{
+}
+
+
+void WarmStartHelper::setState(WarmStart::WarmStartState state)
+{
+    WarmStart::setWarmStartState(m_appName, state);
+
+    m_state = state;
+}
+
+
+WarmStart::WarmStartState WarmStartHelper::getState(void) const
+{
+    return m_state;
+}
+
+
+bool WarmStartHelper::isEnabled(void) const
+{
+    return WarmStart::checkWarmStart(m_appName, m_dockName);
+}
+
+
+bool WarmStartHelper::isReconciled(void) const
+{
+    return (m_state == WarmStart::RECONCILED);
+}
+
+
+uint32_t WarmStartHelper::getRestartTimer(void) const
+{
+    return WarmStart::getWarmStartTimer(m_appName, m_dockName);
+}
+
+
+/*
+ * Invoked by warmStartHelper clients during initialization. All interested parties
+ * are expected to call this method to upload their associated redisDB state into
+ * a temporary buffer, which will eventually serve to resolve any conflict between
+ * 'old' and 'new' state.
+ */
+bool WarmStartHelper::runRecovery()
+{
+    bool state_available;
+
+    SWSS_LOG_NOTICE("Initiating AppDB restoration process");
+
+    if (buildRecoveryMap())
+    {
+        setState(WarmStart::RESTORED);
+        state_available = true;
+    }
+    else
+    {
+        setState( WarmStart::RECONCILED);
+        state_available = false;
+    }
+
+    SWSS_LOG_NOTICE("Completed AppDB restoration process");
+
+    return state_available;
+}
+
+
+bool WarmStartHelper::buildRecoveryMap(void)
+{
+    std::vector<KeyOpFieldsValuesTuple> recoveryVector;
+
+    m_recoveryTable.getContent(recoveryVector);
+    if (!recoveryVector.size())
+    {
+        SWSS_LOG_NOTICE("Warm-Restart: No records received from AppDB\n");
+        return false;
+    }
+    SWSS_LOG_NOTICE("Warm-Restart: Received %d records from AppDB\n",
+                    static_cast<int>(recoveryVector.size()));
+
+    /* Proceed to insert every recovered element into the reconciliation buffer */
+    for (auto &elem : recoveryVector)
+    {
+        insertRecoveryMap(elem, STALE);
+    }
+
+    return true;
+}
+
+
+/*
+ * Method in charge of populating the recoveryMap with old/new state. This state
+ * can either come from southbound data-stores (old/existing state) or from any
+ * of the applications (new state) interested in graceful-restart capabilities.
+ */
+void WarmStartHelper::insertRecoveryMap(const KeyOpFieldsValuesTuple &kfv,
+                                        fvState_t                     state)
+{
+    std::string key = kfvKey(kfv);
+    std::vector<FieldValueTuple> fieldValues = kfvFieldsValues(kfv);
+
+    fieldValuesTupleVoV fvVector;
+
+    /*
+     * Iterate through all the fieldValue-tuples present in this kfv entry to
+     * split its values into separated tuples. Store these separated tuples in
+     * a temporary fieldValue vector.
+     *
+     * Here we are simply converting from KFV format to a split-based layout
+     * represented by the fvVector variable.
+     *
+     * input kfv: 1.1.1.1/30, vector{nexthop: 10.1.1.1, 10.1.1.2, ifname: eth1, eth2}
+     *
+     * output fvVector: vector{v1{nexthop: 10.1.1.1, ifname: eth1},
+     *                         v2{nexthop: 10.1.1.2, ifname: eth2}}
+     */
+    for (auto &fv : fieldValues)
+    {
+        std::string field = fvField(fv);
+        std::vector<std::string> splitValues = tokenize(fvValue(fv), ',');
+
+        /*
+         * Dealing with tuples with empty values. Example: directly connected
+         * intfs will show up as [ nexthop = "" ]
+         */
+        if (!splitValues.size())
+        {
+            splitValues.push_back("");
+        }
+
+        for (int j = 0; j < static_cast<int>(splitValues.size()); ++j)
+        {
+            if (j < static_cast<int>(fvVector.size()))
+            {
+                fvVector[j].emplace_back(field, splitValues[j]);
+            }
+            else
+            {
+                fvVector.emplace_back(std::vector<FieldValueTuple>{make_pair(field, splitValues[j])});
+            }
+        }
+    }
+
+    /*
+     * Now that we have a fvVector with separated fieldvalue-tuples, let's proceed
+     * to insert/update its fieldvalue entries into our recoveryMap.
+     */
+    fvRecoveryMap fvMap;
+
+    if (m_recoveryMap.count(key))
+    {
+        fvMap = m_recoveryMap[key];
+    }
+
+    /*
+     * Let's now deal with transient best-path selections, which is only required
+     * when we are receiving new/refreshed state from north-bound apps (CLEAN
+     * flag).
+     */
+    if (state == CLEAN)
+    {
+        adjustRecoveryMap(fvMap, fvVector, key);
+    }
+
+    /*
+     * We will iterate through each of the fieldvalue-tuples in the fvVector to
+     * either insert or update the corresponding entry in the map.
+     */
+    for (auto &elem : fvVector)
+    {
+        if (fvMap.find(elem) == fvMap.end())
+        {
+            if (state == STALE)
+            {
+                fvMap[elem] = STALE;
+            }
+            else if (state == CLEAN)
+            {
+                fvMap[elem] = NEW;
+            }
+        }
+        else
+        {
+            fvMap[elem] = state;
+        }
+    }
+
+    m_recoveryMap[key] = fvMap;
+}
+
+
+/*
+ * Method takes care of marking eliminated entries (e.g. route paths) within the
+ * recoveryMap buffer.
+ */
+void WarmStartHelper::removeRecoveryMap(const KeyOpFieldsValuesTuple &kfv,
+                                        fvState_t                     state)
+{
+    fvRecoveryMap fvMap;
+
+    /*
+     * Notice that there's no point in processing bgp-withdrawal if an associated
+     * entry doesn't exist in the recoveryMap.
+     */
+    std::string key = kfvKey(kfv);
+    if (!m_recoveryMap.count(key))
+    {
+        return;
+    }
+
+    fvMap = m_recoveryMap[key];
+
+    /*
+     * Iterate through all elements in the map and update the state of the
+     * entries being withdrawwn (i.e. 'paths' in routing case) with the proper
+     * flag.
+     */
+    for (auto &fv : fvMap)
+    {
+        fv.second = state;
+    }
+
+    m_recoveryMap[key] = fvMap;
+}
+
+
+/*
+ * This method is currently required to deal with a specific limitation of quagga
+ * and frr routing-stacks, which causes transient best-path selections to arrive
+ * at fpmSyncd during bgp's initial peering establishments. In these scenarios we
+ * must identify the 'transient' character of a routing-update and eliminate it
+ * from the recoveryMap whenever a better one is received.
+ *
+ * As this issue is only observed when interacting with the routing-stack, we can
+ * safely avoid this call when collecting state from AppDB (restoration phase);
+ * hence caller should invoke this method only if/when the state of the new entry
+ * to add is set to CLEAN.
+ */
+void WarmStartHelper::adjustRecoveryMap(fvRecoveryMap             &fvMap,
+                                        const fieldValuesTupleVoV &fvVector,
+                                        const std::string         &key)
+{
+    /*
+     * Iterate through all field-value entries in the fvMap and determine if there's
+     * matching entry in the fvVector. If that's not the case, and this entry has
+     * been recently added by the north-bound app (NEW flag), then proceed to
+     * eliminate it from the fvMap.
+     *
+     * Notice that even though this is an O(n^2) logic, 'n' here is small (number
+     * of ecmp-paths per prefix), and this is only executed during restarting
+     * events.
+     */
+    for (auto it = fvMap.begin(); it != fvMap.end(); )
+    {
+        bool found = false;
+        /*
+         * Transient best-path selections would only apply to entries marked as
+         * NEW.
+         */
+        if (it->second != NEW)
+        {
+            it++;
+            continue;
+        }
+
+        for (auto const &fv : fvVector)
+        {
+            if (it->first == fv)
+            {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found)
+        {
+            SWSS_LOG_INFO("Warm-Restart: Deleting transient best-path selection "
+                          "for entry %s\n", key.c_str());
+            it = fvMap.erase(it);
+        }
+        else
+        {
+            it++;
+        }
+    }
+}
+
+
+/*
+ * Reconciliation process takes place here.
+ *
+ * In a nutshell, the process relies on the following basic guidelines:
+ *
+ * - An element in the recoveryMap with all its entries in the fvRecMap showing
+ *   as STALE, will be eliminated from AppDB.
+ *
+ * - An element in the recoveryMap with all its entries in the fvRecMap showing
+ *   as CLEAN, will have a NO-OP associated with it -- no changes in AppDB.
+ *
+ * - An element in the recoveryMap with all its entries in the fvRecMap showing
+ *   as NEW, will correspond to a brand-new state, and as such, will be pushed to
+ *   AppDB.
+ *
+ * - An element in the recoveryMap with some of its entries in the fvRecMap
+ *   showing as CLEAN, will have these CLEAN entries, along with any NEW one,
+ *   being pushed down to AppDB.
+ *
+ * - An element in the recoveryMap with some of its entries in the fvRecMap
+ *   showing as NEW, will have these new entries, along with any CLEAN one,
+ *   being pushed to AppDB.
+ *
+ * - An element in the recoveryMap with some/all of its entries in the
+ *   fvRecMap showing as DELETE, will have these entries being eliminated
+ *   from AppDB.
+ *
+ */
+void WarmStartHelper::reconciliate(void)
+{
+    SWSS_LOG_NOTICE("Initiating AppDB reconciliation process...");
+
+    assert(getState() == WarmStart::RESTORED);
+
+    /*
+     * Iterate through all the entries in the recoveryMap and take note of the
+     * attributes associated to each.
+     */
+    auto it = m_recoveryMap.begin();
+    while (it != m_recoveryMap.end())
+    {
+        std::string key = it->first;
+        fvRecoveryMap fvMap = it->second;
+
+        int totalRecElems, staleRecElems, cleanRecElems, newRecElems, deleteRecElems;
+        totalRecElems = staleRecElems = cleanRecElems = newRecElems = deleteRecElems = 0;
+
+        std::vector<FieldValueTuple> fvVector;
+
+        for (auto itMap = fvMap.begin(); itMap != fvMap.end(); )
+        {
+            totalRecElems++;
+
+            auto recElem = itMap->first;
+            auto recElemState = itMap->second;
+
+            if (recElemState == STALE)
+            {
+                itMap = fvMap.erase(itMap);
+                staleRecElems++;
+            }
+            else if (recElemState == CLEAN)
+            {
+                cleanRecElems++;
+                transformKFV(recElem, fvVector);
+                ++itMap;
+            }
+            else if (recElemState == NEW)
+            {
+                newRecElems++;
+                transformKFV(recElem, fvVector);
+                ++itMap;
+            }
+            else if (recElemState == DELETE)
+            {
+                deleteRecElems++;
+                ++itMap;
+            }
+        }
+
+        if (staleRecElems == totalRecElems)
+        {
+            m_syncTable->del(key);
+            SWSS_LOG_NOTICE("Route reconciliation: deleting stale prefix %s\n",
+                            key.c_str());
+        }
+        else if (cleanRecElems == totalRecElems)
+        {
+            SWSS_LOG_NOTICE("Route reconciliation: no changes needed for existing"
+                            " prefix %s\n", key.c_str());
+        }
+        else if (newRecElems == totalRecElems)
+        {
+            m_syncTable->set(key, fvVector);
+            SWSS_LOG_NOTICE("Route reconciliation: creating new prefix %s\n",
+                            key.c_str());
+        }
+        else if (cleanRecElems)
+        {
+            m_syncTable->set(key, fvVector);
+            SWSS_LOG_NOTICE("Route reconciliation: updating attributes for prefix"
+                            " %s\n", key.c_str());
+        }
+        else if (newRecElems)
+        {
+            m_syncTable->set(key, fvVector);
+            SWSS_LOG_NOTICE("Route reconciliation: creating new attributes for "
+                            "prefix %s\n", key.c_str());
+        }
+        else if (deleteRecElems)
+        {
+            m_syncTable->del(key);
+            SWSS_LOG_NOTICE("Route reconciliation: deleting withdrawn prefix %s\n",
+                            key.c_str());
+        }
+
+        it = m_recoveryMap.erase(it);
+    }
+
+    /* Recovery map should be entirely empty by now */
+    assert(m_recoveryMap.size() == 0);
+
+    setState(WarmStart::RECONCILED);
+}
+
+
+/*
+ * Method useful to transform fieldValueTuples from the split-format utilized
+ * in warmStartHelper's reconciliation process to the regular format used
+ * everywhere else.
+ */
+void WarmStartHelper::transformKFV(const std::vector<FieldValueTuple> &data,
+                                   std::vector<FieldValueTuple>       &fvVector)
+{
+    bool emptyVector = false;
+
+    /*
+     * Both input vectors should contain the same number of elements, with the
+     * exception of fvVector not being initialized yet.
+     */
+    if (data.size() != fvVector.size() && fvVector.size())
+    {
+        return;
+    }
+    else if (!fvVector.size())
+    {
+        emptyVector = true;
+    }
+
+    /* Define fields in fvVector result-parameter */
+    for (int i = 0; i < static_cast<int>(data.size()); ++i)
+    {
+        if (emptyVector)
+        {
+            fvVector.push_back(data[i]);
+            continue;
+        }
+
+        std::string newVal = fvValue(fvVector[i]) + "," + fvValue(data[i]);
+
+        fvVector[i].second = newVal;
+    }
+}

--- a/warmrestart/warmRestartHelper.cpp
+++ b/warmrestart/warmRestartHelper.cpp
@@ -46,7 +46,7 @@ WarmStart::WarmStartState WarmStartHelper::getState(void) const
  * To be called by each application to obtain the active/inactive state of
  * warm-restart functionality, and proceed to initialize the FSM accordingly.
  */
-bool WarmStartHelper::isEnabled(void)
+bool WarmStartHelper::checkAndStart(void)
 {
     bool enabled = WarmStart::checkWarmStart(m_appName, m_dockName);
 
@@ -63,6 +63,10 @@ bool WarmStartHelper::isEnabled(void)
         setState(WarmStart::INITIALIZED);
         m_syncTable->clear();
     }
+
+    /* Cleaning state from previous (unsuccessful) warm-restart attempts */
+    m_restorationVector.clear();
+    m_refreshMap.clear();
 
     /* Keeping track of warm-reboot active/inactive state */
     m_enabled = enabled;
@@ -116,9 +120,9 @@ bool WarmStartHelper::runRestoration()
         return false;
     }
 
-    SWSS_LOG_NOTICE("Warm-Restart: Received %d records from AppDB for %s "
+    SWSS_LOG_NOTICE("Warm-Restart: Received %zu records from AppDB for %s "
                     "application.",
-                    static_cast<int>(m_restorationVector.size()),
+                    m_restorationVector.size(),
                     m_appName.c_str());
 
     setState(WarmStart::RESTORED);

--- a/warmrestart/warmRestartHelper.cpp
+++ b/warmrestart/warmRestartHelper.cpp
@@ -263,8 +263,14 @@ bool WarmStartHelper::compareAllFV(const std::vector<FieldValueTuple> &v1,
         /*
          * The sizes of both tuple-vectors should always match within any
          * given application. In other words, all fields within v1 should be
-         * also present within v2. Otherwise we are running into some form of
-         * bug or an unsupported functionality.
+         * also present in v2.
+         *
+         * To make this possible, every application should continue relying on a
+         * uniform schema to create/generate information. For example, fpmsyncd
+         * will be always expected to push FieldValueTuples with "nexthop" and
+         * "ifname" fields; neighsyncd is expected to make use of "family" and
+         * "neigh" fields, etc. The existing reconciliation logic will rely on
+         * this assumption.
          */
         assert(v1Iter != v1Map.end());
 

--- a/warmrestart/warmRestartHelper.h
+++ b/warmrestart/warmRestartHelper.h
@@ -42,7 +42,7 @@ class WarmStartHelper {
 
     WarmStart::WarmStartState getState(void) const;
 
-    bool isEnabled(void);
+    bool checkAndStart(void);
 
     bool isReconciled(void) const;
 

--- a/warmrestart/warmRestartHelper.h
+++ b/warmrestart/warmRestartHelper.h
@@ -56,15 +56,16 @@ class WarmStartHelper {
 
     void reconcile(void);
 
+    const std::string printKFV(const std::string                  &key,
+                               const std::vector<FieldValueTuple> &fv);
+
+  private:
+
     bool compareAllFV(const std::vector<FieldValueTuple> &left,
                       const std::vector<FieldValueTuple> &right);
 
     bool compareOneFV(const std::string &v1, const std::string &v2);
 
-    const std::string printKFV(const std::string                  &key,
-                               const std::vector<FieldValueTuple> &fv);
-
-  private:
     ProducerStateTable       *m_syncTable;         // producer-table to sync/push state to
     Table                     m_restorationTable;  // redis table to import current-state from
     kfvVector                 m_restorationVector; // buffer struct to hold old state

--- a/warmrestart/warmRestartHelper.h
+++ b/warmrestart/warmRestartHelper.h
@@ -1,0 +1,128 @@
+#ifndef __WARMRESTART_HELPER__
+#define __WARMRESTART_HELPER__
+
+
+#include <vector>
+#include <map>
+#include <unordered_map>
+
+#include "dbconnector.h"
+#include "producerstatetable.h"
+#include "netmsg.h"
+#include "table.h"
+#include "tokenize.h"
+#include "warm_restart.h"
+
+
+namespace swss {
+
+
+/* FieldValueTuple functor to serve as comparator for recoveryMap */
+struct fvComparator
+{
+    bool operator()(const std::vector<FieldValueTuple> &left,
+                    const std::vector<FieldValueTuple> &right) const
+    {
+        /*
+         * The sizes of both tuple-vectors should always match within any given
+         * application, otherwise we are running into some form of bug.
+         */
+        assert(left.size() == right.size());
+
+        /*
+         * Iterate through all the tuples present in left-vector and compare them
+         * with those in the right one.
+         */
+        for (auto &fvLeft : left)
+        {
+            /*
+             * Notice that we are forced to iterate through all the tuples in the
+             * right-vector given that the order of fields within a tuple is not
+             * fully deterministic (i.e. 'left' could hold 'nh: 1.1.1.1 / if: eth0'
+             * and 'right' could be 'if: eth0, nh: 1.1.1.1').
+             */
+            for (auto &fvRight : right)
+            {
+                if (fvField(fvRight) == fvField(fvLeft))
+                {
+                    return fvLeft < fvRight;
+                }
+            }
+        }
+
+        return true;
+    }
+};
+
+
+class WarmStartHelper {
+  public:
+
+    WarmStartHelper(RedisPipeline      *pipeline,
+                    ProducerStateTable *syncTable,
+                    const std::string  &dockerName,
+                    const std::string  &appName);
+
+    ~WarmStartHelper();
+
+    /* State of collected fieldValue tuples */
+    enum fvState_t
+    {
+        INVALID = 0,
+        STALE   = 1,
+        CLEAN   = 2,
+        NEW     = 3,
+        DELETE  = 4
+    };
+
+    /*
+     * RecoveryMap types serve as the buffer data-struct where to hold the state
+     * over which to run the reconciliation logic.
+     */
+    using fvRecoveryMap = std::map<std::vector<FieldValueTuple>, fvState_t, fvComparator>;
+    using recoveryMap = std::unordered_map<std::string, fvRecoveryMap>;
+
+    /* Useful type for recoveryMap manipulation */
+    using fieldValuesTupleVoV = std::vector<std::vector<FieldValueTuple>>;
+
+
+    void setState(WarmStart::WarmStartState state);
+
+    WarmStart::WarmStartState getState(void) const;
+
+    bool isEnabled(void) const;
+
+    bool isReconciled(void) const;
+
+    uint32_t getRestartTimer(void) const;
+
+    bool runRecovery(void);
+
+    bool buildRecoveryMap(void);
+
+    void insertRecoveryMap(const KeyOpFieldsValuesTuple &kfv, fvState_t state);
+
+    void removeRecoveryMap(const KeyOpFieldsValuesTuple &kfv, fvState_t state);
+
+    void adjustRecoveryMap(fvRecoveryMap             &fvMap,
+                           const fieldValuesTupleVoV &fvVector,
+                           const std::string         &key);
+
+    void reconciliate(void);
+
+    void transformKFV(const std::vector<FieldValueTuple> &data,
+                      std::vector<FieldValueTuple>       &fvVector);
+
+  private:
+    Table                     m_recoveryTable;  // redis table to import current-state from
+    ProducerStateTable       *m_syncTable;      // producer-table to sync/push state to
+    recoveryMap               m_recoveryMap;    // buffer struct to hold old&new state
+    WarmStart::WarmStartState m_state;          // cached value of warmStart's FSM state
+    std::string               m_dockName;       // sonic-docker requesting warmStart services
+    std::string               m_appName;        // sonic-app requesting warmStart services
+};
+
+
+}
+
+#endif


### PR DESCRIPTION
[ dependencies with PR/600: https://github.com/Azure/sonic-swss/pull/600 ]

Please refer to the corresponding design document for more details: https://github.com/Azure/SONiC/pull/239

The following manual UT plan has been successfully executed. UT automation pending.

Physical topology formed by various BGP peers connecting to the DUT. Both non-ecmp and ecmp prefixes are learned/tested.

```
Testcase Suite 1: Making use of “pkill -9 bgpd && pkill -9 zebra” as trigger.
=============

IPv4 prefixes
==========

    * Restart zebra/bgpd:
            - Verify that all prefixes are properly stale-marked and that no
    change is pushed to AppDB during reconciliation.
            - Result: PASSED

    * Restart zebra/bgpd and add one new non-ecmp IPv4 prefix.
            - To produce a route-state-inconsistency, add prefix in adjacent
    node before bgp sessions are re-established.
            - Verify that new-prefix msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart zebra/bgpd and withdraw one non-ecmp IPv4 prefix.
            - To produce a route-state-inconsistency, remove prefix in adjacent
    node before bgp sessions are re-established.
            - Verify that deleted-prefix msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart zebra/bgpd and add one new path to an IPv4 ecmp-prefix.
            - To produce a route-state-inconsistency, add prefix-path in
    adjacent node before bgp sessions are re-established.
            - Verify that new prefix-path msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart zebra/bgpd and withdraw one ecmp-path from an existing ecmp IPv4
      prefix.
              - To produce a route-state-inconsistency, remove prefix-path in
      adjacent node before bgp sessions are re-established.
              - Verify that deleted-prefix-path msg is NOT pushed down to AppDB
      till reconciliation takes place.
              - Eventually, during reconciliation, this path will be eliminated
      as it’s not being refreshed by remote-peer.
              - Result: PASSED

IPv6 prefixes
==========

    * Restart zebra/bgpd:
            - Verify that all prefixes are properly stale-marked and that no
    change is pushed to AppDB during reconciliation.
            - Result: PASSED

    * Restart zebra/bgpd and add one new non-ecmp IPv6 prefix.
            - To produce a route-state-inconsistency, add prefix in adjacent
    node before bgp sessions are re-established.
            - Verify that new-prefix msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart zebra/bgpd and withdraw one non-ecmp IPv6 prefix.
            - To produce a route-state-inconsistency, remove prefix in adjacent
    node before bgp sessions are re-established.
            - Verify that deleted-prefix msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart zebra/bgpd and add one new path to an IPv6 ecmp-prefix.
            - To produce a route-state-inconsistency, add prefix-path in
    adjacent node before bgp sessions are re-established.
            - Verify that new prefix-path msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart zebra/bgpd and withdraw one ecmp-path from an existing ecmp IPv6
      prefix.
              - To produce a route-state-inconsistency, remove prefix-path in
      adjacent node before bgp sessions are re-established.
              - Verify that deleted-prefix-path msg is NOT pushed down to AppDB
      till reconciliation takes place.
              - Eventually, during reconciliation, this path will be eliminated
      as it’s not being refreshed by remote-peer.
              - Result: PASSED

Testcase Suite 2: Making use of sudo service bgp restart” as trigger.
=============

IPv4 prefixes
==========

    * Restart bgp service/docker:
            - Verify that all prefixes are properly stale-marked and that no
    change is pushed to AppDB during reconciliation.
            - Result: PASSED

    * Restart bgp service/docker and add one new non-ecmp IPv4 prefix.
            - To produce a route-state-inconsistency, add prefix in adjacent
    node before bgp sessions are re-established.
            - Verify that new-prefix msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart bgp service/docker and withdraw one non-ecmp IPv4 prefix.
            - To produce a route-state-inconsistency, remove prefix in adjacent
    node before bgp sessions are re-established.
            - Verify that deleted-prefix msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart bgp service/docker and add one new path to an IPv4 ecmp-prefix.
            - To produce a route-state-inconsistency, add prefix-path in
    adjacent node before bgp sessions are re-established.
            - Verify that new prefix-path msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart bgp service/docker and withdraw one ecmp-path from an existing
      ecmp IPv4 prefix.
              - To produce a route-state-inconsistency, remove prefix-path in
      adjacent node before bgp sessions are re-established.
              - Verify that deleted-prefix-path msg is NOT pushed down to AppDB
      till reconciliation takes place.
              - Eventually, during reconciliation, this path will be eliminated
      as it’s not being refreshed by remote-peer.
              - Result: PASSED

IPv6 prefixes
==========

    * Restart bgp service/docker:
            - Verify that all prefixes are properly stale-marked and that no
    change is pushed to AppDB during reconciliation.
            - Result: PASSED

    * Restart bgp service/docker and add one new non-ecmp IPv6 prefix.
            - To produce a route-state-inconsistency, add prefix in adjacent
    node before bgp sessions are re-established.
            - Verify that new-prefix msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart bgp service/docker and withdraw one non-ecmp IPv6 prefix.
            - To produce a route-state-inconsistency, remove prefix in adjacent
    node before bgp sessions are re-established.
            - Verify that deleted-prefix msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart bgp service/docker and add one new path to an IPv6 ecmp-prefix.
            - To produce a route-state-inconsistency, add prefix-path in
    adjacent node before bgp sessions are re-established.
            - Verify that new prefix-path msg is NOT pushed down to AppDB till
    reconciliation takes place.
            - Result: PASSED

    * Restart bgp service/docker and withdraw one ecmp-path from an existing
      ecmp IPv6 prefix.
              - To produce a route-state-inconsistency, remove prefix-path in
      adjacent node before bgp sessions are re-established.
              - Verify that deleted-prefix-path msg is NOT pushed down to AppDB
      till reconciliation takes place.
              - Eventually, during reconciliation, this path will be eliminated
      as it’s not being refreshed by remote-peer.
              - Result: PASSED
```

Signed-off-by: Rodny Molina <rmolina@linkedin.com>
