### PR TITLE
[portsorch] move ports operational status initial sync to PortInitDone handling code

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -184,6 +184,8 @@ private:
 
     bool getPortOperStatus(const Port& port, sai_port_oper_status_t& status) const;
     void updatePortOperStatus(Port &port, sai_port_oper_status_t status);
+
+    bool portStatusInitialSync();
 };
 #endif /* SWSS_PORTSORCH_H */
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Move ports operational status sync to PortInitDone handling code.

in this approach oper status is synced on portInitDone. When there is a oper_status in DB it is restored as in DB, when there is no oper_status in DB (cold restart) - read oper status from HW



**Why I did it**
The original motivation was that in mlnx fast-fast boot solution orchagent starts in cold mode, so orchagent assumes port operational status is down, however on HW it could be up and SDK will not generate operational status update event.

**How I verified it**
Verified Mellanox fastfast boot flow & vs test

**Details if related**

