### PR TITLE
Adjust schema to match bgp warm-restart timer interval

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -683,7 +683,7 @@ Stores information for physical switch ports managed by the switch chip. Ports t
                                             ; timer, fpmsyncd will execute the reconciliation logic to eliminate all the staled
                                             ; state from AppDB. This timer should match the BGP-GR restart-timer configured within
                                             ; the elected routing-stack.
-                                            ; Supported range: 1-9999.
+                                            ; Supported range: 1-3600.
 
 
 ### VXLAN\_TUNNEL


### PR DESCRIPTION
BGP's warm-restart interval in our schema now matches what is being exposed in the CLI: https://github.com/Azure/sonic-utilities/pull/378


Signed-off-by: Rodny Molina <rmolina@linkedin.com>

