### PR TITLE
[portsorch] Don't flap port when setting speed if port is down

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -71,7 +71,8 @@ public:
     int                 m_index = 0;    // PHY_PORT: index
     uint32_t            m_mtu = DEFAULT_MTU;
     uint32_t            m_speed = 0;    // Mbps
-    bool                m_autoneg = 0;
+    bool                m_autoneg = false;
+    bool                m_admin_state_up = false;
     sai_object_id_t     m_port_id = 0;
     sai_port_fec_mode_t m_fec_mode = SAI_PORT_FEC_MODE_NONE;
     VlanInfo            m_vlan_info;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -542,6 +542,25 @@ bool PortsOrch::setPortAdminStatus(sai_object_id_t id, bool up)
     return true;
 }
 
+bool PortsOrch::getPortAdminStatus(sai_object_id_t id, bool &up)
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    attr.id = SAI_PORT_ATTR_ADMIN_STATE;
+
+    sai_status_t status = sai_port_api->get_port_attribute(id, 1, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get admin status for port pid:%lx", id);
+        return false;
+    }
+
+    up = attr.value.booldata;
+
+    return true;
+}
+
 bool PortsOrch::setPortMtu(sai_object_id_t id, sai_uint32_t mtu)
 {
     SWSS_LOG_ENTER();
@@ -1710,45 +1729,43 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     }
                     else
                     {
-                        sai_uint32_t current_speed;
-
                         if (!isSpeedSupported(alias, p.m_port_id, speed))
                         {
                             it++;
                             continue;
                         }
 
-                        if (getPortSpeed(p.m_port_id, current_speed))
+                        if (p.m_admin_state_up)
                         {
-                            if (speed != current_speed)
+                            /* Bring port down before applying speed */
+                            if (!setPortAdminStatus(p.m_port_id, false))
                             {
-                                if (setPortAdminStatus(p.m_port_id, false))
-                                {
-                                    if (setPortSpeed(p.m_port_id, speed))
-                                    {
-                                        SWSS_LOG_NOTICE("Set port %s speed to %u", alias.c_str(), speed);
-                                    }
-                                    else
-                                    {
-                                        SWSS_LOG_ERROR("Failed to set port %s speed to %u", alias.c_str(), speed);
-                                        it++;
-                                        continue;
-                                    }
-                                }
-                                else
-                                {
-                                    SWSS_LOG_ERROR("Failed to set port admin status DOWN to set speed");
-                                    it++;
-                                    continue;
-                                }
+                                SWSS_LOG_ERROR("Failed to set port %s admin status DOWN to set speed", alias.c_str());
+                                it++;
+                                continue;
+                            }
+
+                            p.m_admin_state_up = false;
+                            m_portList[alias] = p;
+
+                            if (!setPortSpeed(p.m_port_id, speed))
+                            {
+                                SWSS_LOG_ERROR("Failed to set port %s speed to %u", alias.c_str(), speed);
+                                it++;
+                                continue;
                             }
                         }
                         else
                         {
-                            SWSS_LOG_ERROR("Failed to get current speed for port %s", alias.c_str());
-                            it++;
-                            continue;
+                            /* Port is already down, setting speed */
+                            if (!setPortSpeed(p.m_port_id, speed))
+                            {
+                                SWSS_LOG_ERROR("Failed to set port %s speed to %u", alias.c_str(), speed);
+                                it++;
+                                continue;
+                            }
                         }
+                        SWSS_LOG_NOTICE("Set port %s speed to %u", alias.c_str(), speed);
                     }
                     m_portList[alias].m_speed = speed;
                 }
@@ -1768,20 +1785,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     else
                     {
                         SWSS_LOG_ERROR("Failed to set port %s MTU to %u", alias.c_str(), mtu);
-                        it++;
-                        continue;
-                    }
-                }
-
-                if (!admin_status.empty())
-                {
-                    if (setPortAdminStatus(p.m_port_id, admin_status == "up"))
-                    {
-                        SWSS_LOG_NOTICE("Set port %s admin status to %s", alias.c_str(), admin_status.c_str());
-                    }
-                    else
-                    {
-                        SWSS_LOG_ERROR("Failed to set port %s admin status to %s", alias.c_str(), admin_status.c_str());
                         it++;
                         continue;
                     }
@@ -1823,6 +1826,23 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     else
                     {
                         SWSS_LOG_ERROR("Failed to set port %s asymmetric PFC to %s", alias.c_str(), pfc_asym.c_str());
+                        it++;
+                        continue;
+                    }
+                }
+
+                /* Last step set port admin status */
+                if (!admin_status.empty() && (p.m_admin_state_up != (admin_status == "up")))
+                {
+                    if (setPortAdminStatus(p.m_port_id, admin_status == "up"))
+                    {
+                        p.m_admin_state_up = (admin_status == "up");
+                        m_portList[alias] = p;
+                        SWSS_LOG_NOTICE("Set port %s admin status to %s", alias.c_str(), admin_status.c_str());
+                    }
+                    else
+                    {
+                        SWSS_LOG_ERROR("Failed to set port %s admin status to %s", alias.c_str(), admin_status.c_str());
                         it++;
                         continue;
                     }
@@ -2389,6 +2409,20 @@ bool PortsOrch::initializePort(Port &port)
     else
     {
         port.m_oper_status = SAI_PORT_OPER_STATUS_DOWN;
+    }
+
+    /* initialize port admin status */
+    if (!getPortAdminStatus(port.m_port_id, port.m_admin_state_up))
+    {
+        SWSS_LOG_ERROR("Failed to get initial port admin status %s", port.m_alias.c_str());
+        return false;
+    }
+
+    /* initialize port admin speed */
+    if (!getPortSpeed(port.m_port_id, port.m_speed))
+    {
+        SWSS_LOG_ERROR("Failed to get initial port admin speed %d", port.m_speed);
+        return false;
     }
 
     /*

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -160,6 +160,7 @@ private:
     bool initPort(const string &alias, const set<int> &lane_set);
 
     bool setPortAdminStatus(sai_object_id_t id, bool up);
+    bool getPortAdminStatus(sai_object_id_t id, bool& up);
     bool setPortMtu(sai_object_id_t id, sai_uint32_t mtu);
     bool setPortPvid (Port &port, sai_uint32_t pvid);
     bool getPortPvid(Port &port, sai_uint32_t &pvid);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When port is already down during speed configuration don't put port down again.
Cache admin status in Port structure, do not set admin port status again if already set.

**Why I did it**
Avoid unnessesary SAI calls. It also had implications on Mellanox fastfast boot solution causing port flapping.

**How I verified it**
Currently VS fails (Check https://github.com/Azure/sonic-sairedis/pull/419)
Verified it is passing all VS tests.
Mannual testing.

**Details if related**
