### PR TITLE
Orchagent warm restart data restore requires three iterations

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -409,19 +409,26 @@ bool OrchDaemon::warmRestoreAndSyncUp()
     }
 
     /*
-     * First iteration is to handle all the existing data in predefined order.
+     * Three iterations are needed.
+     *
+     * First iteration: Orch(s) which do not have dependency on port table,
+     *   gBufferOrch, gPortsOrch(Port table and VLAN table),
+     *   and orch(s) which have dependency on Port but processed after it.
+     *
+     * Second iteration: gBufferOrch (has inter-dependency with gPortsOrch),
+     *   remaining attributes on port table for gPortsOrch,
+     *   gIntfsOrch which has dependency on both gBufferOrch and port table of gPortsOrch.
+     *   LAG_TABLE in gPortsOrch.
+     *
+     * Third iteration: Drain remaining data that are out of order like LAG_MEMBER_TABLE and
+     * VLAN_MEMBER_TABLE since they were checked before LAG_TABLE and VLAN_TABLE within gPortsOrch.
      */
-    for (Orch *o : m_orchList)
+    for (auto it = 0; it < 3; it++)
     {
-        o->doTask();
-    }
-    /*
-     * Drain remaining data that are out of order like LAG_MEMBER_TABLE and VLAN_MEMBER_TABLE
-     * since they were checked before LAG_TABLE and VLAN_TABLE.
-     */
-    for (Orch *o : m_orchList)
-    {
-        o->doTask();
+        for (Orch *o : m_orchList)
+        {
+            o->doTask();
+        }
     }
 
     /*


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Fix issue of "pending consumer tasks exist after restore even when the data is consistent"

**Why I did it**
Three iterations of `o->doTask();` are needed for orchagent state restore.

**How I verified it**

**Details if related**
