### PR TITLE
Add Intf config state to StateDB

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -21,6 +21,7 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
         m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME),
         m_stateVlanTable(stateDb, STATE_VLAN_TABLE_NAME),
+        m_stateIntfTable(stateDb, STATE_INTERFACE_TABLE_NAME),
         m_appIntfTableProducer(appDb, APP_INTF_TABLE_NAME)
 {
 }
@@ -108,10 +109,12 @@ void IntfMgr::doTask(Consumer &consumer)
                 continue;
             }
             setIntfIp(alias, "add", ip_prefix.to_string(), ip_prefix.isV4());
+            m_stateIntfTable.hset(keys[0] + state_db_key_delimiter + keys[1], "state", "ok");
         }
         else if (op == DEL_COMMAND)
         {
             setIntfIp(alias, "del", ip_prefix.to_string(), ip_prefix.isV4());
+            m_stateIntfTable.del(keys[0] + state_db_key_delimiter + keys[1]);
         }
         else
         {

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -19,7 +19,7 @@ public:
 private:
     ProducerStateTable m_appIntfTableProducer;
     Table m_cfgIntfTable, m_cfgVlanIntfTable;
-    Table m_statePortTable, m_stateLagTable, m_stateVlanTable;
+    Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateIntfTable;
 
     bool setIntfIp(const string &alias, const string &opCmd, const string &ipPrefixStr, const bool ipv4 = true);
     void doTask(Consumer &consumer);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -30,6 +30,7 @@ const char ref_end             = ']';
 const char comma               = ',';
 const char range_specifier     = '-';
 const char config_db_key_delimiter = '|';
+const char state_db_key_delimiter  = '|';
 
 #define MLNX_PLATFORM_SUBSTRING "mellanox"
 #define BRCM_PLATFORM_SUBSTRING "broadcom"


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Add interface IP config state to StateDB.

**Why I did it**
To be used by arp refresh during warm reboot, and other possible scenarios.

**How I verified it**

Add IP address 20.20.20.20/24 and check state
```
root@sonic:/home/admin# config  interface Vlan10  ip add 20.20.20.20/24 
root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# ip add show Vlan10
6: Vlan10@Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:05:64:30:73:c0 brd ff:ff:ff:ff:ff:ff
    inet 11.163.117.119/26 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet 11.213.14.247/26 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet 20.20.20.20/24 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet6 fe80::205:64ff:fe30:73c0/64 scope link 
       valid_lft forever preferred_lft forever


127.0.0.1:6379[6]> select 6
OK
127.0.0.1:6379[6]> keys "INTERFACE_TABLE|Vlan10*"
1) "INTERFACE_TABLE|Vlan10|11.213.14.247/26"
2) "INTERFACE_TABLE|Vlan10|11.163.117.119/26"
3) "INTERFACE_TABLE|Vlan10|20.20.20.20/24"

```

Remove IP address 20.20.20.20/24  and check state
```

root@sonic:/home/admin# config  interface Vlan10  ip remove 20.20.20.20/24 
root@sonic:/home/admin# 
root@sonic:/home/admin# 
root@sonic:/home/admin# ip add show Vlan10
6: Vlan10@Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 00:05:64:30:73:c0 brd ff:ff:ff:ff:ff:ff
    inet 11.163.117.119/26 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet 11.213.14.247/26 scope global Vlan10
       valid_lft forever preferred_lft forever
    inet6 fe80::205:64ff:fe30:73c0/64 scope link 
       valid_lft forever preferred_lft forever


127.0.0.1:6379[6]> keys "INTERFACE_TABLE|Vlan10*"
1) "INTERFACE_TABLE|Vlan10|11.213.14.247/26"
2) "INTERFACE_TABLE|Vlan10|11.163.117.119/26"
127.0.0.1:6379[6]> hgetall  "INTERFACE_TABLE|Vlan10|11.163.117.119/26"
1) "state"
2) "ok"


```

**Details if related**
