### PR TITLE
View comparison needs port oper state applied first.

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -445,10 +445,10 @@ bool OrchDaemon::warmRestoreAndSyncUp()
 
     SWSS_LOG_NOTICE("Orchagent state restore done");
 
-    syncd_apply_view();
-
     /* Start dynamic state sync up */
     gPortsOrch->refreshPortStatus();
+
+    syncd_apply_view();
 
     /*
      * Note. Arp sync up is handled in neighsyncd.


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Push port oper state to syncd for view comparison.

**Why I did it**

View comparison logic needs the port oper state to properly work.

**How I verified it**

**Details if related**
