### PR TITLE
[teammgrd] Fix inconsistent port admin status

### DIFF
--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -10,10 +10,6 @@
 using namespace std;
 using namespace swss;
 
-/* Port default admin status is down */
-#define DEFAULT_ADMIN_STATUS_STR    "down"
-#define DEFAULT_MTU_STR             "9100"
-
 PortMgr::PortMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, const vector<string> &tableNames) :
         Orch(cfgDb, tableNames),
         m_cfgPortTable(cfgDb, CFG_PORT_TABLE_NAME),

--- a/cfgmgr/portmgr.h
+++ b/cfgmgr/portmgr.h
@@ -10,6 +10,10 @@
 
 namespace swss {
 
+/* Port default admin status is down */
+#define DEFAULT_ADMIN_STATUS_STR    "down"
+#define DEFAULT_MTU_STR             "9100"
+
 class PortMgr : public Orch
 {
 public:

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -6,6 +6,7 @@
 #include "shellcmd.h"
 #include "tokenize.h"
 #include "warm_restart.h"
+#include "portmgr.h"
 
 #include <algorithm>
 #include <sstream>
@@ -18,8 +19,6 @@
 using namespace std;
 using namespace swss;
 
-#define DEFAULT_ADMIN_STATUS_STR    "up"
-#define DEFAULT_MTU_STR             "9100"
 
 TeamMgr::TeamMgr(DBConnector *confDb, DBConnector *applDb, DBConnector *statDb,
         const vector<TableConnector> &tables) :
@@ -471,7 +470,7 @@ task_process_status TeamMgr::addLagMember(const string &lag, const string &membe
     vector<FieldValueTuple> fvs;
     m_cfgPortTable.get(member, fvs);
 
-    // Get the member admin status (by default up)
+    // Get the member admin status
     auto it = find_if(fvs.begin(), fvs.end(), [](const FieldValueTuple &fv) {
             return fv.first == "admin_status";
             });
@@ -501,9 +500,7 @@ task_process_status TeamMgr::addLagMember(const string &lag, const string &membe
     EXEC_WITH_ERROR_THROW(cmd.str(), res);
 
     fvs.clear();
-    FieldValueTuple fv("admin_status", admin_status);
-    fvs.push_back(fv);
-    fv = FieldValueTuple("mtu", mtu);
+    FieldValueTuple fv("mtu", mtu);
     fvs.push_back(fv);
     m_appPortTable.set(member, fvs);
 


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
This is try to address:  https://github.com/Azure/sonic-swss/issues/754

**Why I did it**

**How I verified it**
After the fix, port admin status back to normal:

```
US-70998M:sonic-telemetry jipanyang$ ssh root@30.57.185.38
Linux sonic 4.9.0-8-amd64 #1 SMP Debian 4.9.110-3+deb9u6 (2015-12-19) x86_64
You are on
  ____   ___  _   _ _  ____
 / ___| / _ \| \ | (_)/ ___|
 \___ \| | | |  \| | | |
  ___) | |_| | |\  | | |___
 |____/ \___/|_| \_|_|\____|

-- Software for Open Networking in the Cloud --

Unauthorized access and/or use are prohibited.
All access and/or use are subject to monitoring.

Help:    http://azure.github.io/SONiC/

root@sonic:~# show interfaces  description 
  Interface    Oper    Admin         Alias    Description
-----------  ------  -------  ------------  -------------
  Ethernet0    down     down     Ethernet1            N/A
  Ethernet1    down     down     Ethernet2            N/A
  Ethernet2      up       up     Ethernet3            N/A
  Ethernet3      up       up     Ethernet4            N/A
  Ethernet4    down     down     Ethernet5            N/A
  Ethernet5    down     down     Ethernet6            N/A
  Ethernet6    down     down     Ethernet7            N/A
  Ethernet7    down     down     Ethernet8            N/A
  Ethernet8    down     down     Ethernet9            N/A
  Ethernet9    down     down    Ethernet10            N/A
 Ethernet10    down     down    Ethernet11            N/A
 Ethernet11    down     down    Ethernet12            N/A
 Ethernet12    down     down    Ethernet13            N/A
 Ethernet13    down     down    Ethernet14            N/A
 Ethernet14    down     down    Ethernet15            N/A
 Ethernet15    down     down    Ethernet16            N/A
 Ethernet16    down     down    Ethernet17            N/A
 Ethernet17    down     down    Ethernet18            N/A
 Ethernet18    down     down    Ethernet19            N/A
 Ethernet19    down     down    Ethernet20            N/A
 Ethernet20    down     down    Ethernet21            N/A
 Ethernet21    down     down    Ethernet22            N/A
 Ethernet22      up       up    Ethernet23            N/A
 Ethernet23    down       up    Ethernet24            N/A
 Ethernet24    down       up    Ethernet25            N/A
 Ethernet25    down       up    Ethernet26            N/A
 Ethernet26    down       up    Ethernet27            N/A
 Ethernet27    down       up    Ethernet28            N/A
 Ethernet28    down       up    Ethernet29            N/A
 Ethernet29    down     down    Ethernet30            N/A
 Ethernet30    down     down    Ethernet31            N/A
 Ethernet31    down     down    Ethernet32            N/A
 Ethernet32    down     down    Ethernet33            N/A
 Ethernet33    down     down    Ethernet34            N/A
 Ethernet34    down     down    Ethernet35            N/A
 Ethernet35    down     down    Ethernet36            N/A
 Ethernet36    down     down    Ethernet37            N/A
 Ethernet37    down     down    Ethernet38            N/A
 Ethernet38    down     down    Ethernet39            N/A
 Ethernet39    down     down    Ethernet40            N/A
 Ethernet40    down     down    Ethernet41            N/A
 Ethernet41    down     down    Ethernet42            N/A
 Ethernet42    down     down    Ethernet43            N/A
 Ethernet43    down     down    Ethernet44            N/A
 Ethernet44    down     down    Ethernet45            N/A
 Ethernet45    down     down    Ethernet46            N/A
 Ethernet46    down     down    Ethernet47            N/A
 Ethernet47    down       up    Ethernet48            N/A
 Ethernet48    down     down  Ethernet49/1            N/A
 Ethernet52    down     down  Ethernet50/1            N/A
 Ethernet56    down     down  Ethernet51/1            N/A
 Ethernet60    down     down  Ethernet52/1            N/A
 Ethernet64    down     down  Ethernet53/1            N/A
 Ethernet68    down     down  Ethernet54/1            N/A
root@sonic:~# 
root@sonic:~# teamshow
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev       Protocol     Ports
-----  -------------  -----------  -------------
    1  PortChannel1   LACP(A)(Dw)  Ethernet1(D)
    2  PortChannel2   LACP(A)(Up)  Ethernet2(S)
    3  PortChannel3   LACP(A)(Up)  Ethernet3(S)
    4  PortChannel4   LACP(A)(Dw)  Ethernet4(D)
    5  PortChannel5   LACP(A)(Dw)  Ethernet5(D)
    6  PortChannel6   LACP(A)(Dw)  Ethernet6(D)
    7  PortChannel7   LACP(A)(Dw)  Ethernet7(D)
    8  PortChannel8   LACP(A)(Dw)  Ethernet8(D)
    9  PortChannel9   LACP(A)(Dw)  Ethernet9(D)
   10  PortChannel10  LACP(A)(Dw)  Ethernet10(D)
   11  PortChannel11  LACP(A)(Dw)  Ethernet11(D)
   12  PortChannel12  LACP(A)(Dw)  Ethernet12(D)
   13  PortChannel13  LACP(A)(Dw)  Ethernet13(D)
   14  PortChannel14  LACP(A)(Dw)  Ethernet14(D)
   15  PortChannel15  LACP(A)(Dw)  Ethernet15(D)
   16  PortChannel16  LACP(A)(Dw)  Ethernet16(D)
   17  PortChannel17  LACP(A)(Dw)  Ethernet17(D)
   18  PortChannel18  LACP(A)(Dw)  Ethernet18(D)
   19  PortChannel19  LACP(A)(Dw)  Ethernet19(D)
   20  PortChannel20  LACP(A)(Dw)  Ethernet20(D)
```



**Details if related**
