### PR TITLE
[orchagent]: Cast enum class variable to int

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -103,7 +103,7 @@ bool VNetVrfObject::createObj(vector<sai_attribute_t>& attrs)
         sai_object_id_t router_id;
         if (vr_type != VR_TYPE::VR_INVALID && l_fn(router_id))
         {
-            SWSS_LOG_DEBUG("VNET vr_type %d router id %lx  ", vr_type, router_id);
+            SWSS_LOG_DEBUG("VNET vr_type %d router id %lx  ", static_cast<int>(vr_type), router_id);
             vr_ids_.insert(std::pair<VR_TYPE, sai_object_id_t>(vr_type, router_id));
         }
     }

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -82,7 +82,7 @@ create_tunnel_map(MAP_T map_t)
 
     if (map_t == MAP_T::MAP_TO_INVALID)
     {
-        SWSS_LOG_ERROR("Invalid map type %d", map_t);
+        SWSS_LOG_ERROR("Invalid map type %d", static_cast<int>(map_t));
         return SAI_NULL_OBJECT_ID;
     }
 


### PR DESCRIPTION
Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>

```
vxlanorch.cpp: In function 'sai_object_id_t create_tunnel_map(MAP_T)':
/usr/include/swss/logger.h:15:143: error: format '%d' expects argument of type 'int', but argument 5 has type 'MAP_T' [-Werror=format=]
 #define SWSS_LOG_ERROR(MSG, ...)       swss::Logger::getInstance().write(swss::Logger::SWSS_ERROR,  ":- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
                                                                                                                                               ^
vxlanorch.cpp:85:9: note: in expansion of macro 'SWSS_LOG_ERROR'
         SWSS_LOG_ERROR("Invalid map type %d", map_t);
         ^~~~~~~~~~~~~~

vnetorch.cpp: In member function 'bool VNetVrfObject::createObj(std::vector<_sai_attribute_t>&)':
/usr/include/swss/logger.h:19:143: error: format '%d' expects argument of type 'int', but argument 5 has type 'VR_TYPE' [-Werror=format=]
 #define SWSS_LOG_DEBUG(MSG, ...)       swss::Logger::getInstance().write(swss::Logger::SWSS_DEBUG,  ":- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
                                                                                                                                               ^
vnetorch.cpp:98:13: note: in expansion of macro 'SWSS_LOG_DEBUG'
             SWSS_LOG_DEBUG("VNET vr_type %d router id %lx  ", vr_type, router_id);
             ^~~~~~~~~~~~~~
```