### PR TITLE
On a routing vlan, the neighbor entry in the /31 subnet is not added to hardware

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -158,7 +158,7 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
     addSubnetRoute(port, *ip_prefix);
     addIp2MeRoute(vrf_id, *ip_prefix);
 
-    if (port.m_type == Port::VLAN && ip_prefix->isV4())
+    if (port.m_type == Port::VLAN)
     {
         addDirectedBroadcast(port, *ip_prefix);
     }
@@ -345,7 +345,7 @@ void IntfsOrch::doTask(Consumer &consumer)
                     removeSubnetRoute(port, ip_prefix);
                     removeIp2MeRoute(vrf_id, ip_prefix);
 
-                    if(port.m_type == Port::VLAN && ip_prefix.isV4())
+                    if(port.m_type == Port::VLAN)
                     {
                         removeDirectedBroadcast(port, ip_prefix);
                     }
@@ -630,9 +630,9 @@ void IntfsOrch::addDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix
     sai_neighbor_entry_t neighbor_entry;
     IpAddress ip_addr;
 
-    /* For /31 v4 subnets, there is no broadcast address, hence don't
+    /* For /31 and /32 v4 subnets, there is no broadcast address, hence don't
      * add a broadcast route. */
-    if (ip_prefix.getMaskLength() == 31)
+    if ((ip_prefix.isV4()) && (ip_prefix.getMaskLength() > 30))
     {
       return;
     }
@@ -663,8 +663,8 @@ void IntfsOrch::removeDirectedBroadcast(const Port &port, const IpPrefix &ip_pre
     sai_neighbor_entry_t neighbor_entry;
     IpAddress ip_addr;
 
-    /* For /31 v4 subnets, there is no broadcast address */
-    if (ip_prefix.getMaskLength() == 31)
+    /* For /31 and /32 v4 subnets, there is no broadcast address */
+    if ((ip_prefix.isV4()) && (ip_prefix.getMaskLength() > 30))
     {
         return;
     }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -160,7 +160,12 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
 
     if (port.m_type == Port::VLAN && ip_prefix->isV4())
     {
-        addDirectedBroadcast(port, ip_prefix->getBroadcastIp());
+        /* For /31 IPv4 subnets, there is no broadcast address, hence don't
+         * add a net directed broadcast route specific neighbor entry */
+        if (ip_prefix->getMaskLength() != 31)
+        {
+            addDirectedBroadcast(port, ip_prefix->getBroadcastIp());
+        }
     }
 
     m_syncdIntfses[alias].ip_addresses.insert(*ip_prefix);
@@ -346,7 +351,12 @@ void IntfsOrch::doTask(Consumer &consumer)
                     removeIp2MeRoute(vrf_id, ip_prefix);
                     if(port.m_type == Port::VLAN && ip_prefix.isV4())
                     {
-                        removeDirectedBroadcast(port, ip_prefix.getBroadcastIp());
+                        /* For /31 IPv4 subnets, there is no net directed broadcast route
+                         * specific neighbor entry that was added */
+                        if (ip_prefix.getMaskLength() != 31)
+                        {
+                            removeDirectedBroadcast(port, ip_prefix.getBroadcastIp());
+                        }
                     }
 
                     m_syncdIntfses[alias].ip_addresses.erase(ip_prefix);

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -630,9 +630,9 @@ void IntfsOrch::addDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix
     sai_neighbor_entry_t neighbor_entry;
     IpAddress ip_addr;
 
-    /* For /31 and /32 v4 subnets, there is no broadcast address, hence don't
+    /* If not IPv4 subnet or if /31 or /32 subnet, there is no broadcast address, hence don't
      * add a broadcast route. */
-    if ((ip_prefix.isV4()) && (ip_prefix.getMaskLength() > 30))
+    if (!(ip_prefix.isV4()) || (ip_prefix.getMaskLength() > 30))
     {
       return;
     }
@@ -663,8 +663,8 @@ void IntfsOrch::removeDirectedBroadcast(const Port &port, const IpPrefix &ip_pre
     sai_neighbor_entry_t neighbor_entry;
     IpAddress ip_addr;
 
-    /* For /31 and /32 v4 subnets, there is no broadcast address */
-    if ((ip_prefix.isV4()) && (ip_prefix.getMaskLength() > 30))
+    /* If not IPv4 subnet or if /31 or /32 subnet, there is no broadcast address */
+    if (!(ip_prefix.isV4()) || (ip_prefix.getMaskLength() > 30))
     {
         return;
     }

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -52,8 +52,8 @@ private:
     void addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
     void removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
 
-    void addDirectedBroadcast(const Port &port, const IpAddress &ip_addr);
-    void removeDirectedBroadcast(const Port &port, const IpAddress &ip_addr);
+    void addDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix);
+    void removeDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix);
 };
 
 #endif /* SWSS_INTFSORCH_H */


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Don't add broadcast ip specific neighbor entry for the /31 subnet routing vlan.

**Why I did it**
In intfsorch code, it is creating neighbor entry for net directed broadcast address for a Routing VLAN when the routing VLAN interface is created. 
In case of /31 subnets there is no broadcast IP as (last 32nd bit) .0 and .1 corresponding to the only 2 hosts in the subnet. When adding neighbor entry for the .1 host, it is conflicting with the neighbor entry created for the directed broadcast IP and hence it throws the below error. As a result the .1 neighbor entry is not added to the hardware. 

Dec 8 19:15:55.732017 sonic ERR swss#orchagent: :- meta_sai_validate_neighbor_entry: object key SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{"ip":"12.12.1.1","rif":"oid:0x6000000000606","switch_id":"oid:0x21000000000000"} already exists 
Dec 8 19:15:55.732075 sonic DEBUG swss#orchagent: :< meta_sai_validate_neighbor_entry: exit 
Dec 8 19:15:55.732131 sonic DEBUG swss#orchagent: :< meta_sai_create_neighbor_entry: exit 
Dec 8 19:15:55.732189 sonic DEBUG swss#orchagent: :< redis_create_neighbor_entry: exit 
Dec 8 19:15:55.732245 sonic ERR swss#orchagent: :- addNeighbor: Failed to create neighbor 00:0c:9f:01:02:03 on Vlan900, rv:-6 

**How I verified it**
Have back to back nodes, and configure /31 subnet on both (for eg., 12.1.1.0/31 and 12.1.1.1/31). Ping the /31 peer address (12.1.1.1)
Check that the host entry for 12.1.1.1 is added in the hardware host table.

**Details if related**
