### PR TITLE
Remove default docker name value of swss.

### DIFF
--- a/cfgmgr/vlanmgrd.cpp
+++ b/cfgmgr/vlanmgrd.cpp
@@ -57,8 +57,8 @@ int main(int argc, char **argv)
         DBConnector appDb(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
         DBConnector stateDb(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
 
-        WarmStart::initialize("vlanmgrd");
-        WarmStart::checkWarmStart("vlanmgrd");
+        WarmStart::initialize("vlanmgrd", "swss");
+        WarmStart::checkWarmStart("vlanmgrd", "swss");
 
         /*
          * swss service starts after interfaces-config.service which will have

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -102,8 +102,8 @@ int main(int argc, char **argv)
 
     SWSS_LOG_ENTER();
 
-    WarmStart::initialize("orchagent");
-    WarmStart::checkWarmStart("orchagent");
+    WarmStart::initialize("orchagent", "swss");
+    WarmStart::checkWarmStart("orchagent", "swss");
 
     if (signal(SIGHUP, sighup_handler) == SIG_ERR)
     {

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -75,8 +75,8 @@ int main(int argc, char **argv)
     ProducerStateTable p(&appl_db, APP_PORT_TABLE_NAME);
     SubscriberStateTable portCfg(&cfgDb, CFG_PORT_TABLE_NAME);
 
-    WarmStart::initialize("portsyncd");
-    WarmStart::checkWarmStart("portsyncd");
+    WarmStart::initialize("portsyncd", "swss");
+    WarmStart::checkWarmStart("portsyncd", "swss");
     const bool warm = WarmStart::isWarmStart();
 
     LinkSync sync(&appl_db, &state_db);

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -741,7 +741,8 @@ def test_OrchagentWarmRestartReadyCheck(dvs, testlog):
     assert result == "RESTARTCHECK failed\n"
 
     # Cleaning previously pushed route-entry to ease life of subsequent testcases.
-    del_entry_tbl(appl_db, swsscommon.APP_ROUTE_TABLE_NAME, "2.2.2.0/24")
+    ps._del("2.2.2.0/24")
+    time.sleep(1)
 
     # recover for test cases after this one.
     dvs.stop_swss()

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1522,7 +1522,8 @@ def test_system_warmreboot_neighbor_syncup(dvs, testlog):
         dvs.runcmd("ip -6 addr add {}00::1/64 dev Ethernet{}".format(i*4,i*4))
         dvs.servers[i].runcmd("ip link set up dev eth0")
         dvs.servers[i].runcmd("ip addr flush dev eth0")
-        result = dvs.servers[i].runcmd_output("ifconfig eth0 | grep HWaddr | awk '{print $NF}'")
+        #result = dvs.servers[i].runcmd_output("ifconfig eth0 | grep HWaddr | awk '{print $NF}'")
+        result = dvs.servers[i].runcmd_output("cat /sys/class/net/eth0/address")
         macs.append(result.strip())
 
     #


### PR DESCRIPTION
The default docker name caused a lot of confusion when the libraries used in other dockers

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**

Adapt to the change with WarmStart library,  default docker name of swss has been removed.

**Why I did it**
The default docker name caused a lot of confusion when the libraries used in other dockers
**How I verified it**
VS test.
**Details if related**
