### PR TITLE
[aclorch]: Add MIRRORv6 support for ACL table

### DIFF
--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -24,13 +24,14 @@
 #define TABLE_PORTS       "PORTS"
 #define TABLE_SERVICES    "SERVICES"
 
-#define TABLE_TYPE_L3        "L3"
-#define TABLE_TYPE_L3V6      "L3V6"
-#define TABLE_TYPE_MIRROR    "MIRROR"
-#define TABLE_TYPE_PFCWD     "PFCWD"
-#define TABLE_TYPE_CTRLPLANE "CTRLPLANE"
-#define TABLE_TYPE_DTEL_FLOW_WATCHLIST "DTEL_FLOW_WATCHLIST"
-#define TABLE_TYPE_DTEL_DROP_WATCHLIST "DTEL_DROP_WATCHLIST"
+#define TABLE_TYPE_L3                   "L3"
+#define TABLE_TYPE_L3V6                 "L3V6"
+#define TABLE_TYPE_MIRROR               "MIRROR"
+#define TABLE_TYPE_MIRRORV6             "MIRRORV6"
+#define TABLE_TYPE_PFCWD                "PFCWD"
+#define TABLE_TYPE_CTRLPLANE            "CTRLPLANE"
+#define TABLE_TYPE_DTEL_FLOW_WATCHLIST  "DTEL_FLOW_WATCHLIST"
+#define TABLE_TYPE_DTEL_DROP_WATCHLIST  "DTEL_DROP_WATCHLIST"
 
 #define RULE_PRIORITY           "PRIORITY"
 #define MATCH_IN_PORTS          "IN_PORTS"
@@ -55,8 +56,8 @@
 #define MATCH_INNER_L4_SRC_PORT "INNER_L4_SRC_PORT"
 #define MATCH_INNER_L4_DST_PORT "INNER_L4_DST_PORT"
 
-#define ACTION_PACKET_ACTION    "PACKET_ACTION"
-#define ACTION_MIRROR_ACTION    "MIRROR_ACTION"
+#define ACTION_PACKET_ACTION                "PACKET_ACTION"
+#define ACTION_MIRROR_ACTION                "MIRROR_ACTION"
 #define ACTION_DTEL_FLOW_OP                 "FLOW_OP"
 #define ACTION_DTEL_INT_SESSION             "INT_SESSION"
 #define ACTION_DTEL_DROP_REPORT_ENABLE      "DROP_REPORT_ENABLE"
@@ -95,6 +96,7 @@ typedef enum
     ACL_TABLE_L3,
     ACL_TABLE_L3V6,
     ACL_TABLE_MIRROR,
+    ACL_TABLE_MIRRORV6,
     ACL_TABLE_PFCWD,
     ACL_TABLE_CTRLPLANE,
     ACL_TABLE_DTEL_FLOW_WATCHLIST,
@@ -301,6 +303,7 @@ protected:
 
 class AclTable {
     sai_object_id_t m_oid;
+    AclOrch *m_pAclOrch;
 public:
     string id;
     string description;
@@ -317,7 +320,15 @@ public:
     set<string> pendingPortSet;
 
     AclTable()
-        : type(ACL_TABLE_UNKNOWN)
+        : m_pAclOrch(NULL)
+        , type(ACL_TABLE_UNKNOWN)
+        , m_oid(SAI_NULL_OBJECT_ID)
+        , stage(ACL_STAGE_INGRESS)
+    {}
+
+    AclTable(AclOrch *aclOrch)
+        : m_pAclOrch(aclOrch)
+        , type(ACL_TABLE_UNKNOWN)
         , m_oid(SAI_NULL_OBJECT_ID)
         , stage(ACL_STAGE_INGRESS)
     {}
@@ -363,8 +374,8 @@ inline void split(string str, Iterable& out, char delim = ' ')
 class AclOrch : public Orch, public Observer
 {
 public:
-    AclOrch(vector<TableConnector>& connectors, PortsOrch *portOrch, MirrorOrch *mirrorOrch, NeighOrch *neighOrch, RouteOrch *routeOrch);
-    AclOrch(vector<TableConnector>& connectors, PortsOrch *portOrch, MirrorOrch *mirrorOrch, NeighOrch *neighOrch, RouteOrch *routeOrch, DTelOrch *m_dTelOrch);
+    AclOrch(vector<TableConnector>& connectors, TableConnector switchTable,
+            PortsOrch *portOrch, MirrorOrch *mirrorOrch, NeighOrch *neighOrch, RouteOrch *routeOrch, DTelOrch *m_dTelOrch = NULL);
     ~AclOrch();
     void update(SubjectType, void *);
 
@@ -374,6 +385,8 @@ public:
     {
         return m_countersTable;
     }
+
+    Table m_switchTable;
 
     // FIXME: Add getters for them? I'd better to add a common directory of orch objects and use it everywhere
     MirrorOrch *m_mirrorOrch;
@@ -386,12 +399,19 @@ public:
     bool addAclRule(shared_ptr<AclRule> aclRule, string table_id);
     bool removeAclRule(string table_id, string rule_id);
 
+    bool isCombinedMirrorV6Table();
+
+    bool m_isCombinedMirrorV6Table = true;
+    map<acl_table_type_t, bool> m_mirrorTableCapabilities;
+
 private:
     void doTask(Consumer &consumer);
     void doAclTableTask(Consumer &consumer);
     void doAclRuleTask(Consumer &consumer);
     void doTask(SelectableTimer &timer);
     void init(vector<TableConnector>& connectors, PortsOrch *portOrch, MirrorOrch *mirrorOrch, NeighOrch *neighOrch, RouteOrch *routeOrch);
+
+    void queryMirrorTableCapability();
 
     static void collectCountersThread(AclOrch *pAclOrch);
 
@@ -406,7 +426,6 @@ private:
     sai_status_t createDTelWatchListTables();
     sai_status_t deleteDTelWatchListTables();
 
-    //vector <AclTable> m_AclTables;
     map<sai_object_id_t, AclTable> m_AclTables;
     // TODO: Move all ACL tables into one map: name -> instance
     map<string, AclTable> m_ctrlAclTables;
@@ -414,8 +433,11 @@ private:
     static mutex m_countersMutex;
     static condition_variable m_sleepGuard;
     static bool m_bCollectCounters;
-    static swss::DBConnector m_db;
-    static swss::Table m_countersTable;
+    static DBConnector m_db;
+    static Table m_countersTable;
+
+    string m_mirrorTableId;
+    string m_mirrorV6TableId;
 };
 
 #endif /* SWSS_ACLORCH_H */

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -190,10 +190,9 @@ bool OrchDaemon::init()
     {
         dtel_orch = new DTelOrch(m_configDb, dtel_tables, gPortsOrch);
         m_orchList.push_back(dtel_orch);
-        gAclOrch = new AclOrch(acl_table_connectors, gPortsOrch, mirror_orch, gNeighOrch, gRouteOrch, dtel_orch);
-    } else {
-        gAclOrch = new AclOrch(acl_table_connectors, gPortsOrch, mirror_orch, gNeighOrch, gRouteOrch);
     }
+    TableConnector stateDbSwitchTable(m_stateDb, "SWITCH_CAPABILITY");
+    gAclOrch = new AclOrch(acl_table_connectors, stateDbSwitchTable, gPortsOrch, mirror_orch, gNeighOrch, gRouteOrch, dtel_orch);
 
     m_orchList.push_back(gFdbOrch);
     m_orchList.push_back(mirror_orch);

--- a/tests/test_mirror_ipv6_combined.py
+++ b/tests/test_mirror_ipv6_combined.py
@@ -1,0 +1,484 @@
+# This test suite covers the functionality of mirror feature in SwSS
+
+import platform
+import pytest
+import time
+from distutils.version import StrictVersion
+
+from swsscommon import swsscommon
+
+DVS_FAKE_PLATFORM = "broadcom"
+
+
+class TestMirror(object):
+    def setup_db(self, dvs):
+        self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        self.sdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+
+    def setup_mirrorv6_mode(self, mode):
+        tbl = swsscommon.Table(self.sdb, "SWITCH_CAPABILITY")
+        fvs = swsscommon.FieldValuePairs([("mirror_v6_table_mode", mode)])
+        tbl.set("switch", fvs)
+        time.sleep(1)
+
+    def set_interface_status(self, interface, admin_status):
+        if interface.startswith("PortChannel"):
+            tbl_name = "PORTCHANNEL"
+        elif interface.startswith("Vlan"):
+            tbl_name = "VLAN"
+        else:
+            tbl_name = "PORT"
+        tbl = swsscommon.Table(self.cdb, tbl_name)
+        fvs = swsscommon.FieldValuePairs([("admin_status", "up")])
+        tbl.set(interface, fvs)
+        time.sleep(1)
+
+    def add_ip_address(self, interface, ip):
+        if interface.startswith("PortChannel"):
+            tbl_name = "PORTCHANNEL_INTERFACE"
+        elif interface.startswith("Vlan"):
+            tbl_name = "VLAN_INTERFACE"
+        else:
+            tbl_name = "INTERFACE"
+        tbl = swsscommon.Table(self.cdb, tbl_name)
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set(interface + "|" + ip, fvs)
+        time.sleep(1)
+
+    def remove_ip_address(self, interface, ip):
+        if interface.startswith("PortChannel"):
+            tbl_name = "PORTCHANNEL_INTERFACE"
+        elif interface.startswith("Vlan"):
+            tbl_name = "VLAN_INTERFACE"
+        else:
+            tbl_name = "INTERFACE"
+        tbl = swsscommon.Table(self.cdb, tbl_name)
+        tbl._del(interface + "|" + ip)
+        time.sleep(1)
+
+    def add_neighbor(self, interface, ip, mac):
+        tbl = swsscommon.ProducerStateTable(self.pdb, "NEIGH_TABLE")
+        fvs = swsscommon.FieldValuePairs([("neigh", mac),
+                                          ("family", "IPv4")])
+        tbl.set(interface + ":" + ip, fvs)
+        time.sleep(1)
+
+    def remove_neighbor(self, interface, ip):
+        tbl = swsscommon.ProducerStateTable(self.pdb, "NEIGH_TABLE")
+        tbl._del(interface + ":" + ip)
+        time.sleep(1)
+
+    def add_route(self, dvs, prefix, nexthop):
+        dvs.runcmd("ip route add " + prefix + " via " + nexthop)
+        time.sleep(1)
+
+    def remove_route(self, dvs, prefix):
+        dvs.runcmd("ip route del " + prefix)
+        time.sleep(1)
+
+    def create_mirror_session(self, name, src, dst, gre, dscp, ttl, queue):
+        tbl = swsscommon.Table(self.cdb, "MIRROR_SESSION")
+        fvs = swsscommon.FieldValuePairs([("src_ip", src),
+                                          ("dst_ip", dst),
+                                          ("gre_type", gre),
+                                          ("dscp", dscp),
+                                          ("ttl", ttl),
+                                          ("queue", queue)])
+        tbl.set(name, fvs)
+        time.sleep(1)
+
+    def remove_mirror_session(self, name):
+        tbl = swsscommon.Table(self.cdb, "MIRROR_SESSION")
+        tbl._del(name)
+        time.sleep(1)
+
+    def get_mirror_session_status(self, name):
+        return self.get_mirror_session_state(name)["status"]
+
+    def get_mirror_session_state(self, name):
+        tbl = swsscommon.Table(self.sdb, "MIRROR_SESSION")
+        (status, fvs) = tbl.get(name)
+        assert status == True
+        assert len(fvs) > 0
+        return { fv[0]: fv[1] for fv in fvs }
+
+    def create_acl_table(self, table, interfaces, type):
+        tbl = swsscommon.Table(self.cdb, "ACL_TABLE")
+        fvs = swsscommon.FieldValuePairs([("policy_desc", "mirror_test"),
+                                          ("type", type),
+                                          ("ports", ",".join(interfaces))])
+        tbl.set(table, fvs)
+        time.sleep(1)
+
+    def remove_acl_table(self, table):
+        tbl = swsscommon.Table(self.cdb, "ACL_TABLE")
+        tbl._del(table)
+        time.sleep(1)
+
+    def create_mirror_acl_ipv4_rule(self, table, rule, session):
+        tbl = swsscommon.Table(self.cdb, "ACL_RULE")
+        fvs = swsscommon.FieldValuePairs([("priority", "1000"),
+                                          ("mirror_action", session),
+                                          ("SRC_IP", "10.0.0.0/32"),
+                                          ("DST_IP", "20.0.0.0/23")])
+        tbl.set(table + "|" + rule, fvs)
+        time.sleep(1)
+
+    def create_mirror_acl_ipv6_rule(self, table, rule, session):
+        tbl = swsscommon.Table(self.cdb, "ACL_RULE")
+        fvs = swsscommon.FieldValuePairs([("priority", "1000"),
+                                          ("mirror_action", session),
+                                          ("SRC_IPV6", "2777::0/64"),
+                                          ("DST_IPV6", "3666::0/128")])
+        tbl.set(table + "|" + rule, fvs)
+        time.sleep(1)
+
+    def remove_mirror_acl_rule(self, table, rule):
+        tbl = swsscommon.Table(self.cdb, "ACL_RULE")
+        tbl._del(table + "|" + rule)
+        time.sleep(1)
+
+    # Test case - create a MIRROR table and a MIRRORV6 table in combined mode
+    # 0. predefine the VS capability: combined
+    # 1. create a mirror session
+    # 2. create two ACL tables that support both IPv4 and IPv6
+    # 3. create two ACL rules with both IPv4 and IPv6 source and destination IP
+    #    verify the ACL rules are created successfully
+    # 4. remove all the configurations
+    def test_AclBindMirrorV6Combined(self, dvs, testlog):
+        """
+        This test verifies IPv6 rules cannot be inserted into MIRROR table
+        """
+        self.setup_db(dvs)
+
+        self.setup_mirrorv6_mode("combined")
+
+        session = "MIRROR_SESSION"
+        acl_table = "MIRROR_TABLE"
+        acl_table_v6 = "MIRROR_TABLE_V6"
+        acl_rule_1 = "MIRROR_RULE_1"
+        acl_rule_2 = "MIRROR_RULE_2"
+
+        # bring up port; assign ip; create neighbor; create route
+        self.set_interface_status("Ethernet32", "up")
+        self.add_ip_address("Ethernet32", "20.0.0.0/31")
+        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
+        assert self.get_mirror_session_state(session)["status"] == "active"
+
+        # assert mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 1
+        mirror_session_oid = tbl.getKeys()[0]
+
+        # create acl table ipv4
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"], "MIRROR")
+
+        # assert acl table is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
+        table_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_tables]
+        assert len(table_entries) == 1
+
+        # create acl table ipv6
+        self.create_acl_table(acl_table_v6, ["Ethernet0", "Ethernet4"], "MIRRORV6")
+
+        # assert acl table is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
+        table_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_tables]
+        assert len(table_entries) == 1
+
+        table_id = table_entries[0]
+
+        # create acl rule with IPv4 addresses
+        self.create_mirror_acl_ipv4_rule(acl_table, acl_rule_1, session)
+
+        # assert acl rule ipv4 is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 1
+
+        rule_id_v4 = rule_entries[0]
+
+        # assert acl rule is assocaited with table ipv4
+        (status, fvs) = tbl.get(rule_id_v4)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
+                assert fv[1] == table_id
+
+        # create acl rule with IPv6 addresses
+        self.create_mirror_acl_ipv6_rule(acl_table_v6, acl_rule_2, session)
+
+        # assert acl rule ipv6 is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 2
+
+        rule_id_v6 = rule_entries[1] if rule_entries[0] == rule_id_v4 else rule_entries[0]
+
+        # assert acl rule is associated with table ipv6
+        (status, fvs) = tbl.get(rule_id_v6)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
+                assert fv[1] == table_id
+
+        # remove acl rule
+        self.remove_mirror_acl_rule(acl_table, acl_rule_1)
+        self.remove_mirror_acl_rule(acl_table_v6, acl_rule_2)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+        self.remove_acl_table(acl_table_v6)
+
+        # remove mirror session
+        self.remove_mirror_session(session)
+
+        # assert no mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 0
+
+        # remove route; remove neighbor; remove ip; bring down port
+        self.remove_route(dvs, "4.4.4.4")
+        self.remove_neighbor("Ethernet32", "20.0.0.1")
+        self.remove_ip_address("Ethernet32", "20.0.0.0/31")
+        self.set_interface_status("Ethernet32", "down")
+
+
+    # Test case - intervene rule creation in table creation
+    # 0. predefine the VS platform: mellanox platform
+    # 1. create a mirror session
+    # 2. create the ipv4 ACL table
+    # 3. create the ipv4 ACL rule
+    # 4. create the ipv6 ACL table
+    # 5. create the ipv6 ACL rule
+    # 6. verify two rules are inserted successfully
+    def test_AclBindMirrorV6Reorder1(self, dvs, testlog):
+        """
+        This test verifies IPv6 rules cannot be inserted into MIRROR table
+        """
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        acl_table = "MIRROR_TABLE"
+        acl_table_v6 = "MIRROR_TABLE_V6"
+        acl_rule_1 = "MIRROR_RULE_1"
+        acl_rule_2 = "MIRROR_RULE_2"
+
+        # bring up port; assign ip; create neighbor; create route
+        self.set_interface_status("Ethernet32", "up")
+        self.add_ip_address("Ethernet32", "20.0.0.0/31")
+        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
+        assert self.get_mirror_session_state(session)["status"] == "active"
+
+        # assert mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 1
+        mirror_session_oid = tbl.getKeys()[0]
+
+        # create acl table ipv4
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"], "MIRROR")
+
+        # create acl rule with IPv4 addresses
+        self.create_mirror_acl_ipv4_rule(acl_table, acl_rule_1, session)
+
+        # create acl table ipv6
+        self.create_acl_table(acl_table_v6, ["Ethernet0", "Ethernet4"], "MIRRORV6")
+
+        # create acl rule with IPv6 addresses
+        self.create_mirror_acl_ipv6_rule(acl_table_v6, acl_rule_2, session)
+
+        # assert acl rules are created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 2
+
+        # remove acl rule
+        self.remove_mirror_acl_rule(acl_table, acl_rule_1)
+        self.remove_mirror_acl_rule(acl_table_v6, acl_rule_2)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+        self.remove_acl_table(acl_table_v6)
+
+        # remove mirror session
+        self.remove_mirror_session(session)
+
+        # assert no mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 0
+
+        # remove route; remove neighbor; remove ip; bring down port
+        self.remove_route(dvs, "4.4.4.4")
+        self.remove_neighbor("Ethernet32", "20.0.0.1")
+        self.remove_ip_address("Ethernet32", "20.0.0.0/31")
+        self.set_interface_status("Ethernet32", "down")
+
+
+    # Test case - intervene rule creation in table creation
+    # 0. predefine the VS platform: mellanox platform
+    # 1. create a mirror session
+    # 2. create the ipv4 ACL table
+    # 3. create the ipv6 ACL rule
+    # 4. create the ipv6 ACL table
+    # 5. create the ipv4 ACL rule
+    # 6. verify two rules are inserted successfully
+    def test_AclBindMirrorV6Reorder2(self, dvs, testlog):
+        """
+        This test verifies IPv6 rules cannot be inserted into MIRROR table
+        """
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        acl_table = "MIRROR_TABLE"
+        acl_table_v6 = "MIRROR_TABLE_V6"
+        acl_rule_1 = "MIRROR_RULE_1"
+        acl_rule_2 = "MIRROR_RULE_2"
+
+        # bring up port; assign ip; create neighbor; create route
+        self.set_interface_status("Ethernet32", "up")
+        self.add_ip_address("Ethernet32", "20.0.0.0/31")
+        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
+        assert self.get_mirror_session_state(session)["status"] == "active"
+
+        # assert mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 1
+        mirror_session_oid = tbl.getKeys()[0]
+
+        # create acl table ipv4
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"], "MIRROR")
+
+        # create acl rule with IPv6 addresses
+        self.create_mirror_acl_ipv6_rule(acl_table_v6, acl_rule_2, session)
+
+        # assert acl rule is not created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 0
+
+        # create acl table ipv6
+        self.create_acl_table(acl_table_v6, ["Ethernet0", "Ethernet4"], "MIRRORV6")
+
+        # create acl rule with IPv4 addresses
+        self.create_mirror_acl_ipv4_rule(acl_table, acl_rule_1, session)
+
+        # assert acl rules are created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 2
+
+        # remove acl rule
+        self.remove_mirror_acl_rule(acl_table, acl_rule_1)
+        self.remove_mirror_acl_rule(acl_table_v6, acl_rule_2)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+        self.remove_acl_table(acl_table_v6)
+
+        # remove mirror session
+        self.remove_mirror_session(session)
+
+        # assert no mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 0
+
+        # remove route; remove neighbor; remove ip; bring down port
+        self.remove_route(dvs, "4.4.4.4")
+        self.remove_neighbor("Ethernet32", "20.0.0.1")
+        self.remove_ip_address("Ethernet32", "20.0.0.0/31")
+        self.set_interface_status("Ethernet32", "down")
+
+
+    # Test case - create ACL rules associated with wrong table
+    # 0. predefine the VS platform: mellanox platform
+    # 1. create a mirror session
+    # 2. create the ipv4 ACL table
+    # 3. create the ipv6 ACL rule associated with ipv4 table
+    # 4. create the ipv6 ACL table
+    # 5. create the ipv4 ACL rule associated with ipv6 table
+    # 6. verify two rules are inserted successfully
+    def test_AclBindMirrorV6WrongConfig(self, dvs, testlog):
+        """
+        This test verifies IPv6 rules cannot be inserted into MIRROR table
+        """
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        acl_table = "MIRROR_TABLE"
+        acl_table_v6 = "MIRROR_TABLE_V6"
+        acl_rule_1 = "MIRROR_RULE_1"
+        acl_rule_2 = "MIRROR_RULE_2"
+
+        # bring up port; assign ip; create neighbor; create route
+        self.set_interface_status("Ethernet32", "up")
+        self.add_ip_address("Ethernet32", "20.0.0.0/31")
+        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
+        assert self.get_mirror_session_state(session)["status"] == "active"
+
+        # assert mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 1
+        mirror_session_oid = tbl.getKeys()[0]
+
+        # create acl table ipv4
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"], "MIRROR")
+
+        # create WRONG acl rule with IPv6 addresses
+        self.create_mirror_acl_ipv6_rule(acl_table, acl_rule_2, session)
+
+        # assert acl rule is not created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 0
+
+        # create acl table ipv6
+        self.create_acl_table(acl_table_v6, ["Ethernet0", "Ethernet4"], "MIRRORV6")
+
+        # create WRONG acl rule with IPv4 addresses
+        self.create_mirror_acl_ipv4_rule(acl_table_v6, acl_rule_1, session)
+
+        # assert acl rules are created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 0
+
+        # remove acl rule
+        self.remove_mirror_acl_rule(acl_table, acl_rule_1)
+        self.remove_mirror_acl_rule(acl_table_v6, acl_rule_2)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+        self.remove_acl_table(acl_table_v6)
+
+        # remove mirror session
+        self.remove_mirror_session(session)
+
+        # assert no mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 0
+
+        # remove route; remove neighbor; remove ip; bring down port
+        self.remove_route(dvs, "4.4.4.4")
+        self.remove_neighbor("Ethernet32", "20.0.0.1")
+        self.remove_ip_address("Ethernet32", "20.0.0.0/31")
+        self.set_interface_status("Ethernet32", "down")
+
+

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -1,0 +1,478 @@
+# This test suite covers the functionality of mirror feature in SwSS
+
+import platform
+import pytest
+import time
+from distutils.version import StrictVersion
+
+from swsscommon import swsscommon
+
+DVS_FAKE_PLATFORM = "mellanox"
+
+
+class TestMirror(object):
+    def setup_db(self, dvs):
+        self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        self.sdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+
+    def set_interface_status(self, interface, admin_status):
+        if interface.startswith("PortChannel"):
+            tbl_name = "PORTCHANNEL"
+        elif interface.startswith("Vlan"):
+            tbl_name = "VLAN"
+        else:
+            tbl_name = "PORT"
+        tbl = swsscommon.Table(self.cdb, tbl_name)
+        fvs = swsscommon.FieldValuePairs([("admin_status", "up")])
+        tbl.set(interface, fvs)
+        time.sleep(1)
+
+    def add_ip_address(self, interface, ip):
+        if interface.startswith("PortChannel"):
+            tbl_name = "PORTCHANNEL_INTERFACE"
+        elif interface.startswith("Vlan"):
+            tbl_name = "VLAN_INTERFACE"
+        else:
+            tbl_name = "INTERFACE"
+        tbl = swsscommon.Table(self.cdb, tbl_name)
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set(interface + "|" + ip, fvs)
+        time.sleep(1)
+
+    def remove_ip_address(self, interface, ip):
+        if interface.startswith("PortChannel"):
+            tbl_name = "PORTCHANNEL_INTERFACE"
+        elif interface.startswith("Vlan"):
+            tbl_name = "VLAN_INTERFACE"
+        else:
+            tbl_name = "INTERFACE"
+        tbl = swsscommon.Table(self.cdb, tbl_name)
+        tbl._del(interface + "|" + ip)
+        time.sleep(1)
+
+    def add_neighbor(self, interface, ip, mac):
+        tbl = swsscommon.ProducerStateTable(self.pdb, "NEIGH_TABLE")
+        fvs = swsscommon.FieldValuePairs([("neigh", mac),
+                                          ("family", "IPv4")])
+        tbl.set(interface + ":" + ip, fvs)
+        time.sleep(1)
+
+    def remove_neighbor(self, interface, ip):
+        tbl = swsscommon.ProducerStateTable(self.pdb, "NEIGH_TABLE")
+        tbl._del(interface + ":" + ip)
+        time.sleep(1)
+
+    def add_route(self, dvs, prefix, nexthop):
+        dvs.runcmd("ip route add " + prefix + " via " + nexthop)
+        time.sleep(1)
+
+    def remove_route(self, dvs, prefix):
+        dvs.runcmd("ip route del " + prefix)
+        time.sleep(1)
+
+    def create_mirror_session(self, name, src, dst, gre, dscp, ttl, queue):
+        tbl = swsscommon.Table(self.cdb, "MIRROR_SESSION")
+        fvs = swsscommon.FieldValuePairs([("src_ip", src),
+                                          ("dst_ip", dst),
+                                          ("gre_type", gre),
+                                          ("dscp", dscp),
+                                          ("ttl", ttl),
+                                          ("queue", queue)])
+        tbl.set(name, fvs)
+        time.sleep(1)
+
+    def remove_mirror_session(self, name):
+        tbl = swsscommon.Table(self.cdb, "MIRROR_SESSION")
+        tbl._del(name)
+        time.sleep(1)
+
+    def get_mirror_session_status(self, name):
+        return self.get_mirror_session_state(name)["status"]
+
+    def get_mirror_session_state(self, name):
+        tbl = swsscommon.Table(self.sdb, "MIRROR_SESSION")
+        (status, fvs) = tbl.get(name)
+        assert status == True
+        assert len(fvs) > 0
+        return { fv[0]: fv[1] for fv in fvs }
+
+    def create_acl_table(self, table, interfaces, type):
+        tbl = swsscommon.Table(self.cdb, "ACL_TABLE")
+        fvs = swsscommon.FieldValuePairs([("policy_desc", "mirror_test"),
+                                          ("type", type),
+                                          ("ports", ",".join(interfaces))])
+        tbl.set(table, fvs)
+        time.sleep(1)
+
+    def remove_acl_table(self, table):
+        tbl = swsscommon.Table(self.cdb, "ACL_TABLE")
+        tbl._del(table)
+        time.sleep(1)
+
+    def create_mirror_acl_ipv4_rule(self, table, rule, session):
+        tbl = swsscommon.Table(self.cdb, "ACL_RULE")
+        fvs = swsscommon.FieldValuePairs([("priority", "1000"),
+                                          ("mirror_action", session),
+                                          ("SRC_IP", "10.0.0.0/32"),
+                                          ("DST_IP", "20.0.0.0/23")])
+        tbl.set(table + "|" + rule, fvs)
+        time.sleep(1)
+
+    def create_mirror_acl_ipv6_rule(self, table, rule, session):
+        tbl = swsscommon.Table(self.cdb, "ACL_RULE")
+        fvs = swsscommon.FieldValuePairs([("priority", "1000"),
+                                          ("mirror_action", session),
+                                          ("SRC_IPV6", "2777::0/64"),
+                                          ("DST_IPV6", "3666::0/128")])
+        tbl.set(table + "|" + rule, fvs)
+        time.sleep(1)
+
+    def remove_mirror_acl_rule(self, table, rule):
+        tbl = swsscommon.Table(self.cdb, "ACL_RULE")
+        tbl._del(table + "|" + rule)
+        time.sleep(1)
+
+
+    # Test case - create a MIRROR table and a MIRRORV6 table in separated mode
+    # 0. predefine the VS platform: mellanox platform
+    # 1. create a mirror session
+    # 2. create two ACL tables that support IPv4 and IPv6 separatedly
+    # 3. create two ACL rules with both IPv4 and IPv6 source and destination IP
+    #    verify the ACL rules are created successfully
+    # 4. remove all the configurations
+    def test_AclBindMirrorSeparated(self, dvs, testlog):
+        """
+        This test verifies IPv6 rules cannot be inserted into MIRROR table
+        """
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        acl_table = "MIRROR_TABLE"
+        acl_table_v6 = "MIRROR_TABLE_V6"
+        acl_rule_1 = "MIRROR_RULE_1"
+        acl_rule_2 = "MIRROR_RULE_2"
+
+        # bring up port; assign ip; create neighbor; create route
+        self.set_interface_status("Ethernet32", "up")
+        self.add_ip_address("Ethernet32", "20.0.0.0/31")
+        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
+        assert self.get_mirror_session_state(session)["status"] == "active"
+
+        # assert mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 1
+        mirror_session_oid = tbl.getKeys()[0]
+
+        # create acl table ipv4
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"], "MIRROR")
+
+        # assert acl table ipv4 is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
+        table_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_tables]
+        assert len(table_entries) == 1
+
+        table_id_v4 = table_entries[0]
+
+        # create acl table ipv6
+        self.create_acl_table(acl_table_v6, ["Ethernet0", "Ethernet4"], "MIRRORV6")
+
+        # assert acl table ipv6 is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
+        table_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_tables]
+        assert len(table_entries) == 2
+
+        table_id_v6 = table_entries[1] if table_entries[0] == table_id_v4 else table_entries[0]
+
+        # create acl rule with IPv4 addresses
+        self.create_mirror_acl_ipv4_rule(acl_table, acl_rule_1, session)
+
+        # assert acl rule ipv4 is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 1
+
+        rule_id_v4 = rule_entries[0]
+
+        # assert acl rule is assocaited with table ipv4
+        (status, fvs) = tbl.get(rule_id_v4)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
+                assert fv[1] == table_id_v4
+
+        # create acl rule with IPv6 addresses
+        self.create_mirror_acl_ipv6_rule(acl_table_v6, acl_rule_2, session)
+
+        # assert acl rule ipv6 is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 2
+
+        rule_id_v6 = rule_entries[1] if rule_entries[0] == rule_id_v4 else rule_entries[0]
+
+        # assert acl rule is associated with table ipv6
+        (status, fvs) = tbl.get(rule_id_v6)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
+                assert fv[1] == table_id_v6
+
+        # remove acl rule
+        self.remove_mirror_acl_rule(acl_table, acl_rule_1)
+        self.remove_mirror_acl_rule(acl_table_v6, acl_rule_2)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+        self.remove_acl_table(acl_table_v6)
+
+        # remove mirror session
+        self.remove_mirror_session(session)
+
+        # assert no mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 0
+
+        # remove route; remove neighbor; remove ip; bring down port
+        self.remove_route(dvs, "4.4.4.4")
+        self.remove_neighbor("Ethernet32", "20.0.0.1")
+        self.remove_ip_address("Ethernet32", "20.0.0.0/31")
+        self.set_interface_status("Ethernet32", "down")
+
+    # Test case - intervene rule creation in table creation
+    # 0. predefine the VS platform: mellanox platform
+    # 1. create a mirror session
+    # 2. create the ipv4 ACL table
+    # 3. create the ipv4 ACL rule
+    # 4. create the ipv6 ACL table
+    # 5. create the ipv6 ACL rule
+    # 6. verify two rules are inserted successfully
+    def test_AclBindMirrorV6Reorder1(self, dvs, testlog):
+        """
+        This test verifies IPv6 rules cannot be inserted into MIRROR table
+        """
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        acl_table = "MIRROR_TABLE"
+        acl_table_v6 = "MIRROR_TABLE_V6"
+        acl_rule_1 = "MIRROR_RULE_1"
+        acl_rule_2 = "MIRROR_RULE_2"
+
+        # bring up port; assign ip; create neighbor; create route
+        self.set_interface_status("Ethernet32", "up")
+        self.add_ip_address("Ethernet32", "20.0.0.0/31")
+        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
+        assert self.get_mirror_session_state(session)["status"] == "active"
+
+        # assert mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 1
+        mirror_session_oid = tbl.getKeys()[0]
+
+        # create acl table ipv4
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"], "MIRROR")
+
+        # create acl rule with IPv4 addresses
+        self.create_mirror_acl_ipv4_rule(acl_table, acl_rule_1, session)
+
+        # create acl table ipv6
+        self.create_acl_table(acl_table_v6, ["Ethernet0", "Ethernet4"], "MIRRORV6")
+
+        # create acl rule with IPv6 addresses
+        self.create_mirror_acl_ipv6_rule(acl_table_v6, acl_rule_2, session)
+
+        # assert acl rules are created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 2
+
+        # remove acl rule
+        self.remove_mirror_acl_rule(acl_table, acl_rule_1)
+        self.remove_mirror_acl_rule(acl_table_v6, acl_rule_2)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+        self.remove_acl_table(acl_table_v6)
+
+        # remove mirror session
+        self.remove_mirror_session(session)
+
+        # assert no mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 0
+
+        # remove route; remove neighbor; remove ip; bring down port
+        self.remove_route(dvs, "4.4.4.4")
+        self.remove_neighbor("Ethernet32", "20.0.0.1")
+        self.remove_ip_address("Ethernet32", "20.0.0.0/31")
+        self.set_interface_status("Ethernet32", "down")
+
+
+    # Test case - intervene rule creation in table creation
+    # 0. predefine the VS platform: mellanox platform
+    # 1. create a mirror session
+    # 2. create the ipv4 ACL table
+    # 3. create the ipv6 ACL rule
+    # 4. create the ipv6 ACL table
+    # 5. create the ipv4 ACL rule
+    # 6. verify two rules are inserted successfully
+    def test_AclBindMirrorV6Reorder2(self, dvs, testlog):
+        """
+        This test verifies IPv6 rules cannot be inserted into MIRROR table
+        """
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        acl_table = "MIRROR_TABLE"
+        acl_table_v6 = "MIRROR_TABLE_V6"
+        acl_rule_1 = "MIRROR_RULE_1"
+        acl_rule_2 = "MIRROR_RULE_2"
+
+        # bring up port; assign ip; create neighbor; create route
+        self.set_interface_status("Ethernet32", "up")
+        self.add_ip_address("Ethernet32", "20.0.0.0/31")
+        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
+        assert self.get_mirror_session_state(session)["status"] == "active"
+
+        # assert mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 1
+        mirror_session_oid = tbl.getKeys()[0]
+
+        # create acl table ipv4
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"], "MIRROR")
+
+        # create acl rule with IPv6 addresses
+        self.create_mirror_acl_ipv6_rule(acl_table_v6, acl_rule_2, session)
+
+        # assert acl rule is not created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 0
+
+        # create acl table ipv6
+        self.create_acl_table(acl_table_v6, ["Ethernet0", "Ethernet4"], "MIRRORV6")
+
+        # create acl rule with IPv4 addresses
+        self.create_mirror_acl_ipv4_rule(acl_table, acl_rule_1, session)
+
+        # assert acl rules are created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 2
+
+        # remove acl rule
+        self.remove_mirror_acl_rule(acl_table, acl_rule_1)
+        self.remove_mirror_acl_rule(acl_table_v6, acl_rule_2)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+        self.remove_acl_table(acl_table_v6)
+
+        # remove mirror session
+        self.remove_mirror_session(session)
+
+        # assert no mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 0
+
+        # remove route; remove neighbor; remove ip; bring down port
+        self.remove_route(dvs, "4.4.4.4")
+        self.remove_neighbor("Ethernet32", "20.0.0.1")
+        self.remove_ip_address("Ethernet32", "20.0.0.0/31")
+        self.set_interface_status("Ethernet32", "down")
+
+
+    # Test case - create ACL rules associated with wrong table
+    # 0. predefine the VS platform: mellanox platform
+    # 1. create a mirror session
+    # 2. create the ipv4 ACL table
+    # 3. create the ipv6 ACL rule associated with ipv4 table
+    # 4. create the ipv6 ACL table
+    # 5. create the ipv4 ACL rule associated with ipv6 table
+    # 6. verify two rules are inserted successfully
+    def test_AclBindMirrorV6WrongConfig(self, dvs, testlog):
+        """
+        This test verifies IPv6 rules cannot be inserted into MIRROR table
+        """
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        acl_table = "MIRROR_TABLE"
+        acl_table_v6 = "MIRROR_TABLE_V6"
+        acl_rule_1 = "MIRROR_RULE_1"
+        acl_rule_2 = "MIRROR_RULE_2"
+
+        # bring up port; assign ip; create neighbor; create route
+        self.set_interface_status("Ethernet32", "up")
+        self.add_ip_address("Ethernet32", "20.0.0.0/31")
+        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
+        assert self.get_mirror_session_state(session)["status"] == "active"
+
+        # assert mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 1
+        mirror_session_oid = tbl.getKeys()[0]
+
+        # create acl table ipv4
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"], "MIRROR")
+
+        # create WRONG acl rule with IPv6 addresses
+        self.create_mirror_acl_ipv6_rule(acl_table, acl_rule_2, session)
+
+        # assert acl rule is not created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 0
+
+        # create acl table ipv6
+        self.create_acl_table(acl_table_v6, ["Ethernet0", "Ethernet4"], "MIRRORV6")
+
+        # create WRONG acl rule with IPv4 addresses
+        self.create_mirror_acl_ipv4_rule(acl_table_v6, acl_rule_1, session)
+
+        # assert acl rules are created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 0
+
+        # remove acl rule
+        self.remove_mirror_acl_rule(acl_table, acl_rule_1)
+        self.remove_mirror_acl_rule(acl_table_v6, acl_rule_2)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+        self.remove_acl_table(acl_table_v6)
+
+        # remove mirror session
+        self.remove_mirror_session(session)
+
+        # assert no mirror session in asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        assert len(tbl.getKeys()) == 0
+
+        # remove route; remove neighbor; remove ip; bring down port
+        self.remove_route(dvs, "4.4.4.4")
+        self.remove_neighbor("Ethernet32", "20.0.0.1")
+        self.remove_ip_address("Ethernet32", "20.0.0.0/31")
+        self.set_interface_status("Ethernet32", "down")
+
+


### PR DESCRIPTION
Enable both IPv4 and IPv6 source and destination IP match and
mirror functionality in SONiC.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>