### PR TITLE
[VS]: remove incorrect vlan interface create operation

### DIFF
--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -165,15 +165,6 @@ def create_vlan_interface(dvs, vlan_name, ifname, vnet_name, ipaddr):
 
     time.sleep(1)
 
-    # create vlan interface in config db
-    create_entry_tbl(
-        conf_db,
-        "VLAN_INTERFACE", '|', vlan_name,
-        [
-          ("vnet_name", vnet_name),
-        ],
-    )
-
     #FIXME - This is created by IntfMgr
     app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
     create_entry_pst(


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>



**What I did**
remove incorrect vlan interface create operation
**Why I did it**

Triggering intfmgrd error:
```
Dec  4 09:20:33.044836 8719a7e62ab4 ERR #intfmgrd: :- doIntfTask:126: Invalid key Vlan100
```
**How I verified it**
VS test
**Details if related**
