### PR TITLE
Process pending ports for aclOrch at end of db data replay for warm r…

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2127,7 +2127,7 @@ void AclOrch::processPendingPorts()
         auto table = itmap.second;
         for (auto port_alias: table.pendingPortSet)
         {
-            SWSS_LOG_INFO("found the port: %s in ACL table: %s pending port list, bind it to ACL table.", port_alias.c_str(), table.description.c_str());
+            SWSS_LOG_NOTICE("found the port: %s in ACL table: %s pending port list, bind it to ACL table.", port_alias.c_str(), table.description.c_str());
 
             bool suc = processPendingPort(table, port_alias, [&](sai_object_id_t portOid) {
                 table.link(portOid);
@@ -2145,6 +2145,7 @@ void AclOrch::processPendingPorts()
         }
     }
 }
+
 void AclOrch::doAclTablePortUpdateTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -379,7 +379,7 @@ public:
     bool removeAclTable(string table_id);
     bool addAclRule(shared_ptr<AclRule> aclRule, string table_id);
     bool removeAclRule(string table_id, string rule_id);
-
+    void processPendingPorts();
 private:
     void doTask(Consumer &consumer);
     void doAclTableTask(Consumer &consumer);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -432,6 +432,13 @@ bool OrchDaemon::warmRestoreAndSyncUp()
     }
 
     /*
+     * There could be pending ports for ACL.
+     * During warm restore, lag is processed after acl and put into acl pending port list.
+     * The lag state flag needed to trigger pending port clean up won't come at this this stage.
+     * Do it here explicitly.
+     */
+    gAclOrch->processPendingPorts();
+    /*
      * At this point, all the pre-existing data should have been processed properly, and
      * orchagent should be in exact same state of pre-shutdown.
      * Perform restore validation as needed.

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -436,8 +436,10 @@ bool OrchDaemon::warmRestoreAndSyncUp()
      * During warm restore, lag is processed after acl and put into acl pending port list.
      * The lag state flag needed to trigger pending port clean up won't come at this this stage.
      * Do it here explicitly.
+     * TODO: use observer mechanism to notify aclOrch for port state change.
      */
     gAclOrch->processPendingPorts();
+
     /*
      * At this point, all the pre-existing data should have been processed properly, and
      * orchagent should be in exact same state of pre-shutdown.


### PR DESCRIPTION
…estore

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Process pending ports for aclOrch at the end of db data replay for warm restore.

**Why I did it**
Current aclOrch implementation put port into AclTable pendingPortSet if port not available, and wait for lag state flag from stateDB.

During warm restore, no state flag will be checked actively. Here we process the pending ports expicitly.

**How I verified it**

**Details if related**
