### PR TITLE
[vnetorch]: Refactoring

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -100,6 +100,74 @@ set<IpPrefix> IntfsOrch:: getSubnetRoutes()
     return subnet_routes;
 }
 
+bool IntfsOrch::setIntf(Port& port, sai_object_id_t vrf_id, IpPrefix *ip_prefix)
+{
+    SWSS_LOG_ENTER();
+
+    auto alias = port.m_alias;
+    auto it_intfs = m_syncdIntfses.find(alias);
+    if (it_intfs == m_syncdIntfses.end())
+    {
+        if (addRouterIntfs(vrf_id, port))
+        {
+            IntfsEntry intfs_entry;
+            intfs_entry.ref_count = 0;
+            m_syncdIntfses[alias] = intfs_entry;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+
+    vrf_id = port.m_vr_id;
+    if (!ip_prefix || m_syncdIntfses[alias].ip_addresses.count(*ip_prefix))
+    {
+        /* Request to create router interface, no prefix present or Duplicate entry */
+        return true;
+    }
+
+    /* NOTE: Overlap checking is required to handle ifconfig weird behavior.
+     * When set IP address using ifconfig command it applies it in two stages.
+     * On stage one it sets IP address with netmask /8. On stage two it
+     * changes netmask to specified in command. As DB is async event to
+     * add IP address with original netmask may come before event to
+     * delete IP with netmask /8. To handle this we in case of overlap
+     * we should wait until entry with /8 netmask will be removed.
+     * Time frame between those event is quite small.*/
+    bool overlaps = false;
+    for (const auto &prefixIt: m_syncdIntfses[alias].ip_addresses)
+    {
+        if (prefixIt.isAddressInSubnet(ip_prefix->getIp()) ||
+                ip_prefix->isAddressInSubnet(prefixIt.getIp()))
+        {
+            overlaps = true;
+            SWSS_LOG_NOTICE("Router interface %s IP %s overlaps with %s.", port.m_alias.c_str(),
+                    prefixIt.to_string().c_str(), ip_prefix->to_string().c_str());
+            break;
+        }
+    }
+
+    if (overlaps)
+    {
+        /* Overlap of IP address network */
+        return false;
+    }
+
+    addIp2MeRoute(vrf_id, *ip_prefix);
+    addSubnetRoute(port, *ip_prefix);
+
+    if (port.m_type == Port::VLAN && ip_prefix->isV4())
+    {
+        addDirectedBroadcast(port, ip_prefix->getBroadcastIp());
+    }
+
+    m_syncdIntfses[alias].ip_addresses.insert(*ip_prefix);
+
+    return true;
+}
+
 void IntfsOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -149,17 +217,7 @@ void IntfsOrch::doTask(Consumer &consumer)
         }
 
         sai_object_id_t vrf_id = gVirtualRouterId;
-        if (!vnet_name.empty())
-        {
-            VNetOrch* vnet_orch = gDirectory.get<VNetOrch*>();
-            if (!vnet_orch->isVnetExists(vnet_name))
-            {
-                it++;
-                continue;
-            }
-            vrf_id = vnet_orch->getVRid(vnet_name);
-        }
-        else if (!vrf_name.empty())
+        if (!vrf_name.empty())
         {
             if (m_vrfOrch->isVRFexists(vrf_name))
             {
@@ -225,67 +283,28 @@ void IntfsOrch::doTask(Consumer &consumer)
                 continue;
             }
 
-            auto it_intfs = m_syncdIntfses.find(alias);
-            if (it_intfs == m_syncdIntfses.end())
+            if (!vnet_name.empty())
             {
-                if (addRouterIntfs(vrf_id, port))
-                {
-                    IntfsEntry intfs_entry;
-                    intfs_entry.ref_count = 0;
-                    m_syncdIntfses[alias] = intfs_entry;
-                }
-                else
+                VNetOrch* vnet_orch = gDirectory.get<VNetOrch*>();
+                if (!vnet_orch->isVnetExists(vnet_name))
                 {
                     it++;
                     continue;
                 }
-            }
-
-            vrf_id = port.m_vr_id;
-            if (!ip_prefix_in_key || m_syncdIntfses[alias].ip_addresses.count(ip_prefix))
-            {
-                /* Request to create router interface, no prefix present or Duplicate entry */
+                if (!vnet_orch->getVnetPtr(vnet_name)->addIntf(port, ip_prefix_in_key ? &ip_prefix : nullptr))
+                {
+                    it++;
+                    continue;
+                }
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
-
-            /* NOTE: Overlap checking is required to handle ifconfig weird behavior.
-             * When set IP address using ifconfig command it applies it in two stages.
-             * On stage one it sets IP address with netmask /8. On stage two it
-             * changes netmask to specified in command. As DB is async event to
-             * add IP address with original netmask may come before event to
-             * delete IP with netmask /8. To handle this we in case of overlap
-             * we should wait until entry with /8 netmask will be removed.
-             * Time frame between those event is quite small.*/
-            bool overlaps = false;
-            for (const auto &prefixIt: m_syncdIntfses[alias].ip_addresses)
+            else if (!setIntf(port, vrf_id, ip_prefix_in_key ? &ip_prefix : nullptr))
             {
-                if (prefixIt.isAddressInSubnet(ip_prefix.getIp()) ||
-                        ip_prefix.isAddressInSubnet(prefixIt.getIp()))
-                {
-                    overlaps = true;
-                    SWSS_LOG_NOTICE("Router interface %s IP %s overlaps with %s.", port.m_alias.c_str(),
-                            prefixIt.to_string().c_str(), ip_prefix.to_string().c_str());
-                    break;
-                }
-            }
-
-            if (overlaps)
-            {
-                /* Overlap of IP address network */
-                ++it;
+                it++;
                 continue;
             }
 
-            addSubnetRoute(port, ip_prefix);
-            addIp2MeRoute(vrf_id, ip_prefix);
-
-            if (port.m_type == Port::VLAN && ip_prefix.isV4())
-            {
-                addDirectedBroadcast(port, ip_prefix.getBroadcastIp());
-            }
-
-            m_syncdIntfses[alias].ip_addresses.insert(ip_prefix);
             it = consumer.m_toSync.erase(it);
         }
         else if (op == DEL_COMMAND)

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -30,11 +30,18 @@ public:
 
     sai_object_id_t getRouterIntfsId(const string&);
 
+    const IntfsTable& getSyncdIntfses() { return m_syncdIntfses; }
+
     void increaseRouterIntfsRefCount(const string&);
     void decreaseRouterIntfsRefCount(const string&);
 
     bool setRouterIntfsMtu(Port &port);
     std::set<IpPrefix> getSubnetRoutes();
+    bool setIntf(Port&, sai_object_id_t, IpPrefix *);
+
+    void addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
+    void removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
+
 private:
     VRFOrch *m_vrfOrch;
     IntfsTable m_syncdIntfses;
@@ -47,9 +54,6 @@ private:
 
     void addSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
     void removeSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
-
-    void addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
-    void removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
 
     void addDirectedBroadcast(const Port &port, const IpAddress &ip_addr);
     void removeDirectedBroadcast(const Port &port, const IpAddress &ip_addr);

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -42,6 +42,9 @@ public:
     void addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
     void removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
 
+    void addSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
+    void removeSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
+
 private:
     VRFOrch *m_vrfOrch;
     IntfsTable m_syncdIntfses;
@@ -51,9 +54,6 @@ private:
 
     bool addRouterIntfs(sai_object_id_t vrf_id, Port &port);
     bool removeRouterIntfs(Port &port);
-
-    void addSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
-    void removeSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
 
     void addDirectedBroadcast(const Port &port, const IpAddress &ip_addr);
     void removeDirectedBroadcast(const Port &port, const IpAddress &ip_addr);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -77,8 +77,9 @@ bool OrchDaemon::init()
             APP_VNET_RT_TABLE_NAME,
             APP_VNET_RT_TUNNEL_TABLE_NAME
     };
-    VNetOrch *vnet_orch = new VNetOrch(m_applDb, APP_VNET_TABLE_NAME);
+    VNetOrch *vnet_orch = new VNetVrfOrch(m_applDb, APP_VNET_TABLE_NAME);
     gDirectory.set(vnet_orch);
+
     VNetRouteOrch *vnet_rt_orch = new VNetRouteOrch(m_applDb, vnet_tables, vnet_orch);
     gDirectory.set(vnet_rt_orch);
     VRFOrch *vrf_orch = new VRFOrch(m_applDb, APP_VRF_TABLE_NAME);

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -24,6 +24,7 @@ extern sai_object_id_t gSwitchId;
 extern Directory<Orch*> gDirectory;
 extern PortsOrch *gPortsOrch;
 extern sai_object_id_t gVirtualRouterId;
+extern IntfsOrch *gIntfsOrch;
 
 /*
  * VRF Modeling and VNetVrf class definitions
@@ -144,6 +145,19 @@ bool VNetVrfObject::addTunnelRoute(IpPrefix& ipPrefix, tunnelEndpoint& endp)
             break;
         }
     }
+    return true;
+}
+
+bool VNetVrfObject::addIntf(Port& port, IpPrefix *prefix)
+{
+    if (!gIntfsOrch->setIntf(port, getVRidIngress(), nullptr))
+    {
+        return false;
+    }
+
+    gIntfsOrch->addIp2MeRoute(gVirtualRouterId, *prefix);
+    gIntfsOrch->addSubnetRoute(port, *prefix);
+
     return true;
 }
 

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -139,6 +139,8 @@ public:
 
     virtual bool addTunnelRoute(IpPrefix& ipPrefix, tunnelEndpoint& endp);
 
+    virtual bool addIntf(Port& port, IpPrefix *prefix);
+
     bool createObj();
 
     virtual bool updateObj(const VNetInfo& vnetInfo);


### PR DESCRIPTION
Move all logic to VnetObject to make VnetRouteOrch stateless
Make VnetObject class reflect ConfigDb schema

Signed-off-by: Marian Pritsak <marianp@mellanox.com>