### PR TITLE
Revert "Fixed ACL IP type parser"

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -216,11 +216,13 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
         }
         else if (attr_name == MATCH_IP_TYPE)
         {
-            if (!processIpType(attr_value, value.aclfield.data.s32))
+            if (!processIpType(attr_value, value.aclfield.data.u32))
             {
                 SWSS_LOG_ERROR("Invalid IP type %s", attr_value.c_str());
                 return false;
             }
+
+            value.aclfield.mask.u32 = 0xFFFFFFFF;
         }
         else if (attr_name == MATCH_TCP_FLAGS)
         {
@@ -363,7 +365,7 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
     return true;
 }
 
-bool AclRule::processIpType(string type, sai_int32_t &ip_type)
+bool AclRule::processIpType(string type, sai_uint32_t &ip_type)
 {
     SWSS_LOG_ENTER();
 

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -164,7 +164,7 @@ public:
     virtual bool validateAddMatch(string attr_name, string attr_value);
     virtual bool validateAddAction(string attr_name, string attr_value) = 0;
     virtual bool validate() = 0;
-    bool processIpType(string type, sai_int32_t &ip_type);
+    bool processIpType(string type, sai_uint32_t &ip_type);
     inline static void setRulePriorities(sai_uint32_t min, sai_uint32_t max)
     {
         m_minPriority = min;


### PR DESCRIPTION
Reverts Azure/sonic-swss#715

This is breaking the VS test for IP_TYPE since it removed the mask field. For "ACL_FIELD_DATA_INT32" (s32) type, sai redis expects a mask. @nazariig, please work with @kcudnik to resolve this

VS Test logs:

```
            elif fv[0] == "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE":
>               assert fv[1] == "SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff"
E               AssertionError: assert 'SAI_ACL_IP_T...fffff96d47560' == 'SAI_ACL_IP_TY...fffffffffffff'
E                 - SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffff96d47560
E                 ?                                        ^^^^^^^^
E                 + SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff
E                 ?                                        ^^^^^^^^

test_acl.py:373: AssertionError
```