### PR TITLE
[portsorch]: Change set port speed internal logic

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1726,25 +1726,23 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         {
                             if (speed != current_speed)
                             {
-                                if (setPortAdminStatus(p.m_port_id, false))
-                                {
-                                    if (setPortSpeed(p.m_port_id, speed))
-                                    {
-                                        SWSS_LOG_NOTICE("Set port %s speed to %u", alias.c_str(), speed);
-                                    }
-                                    else
-                                    {
-                                        SWSS_LOG_ERROR("Failed to set port %s speed to %u", alias.c_str(), speed);
-                                        it++;
-                                        continue;
-                                    }
-                                }
-                                else
+                                if (!setPortAdminStatus(p.m_port_id, false))
                                 {
                                     SWSS_LOG_ERROR("Failed to set port admin status DOWN to set speed");
                                     it++;
                                     continue;
                                 }
+                            }
+
+                            if (setPortSpeed(p.m_port_id, speed))
+                            {
+                                SWSS_LOG_NOTICE("Set port %s speed to %u", alias.c_str(), speed);
+                            }
+                            else
+                            {
+                                SWSS_LOG_ERROR("Failed to set port %s speed to %u", alias.c_str(), speed);
+                                it++;
+                                continue;
                             }
                         }
                         else


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Changed internal logic for setting speed in orchagent
**Why I did it**
It is required for Mellanox FFB implementation, during fastfast boot, on init stage, we need to always set the speed to HW because ```get speed``` returns operational speed and still need to pass config to HW
**How I verified it**
Verify set speed logic is working and no errors observed
**Details if related**
N/A