### PR TITLE
[neighorch] return back original condition for port oper status

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -90,7 +90,7 @@ bool NeighOrch::addNextHop(IpAddress ipAddress, string alias)
     // flag Should be set on it.
     // This scenario may happen under race condition where buffered neighbor event
     // is processed after incoming port is down.
-    if (p.m_oper_status != SAI_PORT_OPER_STATUS_UP)
+    if (p.m_oper_status == SAI_PORT_OPER_STATUS_DOWN)
     {
         if (setNextHopFlag(ipAddress, NHFLAGS_IFDOWN) == false)
         {


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Return back original condition for port operational status when adding a next hop.

**Why I did it**
port::m_oper_status is by default SAI_PORT_OPER_STATUS_UNKNOWN.
If port is LAG or VLAN m_oper_status is not overridden with value in state DB, so
(p.m_oper_status != SAI_PORT_OPER_STATUS_UP) is true and next hop flag IFDOWN is set.

This is workaround, need to listen to state db to update oper status in port struct

**How I verified it**
Built and verified that next hops are added to ecmp group

**Details if related**
