### PR TITLE
Incremental config add/del of IPv4/IPv6 addr on Loopback0 intf is not working

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -196,10 +196,13 @@ bool IntfMgr::doIntfAddrTask(const vector<string>& keys,
             return false;
         }
 
-        // Set Interface IP except for lo
         if (!is_lo)
         {
             setIntfIp(alias, "add", ip_prefix.to_string(), ip_prefix.isV4());
+        }
+        else
+        {
+            setIntfIp("lo", "add", ip_prefix.to_string(), ip_prefix.isV4());
         }
 
         std::vector<FieldValueTuple> fvVector;
@@ -213,10 +216,13 @@ bool IntfMgr::doIntfAddrTask(const vector<string>& keys,
     }
     else if (op == DEL_COMMAND)
     {
-        // Set Interface IP except for lo
         if (!is_lo)
         {
             setIntfIp(alias, "del", ip_prefix.to_string(), ip_prefix.isV4());
+        }
+        else
+        {
+            setIntfIp("lo", "del", ip_prefix.to_string(), ip_prefix.isV4());
         }
         m_appIntfTableProducer.del(appKey);
         m_stateIntfTable.del(keys[0] + state_db_key_delimiter + keys[1]);


### PR DESCRIPTION
   In intfmgr, add/del the addresses on "lo" interface too.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Intfmgr needs to push the address config into Linux for "lo"

**Why I did it**
The loopback addresses adding via config command are not pushed to Config DB, Linux Stack and to the Hardware

**How I verified it**

root@sonic:/home/admin# config interface Loopback0 ip add 28.28.28.28/32

root@sonic:/home/admin# ip route show table local | grep "dev 28.28.28.28"
local 28.28.28.28 dev lo proto kernel scope host src 28.28.28.28 

root@sonic:/home/admin# config interface Loopback0 ip add 2037::1/128

root@sonic:/home/admin# ip -6 route show | grep 2037::1
unreachable 2037::1 dev lo proto kernel metric 256  error -101 pref medium

root@sonic:/home/admin# show runningconfiguration all | grep Loopback0
        "Loopback0|28.28.28.28/32": {}, 
        "Loopback0|2037::1/128": {}, 

root@sonic:/home/admin# bcmcmd 'l3 defip show'
l3 defip show
Unit 0, Total Number of DEFIP entries: 8192
#     VRF     Net addr             Next Hop Mac        INTF MODID PORT PRIO CLASS HIT VLAN
.....
514   0        28.28.28.28/32       00:00:00:00:00:00 100003    0     0     0    1 n
.....

root@sonic:/home/admin# bcmcmd 'l3 ip6route show'
l3 ip6route show
Unit 0, Total Number of IPv6 entries: 6144 (IPv6/64 4096, IPv6/128 2048)
Max number of ECMP paths 64
Free IPv6 entries available: 6127 (IPv6/64 4087, IPv6/128 2040)
#     VRF     Net addr                                     Next Hop Mac        INTF MODID PORT PRIO CLASS HIT VLAN
....
7     0        2037:0000:0000:0000:0000:0000:0000:0001/128  00:00:00:00:00:00 100003    0     0     0    1 n
....

root@sonic:/home/admin# config interface Loopback0 ip remove 28.28.28.28/32
root@sonic:/home/admin# ip route show table local | grep "28.28.28.28"

root@sonic:/home/admin# config interface Loopback0 ip remove 2037::1/128
root@sonic:/home/admin# ip -6 route show | grep 2037::1
root@sonic:/home/admin# 

**Details if related**
Along with change in cfgmgr/intfmgr.cpp, this issue needed a change in config/main.py in sonic-utilities repo.