### PR TITLE
Create egress ACL table group during the PFCWD stats list installment

### DIFF
--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -526,9 +526,9 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
                 sai_serialize_object_id(queueId));
     }
 
-    // Create egress table group for each port of pfcwd's interest
-    sai_object_id_t group_member_oid;
-    gPortsOrch->bindAclTable(port.m_port_id, SAI_NULL_OBJECT_ID, group_member_oid, ACL_STAGE_EGRESS);
+    // Create egress ACL table group for each port of pfcwd's interest
+    sai_object_id_t group_oid;
+    gPortsOrch->bindAclTableGroup(port.m_port_id, group_oid, ACL_STAGE_EGRESS);
 }
 
 template <typename DropHandler, typename ForwardHandler>

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -525,6 +525,10 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
                 PfcWdOrch<DropHandler, ForwardHandler>::getCountersTable(),
                 sai_serialize_object_id(queueId));
     }
+
+    // Create egress table group for each port of pfcwd's interest
+    sai_object_id_t group_member_oid;
+    gPortsOrch->bindAclTable(port.m_port_id, SAI_NULL_OBJECT_ID, group_member_oid, ACL_STAGE_EGRESS);
 }
 
 template <typename DropHandler, typename ForwardHandler>

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -527,8 +527,8 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
     }
 
     // Create egress ACL table group for each port of pfcwd's interest
-    sai_object_id_t group_oid;
-    gPortsOrch->bindAclTableGroup(port.m_port_id, group_oid, ACL_STAGE_EGRESS);
+    sai_object_id_t groupId;
+    gPortsOrch->createBindAclTableGroup(port.m_port_id, groupId, ACL_STAGE_EGRESS);
 }
 
 template <typename DropHandler, typename ForwardHandler>

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -855,6 +855,12 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
         SWSS_LOG_NOTICE("Create ACL table group and bind port %s to it", port.m_alias.c_str());
     }
 
+    if (table_oid == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_NOTICE("Invalid ACL table %lx; Drop member creation in ACL table group %lx", table_oid, groupOid);
+        return false;
+    }
+
     // Create an ACL group member with table_oid and groupOid
     vector<sai_attribute_t> member_attrs;
 
@@ -874,8 +880,8 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
     status = sai_acl_api->create_acl_table_group_member(&group_member_oid, gSwitchId, (uint32_t)member_attrs.size(), member_attrs.data());
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to create member in ACL table group %lx for ACL table group %lx, rv:%d",
-                table_oid, groupOid, status);
+        SWSS_LOG_ERROR("Failed to create member in ACL table group %lx for ACL table %lx, rv:%d",
+                groupOid, table_oid, status);
         return false;
     }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -706,18 +706,15 @@ bool PortsOrch::setPortPfcAsym(Port &port, string pfc_asym)
     return true;
 }
 
-bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_object_id_t &group_member_oid, acl_stage_type_t acl_stage)
+bool PortsOrch::bindAclTableGroup(sai_object_id_t id, sai_object_id_t &group_oid, acl_stage_type_t acl_stage)
 {
     SWSS_LOG_ENTER();
 
     if (acl_stage == ACL_STAGE_UNKNOWN)
     {
-        SWSS_LOG_ERROR("Unknown ACL stage for ACL table %lx", table_oid);
+        SWSS_LOG_ERROR("unknown ACL stage for table group creation");
         return false;
     }
-
-    sai_status_t status;
-    sai_object_id_t groupOid;
 
     Port port;
     if (!getPort(id, port))
@@ -726,15 +723,16 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
         return false;
     }
 
-    if (acl_stage == ACL_STAGE_INGRESS && port.m_ingress_acl_table_group_id != 0)
+    sai_status_t status;
+    if ((acl_stage == ACL_STAGE_INGRESS) && (port.m_ingress_acl_table_group_id != 0))
     {
-        groupOid = port.m_ingress_acl_table_group_id;
+        group_oid = port.m_ingress_acl_table_group_id;
     }
-    else if (acl_stage == ACL_STAGE_EGRESS && port.m_egress_acl_table_group_id != 0)
+    else if ((acl_stage == ACL_STAGE_EGRESS) && (port.m_egress_acl_table_group_id != 0))
     {
-        groupOid = port.m_egress_acl_table_group_id;
+        group_oid = port.m_egress_acl_table_group_id;
     }
-    // If port ACL table group does not exist, create one
+    // Port ACL table group does not exist, create one
     else if (acl_stage == ACL_STAGE_INGRESS or acl_stage == ACL_STAGE_EGRESS)
     {
         bool ingress = acl_stage == ACL_STAGE_INGRESS ? true : false;
@@ -775,7 +773,7 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
         group_attr.value.s32 = SAI_ACL_TABLE_GROUP_TYPE_PARALLEL;
         group_attrs.push_back(group_attr);
 
-        status = sai_acl_api->create_acl_table_group(&groupOid, gSwitchId, (uint32_t)group_attrs.size(), group_attrs.data());
+        status = sai_acl_api->create_acl_table_group(&group_oid, gSwitchId, (uint32_t)group_attrs.size(), group_attrs.data());
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create ACL table group, rv:%d", status);
@@ -784,11 +782,11 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
 
         if (ingress)
         {
-            port.m_ingress_acl_table_group_id = groupOid;
+            port.m_ingress_acl_table_group_id = group_oid;
         }
         else
         {
-            port.m_egress_acl_table_group_id = groupOid;
+            port.m_egress_acl_table_group_id = group_oid;
         }
 
         setPort(port.m_alias, port);
@@ -802,13 +800,13 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
                 // Bind this ACL group to physical port
                 sai_attribute_t port_attr;
                 port_attr.id = ingress ? SAI_PORT_ATTR_INGRESS_ACL : SAI_PORT_ATTR_EGRESS_ACL;
-                port_attr.value.oid = groupOid;
+                port_attr.value.oid = group_oid;
 
                 status = sai_port_api->set_port_attribute(port.m_port_id, &port_attr);
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("Failed to bind port %s to ACL table group %lx, rv:%d",
-                            port.m_alias.c_str(), groupOid, status);
+                            port.m_alias.c_str(), group_oid, status);
                     return status;
                 }
                 break;
@@ -818,13 +816,13 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
                 // Bind this ACL group to LAG
                 sai_attribute_t lag_attr;
                 lag_attr.id = ingress ? SAI_LAG_ATTR_INGRESS_ACL : SAI_LAG_ATTR_EGRESS_ACL;
-                lag_attr.value.oid = groupOid;
+                lag_attr.value.oid = group_oid;
 
                 status = sai_lag_api->set_lag_attribute(port.m_lag_id, &lag_attr);
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("Failed to bind LAG %s to ACL table group %lx, rv:%d",
-                            port.m_alias.c_str(), groupOid, status);
+                            port.m_alias.c_str(), group_oid, status);
                     return status;
                 }
                 break;
@@ -834,13 +832,13 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
                 // Bind this ACL group to VLAN
                 sai_attribute_t vlan_attr;
                 vlan_attr.id = ingress ? SAI_VLAN_ATTR_INGRESS_ACL : SAI_VLAN_ATTR_EGRESS_ACL;
-                vlan_attr.value.oid = groupOid;
+                vlan_attr.value.oid = group_oid;
 
                 status = sai_vlan_api->set_vlan_attribute(port.m_vlan_info.vlan_oid, &vlan_attr);
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("Failed to bind VLAN %s to ACL table group %lx, rv:%d",
-                            port.m_alias.c_str(), groupOid, status);
+                            port.m_alias.c_str(), group_oid, status);
                     return status;
                 }
                 break;
@@ -855,9 +853,20 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
         SWSS_LOG_NOTICE("Create ACL table group and bind port %s to it", port.m_alias.c_str());
     }
 
-    if (table_oid == SAI_NULL_OBJECT_ID)
+    return true;
+}
+
+bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_object_id_t &group_member_oid, acl_stage_type_t acl_stage)
+{
+    SWSS_LOG_ENTER();
+
+    sai_status_t status;
+    sai_object_id_t groupOid;
+
+    // Create an ACL table group and bind to port
+    if (!bindAclTableGroup(id, groupOid, acl_stage))
     {
-        SWSS_LOG_NOTICE("Invalid ACL table %lx; Drop member creation in ACL table group %lx", table_oid, groupOid);
+        SWSS_LOG_ERROR("Fail to create or bind to port %lx ACL table group", id);
         return false;
     }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -706,7 +706,7 @@ bool PortsOrch::setPortPfcAsym(Port &port, string pfc_asym)
     return true;
 }
 
-bool PortsOrch::bindAclTableGroup(sai_object_id_t id, sai_object_id_t &group_oid, acl_stage_type_t acl_stage)
+bool PortsOrch::createBindAclTableGroup(sai_object_id_t id, sai_object_id_t &group_oid, acl_stage_type_t acl_stage)
 {
     SWSS_LOG_ENTER();
 
@@ -864,7 +864,7 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
     sai_object_id_t groupOid;
 
     // Create an ACL table group and bind to port
-    if (!bindAclTableGroup(id, groupOid, acl_stage))
+    if (!createBindAclTableGroup(id, groupOid, acl_stage))
     {
         SWSS_LOG_ERROR("Fail to create or bind to port %lx ACL table group", id);
         return false;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -860,6 +860,12 @@ bool PortsOrch::bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_
 {
     SWSS_LOG_ENTER();
 
+    if (table_oid == SAI_NULL_OBJECT_ID)
+    {
+        SWSS_LOG_ERROR("Invalid ACL table %lx", table_oid);
+        return false;
+    }
+
     sai_status_t status;
     sai_object_id_t groupOid;
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -73,7 +73,7 @@ public:
 
     bool setHostIntfsOperStatus(const Port& port, bool up) const;
     void updateDbPortOperStatus(const Port& port, sai_port_oper_status_t status) const;
-    bool bindAclTableGroup(sai_object_id_t id, sai_object_id_t &group_oid, acl_stage_type_t acl_stage = ACL_STAGE_EGRESS);
+    bool createBindAclTableGroup(sai_object_id_t id, sai_object_id_t &group_oid, acl_stage_type_t acl_stage = ACL_STAGE_EGRESS);
     bool bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_object_id_t &group_member_oid, acl_stage_type_t acl_stage = ACL_STAGE_INGRESS);
 
     bool getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -73,6 +73,7 @@ public:
 
     bool setHostIntfsOperStatus(const Port& port, bool up) const;
     void updateDbPortOperStatus(const Port& port, sai_port_oper_status_t status) const;
+    bool bindAclTableGroup(sai_object_id_t id, sai_object_id_t &group_oid, acl_stage_type_t acl_stage = ACL_STAGE_EGRESS);
     bool bindAclTable(sai_object_id_t id, sai_object_id_t table_oid, sai_object_id_t &group_member_oid, acl_stage_type_t acl_stage = ACL_STAGE_INGRESS);
 
     bool getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask);


### PR DESCRIPTION
Signed-off-by: Wenda <wenni@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
On the PFCWD stats list installment, create egress ACL table group for each port and bind to it.

**Why I did it**
In pfc watchdog warm-reboot, we find that brcm sai not supporting ACL table group port unbind yet. If pfc storm ever occurred on a port, egress ACL table group will be created and bound to the port, and persist the association with the port even after the storm is restored. In the situation that there is restored but not ongoing pfc storm before warm-reboot, egress table group will not be created in view after warm-reboot. Syncd comparison logic will see the difference, and remove the egress ACL table group object from the port, the underlying unbind operation of which is not supported in brcm sai yet.

We use the workaround solution that we created egress table group proactively for all ports under PFCWD's surveillance so that syncd will not see the difference post warm-reboot even if pfc storm ever occurs on a port.

**How I verified it**

**Details if related**
