### PR TITLE
[intfmgrd]: Support loopback

### DIFF
--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -44,6 +44,7 @@ int main(int argc, char **argv)
             CFG_INTF_TABLE_NAME,
             CFG_LAG_INTF_TABLE_NAME,
             CFG_VLAN_INTF_TABLE_NAME,
+            CFG_LOOPBACK_INTERFACE_TABLE_NAME,
         };
 
         DBConnector cfgDb(CONFIG_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);


### PR DESCRIPTION
In #635, the intfmgrd does not read loopback address from config db at all and then it does not configure the loopback address in the asic. The PR fix the issue by reading from the config db. Since loopback address is configured via /etc/network/interface so it is skipped in intfmgrd. 

Signed-off-by: Marian Pritsak <marianp@mellanox.com>