### PR TITLE
Schema update for warm reboot data check state

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -745,6 +745,19 @@ Stores information for physical switch ports managed by the switch chip. Ports t
                                                                  ; dynanic data like port state, neighbor, routes
                                                                  ; and so on.
 
+    shutdown_check  = "ignored" / "passed" / "failed"            ; passed: pre-shutdown data check passed
+                                                                 ; failed: pre-shutdown data check failed
+                                                                 ; ignored: pre-shutdown data check failed, but asked to ignore it
+                                                                 ;
+                                                                 ; Note, data check is alwarys performed for warm restart.
+
+    restore_check   = "ignored"/ "passed" / "failed"             ; passed: warm restore data check passed
+                                                                 ; failed: warm restore data check failed
+                                                                 ;
+                                                                 ; ignored: warm restore data check failed, but asked to ignore it.
+                                                                 ; If value of shutdown_check is "ignored" or empty,  and the data check
+                                                                 ; failed, "igored" will set on restore_check.
+
 ## Configuration files
 What configuration files should we have?  Do apps, orch agent each need separate files?
 

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -749,7 +749,7 @@ Stores information for physical switch ports managed by the switch chip. Ports t
                                                                  ; failed: pre-shutdown data check failed
                                                                  ; ignored: pre-shutdown data check failed, but asked to ignore it
                                                                  ;
-                                                                 ; Note, data check is alwarys performed for warm restart.
+                                                                 ; Note, data check is always performed for warm restart.
 
     restore_check   = "ignored"/ "passed" / "failed"             ; passed: warm restore data check passed
                                                                  ; failed: warm restore data check failed


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Add state check state schema for warm reboot pre-shutdown and warm restore.

**Why I did it**
Modules like orchagent could save the data check state into StateDB.  Also at restore phase, if data check failed, the program may continue to run if pre-shutdown data check state is "ignored".

**How I verified it**

**Details if related**
