### PR TITLE
[vnetorch]: Add support of local routes for Bitmap VNET implementation

### DIFF
--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -181,6 +181,8 @@ public:
 
     virtual bool addTunnelRoute(IpPrefix& ipPrefix, tunnelEndpoint& endp);
 
+    virtual bool addRoute(IpPrefix& ipPrefix, nextHop& nh);
+
     void setVniInfo(uint32_t vni);
 
     bool updateObj(vector<sai_attribute_t>&);


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added support of local routes for Bitmap VNET implementation.

**Why I did it**
Implemented new logic for Bitmap VNET implementation in order to add support of local routes.

**How I verified it**
1. Verified manually by configuring VNETs and local routes (for Bitmap VNET) and checking that traffic is going between two VNETs.
2. Ran ```vnet_vxlan``` ansible test and verified that third test case, which tests local routes, passed.

**Details if related**
N/A