### PR TITLE
On a routing vlan, the neighbor entry in the /31 subnet is not added …

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -282,7 +282,7 @@ void IntfsOrch::doTask(Consumer &consumer)
 
             if (port.m_type == Port::VLAN && ip_prefix.isV4())
             {
-                addDirectedBroadcast(port, ip_prefix.getBroadcastIp());
+                addDirectedBroadcast(port, ip_prefix);
             }
 
             m_syncdIntfses[alias].ip_addresses.insert(ip_prefix);

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -325,9 +325,10 @@ void IntfsOrch::doTask(Consumer &consumer)
                 {
                     removeSubnetRoute(port, ip_prefix);
                     removeIp2MeRoute(vrf_id, ip_prefix);
-                    if(port.m_type == Port::VLAN && ip_prefix.isV4())
+
+                    if(port.m_type == Port::VLAN)
                     {
-                        removeDirectedBroadcast(port, ip_prefix.getBroadcastIp());
+                        removeDirectedBroadcast(port, ip_prefix);
                     }
 
                     m_syncdIntfses[alias].ip_addresses.erase(ip_prefix);
@@ -604,10 +605,20 @@ void IntfsOrch::removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_pref
     }
 }
 
-void IntfsOrch::addDirectedBroadcast(const Port &port, const IpAddress &ip_addr)
+void IntfsOrch::addDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix)
 {
     sai_status_t status;
     sai_neighbor_entry_t neighbor_entry;
+    IpAddress ip_addr;
+
+    /* If not IPv4 subnet or if /31 or /32 subnet, there is no broadcast address, hence don't
+     * add a broadcast route. */
+    if (!(ip_prefix.isV4()) || (ip_prefix.getMaskLength() > 30))
+    {
+      return;
+    }
+    ip_addr =  ip_prefix.getBroadcastIp();
+
     neighbor_entry.rif_id = port.m_rif_id;
     neighbor_entry.switch_id = gSwitchId;
     copy(neighbor_entry.ip_address, ip_addr);
@@ -627,10 +638,19 @@ void IntfsOrch::addDirectedBroadcast(const Port &port, const IpAddress &ip_addr)
     SWSS_LOG_NOTICE("Add broadcast route for ip:%s", ip_addr.to_string().c_str());
 }
 
-void IntfsOrch::removeDirectedBroadcast(const Port &port, const IpAddress &ip_addr)
+void IntfsOrch::removeDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix)
 {
     sai_status_t status;
     sai_neighbor_entry_t neighbor_entry;
+    IpAddress ip_addr;
+
+    /* If not IPv4 subnet or if /31 or /32 subnet, there is no broadcast address */
+    if (!(ip_prefix.isV4()) || (ip_prefix.getMaskLength() > 30))
+    {
+        return;
+    }
+    ip_addr =  ip_prefix.getBroadcastIp();
+
     neighbor_entry.rif_id = port.m_rif_id;
     neighbor_entry.switch_id = gSwitchId;
     copy(neighbor_entry.ip_address, ip_addr);

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -51,8 +51,8 @@ private:
     void addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
     void removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
 
-    void addDirectedBroadcast(const Port &port, const IpAddress &ip_addr);
-    void removeDirectedBroadcast(const Port &port, const IpAddress &ip_addr);
+    void addDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix);
+    void removeDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix);
 };
 
 #endif /* SWSS_INTFSORCH_H */


### PR DESCRIPTION
**What I did**
Cherry-pick PR771 into 201811 branch and resolve merge conflict.
Method IntfsOrch::setIntf() is not defined in 201811 branch. Removed change in this method.