### PR TITLE
[teammgrd]: Add retry logic for starting port channel with teamd

### DIFF
--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -37,7 +37,7 @@ private:
     void doLagMemberTask(Consumer &consumer);
     void doPortUpdateTask(Consumer &consumer);
 
-    bool addLag(const string &alias, int min_links, bool fall_back);
+    task_process_status addLag(const string &alias, int min_links, bool fall_back);
     bool removeLag(const string &alias);
     task_process_status addLagMember(const string &lag, const string &member);
     bool removeLagMember(const string &lag, const string &member);


### PR DESCRIPTION
teamd command may fail when failed to allocate memory to create the port
channel. Retry logic make sure the creation will be successful.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>