### PR TITLE
Potential fix for timing issue in warm_reboot's routing UT

### DIFF
--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -967,8 +967,7 @@ def enable_warmrestart(dvs, db, app_name):
 #
 ################################################################################
 
-# TODO: Please fix this test case. Here temporarily skip to unblock other pull requests
-@pytest.mark.skip(reason="Suspected unstable test code")
+
 def test_routing_WarmRestart(dvs, testlog):
 
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
@@ -976,7 +975,7 @@ def test_routing_WarmRestart(dvs, testlog):
     state_db = swsscommon.DBConnector(swsscommon.STATE_DB, dvs.redis_sock, 0)
 
     # Restart-timer to utilize during the following testcases
-    restart_timer = 10
+    restart_timer = 15
 
 
     #############################################################################


### PR DESCRIPTION
Goal with this one is to reactivate the unit-tests written as part of the routing warm-reboot effort. There seems to be a timing issue behind the sporadic failure seen during the execution of Testcase-15. I'm adjusting the restart_timer value that i'm using in these testcases to see if that fixes the issue. Notice that i'm unable to reproduce this problem in my testbed, so i'm hoping to be able to run various jenkin's testing-cycles before merging this PR.