### PR TITLE
[vrfmgrd] Fix VRF is not set to VRF_TABLE in APP_DB correctly

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -162,7 +162,7 @@ void VrfMgr::doTask(Consumer &consumer)
             m_stateVrfTable.set(vrfName, fvVector);
 
             SWSS_LOG_NOTICE("Created vrf netdev %s", vrfName.c_str());
-            if (consumer.getTableName() == APP_VRF_TABLE_NAME)
+            if (consumer.getTableName() == CFG_VRF_TABLE_NAME)
             {
                 m_appVrfTableProducer.set(vrfName, kfvFieldsValues(t));
             }
@@ -180,7 +180,7 @@ void VrfMgr::doTask(Consumer &consumer)
 
             m_stateVrfTable.del(vrfName);
 
-            if (consumer.getTableName() == APP_VRF_TABLE_NAME)
+            if (consumer.getTableName() == CFG_VRF_TABLE_NAME)
             {
                 m_appVrfTableProducer.del(vrfName);
             }


### PR DESCRIPTION
    vrfmgrd always set VNET_TABLE in APP_DB whatever the table name is. It should use CFG_VRF_TABLE_NAME instead of APP_VRF_TABLE_NAME to judge which table(Vrf or VNET) to be operated.

Signed-off-by: yorke <yorke.yuan@asterfusion.com>

**What I did**
    Fix bug: vrfmgrd does not read VRF configuration from CONFIG_DB correctly and then it does not add/remove VRF_TABLE in APP_DB.    

**Why I did it**
    vrfmgrd always set VNET_TABLE in APP_DB whatever the table name is. It should use CFG_VRF_TABLE_NAME instead of APP_VRF_TABLE_NAME to judge which table(Vrf or VNET) to be operated.

**How I verified it**
    Add vrf configuration into CONFIG_DB and then can find correct VRF_TABLE in APP_DB. 

    Test configuration likes:
	"VRF": {
		"VRF-red":{}
	}

    Then check the result:
	redis-dump -d 0 -k "VRF*"
	{"VRF_TABLE:VRF-red":{"type":"hash","value":{"NULL":"NULL"}}}