### PR TITLE
Allow ACL entry creation without ACL counter attaching to it

### DIFF
--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -159,7 +159,7 @@ struct AclRuleCounters
 class AclRule
 {
 public:
-    AclRule(AclOrch *m_pAclOrch, string rule, string table, acl_table_type_t type);
+    AclRule(AclOrch *m_pAclOrch, string rule, string table, acl_table_type_t type, bool createCounter = true);
     virtual bool validateAddPriority(string attr_name, string attr_value);
     virtual bool validateAddMatch(string attr_name, string attr_value);
     virtual bool validateAddAction(string attr_name, string attr_value) = 0;
@@ -218,12 +218,15 @@ protected:
 
     vector<sai_object_id_t> m_inPorts;
     vector<sai_object_id_t> m_outPorts;
+
+private:
+    bool m_createCounter;
 };
 
 class AclRuleL3: public AclRule
 {
 public:
-    AclRuleL3(AclOrch *m_pAclOrch, string rule, string table, acl_table_type_t type);
+    AclRuleL3(AclOrch *m_pAclOrch, string rule, string table, acl_table_type_t type, bool createCounter = true);
 
     bool validateAddAction(string attr_name, string attr_value);
     bool validateAddMatch(string attr_name, string attr_value);
@@ -243,7 +246,7 @@ public:
 class AclRulePfcwd: public AclRuleL3
 {
 public:
-    AclRulePfcwd(AclOrch *m_pAclOrch, string rule, string table, acl_table_type_t type);
+    AclRulePfcwd(AclOrch *m_pAclOrch, string rule, string table, acl_table_type_t type, bool createCounter = false);
     bool validateAddMatch(string attr_name, string attr_value);
 };
 


### PR DESCRIPTION
Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**
In pfc watchdog, packet drop stats does not come from the acl counters on brcm platform. In such a case, we do not need to attach the acl counters to the ACL entry. This is also the application case for acl entry creation in QosOrch::initAclEntryForEcn, which does not come with the acl counters attached.


**How I verified it**
On brcm dut
**Details if related**
