### PR TITLE
Remove try/catch for correct coredump file

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -275,24 +275,22 @@ int main(int argc, char **argv)
 
     auto orchDaemon = make_shared<OrchDaemon>(&appl_db, &config_db, &state_db);
 
+    if (!orchDaemon->init())
     {
-        if (!orchDaemon->init())
-        {
-            SWSS_LOG_ERROR("Failed to initialize orchstration daemon");
-            exit(EXIT_FAILURE);
-        }
-
-        /*
-        * In syncd view comparison solution, apply view has been sent
-        * immediately after restore is done
-        */
-        if (!WarmStart::isWarmStart())
-        {
-            syncd_apply_view();
-        }
-
-        orchDaemon->start();
+        SWSS_LOG_ERROR("Failed to initialize orchstration daemon");
+        exit(EXIT_FAILURE);
     }
+
+    /*
+    * In syncd view comparison solution, apply view has been sent
+    * immediately after restore is done
+    */
+    if (!WarmStart::isWarmStart())
+    {
+        syncd_apply_view();
+    }
+
+    orchDaemon->start();
 
     return 0;
 }

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -275,7 +275,6 @@ int main(int argc, char **argv)
 
     auto orchDaemon = make_shared<OrchDaemon>(&appl_db, &config_db, &state_db);
 
-    try
     {
         if (!orchDaemon->init())
         {
@@ -293,14 +292,6 @@ int main(int argc, char **argv)
         }
 
         orchDaemon->start();
-    }
-    catch (char const *e)
-    {
-        SWSS_LOG_ERROR("Exception: %s", e);
-    }
-    catch (exception& e)
-    {
-        SWSS_LOG_ERROR("Failed due to exception: %s", e.what());
     }
 
     return 0;


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**

This is a try to work around the coredump create issue:  https://github.com/Azure/sonic-swss/issues/734

**Why I did it**

**How I verified it**
core dump with right stack trace created.

**Details if related**
Actually It might be caused by incorrect destruct of multiple orch ( inter-dependency, order and etc.), which triggered more segmentation during try/catch stack unwinding, then only the latest segfault got recorded. 

If people have idea about how to fix the possible orch destruct issue, that would be better.


