### PR TITLE
Move warm_restart enable/disable config to stateDB WARM_RESTART_ENABL…

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -695,10 +695,6 @@ Stores information for physical switch ports managed by the switch chip. Ports t
 
     key                 = WARM_RESTART:name ; name is the name of SONiC docker or "system" for global configuration.
 
-    enable              = "true" / "false"  ; Default value as false.
-                                            ; If "system" warm start knob is true, docker level knob will be ignored.
-                                            ; If "system" warm start knob is false, docker level knob takes effect.
-
     neighsyncd_timer    = 1*4DIGIT          ; neighsyncd_timer is the timer used for neighsyncd during the warm restart.
                                             ; Timer is started after we restored the neighborTable to internal data structures.
                                             ; neighborsyncd then starts to read all linux kernel entries and mark the entries in
@@ -715,8 +711,8 @@ Stores information for physical switch ports managed by the switch chip. Ports t
                                             ; Supported range: 1-3600.
 
     teamsyncd_timer     = 1*4DIGIT          ; teamsyncd_timer holds the time interval utilized by teamsyncd during warm-restart episodes.
-                                            ; The timer is started when teamsyncd starts. During the timer interval teamsyncd 
-                                            ; will preserver all LAG interface changes, but it will not apply them. The changes 
+                                            ; The timer is started when teamsyncd starts. During the timer interval teamsyncd
+                                            ; will preserver all LAG interface changes, but it will not apply them. The changes
                                             ; will only be applied when the timer expired. During the changes application the stale
                                             ; LAG entries will be removed, the new LAG entries will be created.
                                             ; Supported range: 1-9999. 0 is invalid
@@ -761,6 +757,17 @@ Stores information for physical switch ports managed by the switch chip. Ports t
     ;State for management port, including at least one key
     key                 = MGMT_PORT_TABLE|ifname    ; ifname must be unique across PORT,INTF,VLAN,LAG TABLES
     oper_status         = "down" / "up" ; oper status
+
+### WARM\_RESTART\_ENABLE\_TABLE
+    ;Stores system warm start and docker warm start enable/disable configuration
+    ;The configuration is persistent across warm reboot but not cold reboot.
+    ;Status: work in progress
+
+    key                 = WARM_RESTART_ENABLE_TABLE:name ; name is the name of SONiC docker or "system" for global configuration.
+
+    enable              = "true" / "false"  ; Default value as false.
+                                            ; If "system" warm start knob is true, docker level knob will be ignored.
+                                            ; If "system" warm start knob is false, docker level knob takes effect.
 
 ### WARM\_RESTART\_TABLE
     ;Stores application and orchdameon warm start status

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -948,19 +948,6 @@ def set_restart_timer(dvs, db, app_name, value):
         ]
     )
 
-
-# Temporary instruction to activate warm_restart. To be deleted once equivalent CLI
-# function is pushed to sonic-utils.
-def enable_warmrestart(dvs, db, app_name):
-    create_entry_tbl(
-        db,
-        swsscommon.CFG_WARM_RESTART_TABLE_NAME, app_name,
-        [
-            ("enable", "true"),
-        ]
-    )
-
-
 ################################################################################
 #
 # Routing warm-restart testcases
@@ -1097,10 +1084,9 @@ def test_routing_WarmRestart(dvs, testlog):
     # Enabling bgp warmrestart and setting restart timer.
     # The following two instructions will be substituted by the commented ones
     # once the later ones are added to sonic-utilities repo.
-    enable_warmrestart(dvs, conf_db, "bgp")
-    set_restart_timer(dvs, conf_db, "bgp", str(restart_timer))
-    #dvs.runcmd("config warm_restart enable bgp")
-    #dvs.runcmd("config warm_restart bgp_timer {}".format(restart_timer))
+
+    dvs.runcmd("config warm_restart enable bgp")
+    dvs.runcmd("config warm_restart bgp_timer {}".format(restart_timer))
 
     time.sleep(1)
 


### PR DESCRIPTION
…E_TABLE

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


Prerequisite PR: 
https://github.com/Azure/sonic-swss-common/pull/260
https://github.com/Azure/sonic-utilities/pull/458

**What I did**


For warm_restart enable/disable configuration,  putting them into configDB caused confusion in configuration save and restore. They are not supposed to be persistent across cold boot. Moving them to stateDB which will be saved and restored during warm reboot.

https://github.com/Azure/sonic-swss-common/pull/260

https://github.com/Azure/sonic-swss/pull/786

https://github.com/Azure/sonic-sairedis/pull/418

https://github.com/Azure/sonic-utilities/pull/458

https://github.com/Azure/sonic-buildimage/pull/2538

**Why I did it**

**How I verified it**

**Details if related**
