### PR TITLE
[vnetorch]: Fix incorrect creation flow for bitmap VNET

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -271,10 +271,10 @@ VNetBitmapObject::VNetBitmapObject(const std::string& vnet, const VNetInfo& vnet
 {
     SWSS_LOG_ENTER();
 
-    setVniInfo(vnetInfo.vni);
-
     vnet_id_ = getFreeBitmapId(vnet);
     vnet_name_ = vnet;
+
+    setVniInfo(vnetInfo.vni);
 }
 
 bool VNetBitmapObject::updateObj(vector<sai_attribute_t>&)


### PR DESCRIPTION
* Initialize VNET ID before creating VNET object

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed incorrect creation flow for bitmap VNET: initialize VNET ID before creating VNET object.
**Why I did it**
It is a bug in VNET creation flow and it should to be fixed (it causes random failures for "decap" traffic flow).

**How I verified it**
- Manual tests
- Ansible tests
- Virtual switch tests

**Details if related**
N/A