### PR TITLE
[orchagent] Fix orchagent SEGV when PortConfigDone not set

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1415,8 +1415,8 @@ bool PortsOrch::bake()
     vector<FieldValueTuple> tuples;
     string value;
     bool foundPortConfigDone = m_portTable->hget("PortConfigDone", "count", value);
-    unsigned long portCount = stoul(value);
-    SWSS_LOG_NOTICE("foundPortConfigDone = %d, portCount = %lu, m_portCount = %u", foundPortConfigDone, portCount, m_portCount);
+    unsigned long portCount;
+    SWSS_LOG_NOTICE("foundPortConfigDone = %d", foundPortConfigDone);
 
     bool foundPortInitDone = m_portTable->get("PortInitDone", tuples);
     SWSS_LOG_NOTICE("foundPortInitDone = %d", foundPortInitDone);
@@ -1432,6 +1432,8 @@ bool PortsOrch::bake()
         return false;
     }
 
+    portCount = stoul(value);
+    SWSS_LOG_NOTICE("portCount = %lu, m_portCount = %u", portCount, m_portCount);
     if (portCount != keys.size() - 2)
     {
         // Invalid port table


### PR DESCRIPTION


**What I did**
Fix uninitialized value access

**Why I did it**
To fix following error:
Feb 25 22:34:17.837004 switch120 NOTICE swss#orchagent: :- bake: Add warm input: BUFFER_PROFILE, 3
Feb 25 22:34:17.837092 switch120 NOTICE swss#orchagent: :- bake: Add warm input: BUFFER_QUEUE, 3
Feb 25 22:34:17.837687 switch120 ERR swss#orchagent: :- main: Failed due to exception: stoul
Feb 25 22:34:17.841919 switch120 INFO kernel: [   35.606307] traps: orchagent[3721] general protection ip:49c16c sp:7ffde2755580 error:0
Feb 25 22:34:17.841922 switch120 WARNING kernel: [   35.606312]  in orchagent[400000+151000]
Feb 25 22:34:18.844587 switch120 INFO swss.sh[2027]: 2019-02-25 22:34:18,843 INFO success: buffermgrd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)

**How I verified it**
Reproduced the condition (PortConfigDone not set) and verified the fix.
Logs from after the fix::
Feb 26 01:23:36.621760 switch120 NOTICE swss#orchagent: :- bake: Add warm input: BUFFER_PROFILE, 3
Feb 26 01:23:36.621854 switch120 NOTICE swss#orchagent: :- bake: Add warm input: BUFFER_QUEUE, 3
Feb 26 01:23:36.621905 switch120 NOTICE swss#orchagent: :- bake: foundPortConfigDone = 0
Feb 26 01:23:36.621959 switch120 NOTICE swss#orchagent: :- bake: foundPortInitDone = 0
Feb 26 01:23:36.622021 switch120 NOTICE swss#orchagent: :- bake: m_portTable->getKeys 0
Feb 26 01:23:36.622021 switch120 NOTICE swss#orchagent: :- bake: No port table, fallback to cold start
Feb 26 01:23:36.622175 switch120 NOTICE swss#orchagent: :- bake: Add warm input: INTF_TABLE, 0
Feb 26 01:23:36.622297 switch120 NOTICE swss#orchagent: :- bake: Add warm input: NEIGH_TABLE, 0


**Details if related**
