### PR TITLE
[watermarkorch] only perform periodic clear if the polling is on

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -148,7 +148,12 @@ bool OrchDaemon::init()
         CFG_DTEL_EVENT_TABLE_NAME
     };
 
-    WatermarkOrch *wm_orch = new WatermarkOrch(m_configDb, CFG_WATERMARK_TABLE_NAME);
+    vector<string> wm_tables = {
+        CFG_WATERMARK_TABLE_NAME,
+        CFG_FLEX_COUNTER_TABLE_NAME
+    };
+
+    WatermarkOrch *wm_orch = new WatermarkOrch(m_configDb, wm_tables);
 
     /*
      * The order of the orch list is important for state restore of warm start and

--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -36,8 +36,6 @@ WatermarkOrch::WatermarkOrch(DBConnector *db, const vector<string> &tables):
     m_telemetryTimer = new SelectableTimer(intervT);
     auto executorT = new ExecutableTimer(m_telemetryTimer, this, "WM_TELEMETRY_TIMER");
     Orch::addExecutor(executorT);
-
-    m_telemetryInterval = DEFAULT_TELEMETRY_INTERVAL;
 }
 
 WatermarkOrch::~WatermarkOrch()
@@ -95,7 +93,9 @@ void WatermarkOrch::handleWmConfigUpdate(const std::string &key, const std::vect
         {
             if (i.first == "interval")
             {
-                m_telemetryInterval = to_uint<uint32_t>(i.second.c_str());
+                auto intervT = timespec { .tv_sec = to_uint<uint32_t>(i.second.c_str()) , .tv_nsec = 0 };
+                m_telemetryTimer->setInterval(intervT);
+
             }
             else
             {
@@ -205,8 +205,6 @@ void WatermarkOrch::doTask(SelectableTimer &timer)
          * if it is disabled we will not restart the timer at the end of current interval */
         if (m_isTimerEnabled)
         {
-            auto intervT = timespec { .tv_sec = m_telemetryInterval , .tv_nsec = 0 };
-            m_telemetryTimer->setInterval(intervT);
             m_telemetryTimer->reset();
         }
 

--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -96,7 +96,8 @@ void WatermarkOrch::handleWmConfigUpdate(const std::string &key, const std::vect
             {
                 auto intervT = timespec { .tv_sec = to_uint<uint32_t>(i.second.c_str()) , .tv_nsec = 0 };
                 m_telemetryTimer->setInterval(intervT);
-
+                // reset the timer interval when current timer expires
+                m_timerChanged = true;
             }
             else
             {
@@ -221,6 +222,11 @@ void WatermarkOrch::doTask(SelectableTimer &timer)
 
     if (&timer == m_telemetryTimer)
     {
+        if (m_timerChanged)
+        {
+            m_telemetryTimer->reset();
+            m_timerChanged = false;
+        }
         if (!m_wmStatus)
         {
             m_telemetryTimer->stop();

--- a/orchagent/watermarkorch.h
+++ b/orchagent/watermarkorch.h
@@ -53,6 +53,7 @@ private:
     [0] - queue wm status (least significant bit) 
     */
     uint8_t m_wmStatus = 0;
+    bool m_timerChanged = false;
 
     shared_ptr<DBConnector> m_countersDb = nullptr;
     shared_ptr<DBConnector> m_appDb = nullptr;

--- a/orchagent/watermarkorch.h
+++ b/orchagent/watermarkorch.h
@@ -36,8 +36,14 @@ public:
         return m_countersDb;
     }
 
+    bool isTimerEnabled()
+    {
+        return m_qWmEnabled || m_pgWmEnabled;
+    }
+
 private:
-    bool m_isTimerEnabled = false;
+    bool m_qWmEnabled = false;
+    bool m_pgWmEnabled = false;
 
     shared_ptr<DBConnector> m_countersDb = nullptr;
     shared_ptr<DBConnector> m_appDb = nullptr;

--- a/orchagent/watermarkorch.h
+++ b/orchagent/watermarkorch.h
@@ -11,7 +11,7 @@
 class WatermarkOrch : public Orch
 {
 public:
-    WatermarkOrch(DBConnector *db, const std::string tableName);
+    WatermarkOrch(DBConnector *db, const vector<string> &tables);
     virtual ~WatermarkOrch(void);
 
     void doTask(Consumer &consumer);
@@ -20,6 +20,9 @@ public:
 
     void init_pg_ids();
     void init_queue_ids();
+
+    void handleWmConfigUpdate(const std::string &key, const std::vector<FieldValueTuple> &fvt);
+    void handleFcConfigUpdate(const std::string &key, const std::vector<FieldValueTuple> &fvt);
 
     void clearSingleWm(Table *table, string wm_name, vector<sai_object_id_t> &obj_ids);
 
@@ -34,6 +37,8 @@ public:
     }
 
 private:
+    bool m_isTimerEnabled = false;
+
     shared_ptr<DBConnector> m_countersDb = nullptr;
     shared_ptr<DBConnector> m_appDb = nullptr;
     shared_ptr<Table> m_countersTable = nullptr;

--- a/orchagent/watermarkorch.h
+++ b/orchagent/watermarkorch.h
@@ -1,12 +1,22 @@
 #ifndef WATERMARKORCH_H
 #define WATERMARKORCH_H
 
+#include <map>
+
 #include "orch.h"
 #include "port.h"
 
 #include "notificationconsumer.h"
 #include "timer.h"
 
+const uint8_t queue_wm_status_mask = 1 << 0;
+const uint8_t pg_wm_status_mask = 1 << 1;
+
+static const map<string, const uint8_t> groupToMask =
+{
+    { "QUEUE_WATERMARK",     queue_wm_status_mask },
+    { "PG_WATERMARK",        pg_wm_status_mask }
+};
 
 class WatermarkOrch : public Orch
 {
@@ -36,14 +46,13 @@ public:
         return m_countersDb;
     }
 
-    bool isTimerEnabled()
-    {
-        return m_qWmEnabled || m_pgWmEnabled;
-    }
-
 private:
-    bool m_qWmEnabled = false;
-    bool m_pgWmEnabled = false;
+    /*
+    [7-2] - unused
+    [1] - pg wm status
+    [0] - queue wm status (least significant bit) 
+    */
+    uint8_t m_wmStatus = 0;
 
     shared_ptr<DBConnector> m_countersDb = nullptr;
     shared_ptr<DBConnector> m_appDb = nullptr;

--- a/orchagent/watermarkorch.h
+++ b/orchagent/watermarkorch.h
@@ -52,8 +52,6 @@ private:
     vector<sai_object_id_t> m_unicast_queue_ids;
     vector<sai_object_id_t> m_multicast_queue_ids;
     vector<sai_object_id_t> m_pg_ids;
-
-    int m_telemetryInterval;
 };
 
 #endif // WATERMARKORCH_H


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>
No need to periodically clear watermarks if the polling is disabled.


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Changes:
 - make watermarkorch aware of Flex Counter config
 - enable/disable periodic timer based on Flex Counter status of watermarks. 
**Why I did it**

**How I verified it**
```
 # config watermark telemetry interval 10

Apr 25 13:02:21.782115 sonic DEBUG swss#orchagent: :- doTask: Periodic watermark cleared by timer!
Apr 25 13:02:31.762604 sonic DEBUG swss#orchagent: :- doTask: Periodic watermark cleared by timer!
Apr 25 13:02:41.772739 sonic DEBUG swss#orchagent: :- doTask: Periodic watermark cleared by timer!

 # config watermark telemetry interval 15

Apr 25 13:02:51.756292 sonic DEBUG swss#orchagent: :- doTask: Periodic watermark cleared by timer!
Apr 25 13:03:06.765902 sonic DEBUG swss#orchagent: :- doTask: Periodic watermark cleared by timer!

 # counterpoll watermark disable

Apr 25 13:03:21.743069 sonic DEBUG swss#orchagent: :- doTask: Periodic watermark cleared by timer!

 # counterpoll watermark enable

Apr 25 13:07:31.556155 sonic DEBUG swss#orchagent: :- doTask: Periodic watermark cleared by timer!

 # counterpoll watermark enable
 # counterpoll watermark enable
 # counterpoll watermark enable

Apr 25 13:07:46.547644 sonic DEBUG swss#orchagent: :- doTask: Periodic watermark cleared by timer!
```
****


**Details if related**
