### PR TITLE
[VS]: fix occasional test_fdb_notifications vs test failure

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -674,6 +674,16 @@ class DockerVirtualSwitch(object):
         tbl.set("Vlan" + vlan + "|" + interface, fvs)
         time.sleep(1)
 
+    def remove_vlan_member(self, vlan, interface):
+        tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
+        tbl._del("Vlan" + vlan + "|" + interface)
+        time.sleep(1)
+
+    def remove_vlan(self, vlan):
+        tbl = swsscommon.Table(self.cdb, "VLAN")
+        tbl._del("Vlan" + vlan)
+        time.sleep(1)
+
     def set_interface_status(self, interface, admin_status):
         if interface.startswith("PortChannel"):
             tbl_name = "PORTCHANNEL"

--- a/tests/test_fdb_cold.py
+++ b/tests/test_fdb_cold.py
@@ -48,22 +48,8 @@ def test_FDBAddedAfterMemberCreated(dvs, testlog):
     vm_before = how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN_MEMBER")
 
     # create vlan
-    create_entry_tbl(
-        dvs.cdb,
-        "VLAN", "Vlan2",
-        [
-            ("vlanid", "2"),
-        ]
-    )
-
-    # create vlan member entry in application db
-    create_entry_tbl(
-        dvs.cdb,
-        "VLAN_MEMBER", "Vlan2|Ethernet0",
-        [
-            ("tagging_mode", "untagged"),
-        ]
-    )
+    dvs.create_vlan("2")
+    dvs.create_vlan_member("2", "Ethernet0")
 
     # check that the vlan information was propagated
     vlan_after = how_many_entries_exist(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
@@ -87,3 +73,8 @@ def test_FDBAddedAfterMemberCreated(dvs, testlog):
                      ('SAI_FDB_ENTRY_ATTR_PACKET_ACTION', 'SAI_PACKET_ACTION_FORWARD')]
     )
     assert ok, str(extra)
+
+    dvs.runcmd("sonic-clear fdb all")
+    dvs.remove_vlan_member("2", "Ethernet0")
+    dvs.remove_vlan("2")
+

--- a/tests/test_fdb_warm.py
+++ b/tests/test_fdb_warm.py
@@ -82,8 +82,13 @@ def test_fdb_notifications(dvs, testlog):
 
     # bring up vlan and member
     dvs.set_interface_status("Vlan6", "up")
+    dvs.set_interface_status("Vlan7", "up")
+    dvs.set_interface_status("Vlan8", "up")
+
     dvs.add_ip_address("Vlan6", "6.6.6.1/24")
+    dvs.add_ip_address("Vlan7", "7.7.7.1/24")
     dvs.add_ip_address("Vlan8", "8.8.8.1/24")
+
     dvs.set_interface_status("Ethernet64", "up")
     dvs.set_interface_status("Ethernet68", "up")
     dvs.set_interface_status("Ethernet72", "up")
@@ -101,6 +106,11 @@ def test_fdb_notifications(dvs, testlog):
     dvs.servers[19].runcmd("ifconfig eth0.8 8.8.8.7/24 up")
     dvs.servers[19].runcmd("ip route add default via 8.8.8.1")
 
+    dvs.servers[18].runcmd("ifconfig eth0 7.7.7.6/24 up")
+    dvs.servers[18].runcmd("ip route add default via 7.7.7.1")
+    dvs.servers[19].runcmd("ifconfig eth0 7.7.7.7/24 up")
+    dvs.servers[19].runcmd("ip route add default via 7.7.7.1")
+
     # get neighbor and arp entry
     time.sleep(2)
     rc = dvs.servers[16].runcmd("ping -c 1 6.6.6.7")
@@ -115,6 +125,11 @@ def test_fdb_notifications(dvs, testlog):
     rc = dvs.servers[19].runcmd("ping -c 1 8.8.8.6")
     assert rc == 0
 
+    time.sleep(2)
+    rc = dvs.servers[18].runcmd("ping -c 1 -I 7.7.7.6 7.7.7.7")
+    assert rc == 0
+    rc = dvs.servers[19].runcmd("ping -c 1 -I 7.7.7.7 7.7.7.6")
+    assert rc == 0
 
     # check that the FDB entries were inserted into ASIC DB
     ok, extra = dvs.is_fdb_entry_exists(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_FDB_ENTRY",
@@ -149,7 +164,11 @@ def test_fdb_notifications(dvs, testlog):
 
     time.sleep(2)
     counter_inserted = dvs.getCrmCounterValue('STATS', 'crm_stats_fdb_entry_used')
-    assert counter_inserted - counter_before == 4
+    # vlan 6: Ethernet64, Ethernet68;
+    # vlan 7: Ethernet72, Ethernet76;
+    # vlan 8 (tagged): Ethernet72, Ethernet76;
+    # 6 FDB entries wil be created in total
+    assert counter_inserted - counter_before == 6
 
     # check that the FDB entries were inserted into State DB
     ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
@@ -169,6 +188,22 @@ def test_fdb_notifications(dvs, testlog):
 
     # check that the FDB entries were inserted into State DB, Vlan8 while not Vlan7(untagged) in the key
     ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
+                    "Vlan7:.*",
+                    [("port", "Ethernet72"),
+                     ("type", "dynamic"),
+                    ]
+    )
+    assert ok, str(extra)
+    ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
+                    "Vlan7:*",
+                    [("port", "Ethernet76"),
+                     ("type", "dynamic"),
+                    ]
+    )
+    assert ok, str(extra)
+
+    # check that the FDB entries were inserted into State DB, Vlan8 while not Vlan7(untagged) in the key
+    ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
                     "Vlan8:.*",
                     [("port", "Ethernet72"),
                      ("type", "dynamic"),
@@ -177,6 +212,22 @@ def test_fdb_notifications(dvs, testlog):
     assert ok, str(extra)
     ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
                     "Vlan8:*",
+                    [("port", "Ethernet76"),
+                     ("type", "dynamic"),
+                    ]
+    )
+    assert ok, str(extra)
+
+    # check that the FDB entries were inserted into State DB, Vlan8 while not Vlan7(untagged) in the key
+    ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
+                    "Vlan7:.*",
+                    [("port", "Ethernet72"),
+                     ("type", "dynamic"),
+                    ]
+    )
+    assert ok, str(extra)
+    ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
+                    "Vlan7:*",
                     [("port", "Ethernet76"),
                      ("type", "dynamic"),
                     ]

--- a/tests/test_fdb_warm.py
+++ b/tests/test_fdb_warm.py
@@ -170,7 +170,7 @@ def test_fdb_notifications(dvs, testlog):
     # 6 FDB entries wil be created in total
     assert counter_inserted - counter_before == 6
 
-    # check that the FDB entries were inserted into State DB
+    # check that the FDB entries were inserted into State DB for Ethernet64, Ethernet68 with Vlan6
     ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
                     "Vlan6:.*",
                     [("port", "Ethernet64"),
@@ -186,7 +186,8 @@ def test_fdb_notifications(dvs, testlog):
     )
     assert ok, str(extra)
 
-    # check that the FDB entries were inserted into State DB, Vlan8 while not Vlan7(untagged) in the key
+    # check that the FDB entries were inserted into State DB,
+    # Vlan7(untagged) in the key for Ethernet72, Ethernet76
     ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
                     "Vlan7:.*",
                     [("port", "Ethernet72"),
@@ -202,7 +203,8 @@ def test_fdb_notifications(dvs, testlog):
     )
     assert ok, str(extra)
 
-    # check that the FDB entries were inserted into State DB, Vlan8 while not Vlan7(untagged) in the key
+    # check that the FDB entries were inserted into State DB,
+    # Vlan8 (tagged) in the key for Ethernet72, Ethernet76
     ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
                     "Vlan8:.*",
                     [("port", "Ethernet72"),
@@ -212,22 +214,6 @@ def test_fdb_notifications(dvs, testlog):
     assert ok, str(extra)
     ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
                     "Vlan8:*",
-                    [("port", "Ethernet76"),
-                     ("type", "dynamic"),
-                    ]
-    )
-    assert ok, str(extra)
-
-    # check that the FDB entries were inserted into State DB, Vlan8 while not Vlan7(untagged) in the key
-    ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
-                    "Vlan7:.*",
-                    [("port", "Ethernet72"),
-                     ("type", "dynamic"),
-                    ]
-    )
-    assert ok, str(extra)
-    ok, extra = dvs.is_table_entry_exists(dvs.sdb, "FDB_TABLE",
-                    "Vlan7:*",
                     [("port", "Ethernet76"),
                      ("type", "dynamic"),
                     ]


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
fix occasional test_fdb_notifications vs test failure
**Why I did it**

We had configurations like below

    # vlan 6: Ethernet64, Ethernet68;
    # vlan 7: Ethernet72, Ethernet76;
    # vlan 8 (tagged): Ethernet72, Ethernet76;

Though no IP configured on vlan 7, layer 2 FDB entries may be created  depending on the timing.

The FDB entry number validation may fail with (assert counter_inserted - counter_before == 4).

Here we explicitly configure IP on all three VLANs, and run ping on the interfaces to trigger creation of the 6 FDB entries.

**How I verified it**

**Details if related**
