### PR TITLE
[VS]: fix syncd crash caused by meta_generic_validation_remove refere…

### DIFF
--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -741,7 +741,8 @@ def test_OrchagentWarmRestartReadyCheck(dvs, testlog):
     assert result == "RESTARTCHECK failed\n"
 
     # Cleaning previously pushed route-entry to ease life of subsequent testcases.
-    del_entry_tbl(appl_db, swsscommon.APP_ROUTE_TABLE_NAME, "2.2.2.0/24")
+    ps._del("2.2.2.0/24")
+    time.sleep(1)
 
     # recover for test cases after this one.
     dvs.stop_swss()


### PR DESCRIPTION
…nce count error

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**What I did**
Delete route entry in appDB with ProducerStateTable instead of force delete using Table.

**Why I did it**
Deleting route entry in appDB using Table will cause meta data reference error in syncd.

```

Nov 17 10:10:22.501319 2022ad5218b7 ERR #syncd: :- meta_generic_validation_remove: object 0x400000012 reference count is 1, can't remove
Nov 17 10:10:22.501329 2022ad5218b7 ERR #syncd: :- processEvent: failed to execute api: remove, key: SAI_OBJECT_TYPE_NEXT_HOP:oid:0x40000000005e4, status: SAI_STATUS_INVALID_PARAMETER
Nov 17 10:10:22.501422 2022ad5218b7 ERR #syncd: :- syncd_main: Runtime error: :- processEvent: failed to execute api: remove, key: SAI_OBJECT_TYPE_NEXT_HOP:oid:0x40000000005e4, status: SAI_STATUS_INVALID_PARAMETER
Nov 17 10:10:22.501425 2022ad5218b7 NOTICE #syncd: :- exit_and_notify: sending switch_shutdown_request notification to OA
Nov 17 10:10:22.501498 2022ad5218b7 NOTICE #syncd: :- exit_and_notify: notification send successfull
Nov 17 10:10:22.501502 2022ad5218b7 WARNING #syncd: :- exit_and_notify: sleep forever to keep data plane active
Nov 17 10:10:22.501571 2022ad5218b7 NOTICE #orchagent: :- handle_switch_shutdown_request: switch shutdown request
Nov 17 10:10:22.501841 2022ad5218b7 INFO #supervisord: orchagent terminate called after throwing an instance of 'std::invalid_argument'
Nov 17 10:10:22.501847 2022ad5218b7 INFO #supervisord: orchagent   what():  parse error - unexpected end of input
```
**How I verified it**

VS test.
**Details if related**
