### PR TITLE
[vstest]: use eth1~32 as physical interface name in vs docker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,15 +79,18 @@ class ApplDbValidator(object):
         self.neighTbl = swsscommon.Table(appl_db, "NEIGH_TABLE")
 
     def __del__(self):
-        # Make sure no neighbors on vEthernet
-        keys = self.neighTbl.getKeys();
+        # Make sure no neighbors on physical interfaces
+        keys = self.neighTbl.getKeys()
         for key in keys:
-            assert not key.startswith("vEthernet")
+            m = re.match("eth(\d+)", key)
+            if not m:
+                continue
+            assert int(m.group(1)) > 0
 
 class VirtualServer(object):
     def __init__(self, ctn_name, pid, i):
         self.nsname = "%s-srv%d" % (ctn_name, i)
-        self.vifname = "vEthernet%d" % (i * 4)
+        self.pifname = "eth%d" % (i + 1)
         self.cleanup = True
 
         # create netns
@@ -97,9 +100,9 @@ class VirtualServer(object):
             ensure_system("ip netns add %s" % self.nsname)
 
             # create vpeer link
-            ensure_system("ip link add %s type veth peer name %s" % (self.nsname[0:12], self.vifname))
+            ensure_system("ip link add %s type veth peer name %s" % (self.nsname[0:12], self.pifname))
             ensure_system("ip link set %s netns %s" % (self.nsname[0:12], self.nsname))
-            ensure_system("ip link set %s netns %d" % (self.vifname, pid))
+            ensure_system("ip link set %s netns %d" % (self.pifname, pid))
 
             # bring up link in the virtual server
             ensure_system("ip netns exec %s ip link set dev %s name eth0" % (self.nsname, self.nsname[0:12]))
@@ -107,11 +110,11 @@ class VirtualServer(object):
             ensure_system("ip netns exec %s ethtool -K eth0 tx off" % (self.nsname))
 
             # bring up link in the virtual switch
-            ensure_system("nsenter -t %d -n ip link set dev %s up" % (pid, self.vifname))
+            ensure_system("nsenter -t %d -n ip link set dev %s up" % (pid, self.pifname))
 
-            # disable arp, so no neigh on vEthernet(s)
-            ensure_system("nsenter -t %d -n ip link set arp off dev %s" % (pid, self.vifname))
-            ensure_system("nsenter -t %d -n sysctl -w net.ipv6.conf.%s.disable_ipv6=1" % (pid, self.vifname))
+            # disable arp, so no neigh on physical interfaces
+            ensure_system("nsenter -t %d -n ip link set arp off dev %s" % (pid, self.pifname))
+            ensure_system("nsenter -t %d -n sysctl -w net.ipv6.conf.%s.disable_ipv6=1" % (pid, self.pifname))
 
     def destroy(self):
         if self.cleanup:
@@ -216,7 +219,7 @@ class DockerVirtualSwitch(object):
             # temp fix: remove them once they are moved to vs start.sh
             self.ctn.exec_run("sysctl -w net.ipv6.conf.default.disable_ipv6=0")
             for i in range(0, 128, 4):
-                self.ctn.exec_run("sysctl -w net.ipv6.conf.vEthernet%d.disable_ipv6=1" % i)
+                self.ctn.exec_run("sysctl -w net.ipv6.conf.eth%d.disable_ipv6=1" % (i + 1))
             self.check_ready()
             self.init_asicdb_validator()
             self.appldb = ApplDbValidator(self)

--- a/tests/test_acl_portchannel.py
+++ b/tests/test_acl_portchannel.py
@@ -134,6 +134,8 @@ class TestPortChannelAcl(object):
         # create ACL table
         self.create_acl_table(dvs, "LAG_ACL_TABLE", "PortChannel01")
 
+        time.sleep(1)
+
         # check ASIC table
         self.check_asic_table_existed(dvs)
 
@@ -153,6 +155,8 @@ class TestPortChannelAcl(object):
 
         # create port channel
         self.create_port_channel(dvs, "PortChannel01")
+
+        time.sleep(1)
 
         # check ASIC table
         self.check_asic_table_existed(dvs)
@@ -178,6 +182,8 @@ class TestPortChannelAcl(object):
 
         # create ACL table
         self.create_acl_table(dvs, "LAG_ACL_TABLE", "Ethernet0")
+
+        time.sleep(1)
 
         # check ASIC table
         self.check_asic_table_absent(dvs)

--- a/tests/test_admin_status.py
+++ b/tests/test_admin_status.py
@@ -70,8 +70,8 @@ class TestAdminStatus(object):
         self.check_admin_status(dvs, "Ethernet8", "up")
 
         # remove port channel members
-        self.remove_port_channel_members(dvs, "PortCHannel6",
+        self.remove_port_channel_members(dvs, "PortChannel6",
                 ["Ethernet0", "Ethernet4", "Ethernet8"])
 
         # remove port channel
-        self.remove_port_channel(dvs, "PortCHannel6")
+        self.remove_port_channel(dvs, "PortChannel6")

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -28,16 +28,13 @@ class TestSpeedSet(object):
 
         buffer_profiles = cfg_buffer_profile_table.getKeys()
         expected_buffer_profiles_num = len(buffer_profiles)
-        # buffers.json used for the test defines 7 static profiles:
+        # buffers.json used for the test defines 4 static profiles:
         #    "ingress_lossless_profile"
         #    "ingress_lossy_profile"
         #    "egress_lossless_profile"
         #    "egress_lossy_profile"
-        #    "pg_lossy_profile"
-        #    "q_lossless_profile"
-        #    "q_lossy_profile"
         # check if they get the DB
-        assert expected_buffer_profiles_num == 7
+        assert expected_buffer_profiles_num == 4
         # and if they were successfully created on ASIC
         assert len(asic_profile_table.getKeys()) == expected_buffer_profiles_num
 


### PR DESCRIPTION
align with vs kvm image physical interface name ethXX instead of vEthernetXXX

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
use eth1~32 as physical interface name in vs docker

**Why I did it**
align with the physical interface name in vs kvm

**How I verified it**
run all vstest. depends on kamil's fix in sonic-sairedis repo.
```
lgh@gulv-vm1:/data/sonic/sonic-swss/tests$ sudo pytest -v --dvsname musing_leakey                     
========================================================= test session starts =========================================================
platform linux2 -- Python 2.7.12, pytest-3.3.1, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /data/sonic/sonic-swss/tests, inifile:
collected 80 items                                                                                                                    

test_acl.py::TestAcl::test_AclTableCreation PASSED                                                                              [  1%]
test_acl.py::TestAcl::test_AclRuleL4SrcPort PASSED                                                                              [  2%]
test_acl.py::TestAcl::test_AclRuleInOutPorts PASSED                                                                             [  3%]
test_acl.py::TestAcl::test_AclTableDeletion PASSED                                                                              [  5%]
test_acl.py::TestAcl::test_V6AclTableCreation PASSED                                                                            [  6%]
test_acl.py::TestAcl::test_V6AclRuleIPv6Any PASSED                                                                              [  7%]
test_acl.py::TestAcl::test_V6AclRuleIPv6AnyDrop PASSED                                                                          [  8%]
test_acl.py::TestAcl::test_V6AclRuleIpProtocol PASSED                                                                           [ 10%]
test_acl.py::TestAcl::test_V6AclRuleSrcIPv6 PASSED                                                                              [ 11%]
test_acl.py::TestAcl::test_V6AclRuleDstIPv6 PASSED                                                                              [ 12%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPort PASSED                                                                            [ 13%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPort PASSED                                                                            [ 15%]
test_acl.py::TestAcl::test_V6AclRuleTCPFlags PASSED                                                                             [ 16%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPortRange PASSED                                                                       [ 17%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPortRange PASSED                                                                       [ 18%]
test_acl.py::TestAcl::test_V6AclTableDeletion PASSED                                                                            [ 20%]
test_acl.py::TestAcl::test_InsertAclRuleBetweenPriorities PASSED                                                                [ 21%]
test_acl.py::TestAcl::test_RulesWithDiffMaskLengths PASSED                                                                      [ 22%]
test_acl_portchannel.py::TestPortChannelAcl::test_PortChannelAfterAcl PASSED                                                    [ 23%]
test_acl_portchannel.py::TestPortChannelAcl::test_PortChannelBeforeAcl PASSED                                                   [ 25%]
test_acl_portchannel.py::TestPortChannelAcl::test_AclOnPortChannelMember PASSED                                                 [ 26%]
test_admin_status.py::TestAdminStatus::test_PortChannelMemberAdminStatus PASSED                                                 [ 27%]
test_crm.py::test_CrmFdbEntry PASSED                                                                                            [ 28%]
test_crm.py::test_CrmIpv4Route PASSED                                                                                           [ 30%]
test_crm.py::test_CrmIpv6Route PASSED                                                                                           [ 31%]
test_crm.py::test_CrmIpv4Nexthop PASSED                                                                                         [ 32%]
test_crm.py::test_CrmIpv6Nexthop PASSED                                                                                         [ 33%]
test_crm.py::test_CrmIpv4Neighbor PASSED                                                                                        [ 35%]
test_crm.py::test_CrmIpv6Neighbor PASSED                                                                                        [ 36%]
test_crm.py::test_CrmNexthopGroup PASSED                                                                                        [ 37%]
test_crm.py::test_CrmNexthopGroupMember PASSED                                                                                  [ 38%]
test_crm.py::test_CrmAcl PASSED                                                                                                 [ 40%]
test_dirbcast.py::test_DirectedBroadcast PASSED                                                                                 [ 41%]
test_dtel.py::TestDtel::test_DtelGlobalAttribs PASSED                                                                           [ 42%]
test_dtel.py::TestDtel::test_DtelReportSessionAttribs PASSED                                                                    [ 43%]
test_dtel.py::TestDtel::test_DtelINTSessionAttribs PASSED                                                                       [ 45%]
test_dtel.py::TestDtel::test_DtelQueueReportAttribs PASSED                                                                      [ 46%]
test_dtel.py::TestDtel::test_DtelEventAttribs PASSED                                                                            [ 47%]
test_fdb_cold.py::test_FDBAddedAfterMemberCreated PASSED                                                                        [ 48%]
test_fdb_warm.py::test_fdb_notifications PASSED                                                                                 [ 50%]
test_interface.py::TestRouterInterface::test_InterfaceAddRemoveIpv6Address PASSED                                               [ 51%]
test_interface.py::TestRouterInterface::test_InterfaceAddRemoveIpv4Address PASSED                                               [ 52%]
test_interface.py::TestRouterInterface::test_InterfaceSetMtu PASSED                                                             [ 53%]
test_interface.py::TestLagRouterInterfaceIpv4::test_InterfaceAddRemoveIpv4Address PASSED                                        [ 55%]
test_interface.py::TestLagRouterInterfaceIpv4::test_InterfaceSetMtu PASSED                                                      [ 56%]
test_mirror.py::TestMirror::test_MirrorAddRemove PASSED                                                                         [ 57%]
test_mirror.py::TestMirror::test_MirrorToVlanAddRemove PASSED                                                                   [ 58%]
test_mirror.py::TestMirror::test_MirrorToLagAddRemove PASSED                                                                    [ 60%]
test_mirror.py::TestMirror::test_MirrorDestMoveVlan PASSED                                                                      [ 61%]
test_mirror.py::TestMirror::test_MirrorDestMoveLag PASSED                                                                       [ 62%]
test_mirror.py::TestMirror::test_AclBindMirror PASSED                                                                           [ 63%]
test_nhg.py::test_route_nhg PASSED                                                                                              [ 65%]
test_pfc.py::test_PfcAsymmetric PASSED                                                                                          [ 66%]
test_port.py::TestPort::test_PortMtu PASSED                                                                                     [ 67%]
test_port.py::test_PortNotification PASSED                                                                                      [ 68%]
test_port.py::test_PortFec PASSED                                                                                               [ 70%]
test_port_an_cold.py::test_PortAutoNeg PASSED                                                                                   [ 71%]
test_port_an_warm.py::test_PortAutoNeg_warm PASSED                                                                              [ 72%]
test_port_buffer_rel.py::test_PortsAreUpAfterBuffers PASSED                                                                     [ 73%]
test_portchannel.py::test_PortChannel PASSED                                                                                    [ 75%]
test_route.py::test_RouteAdd PASSED                                                                                             [ 76%]
test_setro.py::test_SetReadOnlyAttribute PASSED                                                                                 [ 77%]
test_speed.py::TestSpeedSet::test_SpeedAndBufferSet PASSED                                                                      [ 78%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_v4 PASSED                                                                     [ 80%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_v6 PASSED                                                                     [ 81%]
test_tunnel.py::TestSymmetricTunnel::test_TunnelSymmetric_v4 PASSED                                                             [ 82%]
test_tunnel.py::TestSymmetricTunnel::test_TunnelSymmetric_v6 PASSED                                                             [ 83%]
test_vlan.py::TestVlan::test_VlanAddRemove PASSED                                                                               [ 85%]
test_vlan.py::TestVlan::test_MultipleVlan PASSED                                                                                [ 86%]
test_vrf.py::test_VRFOrch_Comprehensive PASSED                                                                                  [ 87%]
test_vrf.py::test_VRFOrch PASSED                                                                                                [ 88%]
test_vrf.py::test_VRFOrch_Update PASSED                                                                                         [ 90%]
test_vxlan_tunnel.py::test_vxlan_term_orch PASSED                                                                               [ 91%]
test_warm_reboot.py::test_PortSyncdWarmRestart PASSED                                                                           [ 92%]
test_warm_reboot.py::test_VlanMgrdWarmRestart PASSED                                                                            [ 93%]
test_warm_reboot.py::test_swss_neighbor_syncup PASSED                                                                           [ 95%]
test_warm_reboot.py::test_OrchagentWarmRestartReadyCheck PASSED                                                                 [ 96%]
test_warm_reboot.py::test_swss_port_state_syncup PASSED                                                                         [ 97%]
test_warm_reboot.py::test_routing_WarmRestart PASSED                                                                            [ 98%]
test_warm_reboot.py::test_system_warmreboot_neighbor_syncup PASSED                                                              [100%]

==================================================== 80 passed in 2706.39 seconds =====================================================
lgh@gulv-vm1:/data/sonic/sonic-swss/tests$ 
```
**Details if related**
