### PR TITLE
[fpmsyncd] align port variable type with sockaddr_in.sin_port

### DIFF
--- a/fpmsyncd/fpmlink.cpp
+++ b/fpmsyncd/fpmlink.cpp
@@ -9,7 +9,7 @@
 using namespace swss;
 using namespace std;
 
-FpmLink::FpmLink(int port) :
+FpmLink::FpmLink(unsigned short port) :
     MSG_BATCH_SIZE(256),
     m_bufSize(FPM_MAX_MSG_LEN * MSG_BATCH_SIZE),
     m_messageBuffer(NULL),

--- a/fpmsyncd/fpmlink.h
+++ b/fpmsyncd/fpmlink.h
@@ -19,7 +19,7 @@ namespace swss {
 class FpmLink : public Selectable {
 public:
     const int MSG_BATCH_SIZE;
-    FpmLink(int port = FPM_DEFAULT_PORT);
+    FpmLink(unsigned short port = FPM_DEFAULT_PORT);
     virtual ~FpmLink();
 
     /* Wait for connection (blocking) */


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed compilation issue when disabled optiomizations (SONIC_PROFILING_ON=y in SONiC build system)

**Why I did it**
To fix compilation issue

**How I verified it**
Built swss debian package

**Details if related**
Error from gcc:
```
stepanb@ac724d5440a8:/sonic/src/sonic-swss$ make
make  all-recursive
make[1]: Entering directory '/sonic/src/sonic-swss'
Making all in fpmsyncd
make[2]: Entering directory '/sonic/src/sonic-swss/fpmsyncd'
g++ -DHAVE_CONFIG_H -I. -I.. -I .. -I ../warmrestart -I  -g  -std=c++11 -Wall -fPIC -Wno-write-strings -I/usr/include/libnl3 -I/usr/include/swss -Werror -Wno-reorder -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Wextra -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Winvalid-pch -Wlong-long -Wmissing-field-initializers -Wmissing-format-attribute -Wno-aggregate-return -Wno-padded -Wno-switch-enum -Wno-unused-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wstack-protector -Wstrict-aliasing=3 -Wswitch -Wswitch-default-Wunreachable-code -Wunused -Wvariadic-macros -Wno-switch-default -Wno-long-long -Wno-redundant-decls -Wdate-time  -g -O0 -fdebug-prefix-map=/sonic/src/sonic-swss=. -fstack-protector-strong -Wformat -Werror=format-security -c -o fpmsyncd-fpmlink.o `test -f 'fpmlink.cpp' || echo './'`fpmlink.cpp
fpmlink.cpp: In constructor 'swss::FpmLink::FpmLink(int)':
fpmlink.cpp:43:31: error: conversion to 'uint16_t {aka short unsigned int}' from 'int' may alter its value [-Werror=conversion]
     addr.sin_port = htons(port);
                               ^
cc1plus: all warnings being treated as errors
Makefile:460: recipe for target 'fpmsyncd-fpmlink.o' failed
make[2]: *** [fpmsyncd-fpmlink.o] Error 1
make[2]: Leaving directory '/sonic/src/sonic-swss/fpmsyncd'
Makefile:405: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/sonic/src/sonic-swss'
Makefile:337: recipe for target 'all' failed
make: *** [all] Error 2
```
