### PR TITLE
 Store mirror session state in StateDB

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -961,7 +961,7 @@ bool AclRuleMirror::create()
     bool state = false;
     sai_object_id_t oid = SAI_NULL_OBJECT_ID;
 
-    if (!m_pMirrorOrch->getSessionState(m_sessionName, state))
+    if (!m_pMirrorOrch->getSessionStatus(m_sessionName, state))
     {
         throw runtime_error("Failed to get mirror session state");
     }

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -11,18 +11,20 @@
 #include "converter.h"
 #include "mirrororch.h"
 
-#define MIRROR_SESSION_STATUS           "status"
-#define MIRROR_SESSION_STATUS_ACTIVE    "active"
-#define MIRROR_SESSION_STATUS_INACTIVE  "inactive"
-#define MIRROR_SESSION_SRC_IP           "src_ip"
-#define MIRROR_SESSION_DST_IP           "dst_ip"
-#define MIRROR_SESSION_GRE_TYPE         "gre_type"
-#define MIRROR_SESSION_DSCP             "dscp"
-#define MIRROR_SESSION_TTL              "ttl"
-#define MIRROR_SESSION_QUEUE            "queue"
-#define MIRROR_SESSION_DST_MAC_ADDRESS  "dst_mac"
-#define MIRROR_SESSION_MONITOR_PORT     "monitor_port"
-#define MIRROR_SESSION_ROUTE_PREFIX     "route_prefix"
+#define MIRROR_SESSION_STATUS               "status"
+#define MIRROR_SESSION_STATUS_ACTIVE        "active"
+#define MIRROR_SESSION_STATUS_INACTIVE      "inactive"
+#define MIRROR_SESSION_SRC_IP               "src_ip"
+#define MIRROR_SESSION_DST_IP               "dst_ip"
+#define MIRROR_SESSION_GRE_TYPE             "gre_type"
+#define MIRROR_SESSION_DSCP                 "dscp"
+#define MIRROR_SESSION_TTL                  "ttl"
+#define MIRROR_SESSION_QUEUE                "queue"
+#define MIRROR_SESSION_DST_MAC_ADDRESS      "dst_mac"
+#define MIRROR_SESSION_MONITOR_PORT         "monitor_port"
+#define MIRROR_SESSION_ROUTE_PREFIX         "route_prefix"
+#define MIRROR_SESSION_VLAN_HEADER_VALID    "vlan_header_valid"
+
 
 #define MIRROR_SESSION_DEFAULT_VLAN_PRI 0
 #define MIRROR_SESSION_DEFAULT_VLAN_CFI 0
@@ -332,6 +334,12 @@ void MirrorOrch::setSessionState(const string& name, const MirrorEntry& session,
     if (attr.empty() || attr == MIRROR_SESSION_ROUTE_PREFIX)
     {
         value = session.nexthopInfo.prefix.to_string();
+        fvVector.emplace_back(attr, value);
+    }
+
+    if (attr.empty() || attr == MIRROR_SESSION_VLAN_HEADER_VALID)
+    {
+        value = to_string(session.neighborInfo.port.m_type == Port::VLAN);
         fvVector.emplace_back(attr, value);
     }
 
@@ -702,6 +710,8 @@ bool MirrorOrch::updateSessionType(const string& name, MirrorEntry& session)
 
     SWSS_LOG_NOTICE("Update mirror session %s VLAN to %s",
             name.c_str(), session.neighborInfo.port.m_alias.c_str());
+
+    setSessionState(name, session, MIRROR_SESSION_VLAN_HEADER_VALID);
 
     return true;
 }

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -306,7 +306,6 @@ void MirrorOrch::setSessionStatus(const string& name, MirrorEntry& session)
 
     SWSS_LOG_INFO("Setting mirroring sessions %s status\n", name.c_str());
 
-    string status = session.status ? MIRROR_SESSION_STATUS_ACTIVE : MIRROR_SESSION_STATUS_INACTIVE;
 
     setSessionState(name, session, MIRROR_SESSION_STATUS);
 }
@@ -319,28 +318,34 @@ void MirrorOrch::setSessionState(const string& name, const MirrorEntry& session,
 
     vector<FieldValueTuple> fvVector;
     string value;
+    if (attr.empty() || attr == MIRROR_SESSION_STATUS)
+    {
+        value = session.status ? MIRROR_SESSION_STATUS_ACTIVE : MIRROR_SESSION_STATUS_INACTIVE;
+        fvVector.emplace_back(MIRROR_SESSION_STATUS, value);
+    }
+
     if (attr.empty() || attr == MIRROR_SESSION_MONITOR_PORT)
     {
         value = sai_serialize_object_id(session.neighborInfo.portId);
-        fvVector.emplace_back(attr, value);
+        fvVector.emplace_back(MIRROR_SESSION_MONITOR_PORT, value);
     }
 
     if (attr.empty() || attr == MIRROR_SESSION_DST_MAC_ADDRESS)
     {
         value = session.neighborInfo.mac.to_string();
-        fvVector.emplace_back(attr, value);
+        fvVector.emplace_back(MIRROR_SESSION_DST_MAC_ADDRESS, value);
     }
 
     if (attr.empty() || attr == MIRROR_SESSION_ROUTE_PREFIX)
     {
         value = session.nexthopInfo.prefix.to_string();
-        fvVector.emplace_back(attr, value);
+        fvVector.emplace_back(MIRROR_SESSION_ROUTE_PREFIX, value);
     }
 
     if (attr.empty() || attr == MIRROR_SESSION_VLAN_HEADER_VALID)
     {
         value = to_string(session.neighborInfo.port.m_type == Port::VLAN);
-        fvVector.emplace_back(attr, value);
+        fvVector.emplace_back(MIRROR_SESSION_VLAN_HEADER_VALID, value);
     }
 
     m_mirrorTable.set(name, fvVector);

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -25,7 +25,6 @@
 #define MIRROR_SESSION_ROUTE_PREFIX         "route_prefix"
 #define MIRROR_SESSION_VLAN_HEADER_VALID    "vlan_header_valid"
 
-
 #define MIRROR_SESSION_DEFAULT_VLAN_PRI 0
 #define MIRROR_SESSION_DEFAULT_VLAN_CFI 0
 #define MIRROR_SESSION_DEFAULT_IP_HDR_VER 4
@@ -298,16 +297,6 @@ void MirrorOrch::deleteEntry(const string& name)
     m_syncdMirrors.erase(sessionIter);
 
     SWSS_LOG_NOTICE("Removed mirror session %s", name.c_str());
-}
-
-void MirrorOrch::setSessionStatus(const string& name, MirrorEntry& session)
-{
-    SWSS_LOG_ENTER();
-
-    SWSS_LOG_INFO("Setting mirroring sessions %s status\n", name.c_str());
-
-
-    setSessionState(name, session, MIRROR_SESSION_STATUS);
 }
 
 void MirrorOrch::setSessionState(const string& name, const MirrorEntry& session, const string& attr)
@@ -600,7 +589,9 @@ bool MirrorOrch::deactivateSession(const string& name, MirrorEntry& session)
     }
 
     session.status = false;
-    setSessionStatus(name, session);
+
+    // Store whole state into StateDB, since it is far from that frequent it's durable
+    setSessionState(name, session);
 
     SWSS_LOG_NOTICE("Deactive mirror session %s", name.c_str());
 

--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -93,7 +93,6 @@ private:
     bool updateSessionDstMac(const string&, MirrorEntry&);
     bool updateSessionDstPort(const string&, MirrorEntry&);
     bool updateSessionType(const string&, MirrorEntry&);
-    void setSessionStatus(const string&, MirrorEntry&);
 
     /*
      * Store mirror session state in StateDB

--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -20,7 +20,7 @@
 /*
  * Contains session data specified by user in config file
  * and data required for MAC address and port resolution
- * */
+ */
 struct MirrorEntry
 {
     bool status;
@@ -94,6 +94,11 @@ private:
     bool updateSessionDstPort(const string&, MirrorEntry&);
     bool updateSessionType(const string&, MirrorEntry&);
     void setSessionStatus(const string&, MirrorEntry&);
+
+    /*
+     * Store mirror session state in StateDB
+     * attr is the field name will be stored, if empty then all fields will be stored
+     */
     void setSessionState(const std::string& name, const MirrorEntry& session, const std::string& attr = "");
     bool getNeighborInfo(const string&, MirrorEntry&);
 

--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -69,7 +69,7 @@ public:
 
     void update(SubjectType, void *);
     bool sessionExists(const string&);
-    bool getSessionState(const string&, bool&);
+    bool getSessionStatus(const string&, bool&);
     bool getSessionOid(const string&, sai_object_id_t&);
     bool increaseRefCount(const string&);
     bool decreaseRefCount(const string&);
@@ -80,7 +80,7 @@ private:
     NeighOrch *m_neighOrch;
     FdbOrch *m_fdbOrch;
 
-    Table m_mirrorTableProducer;
+    Table m_mirrorTable;
 
     MirrorTable m_syncdMirrors;
 
@@ -93,7 +93,8 @@ private:
     bool updateSessionDstMac(const string&, MirrorEntry&);
     bool updateSessionDstPort(const string&, MirrorEntry&);
     bool updateSessionType(const string&, MirrorEntry&);
-    bool setSessionState(const string&, MirrorEntry&);
+    void setSessionStatus(const string&, MirrorEntry&);
+    void setSessionState(const std::string& name, const MirrorEntry& session, const std::string& attr = "");
     bool getNeighborInfo(const string&, MirrorEntry&);
 
     void updateNextHop(const NextHopUpdate&);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -101,9 +101,9 @@ bool OrchDaemon::init()
     };
     gBufferOrch = new BufferOrch(m_configDb, buffer_tables);
 
-    TableConnector appDbMirrorSession(m_applDb, APP_MIRROR_SESSION_TABLE_NAME);
+    TableConnector stateDbMirrorSession(m_stateDb, APP_MIRROR_SESSION_TABLE_NAME);
     TableConnector confDbMirrorSession(m_configDb, CFG_MIRROR_SESSION_TABLE_NAME);
-    MirrorOrch *mirror_orch = new MirrorOrch(appDbMirrorSession, confDbMirrorSession, gPortsOrch, gRouteOrch, gNeighOrch, gFdbOrch);
+    MirrorOrch *mirror_orch = new MirrorOrch(stateDbMirrorSession, confDbMirrorSession, gPortsOrch, gRouteOrch, gNeighOrch, gFdbOrch);
     VRFOrch *vrf_orch = new VRFOrch(m_configDb, CFG_VRF_TABLE_NAME);
 
     TableConnector confDbAclTable(m_configDb, CFG_ACL_TABLE_NAME);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,6 +186,7 @@ class DockerVirtualSwitch(object):
                     network_mode="container:%s" % self.ctn_sw.name,
                     volumes={ self.mount: { 'bind': '/var/run/redis', 'mode': 'rw' } })
 
+        self.appldb = None
         try:
             self.ctn.exec_run("sysctl -w net.ipv6.conf.all.disable_ipv6=0")
             self.check_ready()
@@ -196,7 +197,8 @@ class DockerVirtualSwitch(object):
             raise
 
     def destroy(self):
-        del self.appldb
+        if self.appldb:
+            del self.appldb
         if self.cleanup:
             self.ctn.remove(force=True)
             self.ctn_sw.remove(force=True)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -93,8 +93,9 @@ class TestMirror(object):
             if fv[0] == "status":
                 status = fv[1]
                 return status
-        else:
-            assert False
+
+        # If there is no status field, then it is a logic error
+        assert False
 
     def test_MirrorAddRemove(self, dvs):
         """

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -85,17 +85,16 @@ class TestMirror(object):
 
     def get_mirror_session_status(self, name):
         status = ""
-        # TODO: the status of mirror session will be moved to state database
-        tbl = swsscommon.Table(self.pdb, "MIRROR_SESSION")
+        tbl = swsscommon.Table(self.sdb, "MIRROR_SESSION")
         (status, fvs) = tbl.get(name)
         assert status == True
-        assert len(fvs) == 1
+        assert len(fvs) > 0
         for fv in fvs:
             if fv[0] == "status":
                 status = fv[1]
-            else:
-                assert False
-        return status
+                return status
+        else:
+            assert False
 
     def test_MirrorAddRemove(self, dvs):
         """


### PR DESCRIPTION
The old implementation store only session status in a plain Table in ApplDB, which is not correct databese.
1. Store mirror session state in StateDB
2. Store many session fields besides status