### PR TITLE
Fix issue #850 vlanmgrd will crashed if there has incorrect type value on cfg_db.json.

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -238,7 +238,16 @@ void VlanMgr::doVlanTask(Consumer &consumer)
         }
 
         int vlan_id;
-        vlan_id = stoi(key.substr(4));
+        try
+        {
+            vlan_id = stoi(key.substr(4));
+        }
+        catch (...)
+        {
+            SWSS_LOG_ERROR("Invalid key format. Not a number after 'Vlan' prefix: %s", key.c_str());
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
 
         string vlan_alias, port_alias;
         string op = kfvOp(t);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix the issue #850 vlanmgrd will crashed if there has incorrect type value on cfg_db.json.

**Why I did it**
vlanmgrd will crashed cause by the issue.

**How I verified it**
Add test cases in test_vlan.py to make sure the bug fixed.

1. Add vlan with incorrect key prefix
  - shall not succeed
  - shall not cause vlanmgrd crashed
2. Add vlan with incorrect value type
  - shall not succeed
  - shall not cause vlanmgrd crashed

**Details if related**


Signed-off-by: Emma Lin <emma_lin@edge-core.com>