### PR TITLE
[portsorch] fix bug in speed set

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1788,7 +1788,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         }
                         SWSS_LOG_NOTICE("Set port %s speed to %u", alias.c_str(), speed);
                     }
-                    m_portList[alias].m_speed = speed;
+                    p.m_speed = speed;
+                    m_portList[alias] = p;
                 }
 
                 if (mtu != 0 && mtu != p.m_mtu)


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
After comments handling in https://github.com/Azure/sonic-swss/pull/764 this bug was introduced.
```m_portList[alias]``` will be overridden with ```p```, however ```p``` has no updated speed

**Why I did it**

**How I verified it**

**Details if related**
