### PR TITLE
[fdborch] Store vlan id of FDB entry instead of port pvid into stateD…

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -57,12 +57,18 @@ bool FdbOrch::storeFdbEntryState(const FdbUpdate& update)
 {
     const FdbEntry& entry = update.entry;
     const Port& port = update.port;
-    sai_vlan_id_t vlan_id = port.m_port_vlan_id;
     const MacAddress& mac = entry.mac;
     string portName = port.m_alias;
+    Port vlan;
+
+    if (!m_portsOrch->getPort(entry.bv_id, vlan))
+    {
+        SWSS_LOG_NOTICE("FdbOrch notification: Failed to locate vlan port from bv_id 0x%lx", entry.bv_id);
+        return false;
+    }
 
     // ref: https://github.com/Azure/sonic-swss/blob/master/doc/swss-schema.md#fdb_table
-    string key = "Vlan" + to_string(vlan_id) + ":" + mac.to_string();
+    string key = "Vlan" + to_string(vlan.m_vlan_info.vlan_id) + ":" + mac.to_string();
 
     if (update.add)
     {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -668,6 +668,12 @@ class DockerVirtualSwitch(object):
         tbl.set("Vlan" + vlan + "|" + interface, fvs)
         time.sleep(1)
 
+    def create_vlan_member_tagged(self, vlan, interface):
+        tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
+        fvs = swsscommon.FieldValuePairs([("tagging_mode", "tagged")])
+        tbl.set("Vlan" + vlan + "|" + interface, fvs)
+        time.sleep(1)
+
     def set_interface_status(self, interface, admin_status):
         if interface.startswith("PortChannel"):
             tbl_name = "PORTCHANNEL"


### PR DESCRIPTION
…B FDB table.

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**What I did**
Address issue:
https://github.com/Azure/sonic-swss/issues/758

**Why I did it**
For port in tagged vlan,  fdb data stored in stateDB has wrong vlan id.

**How I verified it**
VS test.

**Details if related**
