### PR TITLE
[vstest]: fix test_port_an_warm.py test

### DIFF
--- a/tests/test_port_an_warm.py
+++ b/tests/test_port_an_warm.py
@@ -12,9 +12,9 @@ def test_PortAutoNeg_warm(dvs, testlog):
     ctbl = swsscommon.Table(cdb, "PORT")
     stbl = swsscommon.Table(sdb, "PORT_TABLE")
 
-    # set autoneg = false and speed = 1000
+    # set autoneg = true and speed = 1000
     fvs = swsscommon.FieldValuePairs([("autoneg","1"), ("speed", "1000")])
-    tbl.set("Ethernet0", fvs)
+    ctbl.set("Ethernet0", fvs)
 
     time.sleep(1)
 
@@ -35,7 +35,7 @@ def test_PortAutoNeg_warm(dvs, testlog):
     # set speed = 100
     fvs = swsscommon.FieldValuePairs([("speed", "100")])
 
-    tbl.set("Ethernet0", fvs)
+    ctbl.set("Ethernet0", fvs)
 
     time.sleep(1)
 


### PR DESCRIPTION
the test should set the speed and autoneg in config db instead
of application db. As if the speed in config db is not changed,
it will override the value in app db after warm reboot

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
