### PR TITLE
[intfmgrd] Fix intfmgrd hanging untill first interface becomes ready

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -215,6 +215,7 @@ void IntfMgr::doTask(Consumer &consumer)
         {
             if (!doIntfGeneralTask(keys, data, op))
             {
+                it++;
                 continue;
             }
         }
@@ -222,6 +223,7 @@ void IntfMgr::doTask(Consumer &consumer)
         {
             if (!doIntfAddrTask(keys, data, op))
             {
+                it++;
                 continue;
             }
         }


### PR DESCRIPTION
intfmgrd can hang on first interface it tries to configure untill this
interface becomes "ready". This delays other interfaces configuration to
be processed.
This commit fixes this issue by skiping "not ready" interface and
proceed with others. Skipped interface can be processed on next
iterations.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Skip interface when it is not ready. Interface will be processed on next iterations.

**Why I did it**

This is to nail the issue described in https://github.com/Azure/sonic-swss/pull/744

What I see from intfmgrd:
```
Jan 11 12:44:17.861611 mts-sonic-dut DEBUG swss#intfmgrd: :> doIntfAddrTask: enter
Jan 11 12:44:17.861830 mts-sonic-dut DEBUG swss#intfmgrd: :- doIntfAddrTask: Interface is not ready, skipping PortChannel0001
Jan 11 12:44:17.861993 mts-sonic-dut DEBUG swss#intfmgrd: :< doIntfAddrTask: exit
Jan 11 12:44:17.862042 mts-sonic-dut DEBUG swss#intfmgrd: :> doIntfAddrTask: enter
Jan 11 12:44:17.862136 mts-sonic-dut DEBUG swss#intfmgrd: :- doIntfAddrTask: Interface is not ready, skipping PortChannel0001
...
...
Jan 11 12:45:06.355028 mts-sonic-dut DEBUG swss#intfmgrd: :- isIntfStateOk: Lag PortChannel0001 is ready
Jan 11 12:45:06.408858 mts-sonic-dut DEBUG swss#intfmgrd: :- exec: /sbin/ip address add 10.0.0.56/31 dev PortChannel0001 :
...
Jan 11 12:45:06.723520 mts-sonic-dut DEBUG swss#intfmgrd: :- isIntfStateOk: Vlan Vlan1000 is ready
Jan 11 12:45:06.768670 mts-sonic-dut DEBUG swss#intfmgrd: :- exec: /sbin/ip address add 192.168.0.1/21 dev Vlan1000 :
```

Almost one minute delay in configuring Vlan1000 interface because of PortChannel0001 "ready" delay.

**How I verified it**
Build swss debian package, installed on DUT, verified that PortChannel0001 can be skipped and Vlan1000 can be configured without delay, verified that eventually PortChannel0001 also gets configured.

**Details if related**
