### PR TITLE
[vstest]: fix redis mount point with --dvsname option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,8 @@ class DockerVirtualSwitch(object):
                 server = VirtualServer(ctn_sw_name, self.ctn_sw_pid, i)
                 self.servers.append(server)
 
+            self.mount = "/var/run/redis-vs/"
+
             self.restart()
         else:
             self.ctn_sw = self.client.containers.run('debian:jessie', privileged=True, detach=True,
@@ -192,7 +194,6 @@ class DockerVirtualSwitch(object):
             # mount redis to base to unique directory
             self.mount = "/var/run/redis-vs/{}".format(self.ctn_sw.name)
             os.system("mkdir -p {}".format(self.mount))
-            self.redis_sock = self.mount + '/' + "redis.sock"
 
             # create virtual switch container
             self.ctn = self.client.containers.run('docker-sonic-vs', privileged=True, detach=True,
@@ -200,6 +201,7 @@ class DockerVirtualSwitch(object):
                     volumes={ self.mount: { 'bind': '/var/run/redis', 'mode': 'rw' } })
 
         self.appldb = None
+        self.redis_sock = self.mount + '/' + "redis.sock"
         try:
             # temp fix: remove them once they are moved to vs start.sh
             self.ctn.exec_run("sysctl -w net.ipv6.conf.default.disable_ipv6=0")


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**
run test with ```--dvsname``` option

```
lgh@gulv-vm1:/data/sonic/sonic-swss/tests$ sudo pytest -v test_crm.py::test_CrmFdbEntry --dvsname=vs
========================================================= test session starts =========================================================
platform linux2 -- Python 2.7.12, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /data/sonic/sonic-swss/tests, inifile:
collected 1 item                                                                                                                      

test_crm.py::test_CrmFdbEntry PASSED                                                                                            [100%]

====================================================== 1 passed in 32.69 seconds ======================================================
```
**Details if related**
