### PR TITLE
[vstest]: change the redis mount point when --dvsname is provided.

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -47,7 +47,7 @@ persists.
     ```
     docker run --privileged -id --name sw debian bash
     sudo ./create_vnet.sh sw
-    docker run --privileged -v /var/run/redis-vs:/var/run/redis --network container:sw -d --name vs docker-sonic-vs
+    docker run --privileged -v /var/run/redis-vs/sw:/var/run/redis --network container:sw -d --name vs docker-sonic-vs
     ```
 
 - Run test using the existing vs container

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ class DockerVirtualSwitch(object):
                 server = VirtualServer(ctn_sw_name, self.ctn_sw_pid, i)
                 self.servers.append(server)
 
-            self.mount = "/var/run/redis-vs/"
+            self.mount = "/var/run/redis-vs/{}".format(ctn_sw_name)
 
             self.restart()
         else:


### PR DESCRIPTION
unify the redis mountpoint to /var/run/redis-vs/{base-container-name}

user can use --keeptb to create a testbed and later use --dvsname
to rerun test on the testbed. In this case, we need to use the redis
mount point

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
