### PR TITLE
portsorch ports init done flag should means buffer, autoneg, speed, m…

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1879,7 +1879,7 @@ void AclOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -671,7 +671,7 @@ void BufferOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortCreated())
     {
         return;
     }

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -671,7 +671,7 @@ void BufferOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isPortCreated())
+    if (!gPortsOrch->isInitDone())
     {
         return;
     }

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -589,7 +589,7 @@ void CoppOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -256,7 +256,7 @@ void FdbOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }
@@ -336,7 +336,7 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -38,7 +38,7 @@ void FlexCounterOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -171,7 +171,7 @@ void IntfsOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -275,13 +275,6 @@ void IntfsOrch::doTask(Consumer &consumer)
                 continue;
             }
 
-            // buffer configuration hasn't been applied yet, hold from intf config.
-            if (!gBufferOrch->isPortReady(alias))
-            {
-                it++;
-                continue;
-            }
-
             if (!vnet_name.empty())
             {
                 VNetOrch* vnet_orch = gDirectory.get<VNetOrch*>();

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -934,7 +934,7 @@ void MirrorOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -275,7 +275,7 @@ void NeighOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -144,7 +144,7 @@ bool OrchDaemon::init()
 
     /*
      * The order of the orch list is important for state restore of warm start and
-     * the queued processing in m_toSync map after gPortsOrch->isInitDone() is set.
+     * the queued processing in m_toSync map after gPortsOrch->isPortReady() is set.
      *
      * For the multiple consumers in ports_tables, tasks for LAG_TABLE is processed before VLAN_TABLE
      * when iterating ConsumerMap.

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -413,21 +413,19 @@ bool OrchDaemon::warmRestoreAndSyncUp()
     }
 
     /*
-     * Three iterations are needed.
+     * Four iterations are needed.
      *
-     * First iteration: Orch(s) which do not have dependency on port table,
-     *   gBufferOrch, gPortsOrch(Port table and VLAN table),
-     *   and orch(s) which have dependency on Port but processed after it.
+     * First iteration: switchorch, Port init/hostif create part of portorch.
      *
-     * Second iteration: gBufferOrch (has inter-dependency with gPortsOrch),
-     *   remaining attributes on port table for gPortsOrch,
-     *   gIntfsOrch which has dependency on both gBufferOrch and port table of gPortsOrch.
-     *   LAG_TABLE in gPortsOrch.
+     * Second iteratoin: gBufferOrch which requires port created,
+     *   then port speed/mtu/fec_mode/pfc_asym/admin_status config.
      *
-     * Third iteration: Drain remaining data that are out of order like LAG_MEMBER_TABLE and
+     * Third iteration: other orch(s) which wait for port init done.
+     *
+     * Fourth iteration: Drain remaining data that are out of order like LAG_MEMBER_TABLE and
      * VLAN_MEMBER_TABLE since they were checked before LAG_TABLE and VLAN_TABLE within gPortsOrch.
      */
-    for (auto it = 0; it < 3; it++)
+    for (auto it = 0; it < 4; it++)
     {
         for (Orch *o : m_orchList)
         {

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -50,7 +50,7 @@ void PfcWdOrch<DropHandler, ForwardHandler>::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -385,13 +385,13 @@ void PortsOrch::removeDefaultBridgePorts()
     SWSS_LOG_NOTICE("Remove bridge ports from default 1Q bridge");
 }
 
-bool PortsOrch::isInitDone()
+bool PortsOrch::isPortReady()
 {
     return m_initDone && m_pendingPortSet.empty();
 }
 
 /* Upon receiving PortInitDone, all the configured ports have been created*/
-bool PortsOrch::isPortCreated()
+bool PortsOrch::isInitDone()
 {
     return m_initDone;
 }
@@ -2245,7 +2245,7 @@ void PortsOrch::doTask(Consumer &consumer)
     else
     {
         /* Wait for all ports to be initialized */
-        if (!isInitDone())
+        if (!isPortReady())
         {
             return;
         }
@@ -3059,7 +3059,7 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
     SWSS_LOG_ENTER();
 
     /* Wait for all ports to be initialized */
-    if (!isInitDone())
+    if (!isPortReady())
     {
         return;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -387,8 +387,15 @@ void PortsOrch::removeDefaultBridgePorts()
 
 bool PortsOrch::isInitDone()
 {
+    return m_initDone && m_pendingPortSet.empty();
+}
+
+/* Upon receiving PortInitDone, all the configured ports have been created*/
+bool PortsOrch::isPortCreated()
+{
     return m_initDone;
 }
+
 
 map<string, Port>& PortsOrch::getAllPorts()
 {
@@ -1626,8 +1633,13 @@ void PortsOrch::doPortTask(Consumer &consumer)
             if (!gBufferOrch->isPortReady(alias))
             {
                 // buffer configuration hasn't been applied yet. save it for future retry
+                m_pendingPortSet.emplace(alias);
                 it++;
                 continue;
+            }
+            else
+            {
+                m_pendingPortSet.erase(alias);
             }
 
             Port p;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -56,6 +56,7 @@ public:
     PortsOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames);
 
     bool isInitDone();
+    bool isPortCreated();
 
     map<string, Port>& getAllPorts();
     bool bake() override;
@@ -117,6 +118,8 @@ private:
     map<set<int>, tuple<string, uint32_t, int, string>> m_lanesAliasSpeedMap;
     map<string, Port> m_portList;
 
+    unordered_set<string> m_pendingPortSet;
+
     NotificationConsumer* m_portStatusNotificationConsumer;
 
     void doTask(Consumer &consumer);
@@ -170,7 +173,7 @@ private:
     bool getPortSpeed(sai_object_id_t port_id, sai_uint32_t &speed);
 
     bool setPortAdvSpeed(sai_object_id_t port_id, sai_uint32_t speed);
-    
+
     bool getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index);
 
     bool m_isQueueMapGenerated = false;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -55,8 +55,8 @@ class PortsOrch : public Orch, public Subject
 public:
     PortsOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames);
 
+    bool isPortReady();
     bool isInitDone();
-    bool isPortCreated();
 
     map<string, Port>& getAllPorts();
     bool bake() override;

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1365,7 +1365,7 @@ void QosOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -269,7 +269,7 @@ void RouteOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -21,7 +21,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }

--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -50,7 +50,7 @@ void WatermarkOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }
@@ -96,7 +96,7 @@ void WatermarkOrch::doTask(Consumer &consumer)
 
 void WatermarkOrch::doTask(NotificationConsumer &consumer)
 {
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isPortReady())
     {
         return;
     }


### PR DESCRIPTION
…tu, fec and other port level initial config done too.

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**

Make sure physical port config is done before proceeding to other configurations which have dependency on physical port.  

**Why I did it**
Other high level objects  like lag, vlan, interface, acl, copp, pfc, mirror, qos, tunnel, route, and etc. check gPortsOrch->isInitDone() before proceeding their tasks. 

The change in https://github.com/Azure/sonic-swss/pull/515 altered the meaning of gPortsOrch->isInitDone(), and caused the possibility that physical port parameter setting may not be done though  gPortsOrch->isInitDone() had become true,  that introduced potential instability.

**How I verified it**

**Details if related**
