### PR TITLE
[mirrororch]: Remove the queue initialization for different platforms

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -50,12 +50,10 @@ MirrorEntry::MirrorEntry(const string& platform) :
     if (platform == MLNX_PLATFORM_SUBSTRING)
     {
         greType = 0x8949;
-        queue = 1;
     }
     else
     {
         greType = 0x88be;
-        queue = 0;
     }
 
     nexthopInfo.prefix = IpPrefix("0.0.0.0/0");


### PR DESCRIPTION
Queue 0 is a lossy queue, it is okay for all platforms to use queue 0
for mirrored packets.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>