### PR TITLE
[vnetorch]: Add VNET interface removal flow for Bitmap VNET implement…

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -206,6 +206,51 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
     return true;
 }
 
+bool IntfsOrch::removeIntf(const string& alias, sai_object_id_t vrf_id, const IpPrefix *ip_prefix)
+{
+    SWSS_LOG_ENTER();
+
+    Port port;
+    if (!gPortsOrch->getPort(alias, port))
+    {
+        return false;
+    }
+
+    if (m_syncdIntfses.find(alias) == m_syncdIntfses.end())
+    {
+        return false;
+    }
+
+    if (ip_prefix && m_syncdIntfses[alias].ip_addresses.count(*ip_prefix))
+    {
+        removeSubnetRoute(port, *ip_prefix);
+        removeIp2MeRoute(vrf_id, *ip_prefix);
+
+        if(port.m_type == Port::VLAN)
+        {
+            removeDirectedBroadcast(port, *ip_prefix);
+        }
+
+        m_syncdIntfses[alias].ip_addresses.erase(*ip_prefix);
+    }
+
+    /* Remove router interface that no IP addresses are associated with */
+    if (m_syncdIntfses[alias].ip_addresses.size() == 0)
+    {
+        if (removeRouterIntfs(port))
+        {
+            m_syncdIntfses.erase(alias);
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void IntfsOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -379,41 +424,50 @@ void IntfsOrch::doTask(Consumer &consumer)
                 continue;
             }
 
-            vrf_id = port.m_vr_id;
-            if (m_syncdIntfses.find(alias) != m_syncdIntfses.end())
+            if (m_syncdIntfses.find(alias) == m_syncdIntfses.end())
             {
-                if (m_syncdIntfses[alias].ip_addresses.count(ip_prefix))
+                /* Cannot locate the interface */
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            if (m_vnetInfses.find(alias) != m_vnetInfses.end())
+            {
+                vnet_name = m_vnetInfses.at(alias);
+            }
+
+            if (!vnet_name.empty())
+            {
+                VNetOrch* vnet_orch = gDirectory.get<VNetOrch*>();
+                if (!vnet_orch->isVnetExists(vnet_name))
                 {
-                    removeSubnetRoute(port, ip_prefix);
-                    removeIp2MeRoute(vrf_id, ip_prefix);
-
-                    if(port.m_type == Port::VLAN)
-                    {
-                        removeDirectedBroadcast(port, ip_prefix);
-                    }
-
-                    m_syncdIntfses[alias].ip_addresses.erase(ip_prefix);
+                    it++;
+                    continue;
                 }
 
-                /* Remove router interface that no IP addresses are associated with */
-                if (m_syncdIntfses[alias].ip_addresses.size() == 0)
+                if (vnet_orch->delIntf(alias, vnet_name, ip_prefix_in_key ? &ip_prefix : nullptr))
                 {
-                    if (removeRouterIntfs(port))
-                    {
-                        m_syncdIntfses.erase(alias);
-                        it = consumer.m_toSync.erase(it);
-                    }
-                    else
-                        it++;
+                    m_vnetInfses.erase(alias);
+                    it = consumer.m_toSync.erase(it);
                 }
                 else
                 {
-                    it = consumer.m_toSync.erase(it);
+                    it++;
+                    continue;
                 }
             }
             else
-                /* Cannot locate the interface */
-                it = consumer.m_toSync.erase(it);
+            {
+                if (removeIntf(alias, port.m_vr_id, ip_prefix_in_key ? &ip_prefix : nullptr))
+                {
+                    it = consumer.m_toSync.erase(it);
+                }
+                else
+                {
+                    it++;
+                    continue;
+                }
+            }
         }
     }
 }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -216,11 +216,6 @@ bool IntfsOrch::removeIntf(const string& alias, sai_object_id_t vrf_id, const Ip
         return false;
     }
 
-    if (m_syncdIntfses.find(alias) == m_syncdIntfses.end())
-    {
-        return false;
-    }
-
     if (ip_prefix && m_syncdIntfses[alias].ip_addresses.count(*ip_prefix))
     {
         removeSubnetRoute(port, *ip_prefix);

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -44,6 +44,7 @@ public:
     void removeRifFromFlexCounter(const string&, const string&);
 
     bool setIntf(const string& alias, sai_object_id_t vrf_id = gVirtualRouterId, const IpPrefix *ip_prefix = nullptr);
+    bool removeIntf(const string& alias, sai_object_id_t vrf_id = gVirtualRouterId, const IpPrefix *ip_prefix = nullptr);
 
     void addIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);
     void removeIp2MeRoute(sai_object_id_t vrf_id, const IpPrefix &ip_prefix);

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -643,7 +643,7 @@ bool VNetBitmapObject::addIntf(const string& alias, const IpPrefix *prefix)
         if (intfMap_.find(alias) != intfMap_.end())
         {
             SWSS_LOG_ERROR("VNET '%s' interface '%s' already exists", getVnetName().c_str(), alias.c_str());
-            throw std::runtime_error("VNET interface creation failed");
+            return false;
         }
 
         if (!gIntfsOrch->setIntf(alias, gVirtualRouterId, nullptr))
@@ -761,7 +761,7 @@ bool VNetBitmapObject::removeIntf(const string& alias, const IpPrefix *prefix)
         {
             SWSS_LOG_ERROR("VNET '%s' interface '%s' prefix '%s' doesn't exist",
                     getVnetName().c_str(), alias.c_str(), prefix->getIp().to_string().c_str());
-            return false;
+            return true;
         }
 
         auto& pfx = intf.pfxMap.at(*prefix);
@@ -782,12 +782,6 @@ bool VNetBitmapObject::removeIntf(const string& alias, const IpPrefix *prefix)
 
     if (intf.pfxMap.size() == 0)
     {
-        if (gIntfsOrch->getSyncdIntfses().find(alias) == gIntfsOrch->getSyncdIntfses().end())
-        {
-            SWSS_LOG_ERROR("VNET '%s' interface '%s' doesn't exist", getVnetName().c_str(), alias.c_str());
-            return false;
-        }
-
         status = sai_bmtor_api->remove_table_bitmap_classification_entry(intf.vnetTableEntryId);
         if (status != SAI_STATUS_SUCCESS)
         {

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -640,12 +640,18 @@ bool VNetBitmapObject::addIntf(const string& alias, const IpPrefix *prefix)
 
     if (gIntfsOrch->getSyncdIntfses().find(alias) == gIntfsOrch->getSyncdIntfses().end())
     {
+        if (intfMap_.find(alias) != intfMap_.end())
+        {
+            SWSS_LOG_ERROR("VNET '%s' interface '%s' already exists", getVnetName().c_str(), alias.c_str());
+            throw std::runtime_error("VNET interface creation failed");
+        }
+
         if (!gIntfsOrch->setIntf(alias, gVirtualRouterId, nullptr))
         {
             return false;
         }
 
-        sai_object_id_t vnetTableEntryId;
+        VnetIntfInfo intfInfo;
 
         attr.id = SAI_TABLE_BITMAP_CLASSIFICATION_ENTRY_ATTR_ACTION;
         attr.value.s32 = SAI_TABLE_BITMAP_CLASSIFICATION_ENTRY_ACTION_SET_METADATA;
@@ -660,7 +666,7 @@ bool VNetBitmapObject::addIntf(const string& alias, const IpPrefix *prefix)
         vnet_attrs.push_back(attr);
 
         status = sai_bmtor_api->create_table_bitmap_classification_entry(
-                &vnetTableEntryId,
+                &intfInfo.vnetTableEntryId,
                 gSwitchId,
                 (uint32_t)vnet_attrs.size(),
                 vnet_attrs.data());
@@ -670,11 +676,23 @@ bool VNetBitmapObject::addIntf(const string& alias, const IpPrefix *prefix)
             SWSS_LOG_ERROR("Failed to create VNET table entry, SAI rc: %d", status);
             throw std::runtime_error("VNet interface creation failed");
         }
+
+        intfMap_.emplace(alias, intfInfo);
     }
 
     if (prefix)
     {
-        sai_object_id_t tunnelRouteTableEntryId;
+        auto& intf = intfMap_.at(alias);
+
+        if (intf.pfxMap.find(*prefix) != intf.pfxMap.end())
+        {
+            SWSS_LOG_WARN("VNET '%s' interface '%s' prefix '%s' already exists",
+                    getVnetName().c_str(), alias.c_str(), prefix->getIp().to_string().c_str());
+            return true;
+        }
+
+        RouteInfo intfPfxInfo;
+
         sai_ip_prefix_t saiPrefix;
         copy(saiPrefix, *prefix);
 
@@ -684,8 +702,9 @@ bool VNetBitmapObject::addIntf(const string& alias, const IpPrefix *prefix)
         attr.value.s32 = SAI_TABLE_BITMAP_ROUTER_ENTRY_ACTION_TO_LOCAL;
         route_attrs.push_back(attr);
 
+        intfPfxInfo.offset = getFreeTunnelRouteTableOffset();
         attr.id = SAI_TABLE_BITMAP_ROUTER_ENTRY_ATTR_PRIORITY;
-        attr.value.u32 = getFreeTunnelRouteTableOffset();
+        attr.value.u32 = intfPfxInfo.offset;
         route_attrs.push_back(attr);
 
         attr.id = SAI_TABLE_BITMAP_ROUTER_ENTRY_ATTR_IN_RIF_METADATA_KEY;
@@ -705,7 +724,7 @@ bool VNetBitmapObject::addIntf(const string& alias, const IpPrefix *prefix)
         route_attrs.push_back(attr);
 
         status = sai_bmtor_api->create_table_bitmap_router_entry(
-                &tunnelRouteTableEntryId,
+                &intfPfxInfo.routeTableEntryId,
                 gSwitchId,
                 (uint32_t)route_attrs.size(),
                 route_attrs.data());
@@ -714,6 +733,73 @@ bool VNetBitmapObject::addIntf(const string& alias, const IpPrefix *prefix)
         {
             SWSS_LOG_ERROR("Failed to create local VNET route entry, SAI rc: %d", status);
             throw std::runtime_error("VNet interface creation failed");
+        }
+
+        intf.pfxMap.emplace(*prefix, intfPfxInfo);
+    }
+
+    return true;
+}
+
+bool VNetBitmapObject::removeIntf(const string& alias, const IpPrefix *prefix)
+{
+    SWSS_LOG_ENTER();
+
+    sai_status_t status;
+
+    if (intfMap_.find(alias) == intfMap_.end())
+    {
+        SWSS_LOG_ERROR("VNET '%s' interface '%s' doesn't exist", getVnetName().c_str(), alias.c_str());
+        return false;
+    }
+
+    auto& intf = intfMap_.at(alias);
+
+    if (prefix)
+    {
+        if (intf.pfxMap.find(*prefix) == intf.pfxMap.end())
+        {
+            SWSS_LOG_ERROR("VNET '%s' interface '%s' prefix '%s' doesn't exist",
+                    getVnetName().c_str(), alias.c_str(), prefix->getIp().to_string().c_str());
+            return false;
+        }
+
+        auto& pfx = intf.pfxMap.at(*prefix);
+
+        status = sai_bmtor_api->remove_table_bitmap_router_entry(pfx.routeTableEntryId);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove VNET local route entry, SAI rc: %d", status);
+            throw std::runtime_error("VNET interface removal failed");
+        }
+
+        gIntfsOrch->removeIp2MeRoute(gVirtualRouterId, *prefix);
+
+        recycleTunnelRouteTableOffset(pfx.offset);
+
+        intf.pfxMap.erase(*prefix);
+    }
+
+    if (intf.pfxMap.size() == 0)
+    {
+        if (gIntfsOrch->getSyncdIntfses().find(alias) == gIntfsOrch->getSyncdIntfses().end())
+        {
+            SWSS_LOG_ERROR("VNET '%s' interface '%s' doesn't exist", getVnetName().c_str(), alias.c_str());
+            return false;
+        }
+
+        status = sai_bmtor_api->remove_table_bitmap_classification_entry(intf.vnetTableEntryId);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to remove VNET table entry, SAI rc: %d", status);
+            throw std::runtime_error("VNET interface removal failed");
+        }
+
+        intfMap_.erase(alias);
+
+        if (!gIntfsOrch->removeIntf(alias, gVirtualRouterId, nullptr))
+        {
+            return false;
         }
     }
 
@@ -1164,6 +1250,33 @@ bool VNetOrch::setIntf(const string& alias, const string name, const IpPrefix *p
 
     return false;
 }
+
+bool VNetOrch::delIntf(const string& alias, const string name, const IpPrefix *prefix)
+{
+    SWSS_LOG_ENTER();
+
+    if (!isVnetExists(name))
+    {
+        SWSS_LOG_WARN("VNET %s doesn't exist", name.c_str());
+        return false;
+    }
+
+    if (isVnetExecVrf())
+    {
+        auto *vnet_obj = getTypePtr<VNetVrfObject>(name);
+        sai_object_id_t vrf_id = vnet_obj->getVRidIngress();
+
+        return gIntfsOrch->removeIntf(alias, vrf_id, prefix);
+    }
+    else
+    {
+        auto *vnet_obj = getTypePtr<VNetBitmapObject>(name);
+        return vnet_obj->removeIntf(alias, prefix);
+    }
+
+    return true;
+}
+
 bool VNetOrch::addOperation(const Request& request)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -195,12 +195,19 @@ struct RouteInfo
     uint32_t offset;
 };
 
+struct VnetIntfInfo
+{
+    sai_object_id_t vnetTableEntryId;
+    map<IpPrefix, RouteInfo> pfxMap;
+};
+
 class VNetBitmapObject: public VNetObject
 {
 public:
     VNetBitmapObject(const string& vnet, const VNetInfo& vnetInfo, vector<sai_attribute_t>& attrs);
 
     bool addIntf(const string& alias, const IpPrefix *prefix);
+    bool removeIntf(const string& alias, const IpPrefix *prefix);
 
     bool addTunnelRoute(IpPrefix& ipPrefix, tunnelEndpoint& endp);
     bool removeTunnelRoute(IpPrefix& ipPrefix);
@@ -247,6 +254,7 @@ private:
 
     map<IpPrefix, RouteInfo> routeMap_;
     map<IpPrefix, TunnelRouteInfo> tunnelRouteMap_;
+    map<string, VnetIntfInfo> intfMap_;
 
     uint32_t vnet_id_;
     string vnet_name_;
@@ -262,6 +270,7 @@ public:
     VNetOrch(DBConnector *db, const std::string&, VNET_EXEC op = VNET_EXEC::VNET_EXEC_VRF);
 
     bool setIntf(const string& alias, const string name, const IpPrefix *prefix = nullptr);
+    bool delIntf(const string& alias, const string name, const IpPrefix *prefix = nullptr);
 
     bool isVnetExists(const std::string& name) const
     {


### PR DESCRIPTION
…ation

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added support of  VNET interface removal flow for Bitmap VNET implementation.

**Why I did it**
Implemented new logic for Bitmap VNET implementation in order to add support of VNET interface removal.

**How I verified it**
1. Verified manually.
2. Ran vnet_vxlan ansible test and verified that it passed.

**Details if related**
N/A
