### PR TITLE
Align default MTU value as SAI default

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -11,7 +11,7 @@ extern "C" {
 #include <map>
 
 #define DEFAULT_PORT_VLAN_ID    1
-#define DEFAULT_MTU              9100
+#define DEFAULT_MTU             1492
 
 namespace swss {
 

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -11,6 +11,11 @@ extern "C" {
 #include <map>
 
 #define DEFAULT_PORT_VLAN_ID    1
+/*
+ * Default MTU is derived from SAI_PORT_ATTR_MTU (1514)
+ * Orchagent adds extra 22 bytes for Ethernet header and FCS,
+ * hence setting to 1492 (1514 - 22)
+ */
 #define DEFAULT_MTU             1492
 
 namespace swss {

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -74,9 +74,9 @@ class TestRouterInterface(object):
                 for fv in fvs:
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_TYPE":
                         assert fv[1] == "SAI_ROUTER_INTERFACE_TYPE_PORT"
-                    # the default MTU without any configuration is 9100
+                    # the default MTU without any configuration is 1492
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_MTU":
-                        assert fv[1] == "9100"
+                        assert fv[1] == "1492"
 
         # check ASIC route database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
@@ -146,9 +146,9 @@ class TestRouterInterface(object):
                 for fv in fvs:
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_TYPE":
                         assert fv[1] == "SAI_ROUTER_INTERFACE_TYPE_PORT"
-                    # the default MTU without any configuration is 9100
+                    # the default MTU without any configuration is 1492
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_MTU":
-                        assert fv[1] == "9100"
+                        assert fv[1] == "1492"
 
         # check ASIC route database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
@@ -296,9 +296,9 @@ class TestLagRouterInterfaceIpv4(object):
                 for fv in fvs:
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_TYPE":
                         assert fv[1] == "SAI_ROUTER_INTERFACE_TYPE_PORT"
-                    # the default MTU without any configuration is 9100
+                    # the default MTU without any configuration is 1492
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_MTU":
-                        assert fv[1] == "9100"
+                        assert fv[1] == "1492"
 
         # check ASIC route database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -74,9 +74,9 @@ class TestRouterInterface(object):
                 for fv in fvs:
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_TYPE":
                         assert fv[1] == "SAI_ROUTER_INTERFACE_TYPE_PORT"
-                    # the default MTU without any configuration is 1492
+                    # the default MTU without any configuration is 9100, set by portmgr
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_MTU":
-                        assert fv[1] == "1492"
+                        assert fv[1] == "9100"
 
         # check ASIC route database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
@@ -146,9 +146,9 @@ class TestRouterInterface(object):
                 for fv in fvs:
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_TYPE":
                         assert fv[1] == "SAI_ROUTER_INTERFACE_TYPE_PORT"
-                    # the default MTU without any configuration is 1492
+                    # the default MTU without any configuration is 9100, set by portmgr
                     if fv[0] == "SAI_ROUTER_INTERFACE_ATTR_MTU":
-                        assert fv[1] == "1492"
+                        assert fv[1] == "9100"
 
         # check ASIC route database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -477,7 +477,7 @@ class VnetVxlanVrfTunnel(object):
         expected_attr = {
                         "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": self.vr_map[name].get('ing'),
                         "SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS": switch_mac,
-                        "SAI_ROUTER_INTERFACE_ATTR_MTU": "9100",
+                        "SAI_ROUTER_INTERFACE_ATTR_MTU": "1492",
                     }
 
         if vlan_oid:
@@ -485,6 +485,7 @@ class VnetVxlanVrfTunnel(object):
             expected_attr.update({'SAI_ROUTER_INTERFACE_ATTR_VLAN_ID': vlan_oid})
         else:
             expected_attr.update({'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_PORT'})
+            expected_attr.update({'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100'})
 
         new_rif = get_created_entry(asic_db, self.ASIC_RIF_TABLE, self.rifs)
         check_object(asic_db, self.ASIC_RIF_TABLE, new_rif, expected_attr)


### PR DESCRIPTION
**What I did**
Set default MTU in orchagent to SAI default value (`1514`)

**Why I did it**
To fix issue https://github.com/Azure/sonic-buildimage/issues/2293

**How I verified it**

_**Before fix:**_

```
admin@str-a7060cx-acs-1:~$ show interfaces status 
  Interface            Lanes    Speed    MTU         Alias    Oper    Admin
-----------  ---------------  -------  -----  ------------  ------  -------
  Ethernet0            33,34      50G   9100   Ethernet1/1      up       up

admin@str-a7060cx-acs-1:~$ bcmcmd 'ps'
xe12( 34)  up     2   50G  FD   SW  No   Forward  TX RX   None   FA    KR2  **9412**    No 
```

**_After fix:_**

```
admin@str-a7060cx-acs-1:~$ bcmcmd 'ps xe12'
                 ena/        speed/ link auto    STP                  lrn  inter   max   cut   loop
           port  link  Lns   duplex scan neg?   state   pause  discrd ops   face frame  thru?  back
xe12( 34)  up     2   50G  FD   SW  No   Forward  TX RX   None   FA    KR2  **9122**    No 
```

**Details if related**
