### PR TITLE
Fix setting default port admin status and mtu

### DIFF
--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -10,6 +10,10 @@
 using namespace std;
 using namespace swss;
 
+/* Port default admin status is down */
+#define DEFAULT_ADMIN_STATUS_STR    "down"
+#define DEFAULT_MTU_STR             "9100"
+
 PortMgr::PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
         Orch(cfgDb, tableNames),
         m_cfgPortTable(cfgDb, CFG_PORT_TABLE_NAME),
@@ -91,22 +95,43 @@ void PortMgr::doTask(Consumer &consumer)
                 continue;
             }
 
+            string admin_status, mtu;
+
+            bool configured = (m_portList.find(alias) != m_portList.end());
+
+            /* If this is the first time we set port settings
+             * asign default admin status and mtu
+             */
+            if (!configured)
+            {
+                admin_status = DEFAULT_ADMIN_STATUS_STR;
+                mtu = DEFAULT_MTU_STR;
+
+                m_portList.insert(alias);
+            }
+
             for (auto i : kfvFieldsValues(t))
             {
                 if (fvField(i) == "mtu")
                 {
-                    auto mtu = fvValue(i);
-                    setPortMtu(alias, mtu);
-                    SWSS_LOG_NOTICE("Configure %s MTU to %s",
-                                    alias.c_str(), mtu.c_str());
+                    mtu = fvValue(i);
                 }
                 else if (fvField(i) == "admin_status")
                 {
-                    auto status = fvValue(i);
-                    setPortAdminStatus(alias, status == "up");
-                    SWSS_LOG_NOTICE("Configure %s %s",
-                            alias.c_str(), status.c_str());
+                    admin_status = fvValue(i);
                 }
+            }
+
+            if (!mtu.empty())
+            {
+                setPortMtu(alias, mtu);
+                SWSS_LOG_NOTICE("Configure %s MTU to %s", alias.c_str(), mtu.c_str());
+            }
+
+            if (!admin_status.empty())
+            {
+                setPortAdminStatus(alias, admin_status == "up");
+                SWSS_LOG_NOTICE("Configure %s %s", alias.c_str(), admin_status.c_str());
             }
         }
 

--- a/cfgmgr/portmgr.h
+++ b/cfgmgr/portmgr.h
@@ -22,6 +22,8 @@ private:
     Table m_statePortTable;
     ProducerStateTable m_appPortTable;
 
+    set<string> m_portList;
+
     void doTask(Consumer &consumer);
     bool setPortMtu(const string &alias, const string &mtu);
     bool setPortAdminStatus(const string &alias, const bool up);

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -28,7 +28,6 @@ private:
     ProducerStateTable m_appPortTable;
     ProducerStateTable m_appLagTable;
 
-    set<string> m_portList;
     set<string> m_lagList;
 
     MacAddress m_mac;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2281,12 +2281,6 @@ bool PortsOrch::initializePort(Port &p)
     }
     SWSS_LOG_DEBUG("initializePort %s with admin %s and oper %s", p.m_alias.c_str(), adminStatus.c_str(), operStatus.c_str());
 
-    /* Set port admin status to DOWN if attr missing */
-    if (adminStatus != "up")
-    {
-        setPortAdminStatus(p.m_port_id, false);
-    }
-
     /**
      * Create database port oper status as DOWN if attr missing
      * This status will be updated when receiving port_oper_status_notification.


### PR DESCRIPTION
This commit moves setting of default admin status and mtu
to portmgrd to be aligned with other managers (e.g. teammgrd).

It also fixes "N/A" admin status in "show interface status" output
for ports which have no 'admin_status' field in config DB.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Move defaults port settings to portmgrd, remove settings admin status down in portsorch in initializePort

**Why I did it**
Remove setting default admin status to down in case of cold boot because of two reasons:
1. SAI default is admin status down
2. Defaults port settings should come from portmgrd

**How I verified it**
Verify on DUT that port settings are applied correctly. Check that iin case admin/mtu is missing for port in config db defaults are applied and no N/A in 'show interface status'

**Details if related**