### PR TITLE
 Save teamsyncd data reconciliation state to stateDB for observability.

### DIFF
--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -11,6 +11,7 @@
 #include "netmsg.h"
 #include <team.h>
 
+#define TEAMSYNCD_APP_NAME  "teamsyncd"
 // seconds
 const uint32_t DEFAULT_WR_PENDING_TIMEOUT = 70;
 

--- a/teamsyncd/teamsyncd.cpp
+++ b/teamsyncd/teamsyncd.cpp
@@ -11,7 +11,7 @@ using namespace swss;
 
 int main(int argc, char **argv)
 {
-    swss::Logger::linkToDbNative("teamsyncd");
+    swss::Logger::linkToDbNative(TEAMSYNCD_APP_NAME);
     DBConnector db(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     DBConnector stateDb(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     Select s;


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>


**What I did**
As other applications with data reconciliation processing, have teamsyncd to provide similar observability.

**Why I did it**

**How I verified it**

```
admin@sonic:~$ show warm_restart state
name          restore_count  state
----------  ---------------  ----------
orchagent                10  reconciled
vlanmgrd                 10
teammgrd                  1
portsyncd                10
neighsyncd               10  reconciled
teamsyncd                 1  reconciled
syncd                     0
bgp                       1  reconciled
```

**Details if related**
