### PR TITLE
[arp] copy arp IO to cpu instead of trap and drop

### DIFF
--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -22,7 +22,7 @@
     {
         "COPP_TABLE:trap.group.arp": {
             "trap_ids": "arp_req,arp_resp,neigh_discovery",
-            "trap_action":"trap",
+            "trap_action":"copy",
             "trap_priority":"4",
             "queue": "4",
             "meter_type":"packets",


### PR DESCRIPTION
**What I did**
Switch arp/arp response/neighbor_discovery IO trap action from 'trap' to 'copy'. These IO, instead of trap to CPU and dropped, they will be copy to CPU and forwarded on VLAN.

**Why I did it**
During warm reboot, we need VLAN take care of ARP traffic by itself.

**How I verified it**
Tested with matching test: https://github.com/Azure/sonic-mgmt/pull/824