### PR TITLE
Add configuration tests for CRM pytests.

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -28,7 +28,7 @@ const map<CrmResourceType, string> crmResTypeNameMap =
     { CrmResourceType::CRM_IPV4_NEXTHOP, "IPV4_NEXTHOP" },
     { CrmResourceType::CRM_IPV6_NEXTHOP, "IPV6_NEXTHOP" },
     { CrmResourceType::CRM_IPV4_NEIGHBOR, "IPV4_NEIGHBOR" },
-    { CrmResourceType::CRM_IPV6_NEIGHBOR, "IPV6_Neighbor" },
+    { CrmResourceType::CRM_IPV6_NEIGHBOR, "IPV6_NEIGHBOR" },
     { CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER, "NEXTHOP_GROUP_MEMBER" },
     { CrmResourceType::CRM_NEXTHOP_GROUP, "NEXTHOP_GROUP" },
     { CrmResourceType::CRM_ACL_TABLE, "ACL_TABLE" },

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -15,6 +15,24 @@ def getCrmCounterValue(dvs, key, counter):
         if k[0] == counter:
             return int(k[1])
 
+def getCrmConfigValue(dvs, key, counter):
+
+    config_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+    crm_stats_table = swsscommon.Table(config_db, 'CRM')
+
+    for k in crm_stats_table.get(key)[1]:
+        if k[0] == counter:
+            return int(k[1])
+
+
+def getCrmConfigStr(dvs, key, counter):
+
+    config_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+    crm_stats_table = swsscommon.Table(config_db, 'CRM')
+
+    for k in crm_stats_table.get(key)[1]:
+        if k[0] == counter:
+            return k[1]
 
 def setReadOnlyAttr(dvs, obj, attr, val):
 
@@ -599,3 +617,205 @@ def test_CrmAcl(dvs, testlog):
     table_used_counter = getCrmCounterValue(dvs, 'ACL_STATS:INGRESS:PORT', 'crm_stats_acl_table_used')
     assert table_used_counter == 0
 
+def test_Configure(dvs, testlog):
+
+    #polling interval
+    dvs.runcmd("crm config polling interval 10")
+    time.sleep(2)
+    polling_interval = getCrmConfigValue(dvs, 'Config', 'polling_interval')
+    assert polling_interval == 10
+
+def test_Configure_ipv4_route(dvs, testlog):
+
+    #ipv4 route low/high threshold/type
+    dvs.runcmd("crm config thresholds ipv4 route low 50")
+    dvs.runcmd("crm config thresholds ipv4 route high 90")
+    dvs.runcmd("crm config thresholds ipv4 route type percentage")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'ipv4_route_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'ipv4_route_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'ipv4_route_threshold_type')
+    assert threshold_type == 'percentage'
+
+def test_Configure_ipv6_route(dvs, testlog):
+
+    #ipv6 route low/high threshold/type
+    dvs.runcmd("crm config thresholds ipv6 route low 50")
+    dvs.runcmd("crm config thresholds ipv6 route high 90")
+    dvs.runcmd("crm config thresholds ipv6 route type used")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'ipv6_route_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'ipv6_route_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'ipv6_route_threshold_type')
+    assert threshold_type == 'used'
+
+def test_Configure_ipv4_nexthop(dvs, testlog):
+
+    #ipv4 nexthop low/high threshold/type
+    dvs.runcmd("crm config thresholds ipv4 nexthop low 50")
+    dvs.runcmd("crm config thresholds ipv4 nexthop high 90")
+    dvs.runcmd("crm config thresholds ipv4 nexthop type 'percentage'")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'ipv4_nexthop_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'ipv4_nexthop_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'ipv4_nexthop_threshold_type')
+    assert threshold_type == 'percentage'
+
+def test_Configure_ipv6_nexthop(dvs, testlog):
+
+    #ipv6 nexthop low/high threshold/type
+    dvs.runcmd("crm config thresholds ipv6 nexthop low 50")
+    dvs.runcmd("crm config thresholds ipv6 nexthop high 90")
+    dvs.runcmd("crm config thresholds ipv6 nexthop type free")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'ipv6_nexthop_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'ipv6_nexthop_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'ipv6_nexthop_threshold_type')
+    assert threshold_type == 'free'
+
+def test_Configure_ipv4_neighbor(dvs, testlog):
+
+    #ipv4 neighbor low/high threshold/type
+    dvs.runcmd("crm config thresholds ipv4 neighbor low 50")
+    dvs.runcmd("crm config thresholds ipv4 neighbor high 90")
+    dvs.runcmd("crm config thresholds ipv4 neighbor type percentage")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'ipv4_neighbor_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'ipv4_neighbor_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'ipv4_neighbor_threshold_type')
+    assert threshold_type == 'percentage'
+
+def test_Configure_ipv6_neighbor(dvs, testlog):
+
+    #ipv6 neighbor low/high threshold/type
+    dvs.runcmd("crm config thresholds ipv6 neighbor low 50")
+    dvs.runcmd("crm config thresholds ipv6 neighbor high 90")
+    dvs.runcmd("crm config thresholds ipv6 neighbor type used")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'ipv6_neighbor_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'ipv6_neighbor_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'ipv6_neighbor_threshold_type')
+    assert threshold_type == 'used'
+
+def test_Configure_group_member(dvs, testlog):
+
+    #nexthop group member low/high threshold/type
+    dvs.runcmd("crm config thresholds nexthop group member low 50")
+    dvs.runcmd("crm config thresholds nexthop group member high 90")
+    dvs.runcmd("crm config thresholds nexthop group member type percentage")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'nexthop_group_member_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'nexthop_group_member_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'nexthop_group_member_threshold_type')
+    assert threshold_type == 'percentage'
+
+def test_Configure_group_object(dvs, testlog):
+
+    #nexthop group object low/high threshold/type
+    dvs.runcmd("crm config thresholds nexthop group object low 50")
+    dvs.runcmd("crm config thresholds nexthop group object high 90")
+    dvs.runcmd("crm config thresholds nexthop group object type free")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'nexthop_group_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'nexthop_group_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'nexthop_group_threshold_type')
+    assert threshold_type == 'free'
+
+def test_Configure_acl_table(dvs, testlog):
+
+    #thresholds acl table low/high threshold/type
+    dvs.runcmd("crm config thresholds acl table low 50")
+    dvs.runcmd("crm config thresholds acl table high 90")
+    dvs.runcmd("crm config thresholds acl table type percentage")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'acl_table_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'acl_table_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'acl_table_threshold_type')
+    assert threshold_type == 'percentage'
+
+def test_Configure_acl_group(dvs, testlog):
+
+    #thresholds acl group low/high threshold/type
+    dvs.runcmd("crm config thresholds acl group low 50")
+    dvs.runcmd("crm config thresholds acl group high 90")
+    dvs.runcmd("crm config thresholds acl group type used")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'acl_group_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'acl_group_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'acl_group_threshold_type')
+    assert threshold_type == 'used'
+
+def test_Configure_acl_group_entry(dvs, testlog):
+
+    #thresholds acl group entry low/high threshold/type
+    dvs.runcmd("crm config thresholds acl group entry low 50")
+    dvs.runcmd("crm config thresholds acl group entry high 90")
+    dvs.runcmd("crm config thresholds acl group entry type percentage")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'acl_entry_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'acl_entry_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'acl_entry_threshold_type')
+    assert threshold_type == 'percentage'
+
+def test_Configure_acl_group_counter(dvs, testlog):
+
+    #thresholds acl group counter low/high threshold/type
+    dvs.runcmd("crm config thresholds acl group counter low 50")
+    dvs.runcmd("crm config thresholds acl group counter high 90")
+    dvs.runcmd("crm config thresholds acl group counter type free")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'acl_counter_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'acl_counter_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'acl_counter_threshold_type')
+    assert threshold_type == 'free'
+
+def test_Configure_fdb(dvs, testlog):
+
+    #thresholds fdb low/high threshold/type
+    dvs.runcmd("crm config thresholds fdb low 50")
+    dvs.runcmd("crm config thresholds fdb high 90")
+    dvs.runcmd("crm config thresholds fdb type percentage")
+
+    time.sleep(2)
+    threshold_low = getCrmConfigValue(dvs, 'Config', 'fdb_entry_low_threshold')
+    assert threshold_low == 50
+    threshold_high = getCrmConfigValue(dvs, 'Config', 'fdb_entry_high_threshold')
+    assert threshold_high == 90
+    threshold_type = getCrmConfigStr(dvs, 'Config', 'fdb_entry_threshold_type')
+    assert threshold_type == 'percentage'


### PR DESCRIPTION
I update some configuration tests for CRM pytests.
Please help to review, thank you.

test result
=============================================== test session starts ===============================================
platform linux2 -- Python 2.7.12, pytest-4.3.1, py-1.8.0, pluggy-0.9.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/iris/project/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 24 items

test_crm.py::test_CrmFdbEntry PASSED [ 4%]
test_crm.py::test_CrmIpv4Route PASSED [ 8%]
test_crm.py::test_CrmIpv6Route PASSED [ 12%]
test_crm.py::test_CrmIpv4Nexthop PASSED [ 16%]
test_crm.py::test_CrmIpv6Nexthop PASSED [ 20%]
test_crm.py::test_CrmIpv4Neighbor PASSED [ 25%]
test_crm.py::test_CrmIpv6Neighbor PASSED [ 29%]
test_crm.py::test_CrmNexthopGroup PASSED [ 33%]
test_crm.py::test_CrmNexthopGroupMember PASSED [ 37%]
test_crm.py::test_CrmAcl PASSED [ 41%]
test_crm.py::test_Configure PASSED [ 45%]
test_crm.py::test_Configure_ipv4_route PASSED [ 50%]
test_crm.py::test_Configure_ipv6_route PASSED [ 54%]
test_crm.py::test_Configure_ipv4_nexthop PASSED [ 58%]
test_crm.py::test_Configure_ipv6_nexthop PASSED [ 62%]
test_crm.py::test_Configure_ipv4_neighbor PASSED [ 66%]
test_crm.py::test_Configure_ipv6_neighbor PASSED [ 70%]
test_crm.py::test_Configure_group_member PASSED [ 75%]
test_crm.py::test_Configure_group_object PASSED [ 79%]
test_crm.py::test_Configure_acl_table PASSED [ 83%]
test_crm.py::test_Configure_acl_group PASSED [ 87%]
test_crm.py::test_Configure_acl_group_entry PASSED [ 91%]
test_crm.py::test_Configure_acl_group_counter PASSED [ 95%]
test_crm.py::test_Configure_fdb PASSED [100%]

=========================================== 24 passed in 201.54 seconds ===========================================