### PR TITLE
If no lanes info exists in configDB for any port, use PortConfigFile

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -195,6 +195,17 @@ bool handlePortConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb, boo
 
     for ( auto &k : keys )
     {
+        // if any port doesn't have lanes data, return false and try from PortConfigFile
+        std::string lanes;
+        if (!table.hget(k, "lanes", lanes))
+        {
+            cout << "To use port configuration file, no port lanes configuration in ConfigDB for " << k << endl;
+            return false;
+        }
+    }
+
+    for ( auto &k : keys )
+    {
         table.get(k, ovalues);
         vector<FieldValueTuple> attrs;
         for ( auto &v : ovalues )


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
Fall back to port config file if no lane info is found for port in configDB.

**Why I did it**

Lane info is not transferred from port config file to configDB automatically, and user may not do that in most cases except for dynamic port break out which is not available in SONiC yet.

**How I verified it**

**Details if related**
