### PR TITLE
[neighsyncd] increase neighbor syncd restore timeout to 110 seconds

### DIFF
--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -11,10 +11,10 @@
 
 /*
  * This is the timer value (in seconds) that the neighsyncd waits for restore_neighbors
- * service to finish, should be longer than the restore_neighbors timeout value (120)
+ * service to finish, should be longer than the restore_neighbors timeout value (110)
  * This should not happen, if happens, system is in a unknown state, we should exit.
  */
-#define RESTORE_NEIGH_WAIT_TIME_OUT 180
+#define RESTORE_NEIGH_WAIT_TIME_OUT 120
 
 namespace swss {
 

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -11,10 +11,10 @@
 
 /*
  * This is the timer value (in seconds) that the neighsyncd waits for restore_neighbors
- * service to finish, should be longer than the restore_neighbors timeout value (60)
+ * service to finish, should be longer than the restore_neighbors timeout value (120)
  * This should not happen, if happens, system is in a unknown state, we should exit.
  */
-#define RESTORE_NEIGH_WAIT_TIME_OUT 70
+#define RESTORE_NEIGH_WAIT_TIME_OUT 130
 
 namespace swss {
 

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -14,7 +14,7 @@
  * service to finish, should be longer than the restore_neighbors timeout value (120)
  * This should not happen, if happens, system is in a unknown state, we should exit.
  */
-#define RESTORE_NEIGH_WAIT_TIME_OUT 130
+#define RESTORE_NEIGH_WAIT_TIME_OUT 180
 
 namespace swss {
 

--- a/neighsyncd/restore_neighbors.py
+++ b/neighsyncd/restore_neighbors.py
@@ -33,8 +33,9 @@ logger.addHandler(logging.NullHandler())
 # timeout the restore process in 1 min if not finished
 # This is mostly to wait for interfaces to be created and up after system warm-reboot
 # and this process is started by supervisord in swss docker.
-# It would be good to keep that time below routing reconciliation time-out.
-TIME_OUT = 60
+# It would be good to keep that time consistent routing reconciliation time-out, here
+# we are upstream, we shouldn't give up before down stream.
+TIME_OUT = 120
 
 # every 5 seconds to check interfaces states
 CHECK_INTERVAL = 5


### PR DESCRIPTION
**What I did**
Neighbor syncd is restoring important information for teamd and BGP. therefore, our timeout should not be shorter than the down stream service.

**Why I did it**
If some interface becomes ready too slow, restore_neighbors script will timeout and leave some neighbors not restored. That will cause sonic to relearn these neighbors and re-create these neighbor entries. And thus that cause data plane disruption.

**How I verified it**
Without the change, when vlan interface becomes ready 20 seconds later, data plane disruption is noticed by test. With the change, there is no data plane disruption.