### PR TITLE
[portmgrd]: portmgrd shall be responsible for all ports update

### DIFF
--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -82,22 +82,6 @@ void PortMgr::doTask(Consumer &consumer)
         string alias = kfvKey(t);
         string op = kfvOp(t);
 
-        // Skip port which is a member of a port channel
-        vector<string> keys;
-        m_cfgLagMemberTable.getKeys(keys);
-
-        for (auto key : keys)
-        {
-            auto tokens = tokenize(key, '|');
-            auto member = tokens[1];
-
-            if (alias == member)
-            {
-                it = consumer.m_toSync.erase(it);
-                continue;
-            }
-        }
-
         if (op == SET_COMMAND)
         {
             if (!isPortStateOk(alias))

--- a/tests/test_admin_status.py
+++ b/tests/test_admin_status.py
@@ -1,0 +1,77 @@
+from swsscommon import swsscommon
+import time
+
+class TestAdminStatus(object):
+    def setup_db(self, dvs):
+        self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+
+    def set_admin_status(self, port, admin_status):
+        assert admin_status == "up" or admin_status == "down"
+        tbl = swsscommon.Table(self.cdb, "PORT")
+        fvs = swsscommon.FieldValuePairs([("admin_status", admin_status)])
+        tbl.set(port, fvs)
+        time.sleep(1)
+
+    def create_port_channel(self, dvs, alias):
+        tbl = swsscommon.Table(self.cdb, "PORTCHANNEL")
+        fvs = swsscommon.FieldValuePairs([("admin_status", "up"),
+                                          ("mtu", "9100")])
+        tbl.set(alias, fvs)
+        time.sleep(1)
+
+    def remove_port_channel(self, dvs, alias):
+        tbl = swsscommon.Table(self.cdb, "PORTCHANNEL")
+        tbl._del(alias)
+        time.sleep(1)
+
+    def add_port_channel_members(self, dvs, lag, members):
+        tbl = swsscommon.Table(self.cdb, "PORTCHANNEL_MEMBER")
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        for member in members:
+            tbl.set(lag + "|" + member, fvs)
+            time.sleep(1)
+
+    def remove_port_channel_members(self, dvs, lag, members):
+        tbl = swsscommon.Table(self.cdb, "PORTCHANNEL_MEMBER")
+        for member in members:
+            tbl._del(lag + "|" + member)
+            time.sleep(1)
+
+    def check_admin_status(self, dvs, port, admin_status):
+        assert admin_status == "up" or admin_status == "down"
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+        (status, fvs) = tbl.get(dvs.asicdb.portnamemap[port])
+        assert status == True
+        assert "SAI_PORT_ATTR_ADMIN_STATE" in [fv[0] for fv in fvs]
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_ADMIN_STATE":
+                assert fv[1] == "true" if admin_status == "up" else "false"
+
+    def test_PortChannelMemberAdminStatus(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        # create port channel
+        self.create_port_channel(dvs, "PortChannel6")
+
+        # add port channel members
+        self.add_port_channel_members(dvs, "PortChannel6",
+                ["Ethernet0", "Ethernet4", "Ethernet8"])
+
+        # configure admin status to interface
+        self.set_admin_status("Ethernet0", "up")
+        self.set_admin_status("Ethernet4", "down")
+        self.set_admin_status("Ethernet8", "up")
+
+        # check ASIC port database
+        self.check_admin_status(dvs, "Ethernet0", "up")
+        self.check_admin_status(dvs, "Ethernet4", "down")
+        self.check_admin_status(dvs, "Ethernet8", "up")
+
+        # remove port channel members
+        self.remove_port_channel_members(dvs, "PortCHannel6",
+                ["Ethernet0", "Ethernet4", "Ethernet8"])
+
+        # remove port channel
+        self.remove_port_channel(dvs, "PortCHannel6")


### PR DESCRIPTION
When a port is enslaved into the portchannel, portmgrd shall still
be able to bring the port admin up/down according to the configuration
changes.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>