### PR TITLE
[portsyncd]: Store eth0 oper status into state DB

### DIFF
--- a/portsyncd/Makefile.am
+++ b/portsyncd/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/warmrestart
+INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/warmrestart -I $(top_srcdir)/cfgmgr
 
 bin_PROGRAMS = portsyncd
 
@@ -8,7 +8,7 @@ else
 DBGFLAGS = -g
 endif
 
-portsyncd_SOURCES = portsyncd.cpp linksync.cpp $(top_srcdir)/warmrestart/warm_restart.cpp $(top_srcdir)/warmrestart/warm_restart.h
+portsyncd_SOURCES = portsyncd.cpp linksync.cpp $(top_srcdir)/warmrestart/warm_restart.cpp $(top_srcdir)/warmrestart/warm_restart.h $(top_srcdir)/cfgmgr/shellcmd.h
 
 portsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)

--- a/portsyncd/linksync.h
+++ b/portsyncd/linksync.h
@@ -20,7 +20,7 @@ public:
 
 private:
     ProducerStateTable m_portTableProducer;
-    Table m_portTable, m_statePortTable;
+    Table m_portTable, m_statePortTable, m_stateMgmtPortTable;
 
     std::map<unsigned int, std::string> m_ifindexNameMap;
     std::map<unsigned int, std::string> m_ifindexOldNameMap;


### PR DESCRIPTION
portsyncd listens to the netlink messages. In order for SNMP
to get the current oper status of the managemnt interface,
portsyncd will store eth0 oper status explicitly into the
state database.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>