### PR TITLE
ASIC temperature sensors support

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -1,6 +1,7 @@
 #include <unordered_map>
 #include "flexcounterorch.h"
 #include "portsorch.h"
+#include "switchorch.h"
 #include "select.h"
 #include "notifier.h"
 #include "redisclient.h"
@@ -16,6 +17,7 @@ unordered_map<string, string> flexCounterGroupMap =
     {"PORT", PORT_STAT_COUNTER_FLEX_COUNTER_GROUP},
     {"QUEUE", QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP},
     {"PFCWD", PFC_WD_FLEX_COUNTER_GROUP},
+    {"SENSORS", SWITCH_SENSORS_FLEX_GROUP},
 };
 
 

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "orch.h"
+#include "producertable.h"
+
+#define SWITCH_SENSORS_FLEX_GROUP "SWITCH_SENSORS"
 
 struct WarmRestartCheck
 {
@@ -22,10 +25,16 @@ public:
     bool setAgingFDB(uint32_t sec);
 private:
     void doTask(Consumer &consumer);
+    std::string  getSwitchSensorsFlexCounterTableKey(std::string);
+    void addSwitchSensorsToFlexCounters();
 
     NotificationConsumer* m_restartCheckNotificationConsumer;
     void doTask(NotificationConsumer& consumer);
     DBConnector *m_db;
+
+    shared_ptr<DBConnector> m_flex_db = nullptr;
+    shared_ptr<ProducerTable> m_flexCounterTable = nullptr;
+    shared_ptr<ProducerTable> m_flexCounterGroupTable = nullptr;
 
     // Information contained in the request from
     // external program for orchagent pre-shutdown state check


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Please do not merge yet.**

Recently (https://github.com/opencomputeproject/SAI/pull/880), new switch attributes were added to retrieve the temperature readings from the ASIC's internal sensors. 

This is a preliminary commit (pending SAI support from vendors) for temperature monitoring. The max, average and the entire list of temperatures are now added to the flex counters DB so that platform sensors scripts may query and use these values in thermal control algorithms.

**What I did**

1. Created a SWITCH_SENSORS_FLEX_GROUP to track sensors in the ASIC
2. Added SAI_SWITCH_ATTR_MAX_TEMP, SAI_SWITCH_ATTR_AVERAGE_TEMP, SAI_SWITCH_ATTR_TEMP_LIST to the SWITCH sensors flex counters.

**Why I did it**

To provide a mechanism for platform sensor scripts to have a generic way of querying the ASIC sensors via SAI.

**How I verified it**

Currently checked using stubs. Awaiting SAI implementation from vendors.

**Details if related**
