### PR TITLE
[vnetorch]: Fix print enum error

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -86,7 +86,7 @@ bool VNetVrfObject::createObj(vector<sai_attribute_t>& attrs)
         sai_object_id_t router_id;
         if (vr_type != VR_TYPE::VR_INVALID && l_fn(router_id))
         {
-            SWSS_LOG_DEBUG("VNET vr_type %d router id %lx  ", vr_type, router_id);
+            SWSS_LOG_DEBUG("VNET vr_type %d router id %lx", (int)vr_type, router_id);
             vr_ids_.insert(std::pair<VR_TYPE, sai_object_id_t>(vr_type, router_id));
         }
     }


### PR DESCRIPTION
Fix the following error:
error: format ‘%d’ expects argument of type ‘int’, but argument 5 has type ‘VR_TYPE’

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>