### PR TITLE
Create ingress ACL table group with bind point PORT during the PFCWD stats list installment

### DIFF
--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -528,6 +528,7 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
 
     // Create egress ACL table group for each port of pfcwd's interest
     sai_object_id_t groupId;
+    gPortsOrch->createBindAclTableGroup(port.m_port_id, groupId, ACL_STAGE_INGRESS);
     gPortsOrch->createBindAclTableGroup(port.m_port_id, groupId, ACL_STAGE_EGRESS);
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -869,7 +869,7 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t id, sai_object_id_t &gro
             }
         }
 
-        SWSS_LOG_NOTICE("Create ACL table group and bind port %s to it", port.m_alias.c_str());
+        SWSS_LOG_NOTICE("Create %s ACL table group and bind port %s to it", ingress ? "ingress" : "egress", port.m_alias.c_str());
     }
 
     return true;


### PR DESCRIPTION


Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
On the PFCWD stats list installment, create ingress ACL table group for each port and bind to it.

**Why I did it**
When a port is in a LAG, typically an uplink port in tier 0, the bind point of ingress ACL table group is LAG not port. Make up this gap by proactive creation of port bind point in accordance to its egress counterpart: https://github.com/Azure/sonic-swss/pull/787

**How I verified it**
On brcm dut
**Details if related**
