### PR TITLE
[watermarkorch] Fix repeated m_pg_ids and m_unicast_queue_ids add up issue

### DIFF
--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -158,9 +158,13 @@ void WatermarkOrch::doTask(SelectableTimer &timer)
 {
     SWSS_LOG_ENTER();
 
-    if (m_pg_ids.empty() or m_multicast_queue_ids.empty() or m_unicast_queue_ids.empty())
+    if (m_pg_ids.empty())
     {
         init_pg_ids();
+    }
+
+    if (m_multicast_queue_ids.empty() and m_unicast_queue_ids.empty())
+    {
         init_queue_ids();
     }
 


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Fix the m_pg_ids, m_unicast_queue_ids and m_multicast_queue_ids init logic error.

**Why I did it**
The problem exhausts  system cpu and memory eventually in case multicast queue does not exist. 

size of m_pg_ids: 873152
```
(gdb) bt
#0  0x00007f3e9345ca9d in read () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f3e928f946e in read (__nbytes=16384, __buf=0x7ffca1347990, __fd=<optimized out>) at /usr/include/x86_64-linux-gnu/bits/unistd.h:44
#2  redisBufferRead (c=0x21eace0) at hiredis.c:802
#3  0x00007f3e928f9760 in redisGetReply (c=0x21eace0, reply=0x7ffca134ba98) at hiredis.c:888
#4  0x00007f3e92f951c1 in pop (this=0x21eaa10) at ../common/redispipeline.h:74
#5  flush (this=<optimized out>) at ../common/redispipeline.h:93
#6  mayflush (this=0x21eaa10) at ../common/redispipeline.h:115
#7  push (expectedType=5, command=..., this=0x21eaa10) at ../common/redispipeline.h:39
#8  swss::Table::set (this=this@entry=0x21e9530, key="oid:0x1a00000000065c", values=std::vector of length 1, capacity 1 = {...}) at table.cpp:132
#9  0x000000000051e42f in WatermarkOrch::clearSingleWm (this=this@entry=0x21e8270, table=0x21e9530, wm_name="SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES", 
    obj_ids=std::vector of length 873152, capacity 1048576 = {...}) at watermarkorch.cpp:220
#10 0x000000000052177f in WatermarkOrch::doTask (this=0x21e8270, timer=...) at watermarkorch.cpp:166
#11 0x000000000041bc3b in OrchDaemon::start (this=this@entry=0x219f830) at orchdaemon.cpp:371
#12 0x000000000040a459 in main (argc=<optimized out>, argv=0x7ffca134c038) at main.cpp:310
(gdb) up 9
#9  0x000000000051e42f in WatermarkOrch::clearSingleWm (this=this@entry=0x21e8270, table=0x21e9530, wm_name="SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES", 
    obj_ids=std::vector of length 873152, capacity 1048576 = {...}) at watermarkorch.cpp:220
220	watermarkorch.cpp: No such file or directory.
(gdb) p m_pg_ids
$1 = std::vector of length 873152, capacity 1048576 = {7318349394478363, 7318349394478364, 7318349394478365, 7318349394478366, 7318349394478367, 7318349394478368, 
  7318349394478369, 7318349394478370, 7318349394477763, 7318349394477764, 7318349394477765, 7318349394477766, 7318349394477767, 7318349394477768, 7318349394477769, 
  7318349394477770, 7318349394477803, 7318349394477804, 7318349394477805, 7318349394477806, 7318349394477807, 7318349394477808, 7318349394477809, 7318349394477810, 
  7318349394477843, 7318349394477844, 7318349394477845, 7318349394477846, 7318349394477847, 7318349394477848, 7318349394477849, 7318349394477850, 7318349394477883, 
  7318349394477884, 7318349394477885, 7318349394477886, 7318349394477887, 7318349394477888, 7318349394477889, 7318349394477890, 7318349394477923, 7318349394477924, 
  7318349394477925, 7318349394477926, 7318349394477927, 7318349394477928, 7318349394477929, 7318349394477930, 7318349394477963, 7318349394477964, 7318349394477965, 
  7318349394477966, 7318349394477967, 7318349394477968, 7318349394477969, 7318349394477970, 7318349394478003, 7318349394478004, 7318349394478005, 7318349394478006, 
  7318349394478007, 7318349394478008, 7318349394478009, 7318349394478010, 7318349394478043, 7318349394478044, 7318349394478045, 7318349394478046, 7318349394478047, 
  7318349394478048, 7318349394478049, 7318349394478050, 7318349394478083, 7318349394478084, 7318349394478085, 7318349394478086, 7318349394478087, 7318349394478088, 
  7318349394478089, 7318349394478090, 7318349394478123, 7318349394478124, 7318349394478125, 7318349394478126, 7318349394478127, 7318349394478128, 7318349394478129, 
  7318349394478130, 7318349394478403, 7318349394478404, 7318349394478405, 7318349394478406, 7318349394478407, 7318349394478408, 7318349394478409, 7318349394478410, 
  7318349394478163, 7318349394478164, 7318349394478165, 7318349394478166, 7318349394478167, 7318349394478168, 7318349394478169, 7318349394478170, 7318349394478203, 
  7318349394478204, 7318349394478205, 7318349394478206, 7318349394478207, 7318349394478208, 7318349394478209, 7318349394478210, 7318349394478243, 7318349394478244, 
  7318349394478245, 7318349394478246, 7318349394478247, 7318349394478248, 7318349394478249, 7318349394478250, 7318349394478283, 7318349394478284, 7318349394478285, 
  7318349394478286, 7318349394478287, 7318349394478288, 7318349394478289, 7318349394478290, 7318349394478323, 7318349394478324, 7318349394478325, 7318349394478326, 
  7318349394478327, 7318349394478328, 7318349394478329, 7318349394478330, 7318349394477187, 7318349394477188, 7318349394477189, 7318349394477190, 7318349394477191, 
  7318349394477192, 7318349394477193, 7318349394477194, 7318349394477283, 7318349394477284, 7318349394477285, 7318349394477286, 7318349394477287, 7318349394477288, 
  7318349394477289, 7318349394477290, 7318349394477323, 7318349394477324, 7318349394477325, 7318349394477326, 7318349394477327, 7318349394477328, 7318349394477329, 
  7318349394477330, 7318349394477363, 7318349394477364, 7318349394477365, 7318349394477366, 7318349394477367, 7318349394477368, 7318349394477369, 7318349394477370, 
  7318349394477403, 7318349394477404, 7318349394477405, 7318349394477406, 7318349394477407, 7318349394477408, 7318349394477409, 7318349394477410, 7318349394478443, 
  7318349394478444, 7318349394478445, 7318349394478446, 7318349394478447, 7318349394478448, 7318349394478449, 7318349394478450, 7318349394477443, 7318349394477444, 
  7318349394477445, 7318349394477446, 7318349394477447, 7318349394477448, 7318349394477449, 7318349394477450, 7318349394477483, 7318349394477484, 7318349394477485, 
  7318349394477486, 7318349394477487, 7318349394477488, 7318349394477489, 7318349394477490...}
(gdb) p m_unicast_queue_ids
$2 = std::vector of length 1091440, capacity 2097152 = {5910974510925578, 5910974510925177, 5910974510925780, 5910974510926133, 5910974510925057, 5910974510924459, 
  5910974510924696, 5910974510925213, 5910974510925331, 5910974510924531, 5910974510924895, 5910974510925659, 5910974510925853, 5910974510924412, 5910974510924698, 
  5910974510924454, 5910974510924814, 5910974510925420, 5910974510925854, 5910974510925020, 5910974510924573, 5910974510925058, 5910974510924132, 5910974510925620, 
  5910974510925459, 5910974510924095, 5910974510924853, 5910974510924491, 5910974510925939, 5910974510926099, 5910974510925418, 5910974510924415, 5910974510925460, 
  5910974510924732, 5910974510924893, 5910974510925419, 5910974510924058, 5910974510925857, 5910974510926057, 5910974510925618, 5910974510926139, 5910974510924499, 
  5910974510926017, 5910974510926018, 5910974510924616, 5910974510924014, 5910974510925215, 5910974510925812, 5910974510924212, 5910974510924652, 5910974510925294, 
  5910974510926096, 5910974510925291, 5910974510925296, 5910974510926177, 5910974510924255, 5910974510925540, 5910974510925613, 5910974510925537, 5910974510925732, 
  5910974510925295, 5910974510924419, 5910974510926137, 5910974510924572, 5910974510924293, 5910974510924173, 5910974510924813, 5910974510924860, 5910974510925051, 
  5910974510926059, 5910974510924771, 5910974510924859, 5910974510925133, 5910974510924056, 5910974510925973, 5910974510925372, 5910974510925693, 5910974510924175, 
  5910974510924380, 5910974510925859, 5910974510924332, 5910974510925214, 5910974510924896, 5910974510925259, 5910974510924176, 5910974510924013, 5910974510926015, 
  5910974510926131, 5910974510925736, 5910974510925697, 5910974510924773, 5910974510924133, 5910974510924299, 5910974510924932, 5910974510924699, 5910974510925734, 
  5910974510925218, 5910974510926172, 5910974510925019, 5910974510925972, 5910974510926097, 5910974510924692, 5910974510924457, 5910974510924059, 5910974510924735, 
  5910974510924657, 5910974510924894, 5910974510924217, 5910974510925056, 5910974510926014, 5910974510924618, 5910974510924816, 5910974510925014, 5910974510924940, 
  5910974510924251, 5910974510926173, 5910974510925538, 5910974510925018, 5910974510924096, 5910974510924134, 5910974510926095, 5910974510926100, 5910974510925054, 
  5910974510926058, 5910974510924372, 5910974510924291, 5910974510924971, 5910974510924576, 5910974510924493, 5910974510925297, 5910974510925335, 5910974510925898, 
  5910974510925737, 5910974510926060, 5910974510925096, 5910974510924016, 5910974510924336, 5910974510925653, 5910974510924256, 5910974510924775, 5910974510924731, 
  5910974510925612, 5910974510925412, 5910974510924815, 5910974510925095, 5910974510924654, 5910974510925498, 5910974510925171, 5910974510924297, 5910974510926020, 
  5910974510925011, 5910974510926011, 5910974510925891, 5910974510925414, 5910974510925499, 5910974510926171, 5910974510925220, 5910974510924377, 5910974510924972, 
  5910974510925773, 5910974510924333, 5910974510925531, 5910974510926175, 5910974510924334, 5910974510924659, 5910974510924580, 5910974510926051, 5910974510925817, 
  5910974510925179, 5910974510925298, 5910974510924536, 5910974510924857, 5910974510924934, 5910974510925455, 5910974510924693, 5910974510923976, 5910974510924254, 
  5910974510925211, 5910974510925135, 5910974510925778, 5910974510925733, 5910974510924733, 5910974510925378, 5910974510924019, 5910974510924137, 5910974510924980, 
  5910974510924695, 5910974510926140, 5910974510925974, 5910974510926052, 5910974510924538, 5910974510925253, 5910974510925339, 5910974510926134, 5910974510924215, 
  5910974510925336, 5910974510925536, 5910974510925456, 5910974510925258, 5910974510924936...}
(gdb) qp m_multicast_queue_ids
Undefined command: "qp".  Try "help".
```



size of m_pg_ids:  873600
```

Program received signal SIGINT, Interrupt.
0x00007f3e9345ca9d in read () from /lib/x86_64-linux-gnu/libpthread.so.0
(gdb) bt
#0  0x00007f3e9345ca9d in read () from /lib/x86_64-linux-gnu/libpthread.so.0
#1  0x00007f3e928f946e in read (__nbytes=16384, __buf=0x7ffca1347990, __fd=<optimized out>) at /usr/include/x86_64-linux-gnu/bits/unistd.h:44
#2  redisBufferRead (c=0x21eace0) at hiredis.c:802
#3  0x00007f3e928f9760 in redisGetReply (c=0x21eace0, reply=0x7ffca134ba98) at hiredis.c:888
#4  0x00007f3e92f951c1 in pop (this=0x21eaa10) at ../common/redispipeline.h:74
#5  flush (this=<optimized out>) at ../common/redispipeline.h:93
#6  mayflush (this=0x21eaa10) at ../common/redispipeline.h:115
#7  push (expectedType=5, command=..., this=0x21eaa10) at ../common/redispipeline.h:39
#8  swss::Table::set (this=this@entry=0x21e9530, key="oid:0x1a00000000031a", values=std::vector of length 1, capacity 1 = {...}) at table.cpp:132
#9  0x000000000051e42f in WatermarkOrch::clearSingleWm (this=this@entry=0x21e8270, table=0x21e9530, wm_name="SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES", 
    obj_ids=std::vector of length 873600, capacity 1048576 = {...}) at watermarkorch.cpp:220
#10 0x000000000052177f in WatermarkOrch::doTask (this=0x21e8270, timer=...) at watermarkorch.cpp:166
#11 0x000000000041bc3b in OrchDaemon::start (this=this@entry=0x219f830) at orchdaemon.cpp:371
#12 0x000000000040a459 in main (argc=<optimized out>, argv=0x7ffca134c038) at main.cpp:310
(gdb) up 9
#9  0x000000000051e42f in WatermarkOrch::clearSingleWm (this=this@entry=0x21e8270, table=0x21e9530, wm_name="SAI_INGRESS_PRIORITY_GROUP_STAT_XOFF_ROOM_WATERMARK_BYTES", 
    obj_ids=std::vector of length 873600, capacity 1048576 = {...}) at watermarkorch.cpp:220
220	in watermarkorch.cpp
(gdb) up 1
#10 0x000000000052177f in WatermarkOrch::doTask (this=0x21e8270, timer=...) at watermarkorch.cpp:166
166	in watermarkorch.cpp
(gdb) p m_pg_id
No symbol "m_pg_id" in current context.
(gdb) p m_pg_ids
$4 = std::vector of length 873600, capacity 1048576 = {7318349394478363, 7318349394478364, 7318349394478365, 7318349394478366, 7318349394478367, 7318349394478368, 
  7318349394478369, 7318349394478370, 7318349394477763, 7318349394477764, 7318349394477765, 7318349394477766, 7318349394477767, 7318349394477768, 7318349394477769, 
  7318349394477770, 7318349394477803, 7318349394477804, 7318349394477805, 7318349394477806, 7318349394477807, 7318349394477808, 7318349394477809, 7318349394477810, 
  7318349394477843, 7318349394477844, 7318349394477845, 7318349394477846, 7318349394477847, 7318349394477848, 7318349394477849, 7318349394477850, 7318349394477883, 
  7318349394477884, 7318349394477885, 7318349394477886, 7318349394477887, 7318349394477888, 7318349394477889, 7318349394477890, 7318349394477923, 7318349394477924, 
  7318349394477925, 7318349394477926, 7318349394477927, 7318349394477928, 7318349394477929, 7318349394477930, 7318349394477963, 7318349394477964, 7318349394477965, 
  7318349394477966, 7318349394477967, 7318349394477968, 7318349394477969, 7318349394477970, 7318349394478003, 7318349394478004, 7318349394478005, 7318349394478006, 
  7318349394478007, 7318349394478008, 7318349394478009, 7318349394478010, 7318349394478043, 7318349394478044, 7318349394478045, 7318349394478046, 7318349394478047, 
  7318349394478048, 7318349394478049, 7318349394478050, 7318349394478083, 7318349394478084, 7318349394478085, 7318349394478086, 7318349394478087, 7318349394478088, 
  7318349394478089, 7318349394478090, 7318349394478123, 7318349394478124, 7318349394478125, 7318349394478126, 7318349394478127, 7318349394478128, 7318349394478129, 
  7318349394478130, 7318349394478403, 7318349394478404, 7318349394478405, 7318349394478406, 7318349394478407, 7318349394478408, 7318349394478409, 7318349394478410, 
  7318349394478163, 7318349394478164, 7318349394478165, 7318349394478166, 7318349394478167, 7318349394478168, 7318349394478169, 7318349394478170, 7318349394478203, 
  7318349394478204, 7318349394478205, 7318349394478206, 7318349394478207, 7318349394478208, 7318349394478209, 7318349394478210, 7318349394478243, 7318349394478244, 
  7318349394478245, 7318349394478246, 7318349394478247, 7318349394478248, 7318349394478249, 7318349394478250, 7318349394478283, 7318349394478284, 7318349394478285, 
  7318349394478286, 7318349394478287, 7318349394478288, 7318349394478289, 7318349394478290, 7318349394478323, 7318349394478324, 7318349394478325, 7318349394478326, 
  7318349394478327, 7318349394478328, 7318349394478329, 7318349394478330, 7318349394477187, 7318349394477188, 7318349394477189, 7318349394477190, 7318349394477191, 
  7318349394477192, 7318349394477193, 7318349394477194, 7318349394477283, 7318349394477284, 7318349394477285, 7318349394477286, 7318349394477287, 7318349394477288, 
  7318349394477289, 7318349394477290, 7318349394477323, 7318349394477324, 7318349394477325, 7318349394477326, 7318349394477327, 7318349394477328, 7318349394477329, 
  7318349394477330, 7318349394477363, 7318349394477364, 7318349394477365, 7318349394477366, 7318349394477367, 7318349394477368, 7318349394477369, 7318349394477370, 
  7318349394477403, 7318349394477404, 7318349394477405, 7318349394477406, 7318349394477407, 7318349394477408, 7318349394477409, 7318349394477410, 7318349394478443, 
  7318349394478444, 7318349394478445, 7318349394478446, 7318349394478447, 7318349394478448, 7318349394478449, 7318349394478450, 7318349394477443, 7318349394477444, 
  7318349394477445, 7318349394477446, 7318349394477447, 7318349394477448, 7318349394477449, 7318349394477450, 7318349394477483, 7318349394477484, 7318349394477485, 
  7318349394477486, 7318349394477487, 7318349394477488, 7318349394477489, 7318349394477490...}
(gdb) 
```

**How I verified it**

**Details if related**
