### PR TITLE
[mirrororch]: Fix bug when no need to update session type

### DIFF
--- a/orchagent/dtelorch.cpp
+++ b/orchagent/dtelorch.cpp
@@ -40,6 +40,7 @@ DTelOrch::DTelOrch(DBConnector *db, vector<string> tableNames, PortsOrch *portOr
 
     attr.id = SAI_DTEL_ATTR_INT_L4_DSCP;
 
+    attr.value.aclfield.enable = true;
     attr.value.aclfield.data.u8 = 0x11;
     attr.value.aclfield.mask.u8 = 0x3f;
 
@@ -660,6 +661,8 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                     SWSS_LOG_ERROR("DTEL ERROR: Invalid INT L4 DSCP value/mask");
                     goto dtel_table_continue;
                 }
+
+                attr.value.aclfield.enable = true;
 
                 status = sai_dtel_api->set_dtel_attribute(dtelId, &attr);
                 if (status != SAI_STATUS_SUCCESS)

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -424,7 +424,9 @@ bool MirrorOrch::updateSession(const string& name, MirrorEntry& session)
         if (session.status)
         {
             if (old_session.neighborInfo.port.m_type !=
-                    session.neighborInfo.port.m_type)
+                    session.neighborInfo.port.m_type &&
+                (old_session.neighborInfo.port.m_type == Port::VLAN ||
+                 session.neighborInfo.port.m_type == Port::VLAN))
             {
                 ret &= updateSessionType(name, session);
             }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1312,8 +1312,10 @@ bool PortsOrch::bake()
 
     // Check the APP_DB port table for warm reboot
     vector<FieldValueTuple> tuples;
-    bool foundPortConfigDone = m_portTable->get("PortConfigDone", tuples);
-    SWSS_LOG_NOTICE("foundPortConfigDone = %d", foundPortConfigDone);
+    string value;
+    bool foundPortConfigDone = m_portTable->hget("PortConfigDone", "count", value);
+    unsigned long portCount = stoul(value);
+    SWSS_LOG_NOTICE("foundPortConfigDone = %d, portCount = %lu, m_portCount = %u", foundPortConfigDone, portCount, m_portCount);
 
     bool foundPortInitDone = m_portTable->get("PortInitDone", tuples);
     SWSS_LOG_NOTICE("foundPortInitDone = %d", foundPortInitDone);
@@ -1329,11 +1331,11 @@ bool PortsOrch::bake()
         return false;
     }
 
-    if (m_portCount != keys.size() - 2)
+    if (portCount != keys.size() - 2)
     {
         // Invalid port table
-        SWSS_LOG_ERROR("Invalid port table: m_portCount, expecting %u, got %lu",
-                m_portCount, keys.size() - 2);
+        SWSS_LOG_ERROR("Invalid port table: portCount, expecting %lu, got %lu",
+                portCount, keys.size() - 2);
 
         cleanPortTable(keys);
         return false;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import commands
 import tarfile
 import StringIO
 import subprocess
+from datetime import datetime
 from swsscommon import swsscommon
 
 def ensure_system(cmd):
@@ -20,6 +21,8 @@ def ensure_system(cmd):
 def pytest_addoption(parser):
     parser.addoption("--dvsname", action="store", default=None,
                       help="dvs name")
+    parser.addoption("--keeptb", action="store_true", default=False,
+                      help="keep testbed after test")
 
 class AsicDbValidator(object):
     def __init__(self, dvs):
@@ -110,14 +113,14 @@ class VirtualServer(object):
             ensure_system("nsenter -t %d -n ip link set arp off dev %s" % (pid, self.vifname))
             ensure_system("nsenter -t %d -n sysctl -w net.ipv6.conf.%s.disable_ipv6=1" % (pid, self.vifname))
 
-    def __del__(self):
+    def destroy(self):
         if self.cleanup:
             pids = subprocess.check_output("ip netns pids %s" % (self.nsname), shell=True)
             if pids:
                 for pid in pids.split('\n'):
                     if len(pid) > 0:
                         os.system("kill %s" % int(pid))
-            os.system("ip netns delete %s" % self.nsname)
+            ensure_system("ip netns delete %s" % self.nsname)
 
     def runcmd(self, cmd):
         return os.system("ip netns exec %s %s" % (self.nsname, cmd))
@@ -126,25 +129,28 @@ class VirtualServer(object):
         return subprocess.Popen("ip netns exec %s %s" % (self.nsname, cmd), shell=True)
 
 class DockerVirtualSwitch(object):
-    def __init__(self, name=None):
-        self.pnames = ['fpmsyncd',
-                       'intfmgrd',
-                       'intfsyncd',
-                       'neighsyncd',
-                       'orchagent',
-                       'portsyncd',
-                       'redis-server',
-                       'rsyslogd',
-                       'syncd',
-                       'teamsyncd',
-                       'vlanmgrd',
-                       'zebra']
-        self.mount = "/var/run/redis-vs"
-        self.redis_sock = self.mount + '/' + "redis.sock"
+    def __init__(self, name=None, keeptb=False):
+        self.basicd = ['redis-server',
+                       'rsyslogd']
+        self.swssd = ['orchagent',
+                      'intfmgrd',
+                      'intfsyncd',
+                      'neighsyncd',
+                      'portsyncd',
+                      'vlanmgrd',
+                      'vrfmgrd',
+                      'portmgrd']
+        self.syncd = ['syncd']
+        self.rtd   = ['fpmsyncd', 'zebra']
+        self.teamd = ['teamsyncd', 'teammgrd']
+        self.alld  = self.basicd + self.swssd + self.syncd + self.rtd + self.teamd
         self.client = docker.from_env()
 
         self.ctn = None
-        self.cleanup = True
+        if keeptb:
+            self.cleanup = False
+        else:
+            self.cleanup = True
         if name != None:
             # get virtual switch container
             for ctn in self.client.containers.list():
@@ -183,6 +189,11 @@ class DockerVirtualSwitch(object):
                 server = VirtualServer(self.ctn_sw.name, self.ctn_sw_pid, i)
                 self.servers.append(server)
 
+            # mount redis to base to unique directory
+            self.mount = "/var/run/redis-vs/{}".format(self.ctn_sw.name)
+            os.system("mkdir -p {}".format(self.mount))
+            self.redis_sock = self.mount + '/' + "redis.sock"
+
             # create virtual switch container
             self.ctn = self.client.containers.run('docker-sonic-vs', privileged=True, detach=True,
                     network_mode="container:%s" % self.ctn_sw.name,
@@ -207,8 +218,9 @@ class DockerVirtualSwitch(object):
         if self.cleanup:
             self.ctn.remove(force=True)
             self.ctn_sw.remove(force=True)
+            os.system("rm -rf {}".format(self.mount))
             for s in self.servers:
-                del(s)
+                s.destroy()
 
     def check_ready(self, timeout=30):
         '''check if all processes in the dvs is ready'''
@@ -232,12 +244,16 @@ class DockerVirtualSwitch(object):
 
             # check if all processes are running
             ready = True
-            for pname in self.pnames:
+            for pname in self.alld:
                 try:
                     if process_status[pname] != "RUNNING":
                         ready = False
                 except KeyError:
                     ready = False
+
+            # check if start.sh exited
+            if process_status["start.sh"] != "EXITED":
+                ready = False
 
             if ready == True:
                 break
@@ -250,6 +266,20 @@ class DockerVirtualSwitch(object):
 
     def restart(self):
         self.ctn.restart()
+
+    # start processes in SWSS
+    def start_swss(self):
+        cmd = ""
+        for pname in self.swssd:
+            cmd += "supervisorctl start {}; ".format(pname)
+        self.runcmd(['sh', '-c', cmd])
+
+    # stop processes in SWSS
+    def stop_swss(self):
+        cmd = ""
+        for pname in self.swssd:
+            cmd += "supervisorctl stop {}; ".format(pname)
+        self.runcmd(['sh', '-c', cmd])
 
     def init_asicdb_validator(self):
         self.asicdb = AsicDbValidator(self)
@@ -272,6 +302,57 @@ class DockerVirtualSwitch(object):
         self.ctn.exec_run("mkdir -p %s" % path)
         self.ctn.put_archive(path, tarstr.getvalue())
         tarstr.close()
+
+    def get_logs(self, modname=None):
+        stream, stat = self.ctn.get_archive("/var/log/")
+        if modname == None:
+            log_dir = "log"
+        else:
+            log_dir = "log/{}".format(modname)
+        os.system("rm -rf {}".format(log_dir))
+        os.system("mkdir -p {}".format(log_dir))
+        p = subprocess.Popen(["tar", "--no-same-owner", "-C", "./{}".format(log_dir), "-x"], stdin=subprocess.PIPE)
+        for x in stream:
+            p.stdin.write(x)
+        p.stdin.close()
+        p.wait()
+        if p.returncode:
+            raise RuntimeError("Failed to unpack the archive.")
+        os.system("chmod a+r -R log")
+
+    def add_log_marker(self):
+        marker = "=== start marker {} ===".format(datetime.now().isoformat())
+        self.ctn.exec_run("logger {}".format(marker))
+        return marker
+
+    def SubscribeAsicDbObject(self, objpfx):
+        r = redis.Redis(unix_socket_path=self.redis_sock, db=swsscommon.ASIC_DB)
+        pubsub = r.pubsub()
+        pubsub.psubscribe("__keyspace@1__:ASIC_STATE:%s*" % objpfx)
+        return pubsub
+
+    def CountSubscribedObjects(self, pubsub, ignore=None, timeout=10):
+        nadd = 0
+        ndel = 0
+        idle = 0
+        while True and idle < timeout:
+            message = pubsub.get_message()
+            if message:
+                print message
+                if ignore:
+                    fds = message['channel'].split(':')
+                    if fds[2] in ignore:
+                        continue
+                if message['data'] == 'hset':
+                    nadd += 1
+                elif message['data'] == 'del':
+                    ndel += 1
+                idle = 0
+            else:
+                time.sleep(1)
+                idle += 1
+
+        return (nadd, ndel)
 
     def get_map_iface_bridge_port_id(self, asic_db):
         port_id_2_iface = self.asicdb.portoidmap
@@ -481,21 +562,20 @@ class DockerVirtualSwitch(object):
 
         ntf.send("set_ro", key, fvp)
 
-    # start processes in SWSS
-    def start_swss(self):
-        self.runcmd(['sh', '-c', 'supervisorctl start orchagent; supervisorctl start portsyncd; supervisorctl start intfsyncd; \
-            supervisorctl start neighsyncd; supervisorctl start intfmgrd; supervisorctl start vlanmgrd; \
-            supervisorctl start buffermgrd; supervisorctl start arp_update'])
-
-    # stop processes in SWSS
-    def stop_swss(self):
-        self.runcmd(['sh', '-c', 'supervisorctl stop orchagent; supervisorctl stop portsyncd; supervisorctl stop intfsyncd; \
-            supervisorctl stop neighsyncd;  supervisorctl stop intfmgrd; supervisorctl stop vlanmgrd; \
-            supervisorctl stop buffermgrd; supervisorctl stop arp_update'])
-
 @pytest.yield_fixture(scope="module")
 def dvs(request):
     name = request.config.getoption("--dvsname")
-    dvs = DockerVirtualSwitch(name)
+    keeptb = request.config.getoption("--keeptb")
+    dvs = DockerVirtualSwitch(name, keeptb)
     yield dvs
+    if name == None:
+        dvs.get_logs(request.module.__name__)
+    else:
+        dvs.get_logs()
     dvs.destroy()
+
+@pytest.yield_fixture
+def testlog(request, dvs):
+    dvs.runcmd("logger === start test %s ===" % request.node.name)
+    yield testlog
+    dvs.runcmd("logger === finish test %s ===" % request.node.name)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -130,7 +130,7 @@ class TestAcl(object):
         assert len(port_groups) == len(lag_ids)
         assert set(port_groups) == set(acl_table_groups)
 
-    def test_AclTableCreation(self, dvs):
+    def test_AclTableCreation(self, dvs, testlog):
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
 
@@ -159,7 +159,7 @@ class TestAcl(object):
         # check port binding
         self.verify_acl_port_binding(dvs, adb, bind_ports)
 
-    def test_AclRuleL4SrcPort(self, dvs):
+    def test_AclRuleL4SrcPort(self, dvs, testlog):
         """
         hmset ACL_RULE|test|acl_test_rule priority 55 PACKET_ACTION FORWARD L4_SRC_PORT 65000
         """
@@ -210,7 +210,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_AclRuleInOutPorts(self, dvs):
+    def test_AclRuleInOutPorts(self, dvs, testlog):
         """
         hmset ACL_RULE|test|acl_test_rule priority 55 PACKET_ACTION FORWARD IN_PORTS Ethernet0,Ethernet4 OUT_PORTS Ethernet8,Ethernet12
         """
@@ -270,7 +270,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_AclTableDeletion(self, dvs):
+    def test_AclTableDeletion(self, dvs, testlog):
 
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -286,7 +286,7 @@ class TestAcl(object):
         # only the default table was left along with DTel tables
         assert len(keys) >= 1
 
-    def test_V6AclTableCreation(self, dvs):
+    def test_V6AclTableCreation(self, dvs, testlog):
 
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -359,7 +359,7 @@ class TestAcl(object):
 
         assert set(port_groups) == set(acl_table_groups)
 
-    def test_V6AclRuleIPv6Any(self, dvs):
+    def test_V6AclRuleIPv6Any(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule1 priority 1000 PACKET_ACTION FORWARD IPv6Any
         """
@@ -410,7 +410,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleIPv6AnyDrop(self, dvs):
+    def test_V6AclRuleIPv6AnyDrop(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule2 priority 1002 PACKET_ACTION DROP IPv6Any
         """
@@ -461,7 +461,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleIpProtocol(self, dvs):
+    def test_V6AclRuleIpProtocol(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule3 priority 1003 PACKET_ACTION DROP IP_PROTOCOL 6
         """
@@ -512,7 +512,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleSrcIPv6(self, dvs):
+    def test_V6AclRuleSrcIPv6(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule4 priority 1004 PACKET_ACTION DROP SRC_IPV6 2777::0/64
         """
@@ -563,7 +563,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleDstIPv6(self, dvs):
+    def test_V6AclRuleDstIPv6(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule5 priority 1005 PACKET_ACTION DROP DST_IPV6 2002::2/128
         """
@@ -614,7 +614,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleL4SrcPort(self, dvs):
+    def test_V6AclRuleL4SrcPort(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule6 priority 1006 PACKET_ACTION DROP L4_SRC_PORT 65000
         """
@@ -665,7 +665,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleL4DstPort(self, dvs):
+    def test_V6AclRuleL4DstPort(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule7 priority 1007 PACKET_ACTION DROP L4_DST_PORT 65001
         """
@@ -716,7 +716,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleTCPFlags(self, dvs):
+    def test_V6AclRuleTCPFlags(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule8 priority 1008 PACKET_ACTION DROP TCP_FLAGS 0x7/0x3f
         """
@@ -767,7 +767,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleL4SrcPortRange(self, dvs):
+    def test_V6AclRuleL4SrcPortRange(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule9 priority 1009 PACKET_ACTION DROP L4_SRC_PORT_RANGE 1-100
         """
@@ -832,7 +832,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclRuleL4DstPortRange(self, dvs):
+    def test_V6AclRuleL4DstPortRange(self, dvs, testlog):
         """
         hmset ACL_RULE|test-aclv6|test_rule10 priority 1010 PACKET_ACTION DROP L4_DST_PORT_RANGE 101-200
         """
@@ -897,7 +897,7 @@ class TestAcl(object):
         (status, fvs) = atbl.get(acl_entry[0])
         assert status == False
 
-    def test_V6AclTableDeletion(self, dvs):
+    def test_V6AclTableDeletion(self, dvs, testlog):
 
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -928,7 +928,7 @@ class TestAcl(object):
         #did not find the rule
         return False
 
-    def test_InsertAclRuleBetweenPriorities(self, dvs):
+    def test_InsertAclRuleBetweenPriorities(self, dvs, testlog):
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
 
@@ -1026,7 +1026,7 @@ class TestAcl(object):
         # only the default table was left
         assert len(keys) >= 1
 
-    def test_RulesWithDiffMaskLengths(self, dvs):
+    def test_RulesWithDiffMaskLengths(self, dvs, testlog):
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
 
@@ -1111,7 +1111,7 @@ class TestAcl(object):
         keys = atbl.getKeys()
         assert len(keys) >= 1
 
-    def test_AclTableCreationOnLAGMember(self, dvs):
+    def test_AclTableCreationOnLAGMember(self, dvs, testlog):
         # prepare db and tables
         self.clean_up_left_over(dvs)
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
@@ -1139,7 +1139,7 @@ class TestAcl(object):
         # verify test result - ACL table creation should fail
         assert self.verify_if_any_acl_table_created(dvs, adb) == False
 
-    def test_AclTableCreationOnLAG(self, dvs):
+    def test_AclTableCreationOnLAG(self, dvs, testlog):
         # prepare db and tables
         self.clean_up_left_over(dvs)
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
@@ -1189,7 +1189,7 @@ class TestAcl(object):
         tbl = swsscommon.Table(db, "ACL_TABLE")
         tbl._del("test_LAG")
 
-    def test_AclTableCreationBeforeLAG(self, dvs):
+    def test_AclTableCreationBeforeLAG(self, dvs, testlog):
         # prepare db and tables
         self.clean_up_left_over(dvs)
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -39,8 +39,12 @@ def setReadOnlyAttr(dvs, obj, attr, val):
     ntf.send("set_ro", key, fvp)
 
 
-def test_CrmFdbEntry(dvs):
+def test_CrmFdbEntry(dvs, testlog):
 
+    # disable ipv6 on Ethernet8 neighbor as once ipv6 link-local address is
+    # configured, server 2 will send packet which can switch to learn another
+    # mac and fail the test.
+    dvs.servers[2].runcmd("sysctl -w net.ipv6.conf.eth0.disable_ipv6=1")
     dvs.runcmd("crm config polling interval 1")
 
     setReadOnlyAttr(dvs, 'SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_FDB_ENTRY', '1000')
@@ -91,8 +95,10 @@ def test_CrmFdbEntry(dvs):
 
     assert new_avail_counter == avail_counter
 
+    # enable ipv6 on server 2
+    dvs.servers[2].runcmd("sysctl -w net.ipv6.conf.eth0.disable_ipv6=0")
 
-def test_CrmIpv4Route(dvs):
+def test_CrmIpv4Route(dvs, testlog):
 
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
 
@@ -141,7 +147,7 @@ def test_CrmIpv4Route(dvs):
     assert new_avail_counter == avail_counter
 
 
-def test_CrmIpv6Route(dvs):
+def test_CrmIpv6Route(dvs, testlog):
 
     # Enable IPv6 routing
     dvs.runcmd("sysctl net.ipv6.conf.all.disable_ipv6=0")
@@ -197,7 +203,7 @@ def test_CrmIpv6Route(dvs):
     assert new_avail_counter == avail_counter
 
 
-def test_CrmIpv4Nexthop(dvs):
+def test_CrmIpv4Nexthop(dvs, testlog):
 
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
 
@@ -238,7 +244,7 @@ def test_CrmIpv4Nexthop(dvs):
     assert new_avail_counter == avail_counter
 
 
-def test_CrmIpv6Nexthop(dvs):
+def test_CrmIpv6Nexthop(dvs, testlog):
 
     # Enable IPv6 routing
     dvs.runcmd("sysctl net.ipv6.conf.all.disable_ipv6=0")
@@ -283,7 +289,7 @@ def test_CrmIpv6Nexthop(dvs):
     assert new_avail_counter == avail_counter
 
 
-def test_CrmIpv4Neighbor(dvs):
+def test_CrmIpv4Neighbor(dvs, testlog):
 
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
 
@@ -324,7 +330,7 @@ def test_CrmIpv4Neighbor(dvs):
     assert new_avail_counter == avail_counter
 
 
-def test_CrmIpv6Neighbor(dvs):
+def test_CrmIpv6Neighbor(dvs, testlog):
 
     # Enable IPv6 routing
     dvs.runcmd("sysctl net.ipv6.conf.all.disable_ipv6=0")
@@ -369,7 +375,7 @@ def test_CrmIpv6Neighbor(dvs):
     assert new_avail_counter == avail_counter
 
 
-def test_CrmNexthopGroup(dvs):
+def test_CrmNexthopGroup(dvs, testlog):
 
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
     dvs.runcmd("ifconfig Ethernet4 10.0.0.2/31 up")
@@ -421,7 +427,7 @@ def test_CrmNexthopGroup(dvs):
     assert new_avail_counter == avail_counter
 
 
-def test_CrmNexthopGroupMember(dvs):
+def test_CrmNexthopGroupMember(dvs, testlog):
 
     # down, then up to generate port up signal
     dvs.servers[0].runcmd("ip link set down dev eth0") == 0
@@ -479,7 +485,7 @@ def test_CrmNexthopGroupMember(dvs):
     assert new_avail_counter == avail_counter
 
 
-def test_CrmAcl(dvs):
+def test_CrmAcl(dvs, testlog):
 
     db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
     adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)

--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -3,7 +3,7 @@ import time
 import re
 import json
 
-def test_DirectedBroadcast(dvs):
+def test_DirectedBroadcast(dvs, testlog):
 
     db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
     adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)

--- a/tests/test_dtel.py
+++ b/tests/test_dtel.py
@@ -6,7 +6,7 @@ import re
 import json
 
 class TestDtel(object):
-    def test_DtelGlobalAttribs(self, dvs):
+    def test_DtelGlobalAttribs(self, dvs, testlog):
     
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -86,7 +86,7 @@ class TestDtel(object):
         tbl._del("QUEUE_REPORT")
         tbl._del("SINK_PORT_LIST")
     
-    def test_DtelReportSessionAttribs(self, dvs):
+    def test_DtelReportSessionAttribs(self, dvs, testlog):
     
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -127,7 +127,7 @@ class TestDtel(object):
 
         tbl._del("RS-1")
 
-    def test_DtelINTSessionAttribs(self, dvs):
+    def test_DtelINTSessionAttribs(self, dvs, testlog):
     
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -171,7 +171,7 @@ class TestDtel(object):
 
         tbl._del("INT-1")
 
-    def test_DtelQueueReportAttribs(self, dvs):
+    def test_DtelQueueReportAttribs(self, dvs, testlog):
     
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
@@ -212,7 +212,7 @@ class TestDtel(object):
         tbl._del("Ethernet0|0")
     
 
-    def test_DtelEventAttribs(self, dvs):
+    def test_DtelEventAttribs(self, dvs, testlog):
     
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)

--- a/tests/test_fdb_cold.py
+++ b/tests/test_fdb_cold.py
@@ -24,7 +24,7 @@ def how_many_entries_exist(db, table):
     tbl =  swsscommon.Table(db, table)
     return len(tbl.getKeys())
 
-def test_FDBAddedAfterMemberCreated(dvs):
+def test_FDBAddedAfterMemberCreated(dvs, testlog):
     dvs.setup_db()
 
     dvs.runcmd("sonic-clear fdb all")

--- a/tests/test_fdb_warm.py
+++ b/tests/test_fdb_warm.py
@@ -24,7 +24,7 @@ def how_many_entries_exist(db, table):
     tbl =  swsscommon.Table(db, table)
     return len(tbl.getKeys())
 
-def test_fdb_notifications(dvs):
+def test_fdb_notifications(dvs, testlog):
     dvs.setup_db()
 
     dvs.runcmd("sonic-clear fdb all")

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -26,7 +26,7 @@ class TestRouterInterfaceIpv4(object):
         tbl.set(interface, fvs)
         time.sleep(1)
 
-    def test_InterfaceAddRemoveIpv4Address(self, dvs):
+    def test_InterfaceAddRemoveIpv4Address(self, dvs, testlog):
         self.setup_db(dvs)
 
         # assign IP to interface
@@ -95,7 +95,7 @@ class TestRouterInterfaceIpv4(object):
             if route["dest"] == "10.0.0.4/32":
                 assert False
 
-    def test_InterfaceSetMtu(self, dvs):
+    def test_InterfaceSetMtu(self, dvs, testlog):
         self.setup_db(dvs)
 
         # assign IP to interface
@@ -175,7 +175,7 @@ class TestLagRouterInterfaceIpv4(object):
         tbl.set(interface, fvs)
         time.sleep(1)
 
-    def test_InterfaceAddRemoveIpv4Address(self, dvs):
+    def test_InterfaceAddRemoveIpv4Address(self, dvs, testlog):
         self.setup_db(dvs)
 
         # create port channel
@@ -251,7 +251,7 @@ class TestLagRouterInterfaceIpv4(object):
         self.remove_port_channel(dvs, "PortChannel001")
 
 
-    def test_InterfaceSetMtu(self, dvs):
+    def test_InterfaceSetMtu(self, dvs, testlog):
         self.setup_db(dvs)
 
         # create port channel

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -97,7 +97,7 @@ class TestMirror(object):
         return { fv[0]: fv[1] for fv in fvs }
 
 
-    def test_MirrorAddRemove(self, dvs):
+    def test_MirrorAddRemove(self, dvs, testlog):
         """
         This test covers the basic mirror session creation and removal operations
         Operation flow:
@@ -229,7 +229,7 @@ class TestMirror(object):
     # Ignore testcase in Debian Jessie
     # TODO: Remove this skip if Jessie support is no longer needed
     @pytest.mark.skipif(StrictVersion(platform.linux_distribution()[1]) <= StrictVersion('8.9'), reason="Debian 8.9 or before has no support")
-    def test_MirrorToVlanAddRemove(self, dvs):
+    def test_MirrorToVlanAddRemove(self, dvs, testlog):
         """
         This test covers basic mirror session creation and removal operation
         with destination port sits in a VLAN
@@ -365,7 +365,7 @@ class TestMirror(object):
         time.sleep(1)
 
 
-    def test_MirrorToLagAddRemove(self, dvs):
+    def test_MirrorToLagAddRemove(self, dvs, testlog):
         """
         This test covers basic mirror session creation and removal operations
         with destination port sits in a LAG
@@ -436,7 +436,7 @@ class TestMirror(object):
     # Ignore testcase in Debian Jessie
     # TODO: Remove this skip if Jessie support is no longer needed
     @pytest.mark.skipif(StrictVersion(platform.linux_distribution()[1]) <= StrictVersion('8.9'), reason="Debian 8.9 or before has no support")
-    def test_MirrorDestMoveVlan(self, dvs):
+    def test_MirrorDestMoveVlan(self, dvs, testlog):
         """
         This test tests mirror session destination move from non-VLAN to VLAN
         and back to non-VLAN port
@@ -554,7 +554,7 @@ class TestMirror(object):
         self.remove_mirror_session(session)
 
 
-    def test_MirrorDestMoveLag(self, dvs):
+    def test_MirrorDestMoveLag(self, dvs, testlog):
         """
         This test tests mirror session destination move from non-LAG to LAG
         and back to non-LAG port
@@ -707,7 +707,7 @@ class TestMirror(object):
         time.sleep(1)
 
 
-    def test_AclBindMirror(self, dvs):
+    def test_AclBindMirror(self, dvs, testlog):
         """
         This test tests ACL associated with mirror session with DSCP value
         The DSCP value is tested on both with mask and without mask

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -4,7 +4,7 @@ import re
 import time
 import json
 
-def test_route_nhg(dvs):
+def test_route_nhg(dvs, testlog):
 
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
     dvs.runcmd("ifconfig Ethernet4 10.0.0.2/31 up")

--- a/tests/test_pfc.py
+++ b/tests/test_pfc.py
@@ -58,7 +58,7 @@ def getPortAttr(dvs, port_oid, port_attr):
     return ''
 
 
-def test_PfcAsymmetric(dvs):
+def test_PfcAsymmetric(dvs, testlog):
 
     port_name = 'Ethernet0'
     pfc_queues = [ 3, 4 ]

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -4,7 +4,7 @@ import time
 import os
 
 class TestPort(object):
-    def test_PortMtu(self, dvs):
+    def test_PortMtu(self, dvs, testlog):
         pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
@@ -23,7 +23,7 @@ class TestPort(object):
             if fv[0] == "mtu":
                 assert fv[1] == "9100"
 
-def test_PortNotification(dvs):
+def test_PortNotification(dvs, testlog):
 
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up") == 0
     dvs.runcmd("ifconfig Ethernet4 10.0.0.2/31 up") == 0
@@ -66,7 +66,7 @@ def test_PortNotification(dvs):
 
     assert oper_status == "up"
 
-def test_PortFec(dvs):
+def test_PortFec(dvs, testlog):
 
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up") == 0
     dvs.runcmd("ifconfig Ethernet4 10.0.0.2/31 up") == 0

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -2,7 +2,7 @@ from swsscommon import swsscommon
 import time
 import os
 
-def test_PortAutoNeg(dvs):
+def test_PortAutoNeg(dvs, testlog):
 
     db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
 

--- a/tests/test_port_buffer_rel.py
+++ b/tests/test_port_buffer_rel.py
@@ -3,7 +3,7 @@ import time
 
 # The test check that the ports will be up, when the admin state is UP by conf db.
 
-def test_PortsAreUpAfterBuffers(dvs):    
+def test_PortsAreUpAfterBuffers(dvs, testlog):
     num_ports = 32
     asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -3,7 +3,7 @@ import time
 import re
 import json
 
-def test_PortChannel(dvs):
+def test_PortChannel(dvs, testlog):
 
     # create port channel
     db = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -4,7 +4,7 @@ import re
 import time
 import json
 
-def test_RouteAdd(dvs):
+def test_RouteAdd(dvs, testlog):
 
     dvs.runcmd("ifconfig Ethernet0 10.0.0.0/31 up")
     dvs.runcmd("ifconfig Ethernet4 10.0.0.2/31 up")

--- a/tests/test_setro.py
+++ b/tests/test_setro.py
@@ -4,7 +4,7 @@ import json
 import redis
 from pprint import pprint
 
-def test_SetReadOnlyAttribute(dvs):
+def test_SetReadOnlyAttribute(dvs, testlog):
 
     db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
 

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -15,7 +15,7 @@ import os
 
 class TestSpeedSet(object):
     num_ports = 32
-    def test_SpeedAndBufferSet(self, dvs):
+    def test_SpeedAndBufferSet(self, dvs, testlog):
         speed_list = ['50000', '25000', '40000', '10000', '100000']
 
         cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -163,7 +163,7 @@ class TestTunnelBase(object):
 class TestDecapTunnel(TestTunnelBase):
     """ Tests for decap tunnel creation and removal """
 
-    def test_TunnelDecap_v4(self, dvs):
+    def test_TunnelDecap_v4(self, dvs, testlog):
         """ test IPv4 tunnel creation """
 
         db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
@@ -177,7 +177,7 @@ class TestDecapTunnel(TestTunnelBase):
                                    ecn_mode="standard", ttl_mode="pipe")
         self.remove_and_test_tunnel(db, asicdb, "IPINIPv4Decap")
 
-    def test_TunnelDecap_v6(self, dvs):
+    def test_TunnelDecap_v6(self, dvs, testlog):
         """ test IPv6 tunnel creation """
 
         db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
@@ -195,7 +195,7 @@ class TestDecapTunnel(TestTunnelBase):
 class TestSymmetricTunnel(TestTunnelBase):
     """ Tests for symmetric tunnel creation and removal """
 
-    def test_TunnelSymmetric_v4(self, dvs):
+    def test_TunnelSymmetric_v4(self, dvs, testlog):
         """ test IPv4 tunnel creation """
 
         db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
@@ -210,7 +210,7 @@ class TestSymmetricTunnel(TestTunnelBase):
                                    ecn_mode="copy_from_outer", ttl_mode="uniform")
         self.remove_and_test_tunnel(db, asicdb, "IPINIPv4Symmetric")
 
-    def test_TunnelSymmetric_v6(self, dvs):
+    def test_TunnelSymmetric_v6(self, dvs, testlog):
         """ test IPv6 tunnel creation """
 
         db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -35,7 +35,7 @@ class TestVlan(object):
         tbl._del("Vlan" + vlan + "|" + interface)
         time.sleep(1)
 
-    def test_VlanAddRemove(self, dvs):
+    def test_VlanAddRemove(self, dvs, testlog):
         self.setup_db(dvs)
 
         # create vlan
@@ -108,7 +108,7 @@ class TestVlan(object):
         # remvoe vlan
         self.remove_vlan("2")
 
-    def test_MultipleVlan(self, dvs):
+    def test_MultipleVlan(self, dvs, testlog):
         return
         self.setup_db(dvs)
 

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -151,7 +151,7 @@ def packet_action_gen():
     return r[0], r[1]
 
 
-def test_VRFOrch_Comprehensive(dvs):
+def test_VRFOrch_Comprehensive(dvs, testlog):
     asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
 
@@ -182,7 +182,7 @@ def test_VRFOrch_Comprehensive(dvs):
         vrf_remove(asic_db, appl_db, vrf_name, state)
 
 
-def test_VRFOrch(dvs):
+def test_VRFOrch(dvs, testlog):
     asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
     state = vrf_create(asic_db, appl_db, "vrf0",
@@ -205,7 +205,7 @@ def test_VRFOrch(dvs):
     )
     vrf_remove(asic_db, appl_db, "vrf1", state)
 
-def test_VRFOrch_Update(dvs):
+def test_VRFOrch_Update(dvs, testlog):
     asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
 

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -235,7 +235,7 @@ def get_lo(dvs):
     return lo_id
 
 
-def test_vxlan_term_orch(dvs):
+def test_vxlan_term_orch(dvs, testlog):
     tunnel_map_ids       = set()
     tunnel_map_entry_ids = set()
     tunnel_ids           = set()

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -4,19 +4,6 @@ import re
 import time
 import json
 
-# start processes in SWSS
-def start_swss(dvs):
-    dvs.runcmd(['sh', '-c', 'supervisorctl start orchagent; supervisorctl start portsyncd; supervisorctl start intfsyncd; \
-        supervisorctl start neighsyncd; supervisorctl start intfmgrd; supervisorctl start vlanmgrd; \
-        supervisorctl start buffermgrd; supervisorctl start arp_update'])
-
-# stop processes in SWSS
-def stop_swss(dvs):
-    dvs.runcmd(['sh', '-c', 'supervisorctl stop orchagent; supervisorctl stop portsyncd; supervisorctl stop intfsyncd; \
-        supervisorctl stop neighsyncd;  supervisorctl stop intfmgrd; supervisorctl stop vlanmgrd; \
-        supervisorctl stop buffermgrd; supervisorctl stop arp_update'])
-
-
 # Get restore count of all processes supporting warm restart
 def swss_get_RestoreCount(state_db):
     restore_count = {}
@@ -114,16 +101,7 @@ def how_many_entries_exist(db, table):
     tbl =  swsscommon.Table(db, table)
     return len(tbl.getKeys())
 
-# No create/set/remove operations should be passed down to syncd for vlanmgr/portsyncd warm restart
-def checkCleanSaiRedisCSR(dvs):
-    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|c\| /var/log/swss/sairedis.rec | wc -l'])
-    assert num == '0\n'
-    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|s\| /var/log/swss/sairedis.rec | wc -l'])
-    assert num == '0\n'
-    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|r\| /var/log/swss/sairedis.rec | wc -l'])
-    assert num == '0\n'
-
-def test_PortSyncdWarmRestart(dvs):
+def test_PortSyncdWarmRestart(dvs, testlog):
 
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
@@ -169,11 +147,14 @@ def test_PortSyncdWarmRestart(dvs):
     restore_count = swss_get_RestoreCount(state_db)
 
     # restart portsyncd
-    dvs.runcmd(['sh', '-c', 'pkill -x portsyncd; cp /var/log/swss/sairedis.rec /var/log/swss/sairedis.rec.b; echo > /var/log/swss/sairedis.rec'])
-    dvs.runcmd(['sh', '-c', 'supervisorctl start portsyncd'])
-    time.sleep(2)
+    dvs.runcmd(['sh', '-c', 'pkill -x portsyncd'])
 
-    checkCleanSaiRedisCSR(dvs)
+    pubsub = dvs.SubscribeAsicDbObject("SAI_OBJECT_TYPE")
+    dvs.runcmd(['sh', '-c', 'supervisorctl start portsyncd'])
+
+    (nadd, ndel) = dvs.CountSubscribedObjects(pubsub)
+    assert nadd == 0
+    assert ndel == 0
 
     #new ip on server 5
     dvs.servers[5].runcmd("ifconfig eth0 11.0.0.11/29")
@@ -198,7 +179,7 @@ def test_PortSyncdWarmRestart(dvs):
     swss_app_check_RestoreCount_single(state_db, restore_count, "portsyncd")
 
 
-def test_VlanMgrdWarmRestart(dvs):
+def test_VlanMgrdWarmRestart(dvs, testlog):
 
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
@@ -276,14 +257,19 @@ def test_VlanMgrdWarmRestart(dvs):
 
     restore_count = swss_get_RestoreCount(state_db)
 
-    dvs.runcmd(['sh', '-c', 'pkill -x vlanmgrd; cp /var/log/swss/sairedis.rec /var/log/swss/sairedis.rec.b; echo > /var/log/swss/sairedis.rec'])
+    dvs.runcmd(['sh', '-c', 'pkill -x vlanmgrd'])
+
+    pubsub = dvs.SubscribeAsicDbObject("SAI_OBJECT_TYPE")
+
     dvs.runcmd(['sh', '-c', 'supervisorctl start vlanmgrd'])
     time.sleep(2)
 
     (exitcode, bv_after) = dvs.runcmd("bridge vlan")
     assert bv_after == bv_before
 
-    checkCleanSaiRedisCSR(dvs)
+    (nadd, ndel) = dvs.CountSubscribedObjects(pubsub, ignore=["SAI_OBJECT_TYPE_FDB_ENTRY"])
+    assert nadd == 0
+    assert ndel == 0
 
     #new ip on server 5
     dvs.servers[5].runcmd("ifconfig eth0 11.0.0.11/29")
@@ -297,13 +283,8 @@ def test_VlanMgrdWarmRestart(dvs):
 
     swss_app_check_RestoreCount_single(state_db, restore_count, "vlanmgrd")
 
-# function to stop neighsyncd service and clear syslog and sairedis records
-def stop_neighsyncd_clear_syslog_sairedis(dvs, save_number):
+def stop_neighsyncd(dvs):
     dvs.runcmd(['sh', '-c', 'pkill -x neighsyncd'])
-    dvs.runcmd("cp /var/log/swss/sairedis.rec /var/log/swss/sairedis.rec.back{}".format(save_number))
-    dvs.runcmd(['sh', '-c', '> /var/log/swss/sairedis.rec'])
-    dvs.runcmd("cp /var/log/syslog /var/log/syslog.back{}".format(save_number))
-    dvs.runcmd(['sh', '-c', '> /var/log/syslog'])
 
 def start_neighsyncd(dvs):
     dvs.runcmd(['sh', '-c', 'supervisorctl start neighsyncd'])
@@ -313,38 +294,21 @@ def check_no_neighsyncd_timer(dvs):
     assert string.strip() != ""
 
 def check_neighsyncd_timer(dvs, timer_value):
-    (exitcode, num) = dvs.runcmd(['sh', '-c', "grep getWarmStartTimer /var/log/syslog | grep neighsyncd | rev | cut -d ' ' -f 1 | rev"])
+    (exitcode, num) = dvs.runcmd(['sh', '-c', "grep getWarmStartTimer /var/log/syslog | grep neighsyncd | tail -n 1 | rev | cut -d ' ' -f 1 | rev"])
     assert num.strip() == timer_value
 
 # function to check neighbor entry reconciliation status written in syslog
-def check_syslog_for_neighbor_entry(dvs, new_cnt, delete_cnt, iptype):
+def check_syslog_for_neighbor_entry(dvs, marker, new_cnt, delete_cnt, iptype):
     # check reconciliation results (new or delete entries) for ipv4 and ipv6
-    if iptype == "ipv4":
-        (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep neighsyncd /var/log/syslog| grep cache-state:NEW | grep IPv4 | wc -l'])
+    if iptype == "ipv4" or iptype == "ipv6":
+        (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep neighsyncd | grep cache-state:NEW | grep -i %s | wc -l" % (marker, iptype)])
         assert num.strip() == str(new_cnt)
-        (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep neighsyncd /var/log/syslog| grep cache-state:DELETE | grep IPv4 | wc -l'])
-        assert num.strip() == str(delete_cnt)
-    elif iptype == "ipv6":
-        (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep neighsyncd /var/log/syslog| grep cache-state:NEW | grep IPv6 | wc -l'])
-        assert num.strip() == str(new_cnt)
-        (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep neighsyncd /var/log/syslog| grep cache-state:DELETE | grep IPv6 | wc -l'])
+        (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep neighsyncd | grep -E \"cache-state:(DELETE|STALE)\" | grep -i %s | wc -l" % (marker, iptype)])
         assert num.strip() == str(delete_cnt)
     else:
         assert "iptype is unknown" == ""
 
-
-# function to check sairedis record for neighbor entries
-def check_sairedis_for_neighbor_entry(dvs, create_cnt, set_cnt, remove_cnt):
-    # check create/set/remove operations for neighbor entries during warm restart
-    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|c\| /var/log/swss/sairedis.rec | grep NEIGHBOR_ENTRY | wc -l'])
-    assert num.strip() == str(create_cnt)
-    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|s\| /var/log/swss/sairedis.rec | grep NEIGHBOR_ENTRY | wc -l'])
-    assert num.strip() == str(set_cnt)
-    (exitcode, num) = dvs.runcmd(['sh', '-c', 'grep \|r\| /var/log/swss/sairedis.rec | grep NEIGHBOR_ENTRY | wc -l'])
-    assert num.strip() == str(remove_cnt)
-
-
-def test_swss_neighbor_syncup(dvs):
+def test_swss_neighbor_syncup(dvs, testlog):
 
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
@@ -414,9 +378,10 @@ def test_swss_neighbor_syncup(dvs):
     # get restore_count
     restore_count = swss_get_RestoreCount(state_db)
 
-    # stop neighsyncd and clear syslog and sairedis.rec
-    stop_neighsyncd_clear_syslog_sairedis(dvs, 1)
-
+    # stop neighsyncd and sairedis.rec
+    stop_neighsyncd(dvs)
+    marker = dvs.add_log_marker()
+    pubsub = dvs.SubscribeAsicDbObject("SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
     start_neighsyncd(dvs)
     time.sleep(10)
 
@@ -442,9 +407,11 @@ def test_swss_neighbor_syncup(dvs):
                 assert v[1] == "IPv6"
 
     # check syslog and sairedis.rec file for activities
-    check_syslog_for_neighbor_entry(dvs, 0, 0, "ipv4")
-    check_syslog_for_neighbor_entry(dvs, 0, 0, "ipv6")
-    check_sairedis_for_neighbor_entry(dvs, 0, 0, 0)
+    check_syslog_for_neighbor_entry(dvs, marker, 0, 0, "ipv4")
+    check_syslog_for_neighbor_entry(dvs, marker, 0, 0, "ipv6")
+    (nadd, ndel) = dvs.CountSubscribedObjects(pubsub)
+    assert nadd == 0
+    assert ndel == 0
 
     # check restore Count
     swss_app_check_RestoreCount_single(state_db, restore_count, "neighsyncd")
@@ -460,8 +427,9 @@ def test_swss_neighbor_syncup(dvs):
     # get restore_count
     restore_count = swss_get_RestoreCount(state_db)
 
-    # stop neighsyncd and clear syslog and sairedis.rec
-    stop_neighsyncd_clear_syslog_sairedis(dvs, 2)
+    # stop neighsyncd
+    stop_neighsyncd(dvs)
+    marker = dvs.add_log_marker()
 
     # delete even nummber of ipv4/ipv6 neighbor entries from each interface
     for i in range(0, len(ips), 2):
@@ -509,33 +477,48 @@ def test_swss_neighbor_syncup(dvs):
 
     # check syslog and sairedis.rec file for activities
     # 2 deletes each for ipv4 and ipv6
-    # 4 remove actions in sairedis
-    check_syslog_for_neighbor_entry(dvs, 0, 2, "ipv4")
-    check_syslog_for_neighbor_entry(dvs, 0, 2, "ipv6")
-    check_sairedis_for_neighbor_entry(dvs, 0, 0, 4)
+    # 4 neighbor removal in asic db
+    check_syslog_for_neighbor_entry(dvs, marker, 0, 2, "ipv4")
+    check_syslog_for_neighbor_entry(dvs, marker, 0, 2, "ipv6")
+    (nadd, ndel) = dvs.CountSubscribedObjects(pubsub)
+    assert nadd == 0
+    assert ndel == 4
+
     # check restore Count
     swss_app_check_RestoreCount_single(state_db, restore_count, "neighsyncd")
 
 
     #
     # Testcase 4:
-    # Stop neighsyncd, add even nummber of ipv4/ipv6 neighbor entries to each interface again,
-    # use "change" due to the kernel behaviour, start neighsyncd.
+    # Stop neighsyncd, add even nummber of ipv4/ipv6 neighbor entries to each interface again, 
+    # Start neighsyncd
     # The neighsyncd is supposed to sync up the entries from kernel after warm restart
     # Check the timer is not retrieved from configDB since it is not configured
 
     # get restore_count
     restore_count = swss_get_RestoreCount(state_db)
 
-    # stop neighsyncd and clear syslog and sairedis.rec
-    stop_neighsyncd_clear_syslog_sairedis(dvs, 3)
+    # stop neighsyncd
+    stop_neighsyncd(dvs)
+    marker = dvs.add_log_marker()
 
     # add even nummber of ipv4/ipv6 neighbor entries to each interface
+    # use "change" if neighbor is in FAILED state
     for i in range(0, len(ips), 2):
-        dvs.runcmd("ip neigh change {} dev {} lladdr {}".format(ips[i], intfs[i%2], macs[i]))
+        (rc, output) = dvs.runcmd(['sh', '-c', "ip -4 neigh | grep {}".format(ips[i])])
+        print output
+        if rc == 0:
+            dvs.runcmd("ip neigh change {} dev {} lladdr {}".format(ips[i], intfs[i%2], macs[i]))
+        else:
+            dvs.runcmd("ip neigh add {} dev {} lladdr {}".format(ips[i], intfs[i%2], macs[i]))
 
     for i in range(0, len(v6ips), 2):
-        dvs.runcmd("ip -6 neigh change {} dev {} lladdr {}".format(v6ips[i], intfs[i%2], macs[i]))
+        (rc, output) = dvs.runcmd(['sh', '-c', "ip -6 neigh | grep {}".format(v6ips[i])])
+        print output
+        if rc == 0:
+            dvs.runcmd("ip -6 neigh change {} dev {} lladdr {}".format(v6ips[i], intfs[i%2], macs[i]))
+        else:
+            dvs.runcmd("ip -6 neigh add {} dev {} lladdr {}".format(v6ips[i], intfs[i%2], macs[i]))
 
     # start neighsyncd again
     start_neighsyncd(dvs)
@@ -563,12 +546,15 @@ def test_swss_neighbor_syncup(dvs):
             if v[0] == "family":
                 assert v[1] == "IPv6"
 
-    # check syslog and sairedis.rec file for activities
+    # check syslog and asic db for activities
     # 2 news entries for ipv4 and ipv6 each
-    # 4 create actions for sairedis
-    check_syslog_for_neighbor_entry(dvs, 2, 0, "ipv4")
-    check_syslog_for_neighbor_entry(dvs, 2, 0, "ipv6")
-    check_sairedis_for_neighbor_entry(dvs, 4, 0, 0)
+    # 4 neighbor creation in asic db
+    check_syslog_for_neighbor_entry(dvs, marker, 2, 0, "ipv4")
+    check_syslog_for_neighbor_entry(dvs, marker, 2, 0, "ipv6")
+    (nadd, ndel) = dvs.CountSubscribedObjects(pubsub)
+    assert nadd == 4
+    assert ndel == 0
+
     # check restore Count
     swss_app_check_RestoreCount_single(state_db, restore_count, "neighsyncd")
 
@@ -587,8 +573,9 @@ def test_swss_neighbor_syncup(dvs):
     # get restore_count
     restore_count = swss_get_RestoreCount(state_db)
 
-    # stop neighsyncd and clear syslog and sairedis.rec
-    stop_neighsyncd_clear_syslog_sairedis(dvs, 4)
+    # stop neighsyncd
+    stop_neighsyncd(dvs)
+    marker = dvs.add_log_marker()
 
     # Even number of ip4/6 neigbors updated with new mac.
     # Odd number of ipv4/6 neighbors removed and added to different interfaces.
@@ -656,19 +643,23 @@ def test_swss_neighbor_syncup(dvs):
                 if v[0] == "family":
                     assert v[1] == "IPv6"
 
-    # check syslog and sairedis.rec file for activities
+    time.sleep(2)
+
+    # check syslog and asic db for activities
     # 4 news, 2 deletes for ipv4 and ipv6 each
-    # 8 create, 4 set, 4 removes for sairedis
-    check_syslog_for_neighbor_entry(dvs, 4, 2, "ipv4")
-    check_syslog_for_neighbor_entry(dvs, 4, 2, "ipv6")
-    check_sairedis_for_neighbor_entry(dvs, 4, 4, 4)
+    # 4 create, 4 set, 4 removes for neighbor in asic db
+    check_syslog_for_neighbor_entry(dvs, marker, 4, 2, "ipv4")
+    check_syslog_for_neighbor_entry(dvs, marker, 4, 2, "ipv6")
+    (nadd, ndel) = dvs.CountSubscribedObjects(pubsub)
+    assert nadd == 8
+    assert ndel == 4
 
     # check restore Count
     swss_app_check_RestoreCount_single(state_db, restore_count, "neighsyncd")
 
 
 # TODO: The condition of warm restart readiness check is still under discussion.
-def test_OrchagentWarmRestartReadyCheck(dvs):
+def test_OrchagentWarmRestartReadyCheck(dvs, testlog):
 
     # do a pre-cleanup
     dvs.runcmd("ip -s -s neigh flush all")
@@ -714,11 +705,11 @@ def test_OrchagentWarmRestartReadyCheck(dvs):
     assert result == "RESTARTCHECK failed\n"
 
     # recover for test cases after this one.
-    stop_swss(dvs)
-    start_swss(dvs)
+    dvs.stop_swss()
+    dvs.start_swss()
     time.sleep(5)
 
-def test_swss_port_state_syncup(dvs):
+def test_swss_port_state_syncup(dvs, testlog):
 
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
@@ -760,7 +751,7 @@ def test_swss_port_state_syncup(dvs):
         else:
             assert oper_status == "down"
 
-    stop_swss(dvs)
+    dvs.stop_swss()
     time.sleep(3)
 
     # flap the port oper status for Ethernet0, Ethernet4 and Ethernet8
@@ -772,7 +763,7 @@ def test_swss_port_state_syncup(dvs):
     dvs.servers[1].runcmd("ip link set up dev eth0") == 0
 
     time.sleep(5)
-    start_swss(dvs)
+    dvs.start_swss()
     time.sleep(10)
 
     swss_check_RestoreCount(state_db, restore_count)


### PR DESCRIPTION
When the destination port type is not VLAN related, there
is no need to update the session type.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>