### PR TITLE
[vstest]: print output when runcmd returns error

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,14 @@ class VirtualServer(object):
             ensure_system("ip netns delete %s" % self.nsname)
 
     def runcmd(self, cmd):
-        return os.system("ip netns exec %s %s" % (self.nsname, cmd))
+        try:
+            out = subprocess.check_output("ip netns exec %s %s" % (self.nsname, cmd), stderr=subprocess.STDOUT, shell=True)
+        except subprocess.CalledProcessError as e:
+            print "------rc={} for cmd: {}------".format(e.returncode, e.cmd)
+            print e.output
+            print "------"
+            return e.returncode
+        return 0
 
     def runcmd_async(self, cmd):
         return subprocess.Popen("ip netns exec %s %s" % (self.nsname, cmd), shell=True)
@@ -294,6 +301,11 @@ class DockerVirtualSwitch(object):
         except AttributeError:
             exitcode = 0
             out = res
+        if exitcode != 0:
+            print "-----rc={} for cmd {}-----".format(exitcode, cmd)
+            print out
+            print "-----"
+
         return (exitcode, out)
 
     def copy_file(self, path, filename):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,7 @@ class VirtualServer(object):
             out = subprocess.check_output("ip netns exec %s %s" % (self.nsname, cmd), stderr=subprocess.STDOUT, shell=True)
         except subprocess.CalledProcessError as e:
             print "------rc={} for cmd: {}------".format(e.returncode, e.cmd)
-            print e.output
+            print e.output.rstrip()
             print "------"
             return e.returncode
         return 0
@@ -303,7 +303,7 @@ class DockerVirtualSwitch(object):
             out = res
         if exitcode != 0:
             print "-----rc={} for cmd {}-----".format(exitcode, cmd)
-            print out
+            print out.rstrip()
             print "-----"
 
         return (exitcode, out)


### PR DESCRIPTION
Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
print output when runcmd returns error

**Why I did it**
make it easier to debug issue

**How I verified it**
sample output when test goes wrong.

```
-------------------------------------------------------- Captured stdout call ---------------------------------------------------------

------rc=2 for cmd: ip netns exec suspicious_noyce-srv16 ip route add default via 6.6.6.1------
RTNETLINK answers: File exists

------

------rc=2 for cmd: ip netns exec suspicious_noyce-srv17 ip route add default via 6.6.6.1------
RTNETLINK answers: File exists

------

-----rc=1 for cmd config warm_restart enable swss-----
Traceback (most recent call last):
  File "/usr/bin/config", line 9, in <module>
    load_entry_point('sonic-utilities==1.2', 'console_scripts', 'config')()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 484, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2725, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2343, in load
    return self.resolve()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 2349, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python2.7/dist-packages/config/main.py", line 945, in <module>
    @cli.group()
NameError: name 'cli' is not defined

-----
````
**Details if related**
