### PR TITLE
[teammgr] use boolean value for active/fallback in teamd conf

### DIFF
--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -376,7 +376,7 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
     conf << "'{\"device\":\"" << alias << "\","
          << "\"hwaddr\":\"" << m_mac.to_string() << "\","
          << "\"runner\":{"
-         << "\"active\":\"true\","
+         << "\"active\":true,"
          << "\"name\":\"lacp\"";
 
     if (min_links != 0)
@@ -386,7 +386,7 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
 
     if (fallback)
     {
-        conf << ",\"fallback\":\"true\"";
+        conf << ",\"fallback\":true";
     }
 
     conf << "}}'";


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
change the team conf active/fallback value to Boolean type

**Why I did it**
Teamd failed to get the correct boolean value for active/fallback config, because teammgr use string "true" in the conf.

/var/log/teamd.log:44324:Feb 15 10:15:24.023782 ASW-C2-4-C11-A.NA61 ERR teamd#teamd_PortChannel2[37]: Failed to get boolean from non-boolean object
/var/log/teamd.log-44447-Feb 15 10:15:24.023782 ASW-C2-4-C11-A.NA61 DEBUG teamd#teamd_PortChannel2[37]: Using active "1".

**How I verified it**
With the fix, the teamd was able to get the correct boolean value from teammgr without above error.

**Details if related**
