### PR TITLE
Fix PFC watchdog not getting lossless TC

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -32,6 +32,7 @@ AclOrch *gAclOrch;
 CrmOrch *gCrmOrch;
 BufferOrch *gBufferOrch;
 SwitchOrch *gSwitchOrch;
+QosOrch *gQosOrch;
 Directory<Orch*> gDirectory;
 
 OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *stateDb) :
@@ -116,7 +117,7 @@ bool OrchDaemon::init()
         CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME,
         CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME
     };
-    QosOrch *qos_orch = new QosOrch(m_configDb, qos_tables);
+    gQosOrch = new QosOrch(m_configDb, qos_tables);
 
     vector<string> buffer_tables = {
         CFG_BUFFER_POOL_TABLE_NAME,
@@ -158,7 +159,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap.
      * That is ensured implicitly by the order of map key, "LAG_TABLE" is smaller than "VLAN_TABLE" in lexicographic order.
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gBufferOrch, gPortsOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, wm_orch };
+    m_orchList = { gSwitchOrch, gCrmOrch, gBufferOrch, gPortsOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, gQosOrch, wm_orch };
 
 
     bool initialize_dtel = false;

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -8,6 +8,7 @@
 #include "select.h"
 #include "notifier.h"
 #include "redisclient.h"
+#include "qosorch.h"
 
 #define PFC_WD_GLOBAL                   "GLOBAL"
 #define PFC_WD_ACTION                   "action"
@@ -28,6 +29,7 @@ extern sai_port_api_t *sai_port_api;
 extern sai_queue_api_t *sai_queue_api;
 
 extern PortsOrch *gPortsOrch;
+extern QosOrch   *gQosOrch;
 
 template <typename DropHandler, typename ForwardHandler>
 PfcWdOrch<DropHandler, ForwardHandler>::PfcWdOrch(DBConnector *db, vector<string> &tableNames):
@@ -50,7 +52,7 @@ void PfcWdOrch<DropHandler, ForwardHandler>::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isPortReady())
+    if ((!gPortsOrch->isPortReady()) || (!gQosOrch->isQosMapsApplied()))
     {
         return;
     }

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -469,6 +469,11 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
 
         losslessTc.insert(i);
     }
+    if (losslessTc.empty())
+    {
+        SWSS_LOG_ERROR("No lossless TC found on port %s", port.m_alias.c_str());
+        return;
+    }
 
     if (!c_portStatIds.empty())
     {

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1357,6 +1357,7 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
         }
     }
 
+    m_qosMapsApplied = true;
     SWSS_LOG_NOTICE("Applied QoS maps to ports");
     return task_process_status::task_success;
 }

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -113,6 +113,11 @@ public:
 
     static type_map& getTypeMap();
     static type_map m_qos_maps;
+
+    bool isQosMapsApplied(void)
+    {
+        return m_qosMapsApplied;
+    }
 private:
     virtual void doTask(Consumer& consumer);
 
@@ -155,5 +160,7 @@ private:
     };
 
     std::unordered_map<sai_object_id_t, SchedulerGroupPortInfo_t> m_scheduler_group_port_info;
+
+    bool m_qosMapsApplied = false;
 };
 #endif /* SWSS_QOSORCH_H */


### PR DESCRIPTION
Fix PFC watchdog not getting lossless TCs. This will cause the PFC watchdog not getting started properly if enabled by default. A patch that hard-codes the TCs was used. With this fix, the patch can be removed.

Log error and return if no lossless TC is found when registering pfcwd stats on a port

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**
Tested on brcm dut
**Details if related**
