### PR TITLE
modify the string from IPV6_Neighbor to IPV6_NEIGHBOR for crmResTypeNameMap.

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -28,7 +28,7 @@ const map<CrmResourceType, string> crmResTypeNameMap =
     { CrmResourceType::CRM_IPV4_NEXTHOP, "IPV4_NEXTHOP" },
     { CrmResourceType::CRM_IPV6_NEXTHOP, "IPV6_NEXTHOP" },
     { CrmResourceType::CRM_IPV4_NEIGHBOR, "IPV4_NEIGHBOR" },
-    { CrmResourceType::CRM_IPV6_NEIGHBOR, "IPV6_Neighbor" },
+    { CrmResourceType::CRM_IPV6_NEIGHBOR, "IPV6_NEIGHBOR" },
     { CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER, "NEXTHOP_GROUP_MEMBER" },
     { CrmResourceType::CRM_NEXTHOP_GROUP, "NEXTHOP_GROUP" },
     { CrmResourceType::CRM_ACL_TABLE, "ACL_TABLE" },


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

1. Modify IPV6_Neighbor to IPV6_NEIGHBOR using upper case of full word.
2. Except this variable, the others all use upper case full word.
For consistency, I modified it to use upper case full word.
3. I test the case by python test. I set the high thresholds of ipv6 neighbor to 90 ,  and  set the thresholds ipv6 neighbor type to "free". Setting the value to 1000 for ipv6 neighbors by function setReadOnlyAttr, and check the syslog . The syslog should display as  "IPV6_NEIGHBOR THRESHOLD_EXCEEDED for TH_FREE" .
