### PR TITLE
Add vxlan attributes to switch profile

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -4,6 +4,7 @@
 #include "converter.h"
 #include "notifier.h"
 #include "notificationproducer.h"
+#include "macaddress.h"
 
 using namespace std;
 using namespace swss;
@@ -18,7 +19,9 @@ const map<string, sai_switch_attr_t> switch_attribute_map =
     {"fdb_multicast_miss_packet_action",    SAI_SWITCH_ATTR_FDB_MULTICAST_MISS_PACKET_ACTION},
     {"ecmp_hash_seed",                      SAI_SWITCH_ATTR_ECMP_DEFAULT_HASH_SEED},
     {"lag_hash_seed",                       SAI_SWITCH_ATTR_LAG_DEFAULT_HASH_SEED},
-    {"fdb_aging_time",                      SAI_SWITCH_ATTR_FDB_AGING_TIME}
+    {"fdb_aging_time",                      SAI_SWITCH_ATTR_FDB_AGING_TIME},
+    {"vxlan_port",                          SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT},
+    {"vxlan_router_mac",                    SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC}
 };
 
 const map<string, sai_packet_action_t> packet_action_map =
@@ -66,6 +69,7 @@ void SwitchOrch::doTask(Consumer &consumer)
                 sai_attribute_t attr;
                 attr.id = switch_attribute_map.at(attribute);
 
+                MacAddress mac_addr;
                 bool invalid_attr = false;
                 switch (attr.id)
                 {
@@ -88,6 +92,15 @@ void SwitchOrch::doTask(Consumer &consumer)
 
                     case SAI_SWITCH_ATTR_FDB_AGING_TIME:
                         attr.value.u32 = to_uint<uint32_t>(value);
+                        break;
+
+                    case SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT:
+                        attr.value.u16 = to_uint<uint16_t>(value);
+                        break;
+
+                    case SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC:
+                        mac_addr = value;
+                        memcpy(attr.value.mac, mac_addr.getMac(), sizeof(sai_mac_t));
                         break;
 
                     default:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,73 @@
+from swsscommon import swsscommon
+import time
+
+
+def create_entry(tbl, key, pairs):
+    fvs = swsscommon.FieldValuePairs(pairs)
+    tbl.set(key, fvs)
+    time.sleep(1)
+
+
+def get_exist_entry(dvs, table):
+    db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+    tbl =  swsscommon.Table(db, table)
+    entries = list(tbl.getKeys())
+    return entries[0]
+
+
+def create_entry_pst(db, table, separator, key, pairs):
+    tbl = swsscommon.ProducerStateTable(db, table)
+    create_entry(tbl, key, pairs)
+
+
+def check_object(db, table, key, expected_attributes):
+    tbl =  swsscommon.Table(db, table)
+    keys = tbl.getKeys()
+    assert key in keys, "The desired key is not presented"
+
+    status, fvs = tbl.get(key)
+    assert status, "Got an error when get a key"
+
+    assert len(fvs) >= len(expected_attributes), "Incorrect attributes"
+
+    attr_keys = {entry[0] for entry in fvs}
+
+    for name, value in fvs:
+        if name in expected_attributes:
+            assert expected_attributes[name] == value, "Wrong value %s for the attribute %s = %s" % \
+                                               (value, name, expected_attributes[name])
+
+
+def vxlan_switch_test(dvs, oid, port, mac):
+    app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+    create_entry_pst(
+        app_db,
+        "SWITCH_TABLE", ':', "switch",
+        [
+            ("vxlan_port", port),
+            ("vxlan_router_mac", mac)
+        ],
+    )
+    time.sleep(2)
+
+    asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+    check_object(asic_db, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH", oid,
+        {
+            'SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT': port,
+            'SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC': mac,
+        }
+    )
+
+
+class TestSwitch(object):
+    
+    '''
+    Test- Check switch attributes
+    '''
+    def test_switch_attribute(self, dvs, testlog):
+        switch_oid = get_exist_entry(dvs, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")
+        
+        vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05")
+        
+        vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E")
+


### PR DESCRIPTION
**What I did**
Add vxlan port and router mac to switch profile

**Why I did it**
Require for Vxlan use-case

**How I verified it**
VS test. 

**Details if related**

```
127.0.0.1:6379> HGETALL "SWITCH_TABLE:switch"
1) "vxlan_port"
2) "12345"
3) "vxlan_router_mac"
4) "00:01:02:03:04:05"
```
