### PR TITLE
[portsorch] fix bug in initializePort

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2380,7 +2380,8 @@ bool PortsOrch::initializePort(Port &port)
     /*
      * always initialize Port SAI_HOSTIF_ATTR_OPER_STATUS based on oper_status value in appDB.
      */
-    if (!setHostIntfsOperStatus(port, port.m_oper_status))
+    bool isUp = port.m_oper_status == SAI_PORT_OPER_STATUS_UP;
+    if (!setHostIntfsOperStatus(port, isUp))
     {
         SWSS_LOG_WARN("Failed to set operation status %s to host interface %s",
                       operStatus.c_str(), port.m_alias.c_str());


### PR DESCRIPTION
setHostIntfsOperStatus accepts bool instead of sai_oper_status_t

While trying to investigate issue described in #744 I tried to find a diff in behaviour that #718 brought to fast/warm reboot and noticed a bug.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
