### PR TITLE
[vlanmgrd]: Create a dummy interface and put into the Bridge

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -33,15 +33,21 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
 
     // Initialize Linux dot1q bridge and enable vlan filtering
     // The command should be generated as:
-    // /bin/bash -c "/sbin/ip link del Bridge 2>/dev/null ;
+    // /bin/bash -c "/sbin/ip link del Bridge 2>/dev/null;
     //               /sbin/ip link add Bridge up type bridge &&
-    //               /sbin/bridge vlan del vid 1 dev Bridge self"
+    //               /sbin/bridge vlan del vid 1 dev Bridge self;
+    //               /sbin/ip link del dummy 2>/dev/null;
+    //               /sbin/ip link add dummy type dummy &&"
+    //               /sbin/ip link set dummy up master Bridge"
 
     const std::string cmds = std::string("")
       + BASH_CMD + " -c \""
       + IP_CMD + " link del " + DOT1Q_BRIDGE_NAME + " 2>/dev/null; "
       + IP_CMD + " link add " + DOT1Q_BRIDGE_NAME + " up type bridge && "
-      + BRIDGE_CMD + " vlan del vid " + DEFAULT_VLAN_ID + " dev " + DOT1Q_BRIDGE_NAME + " self\"";
+      + BRIDGE_CMD + " vlan del vid " + DEFAULT_VLAN_ID + " dev " + DOT1Q_BRIDGE_NAME + " self; "
+      + IP_CMD + " link del dummy 2>/dev/null; "
+      + IP_CMD + " link add dummy type dummy && "
+      + IP_CMD + " link set dummy up master " + DOT1Q_BRIDGE_NAME + "\"";
 
     std::string res;
     EXEC_WITH_ERROR_THROW(cmds, res);


### PR DESCRIPTION
In order to maintain the interface Bridge to be UP all the time,
the dummy interface is needed to be the member of the Bridge.

Refactored test_vlan.py so that each test is independent from
each other and intermediate state will be cleaned up afterwards.

Add test_MultipleVlan test to cover scenarios with VLAN and
VLAN members change. Before the change of the vlanmgrd, this
test would fail when all the VLAN members were removed out of
the master. Interface Bridge would show NO-CARRIER and new
VLAN cannot be created afterwards.

After adding the dummy interface, this test will pass.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>