### PR TITLE
Don't add loopback ip2me route again if already configured

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -292,6 +292,7 @@ void IntfsOrch::doTask(Consumer &consumer)
         {
             if (alias == "lo")
             {
+                // TODO: handle case for which lo is not in default vrf gVirtualRouterId
                 if (m_syncdIntfses.find(alias) != m_syncdIntfses.end())
                 {
                     if (m_syncdIntfses[alias].ip_addresses.count(ip_prefix))

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -174,13 +174,35 @@ void IntfsOrch::doTask(Consumer &consumer)
         {
             if (alias == "lo")
             {
-                // set request for lo may come after warm start restore
+                if (!ip_prefix_in_key)
+                {
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
+                bool addIp2Me = false;
+                // set request for lo may come after warm start restore.
+                // It is also to prevent dupicate set requests in normal running case.
                 auto it_intfs = m_syncdIntfses.find(alias);
                 if (it_intfs == m_syncdIntfses.end())
                 {
                     IntfsEntry intfs_entry;
+
                     intfs_entry.ref_count = 0;
+                    intfs_entry.ip_addresses.insert(ip_prefix);
                     m_syncdIntfses[alias] = intfs_entry;
+                    addIp2Me = true;
+                }
+                else
+                {
+                     if (m_syncdIntfses[alias].ip_addresses.count(ip_prefix) == 0)
+                     {
+                        m_syncdIntfses[alias].ip_addresses.insert(ip_prefix);
+                        addIp2Me = true;
+                     }
+                }
+                if (addIp2Me)
+                {
                     addIp2MeRoute(vrf_id, ip_prefix);
                 }
 
@@ -270,8 +292,15 @@ void IntfsOrch::doTask(Consumer &consumer)
         {
             if (alias == "lo")
             {
-                m_syncdIntfses.erase(alias);
-                removeIp2MeRoute(vrf_id, ip_prefix);
+                if (m_syncdIntfses[alias].ip_addresses.count(ip_prefix))
+                {
+                    m_syncdIntfses[alias].ip_addresses.erase(ip_prefix);
+                    removeIp2MeRoute(vrf_id, ip_prefix);
+                }
+                if (m_syncdIntfses[alias].ip_addresses.size() == 0)
+                {
+                    m_syncdIntfses.erase(alias);
+                }
                 it = consumer.m_toSync.erase(it);
                 continue;
             }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -292,15 +292,19 @@ void IntfsOrch::doTask(Consumer &consumer)
         {
             if (alias == "lo")
             {
-                if (m_syncdIntfses[alias].ip_addresses.count(ip_prefix))
+                if (m_syncdIntfses.find(alias) != m_syncdIntfses.end())
                 {
-                    m_syncdIntfses[alias].ip_addresses.erase(ip_prefix);
-                    removeIp2MeRoute(vrf_id, ip_prefix);
+                    if (m_syncdIntfses[alias].ip_addresses.count(ip_prefix))
+                    {
+                        m_syncdIntfses[alias].ip_addresses.erase(ip_prefix);
+                        removeIp2MeRoute(vrf_id, ip_prefix);
+                    }
+                    if (m_syncdIntfses[alias].ip_addresses.size() == 0)
+                    {
+                        m_syncdIntfses.erase(alias);
+                    }
                 }
-                if (m_syncdIntfses[alias].ip_addresses.size() == 0)
-                {
-                    m_syncdIntfses.erase(alias);
-                }
+
                 it = consumer.m_toSync.erase(it);
                 continue;
             }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -174,7 +174,16 @@ void IntfsOrch::doTask(Consumer &consumer)
         {
             if (alias == "lo")
             {
-                addIp2MeRoute(vrf_id, ip_prefix);
+                // set request for lo may come after warm start restore
+                auto it_intfs = m_syncdIntfses.find(alias);
+                if (it_intfs == m_syncdIntfses.end())
+                {
+                    IntfsEntry intfs_entry;
+                    intfs_entry.ref_count = 0;
+                    m_syncdIntfses[alias] = intfs_entry;
+                    addIp2MeRoute(vrf_id, ip_prefix);
+                }
+
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
@@ -261,6 +270,7 @@ void IntfsOrch::doTask(Consumer &consumer)
         {
             if (alias == "lo")
             {
+                m_syncdIntfses.erase(alias);
                 removeIp2MeRoute(vrf_id, ip_prefix);
                 it = consumer.m_toSync.erase(it);
                 continue;


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Add check to see if lo interface already processed. If yes, skip addIp2MeRoute() for it.

**Why I did it**
It is possible lo interface request comes again,  or comes after warm restore in case of warm reboot.

**How I verified it**


**Details if related**
