### PR TITLE
[portsorch] Fix inconsistent return value in bindAclTable

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -807,7 +807,7 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t id, sai_object_id_t &gro
                 {
                     SWSS_LOG_ERROR("Failed to bind port %s to ACL table group %lx, rv:%d",
                             port.m_alias.c_str(), group_oid, status);
-                    return status;
+                    return false;
                 }
                 break;
             }
@@ -823,7 +823,7 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t id, sai_object_id_t &gro
                 {
                     SWSS_LOG_ERROR("Failed to bind LAG %s to ACL table group %lx, rv:%d",
                             port.m_alias.c_str(), group_oid, status);
-                    return status;
+                    return false;
                 }
                 break;
             }
@@ -839,14 +839,14 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t id, sai_object_id_t &gro
                 {
                     SWSS_LOG_ERROR("Failed to bind VLAN %s to ACL table group %lx, rv:%d",
                             port.m_alias.c_str(), group_oid, status);
-                    return status;
+                    return false;
                 }
                 break;
             }
             default:
             {
                 SWSS_LOG_ERROR("Failed to bind %s port with type %d", port.m_alias.c_str(), port.m_type);
-                return SAI_STATUS_FAILURE;
+                return false;
             }
         }
 


### PR DESCRIPTION
Signed-off-by: yorke <yorke.yuan@asterfusion.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix inconsistent return value in PortsOrch::bindAclTable.

**Why I did it**
The type of return value for PortsOrch::bindAclTable is bool, but type sai_status_t is returned in PortsOrch::bindAclTable. Once it is failed on binding acl group to port by set_port_attribute, the return value would be true as non-SAI_STATUS_SUCCESS.

**How I verified it**

**Details if related**
