### PR TITLE
[warm-reboot]: add bgp eoiu support to speed up route reconciliation …

### DIFF
--- a/debian/swss.install
+++ b/debian/swss.install
@@ -1,3 +1,4 @@
 swssconfig/sample/netbouncer.json etc/swss/config.d
 swssconfig/sample/00-copp.config.json etc/swss/config.d
 neighsyncd/restore_neighbors.py usr/bin
+fpmsyncd/bgp_eoiu_marker.py  usr/bin

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -843,13 +843,28 @@ Stores information for physical switch ports managed by the switch chip. Ports t
     ;Stores bgp status
     ;Status: work in progress
 
-    key             = WARM_RESTART_TABLE|family|eoiu             ; family = "IPv4" / "IPv6"  ; address family.
+    key             = BGP_STATE_TABLE|family|eoiu             ; family = "IPv4" / "IPv6"  ; address family.
 
     state           = "unknown" / "reached" / "consumed"         ; unknown: eoiu state not fetched yet.
                                                                  ; reached: bgp eoiu done.
                                                                  ;
                                                                  ; consumed: the reached state has been consumed by application.
+    timestamp       = time-stamp                                 ; "%Y-%m-%d %H:%M:%S", full-date and partial-time separated by
+                                                                 ; white space.  Example: 2019-04-25 09:39:19
 
+    ;value annotations
+    date-fullyear   = 4DIGIT
+    date-month      = 2DIGIT  ; 01-12
+    date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
+                              ; month/year
+    time-hour       = 2DIGIT  ; 00-23
+    time-minute     = 2DIGIT  ; 00-59
+    time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second
+                              ; rules
+
+    partial-time    = time-hour ":" time-minute ":" time-second
+    full-date       = date-fullyear "-" date-month "-" date-mday
+    time-stamp      = full-date %x20 partial-time
 
 ## Configuration files
 What configuration files should we have?  Do apps, orch agent each need separate files?

--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -809,7 +809,7 @@ Stores information for physical switch ports managed by the switch chip. Ports t
     ;Stores application and orchdameon warm start status
     ;Status: work in progress
 
-    key             = WARM_RESTART_TABLE:process_name         ; process_name is a unique process identifier.
+    key             = WARM_RESTART_TABLE|process_name         ; process_name is a unique process identifier.
                                                               ; with exception of 'warm-shutdown' operation.
                                                               ; 'warm-shutdown' operation key is used to
                                                               ; track warm shutdown stages and results.
@@ -838,6 +838,18 @@ Stores information for physical switch ports managed by the switch chip. Ports t
     ;State for neighbor table restoring process during warm reboot
     key                 = NEIGH_RESTORE_TABLE|Flags
     restored            = "true" / "false" ; restored state
+
+### BGP\_STATE\_TABLE
+    ;Stores bgp status
+    ;Status: work in progress
+
+    key             = WARM_RESTART_TABLE|family|eoiu             ; family = "IPv4" / "IPv6"  ; address family.
+
+    state           = "unknown" / "reached" / "consumed"         ; unknown: eoiu state not fetched yet.
+                                                                 ; reached: bgp eoiu done.
+                                                                 ;
+                                                                 ; consumed: the reached state has been consumed by application.
+
 
 ## Configuration files
 What configuration files should we have?  Do apps, orch agent each need separate files?

--- a/fpmsyncd/bgp_eoiu_marker.py
+++ b/fpmsyncd/bgp_eoiu_marker.py
@@ -146,7 +146,6 @@ class BgpStateCheck():
     # The function will timeout in case eoiu states never meet the condition
     # after some time (DEF_TIME_OUT).
     def wait_for_bgp_eoiu(self):
-        #mtime = monotonic.time.time
         wait_time = self.DEF_TIME_OUT
         while wait_time >= 0:
             if not self.bgp_ipv4_eoiu:

--- a/fpmsyncd/bgp_eoiu_marker.py
+++ b/fpmsyncd/bgp_eoiu_marker.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+
+""""
+Description: bgp_eoiu_marker.py -- populating bgp eoiu marker flags in stateDB during warm reboot.
+    The script is started by supervisord in bgp docker when the docker is started.
+    It does not do anything in case neither system nor bgp warm restart is enabled.
+
+    The script check bgp neighbor state via vtysh cli interface periodically (every 1 second).
+    It looks for explicit EOR and implicit EOR (keep alive after established) in the json output of show ip bgp neighbors A.B.C.D json
+
+    Once the script has collected all needed EORs, it set a EOIU flags in stateDB.
+
+    fpmsyncd may hold a few seconds (2~5 seconds) after getting the flag before starting routing reconciliation.
+    2-5 seconds should be enough for all the route to be synced to fpmsyncd from bgp. If not, the system probably is already in wrong state.
+
+    For any reason the script failed to set EOIU flag in stateDB, the current warm_restart bgp_timer will kick in later.
+"""
+
+import sys
+import swsssdk
+import time
+import syslog
+import traceback
+import commands
+import json
+from swsscommon import swsscommon
+import errno
+from time import gmtime, strftime
+
+class BgpStateCheck():
+    # timeout the restore process in 120 seconds if not finished
+    # This is in consistent with the default timerout for bgp warm restart set in fpmsyncd
+
+    DEF_TIME_OUT = 120
+
+    # every 1 seconds to check bgp neighbors state
+    CHECK_INTERVAL = 1
+    def __init__(self):
+        self.ipv4_neighbors = []
+        self.ipv4_neigh_eor_status = {}
+        self.ipv6_neighbors = []
+        self.ipv6_neigh_eor_status = {}
+        self.keepalivesRecvCnt = {}
+        self.bgp_ipv4_eoiu = False
+        self.bgp_ipv6_eoiu = False
+
+    def get_all_peers(self):
+        try:
+            cmd = "vtysh -c 'show bgp summary json'"
+            output = commands.getoutput(cmd)
+            peer_info = json.loads(output)
+            if "ipv4Unicast" in peer_info and "peers" in peer_info["ipv4Unicast"]:
+                self.ipv4_neighbors = peer_info["ipv4Unicast"]["peers"].keys()
+
+            if "ipv6Unicast" in peer_info and "peers" in peer_info["ipv6Unicast"]:
+                self.ipv6_neighbors = peer_info["ipv6Unicast"]["peers"].keys()
+
+            syslog.syslog('BGP ipv4 neighbors: {}'.format(self.ipv4_neighbors))
+            syslog.syslog('BGP ipv4 neighbors: {}'.format(self.ipv6_neighbors))
+
+        except Exception:
+            syslog.syslog(syslog.LOG_ERR, "*ERROR* get_all_peers Exception: %s" % (traceback.format_exc()))
+            time.sleep(5)
+            self.get_all_peers()
+
+    def init_peers_eor_status(self):
+        # init neigh eor status to unknown
+        for neigh in self.ipv4_neighbors:
+            self.ipv4_neigh_eor_status[neigh] = "unknown"
+        for neigh in self.ipv6_neighbors:
+            self.ipv6_neigh_eor_status[neigh] = "unknown"
+
+    # Set the statedb "BGP_STATE_TABLE|eoiu", so fpmsyncd can get the bgp eoiu signal
+    # Only two families: 'ipv4' and 'ipv6'
+    # state is 'true' or 'false'
+    def set_bgp_eoiu_marker(self, family, state):
+        db = swsssdk.SonicV2Connector(host='127.0.0.1')
+        db.connect(db.STATE_DB, False)
+        key = "BGP_STATE_TABLE|%s|eoiu" % family
+        db.set(db.STATE_DB, key, 'state', state)
+        timesamp = strftime("%Y-%m-%d %H:%M:%S", gmtime())
+        db.set(db.STATE_DB, key, 'timestamp', timesamp)
+        db.close(db.STATE_DB)
+        return
+
+    def clean_bgp_eoiu_marker(self):
+        db = swsssdk.SonicV2Connector(host='127.0.0.1')
+        db.connect(db.STATE_DB, False)
+        db.delete(db.STATE_DB, "BGP_STATE_TABLE|IPv4|eoiu")
+        db.delete(db.STATE_DB, "BGP_STATE_TABLE|IPv6|eoiu")
+        db.close(db.STATE_DB)
+        syslog.syslog('Cleaned ipv4 and ipv6 eoiu marker flags')
+        return
+
+    def bgp_eor_received(self, neigh, is_ipv4):
+        try:
+            neighstr = "%s" % neigh
+            eor_received = False
+            cmd = "vtysh -c 'show bgp neighbors %s json'" % neighstr
+            output = commands.getoutput(cmd)
+            neig_status = json.loads(output)
+            if neighstr in neig_status:
+                if "gracefulRestartInfo" in neig_status[neighstr]:
+                    if "endOfRibRecv" in neig_status[neighstr]["gracefulRestartInfo"]:
+                        eor_info = neig_status[neighstr]["gracefulRestartInfo"]["endOfRibRecv"]
+                        if is_ipv4 and "IPv4 Unicast" in eor_info and eor_info["IPv4 Unicast"] == "true":
+                            eor_received = True
+                        elif not is_ipv4 and "IPv6 Unicast" in eor_info and eor_info["IPv6 Unicast"] == "true":
+                            eor_received = True
+                if eor_received:
+                    syslog.syslog('BGP eor received for neighbors: {}'.format(neigh))
+
+                # No explict eor, try implicit eor
+                if eor_received == False and "bgpState" in neig_status[neighstr] and neig_status[neighstr]["bgpState"] == "Established":
+                    # if "messageStats" in neig_status and "keepalivesRecv" in neig_status["messageStats"]:
+                    # it looks we need to record the keepalivesRecv count for detecting count change
+                    if neighstr not in self.keepalivesRecvCnt:
+                        self.keepalivesRecvCnt[neighstr] = neig_status[neighstr]["messageStats"]["keepalivesRecv"]
+                    else :
+                        eor_received = (self.keepalivesRecvCnt[neighstr] is not neig_status[neighstr]["messageStats"]["keepalivesRecv"])
+                        if eor_received:
+                            syslog.syslog('BGP implicit eor received for neighbors: {}'.format(neigh))
+
+            return eor_received
+
+        except Exception:
+            syslog.syslog(syslog.LOG_ERR, "*ERROR* bgp_eor_received Exception: %s" % (traceback.format_exc()))
+
+
+    # This function is to collect eor state based on the saved ipv4_neigh_eor_status and ipv6_neigh_eor_status dictionaries
+    # It iterates through the dictionary, and check whether the specific neighbor has EOR received.
+    # EOR may be explicit EOR (End-Of-RIB) or an implicit-EOR.
+    # The first keep-alive after BGP has reached Established is considered an implicit-EOR.
+    #
+    # ipv4 and ipv6 neighbors are processed separately.
+    # Once all ipv4 neighbors have EOR received, bgp_ipv4_eoiu becomes True.
+    # Once all ipv6 neighbors have EOR received, bgp_ipv6_eoiu becomes True.
+
+    # The neighbor EoR states were checked in a loop with an interval (CHECK_INTERVAL)
+    # The function will timeout in case eoiu states never meet the condition
+    # after some time (DEF_TIME_OUT).
+    def wait_for_bgp_eoiu(self):
+        #mtime = monotonic.time.time
+        wait_time = self.DEF_TIME_OUT
+        while wait_time >= 0:
+            if not self.bgp_ipv4_eoiu:
+                for neigh, eor_status in self.ipv4_neigh_eor_status.items():
+                    if eor_status == "unknown" and self.bgp_eor_received(neigh, True):
+                        self.ipv4_neigh_eor_status[neigh] = "rcvd"
+                if "unknown" not in self.ipv4_neigh_eor_status.values():
+                    self.bgp_ipv4_eoiu = True
+                    syslog.syslog("BGP ipv4 eoiu reached")
+
+            if not self.bgp_ipv6_eoiu:
+                for neigh, eor_status in self.ipv6_neigh_eor_status.items():
+                    if eor_status == "unknown" and self.bgp_eor_received(neigh, False):
+                        self.ipv6_neigh_eor_status[neigh] = "rcvd"
+                if "unknown" not in self.ipv6_neigh_eor_status.values():
+                    self.bgp_ipv6_eoiu = True
+                    syslog.syslog('BGP ipv6 eoiu reached')
+
+            if self.bgp_ipv6_eoiu and self.bgp_ipv4_eoiu:
+                break;
+            time.sleep(self.CHECK_INTERVAL)
+            wait_time -= self.CHECK_INTERVAL
+
+        if not self.bgp_ipv6_eoiu:
+            syslog.syslog(syslog.LOG_ERR, "BGP ipv6 eoiu not reached: {}".format(self.ipv6_neigh_eor_status));
+
+        if not self.bgp_ipv4_eoiu:
+            syslog.syslog(syslog.LOG_ERR, "BGP ipv4 eoiu not reached: {}".format(self.ipv4_neigh_eor_status));
+
+def main():
+
+    print "bgp_eoiu_marker service is started"
+
+    try:
+        bgp_state_check = BgpStateCheck()
+    except Exception, e:
+        syslog.syslog(syslog.LOG_ERR, "{}: error exit 1, reason {}".format(THIS_MODULE, str(e)))
+        exit(1)
+
+    # Always clean the eoiu marker in stateDB first
+    bgp_state_check.clean_bgp_eoiu_marker()
+
+    # Use warmstart python binding to check warmstart information
+    warmstart = swsscommon.WarmStart()
+    warmstart.initialize("bgp", "bgp")
+    warmstart.checkWarmStart("bgp", "bgp", False)
+
+    # if bgp or system warm reboot not enabled, don't run
+    if not warmstart.isWarmStart():
+        print "bgp_eoiu_marker service is skipped as warm restart not enabled"
+        return
+
+    bgp_state_check.set_bgp_eoiu_marker("IPv4", "unknown")
+    bgp_state_check.set_bgp_eoiu_marker("IPv6", "unknown")
+    bgp_state_check.get_all_peers()
+    bgp_state_check.init_peers_eor_status()
+    try:
+        bgp_state_check.wait_for_bgp_eoiu()
+    except Exception as e:
+        syslog.syslog(syslog.LOG_ERR, str(e))
+        sys.exit(1)
+
+    # set statedb to signal other processes like fpmsynd
+    if bgp_state_check.bgp_ipv4_eoiu:
+        bgp_state_check.set_bgp_eoiu_marker("IPv4", "reached")
+    if bgp_state_check.bgp_ipv6_eoiu:
+        bgp_state_check.set_bgp_eoiu_marker("IPv6", "reached")
+
+    print "bgp_eoiu_marker service is done"
+    return
+
+if __name__ == '__main__':
+    main()

--- a/fpmsyncd/bgp_eoiu_marker.py
+++ b/fpmsyncd/bgp_eoiu_marker.py
@@ -103,9 +103,9 @@ class BgpStateCheck():
                 if "gracefulRestartInfo" in neig_status[neighstr]:
                     if "endOfRibRecv" in neig_status[neighstr]["gracefulRestartInfo"]:
                         eor_info = neig_status[neighstr]["gracefulRestartInfo"]["endOfRibRecv"]
-                        if is_ipv4 and "IPv4 Unicast" in eor_info and eor_info["IPv4 Unicast"] == "true":
+                        if is_ipv4 and "IPv4 Unicast" in eor_info and eor_info["IPv4 Unicast"] == True:
                             eor_received = True
-                        elif not is_ipv4 and "IPv6 Unicast" in eor_info and eor_info["IPv6 Unicast"] == "true":
+                        elif not is_ipv4 and "IPv6 Unicast" in eor_info and eor_info["IPv6 Unicast"] == True:
                             eor_received = True
                 if eor_received:
                     syslog.syslog('BGP eor received for neighbors: {}'.format(neigh))

--- a/fpmsyncd/bgp_eoiu_marker.py
+++ b/fpmsyncd/bgp_eoiu_marker.py
@@ -78,7 +78,7 @@ class BgpStateCheck():
 
     # Set the statedb "BGP_STATE_TABLE|eoiu", so fpmsyncd can get the bgp eoiu signal
     # Only two families: 'ipv4' and 'ipv6'
-    # state is 'true' or 'false'
+    # state is "unknown" / "reached" / "consumed"
     def set_bgp_eoiu_marker(self, family, state):
         db = swsssdk.SonicV2Connector(host='127.0.0.1')
         db.connect(db.STATE_DB, False)

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -18,6 +18,30 @@ using namespace swss;
  */
 const uint32_t DEFAULT_ROUTING_RESTART_INTERVAL = 120;
 
+// Wait 3 seconds after detecting EOIU reached state
+// TODO: support eoiu hold interval config
+const uint32_t DEFAULT_EOIU_HOLD_INTERVAL = 3;
+
+// Check if eoiu state reached by both ipv4 and ipv6
+static bool eoiuFlagsSet(Table &bgpStateTable)
+{
+    string value;
+
+    bgpStateTable.hget("IPv4|eoiu", "state", value);
+    if (value != "reached")
+    {
+        SWSS_LOG_DEBUG("IPv4|eoiu state: %s", value.c_str());
+        return false;
+    }
+    bgpStateTable.hget("IPv6|eoiu", "state", value);
+    if (value != "reached")
+    {
+        SWSS_LOG_DEBUG("IPv6|eoiu state: %s", value.c_str());
+        return false;
+    }
+    SWSS_LOG_NOTICE("Warm-Restart bgp eoiu reached for both ipv4 and ipv6");
+    return true;
+}
 
 int main(int argc, char **argv)
 {
@@ -25,6 +49,9 @@ int main(int argc, char **argv)
     DBConnector db(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     RedisPipeline pipeline(&db);
     RouteSync sync(&pipeline);
+
+    DBConnector stateDb(STATE_DB, 0);
+    Table bgpStateTable(&stateDb, STATE_BGP_TABLE_NAME);
 
     NetDispatcher::getInstance().registerMessageHandler(RTM_NEWROUTE, &sync);
     NetDispatcher::getInstance().registerMessageHandler(RTM_DELROUTE, &sync);
@@ -36,7 +63,10 @@ int main(int argc, char **argv)
             FpmLink fpm;
             Select s;
             SelectableTimer warmStartTimer(timespec{0, 0});
-
+            // Before eoiu flags detected, check them periodically. It also stop upon detection of reconciliation done.
+            SelectableTimer eoiuCheckTimer(timespec{0, 0});
+            // After eoiu flags are detected, start a hold timer before starting reconciliation.
+            SelectableTimer eoiuHoldTimer(timespec{0, 0});
             /*
              * Pipeline should be flushed right away to deal with state pending
              * from previous try/catch iterations.
@@ -69,7 +99,14 @@ int main(int argc, char **argv)
                 {
                     warmStartTimer.start();
                     s.addSelectable(&warmStartTimer);
+                    SWSS_LOG_NOTICE("Warm-Restart timer started.");
                 }
+
+                // Also start periodic eoiu check timer, first wait 5 seconds, then check every 1 second
+                eoiuCheckTimer.setInterval(timespec{5, 0});
+                eoiuCheckTimer.start();
+                s.addSelectable(&eoiuCheckTimer);
+                SWSS_LOG_NOTICE("Warm-Restart eoiuCheckTimer timer started.");
             }
 
             while (true)
@@ -80,18 +117,53 @@ int main(int argc, char **argv)
                 s.select(&temps);
 
                 /*
-                 * Upon expiration of the warm-restart timer, proceed to run the
-                 * reconciliation process and remove warm-restart timer from
+                 * Upon expiration of the warm-restart timer or eoiu Hold Timer, proceed to run the
+                 * reconciliation process if not done yet and remove the timer from
                  * select() loop.
+                 * Note:  route reconciliation always succeeds, it will not be done twice.
                  */
-                if (warmStartEnabled && temps == &warmStartTimer)
+                if (temps == &warmStartTimer || temps == &eoiuHoldTimer)
                 {
-                    SWSS_LOG_NOTICE("Warm-Restart timer expired.");
-                    sync.m_warmStartHelper.reconcile();
-                    s.removeSelectable(&warmStartTimer);
-
+                    if (temps == &warmStartTimer)
+                    {
+                        SWSS_LOG_NOTICE("Warm-Restart timer expired.");
+                    }
+                    else
+                    {
+                        SWSS_LOG_NOTICE("Warm-Restart EOIU hold timer expired.");
+                    }
+                    if (sync.m_warmStartHelper.inProgress())
+                    {
+                        sync.m_warmStartHelper.reconcile();
+                        SWSS_LOG_NOTICE("Warm-Restart reconciliation processed.");
+                    }
+                    // remove the one-shot timer.
+                    s.removeSelectable(temps);
                     pipeline.flush();
                     SWSS_LOG_DEBUG("Pipeline flushed");
+                }
+                else if (temps == &eoiuCheckTimer)
+                {
+                    if (sync.m_warmStartHelper.inProgress())
+                    {
+                        if (eoiuFlagsSet(bgpStateTable))
+                        {
+                            eoiuHoldTimer.setInterval(timespec{DEFAULT_EOIU_HOLD_INTERVAL, 0});
+                            eoiuHoldTimer.start();
+                            s.addSelectable(&eoiuHoldTimer);
+                            SWSS_LOG_NOTICE("Warm-Restart started EOIU hold timer which is to expire in %d seconds.", DEFAULT_EOIU_HOLD_INTERVAL);
+                            s.removeSelectable(&eoiuCheckTimer);
+                            continue;
+                        }
+                        eoiuCheckTimer.setInterval(timespec{1, 0});
+                        // re-start eoiu check timer
+                        eoiuCheckTimer.start();
+                        SWSS_LOG_DEBUG("Warm-Restart eoiuCheckTimer restarted");
+                    }
+                    else
+                    {
+                        s.removeSelectable(&eoiuCheckTimer);
+                    }
                 }
                 else if (!warmStartEnabled || sync.m_warmStartHelper.isReconciled())
                 {

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
     RedisPipeline pipeline(&db);
     RouteSync sync(&pipeline);
 
-    DBConnector stateDb(STATE_DB, 0);
+    DBConnector stateDb(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     Table bgpStateTable(&stateDb, STATE_BGP_TABLE_NAME);
 
     NetDispatcher::getInstance().registerMessageHandler(RTM_NEWROUTE, &sync);

--- a/fpmsyncd/fpmsyncd.cpp
+++ b/fpmsyncd/fpmsyncd.cpp
@@ -148,10 +148,20 @@ int main(int argc, char **argv)
                     {
                         if (eoiuFlagsSet(bgpStateTable))
                         {
-                            eoiuHoldTimer.setInterval(timespec{DEFAULT_EOIU_HOLD_INTERVAL, 0});
+                            /* Obtain eoiu hold timer defined for bgp docker */
+                            uint32_t eoiuHoldIval = WarmStart::getWarmStartTimer("eoiu_hold", "bgp");
+                            if (!eoiuHoldIval)
+                            {
+                                eoiuHoldTimer.setInterval(timespec{DEFAULT_EOIU_HOLD_INTERVAL, 0});
+                                eoiuHoldIval = DEFAULT_EOIU_HOLD_INTERVAL;
+                            }
+                            else
+                            {
+                                eoiuHoldTimer.setInterval(timespec{eoiuHoldIval, 0});
+                            }
                             eoiuHoldTimer.start();
                             s.addSelectable(&eoiuHoldTimer);
-                            SWSS_LOG_NOTICE("Warm-Restart started EOIU hold timer which is to expire in %d seconds.", DEFAULT_EOIU_HOLD_INTERVAL);
+                            SWSS_LOG_NOTICE("Warm-Restart started EOIU hold timer which is to expire in %d seconds.", eoiuHoldIval);
                             s.removeSelectable(&eoiuCheckTimer);
                             continue;
                         }

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1927,6 +1927,7 @@ class TestWarmReboot(object):
 
         time.sleep(10)
 
+
         # check syslog and sairedis.rec file for activities
         check_syslog_for_neighbor_entry(dvs, marker, 0, NUM_OF_NEIGHS/2, "ipv4")
         check_syslog_for_neighbor_entry(dvs, marker, 0, NUM_OF_NEIGHS/2, "ipv6")

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1,3 +1,4 @@
+
 from swsscommon import swsscommon
 import os
 import re
@@ -1944,4 +1945,3 @@ class TestWarmReboot(object):
             intf_tbl._del("Ethernet{}|{}00::1/64".format(i*4, i*4))
             intf_tbl._del("Ethernet{}".format(i*4, i*4))
             intf_tbl._del("Ethernet{}".format(i*4, i*4))
-

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1659,6 +1659,127 @@ class TestWarmReboot(object):
         rt_key = json.loads(addobjs[0]['key'])
         assert rt_key['dest'] == "192.168.100.0/24"
 
+
+        #############################################################################
+        #
+        # Testcase 16. Restart zebra and make no control-plane changes.
+        #             Set WARM_RESTART_TABLE|IPv4|eoiu
+        #                 WARM_RESTART_TABLE|IPv6|eoiu
+        #             Check route reconciliation wait time is reduced
+        #             For this and all subsequent test-cases routing-warm-reboot
+        #             feature will be kept enabled.
+        #
+        #############################################################################
+
+
+        time.sleep(1)
+        # Hold time from EOIU detected for both Ipv4/Ipv6 to start route reconciliation
+        DEFAULT_EOIU_HOLD_INTERVAL = 3
+
+        # change to 20 for easy timeline check
+        restart_timer = 20
+
+        # clean up as that in bgp_eoiu_marker.py
+        del_entry_tbl(state_db, "BGP_STATE_TABLE", "IPv4|eoiu")
+        del_entry_tbl(state_db, "BGP_STATE_TABLE", "IPv6|eoiu")
+
+        dvs.runcmd("config warm_restart bgp_timer {}".format(restart_timer))
+        # Restart zebra
+        dvs.stop_zebra()
+        dvs.start_zebra()
+
+        #
+        # Verify FSM:  no eoiu, just default warm restart timer
+        #
+        swss_app_check_warmstart_state(state_db, "bgp", "restored")
+        # Periodic eoiu check timer, first wait 5 seconds, then check every 1 second
+        # DEFAULT_EOIU_HOLD_INTERVAL is 3 seconds.
+        # Since no EOIU set, after 3+ 5 + 1 seconds, the state still in restored state
+        time.sleep(DEFAULT_EOIU_HOLD_INTERVAL + 5 +1)
+        swss_app_check_warmstart_state(state_db, "bgp", "restored")
+        # default restart timer kicks in:
+        time.sleep(restart_timer - DEFAULT_EOIU_HOLD_INTERVAL -5)
+        swss_app_check_warmstart_state(state_db, "bgp", "reconciled")
+
+
+        time.sleep(1)
+        # Restart zebra
+        dvs.stop_zebra()
+        dvs.start_zebra()
+
+        #
+        # Verify FSM:  eoiu works as expected
+        #
+        swss_app_check_warmstart_state(state_db, "bgp", "restored")
+        # Set BGP_STATE_TABLE|Ipv4|eoiu BGP_STATE_TABLE|IPv6|eoiu
+        create_entry_tbl(
+            state_db,
+            "BGP_STATE_TABLE", "IPv4|eoiu",
+            [
+                ("state", "reached"),
+                ("timestamp", "2019-04-25 09:39:19"),
+            ]
+        )
+        create_entry_tbl(
+            state_db,
+            "BGP_STATE_TABLE", "IPv6|eoiu",
+            [
+                ("state", "reached"),
+                ("timestamp", "2019-04-25 09:39:22"),
+            ]
+        )
+
+        # after DEFAULT_EOIU_HOLD_INTERVAL + inital eoiu check timer wait time + 1 seconds: 3+5+1
+        # verify that bgp reached reconciled state
+        time.sleep(DEFAULT_EOIU_HOLD_INTERVAL + 5 + 1)
+        swss_app_check_warmstart_state(state_db, "bgp", "reconciled")
+
+        # Verify swss changes -- none are expected this time
+        (addobjs, delobjs) = dvs.GetSubscribedAppDbObjects(pubsubAppDB)
+        assert len(addobjs) == 0 and len(delobjs) == 0
+        # Verify swss changes -- none are expected this time
+        (addobjs, delobjs) = dvs.GetSubscribedAsicDbObjects(pubsubAsicDB)
+        assert len(addobjs) == 0 and len(delobjs) == 0
+
+
+        del_entry_tbl(state_db, "BGP_STATE_TABLE", "IPv4|eoiu")
+        del_entry_tbl(state_db, "BGP_STATE_TABLE", "IPv6|eoiu")
+        time.sleep(1)
+        # Restart zebra
+        dvs.stop_zebra()
+        dvs.start_zebra()
+
+        #
+        # Verify FSM:  partial eoiu,  fallback to default warm restart timer
+        #
+        swss_app_check_warmstart_state(state_db, "bgp", "restored")
+        # Set BGP_STATE_TABLE|Ipv4|eoiu but not BGP_STATE_TABLE|IPv6|eoiu
+        create_entry_tbl(
+            state_db,
+            "BGP_STATE_TABLE", "IPv4|eoiu",
+            [
+                ("state", "reached"),
+                ("timestamp", "2019-04-25 09:39:19"),
+            ]
+        )
+
+        # Periodic eoiu check timer, first wait 5 seconds, then check every 1 second
+        # DEFAULT_EOIU_HOLD_INTERVAL is 3 seconds.
+        # Current bgp eoiu needs flag set on both Ipv4/Ipv6 to work, after 3+ 5 + 1 seconds, the state still in restored state
+        time.sleep(DEFAULT_EOIU_HOLD_INTERVAL + 5 +1)
+        swss_app_check_warmstart_state(state_db, "bgp", "restored")
+        # Fall back to warm restart timer, it kicks in after 15 seconds, +1 to avoid race condition:
+        time.sleep(restart_timer - DEFAULT_EOIU_HOLD_INTERVAL -5 )
+        swss_app_check_warmstart_state(state_db, "bgp", "reconciled")
+
+        # Verify swss changes -- none are expected this time
+        (addobjs, delobjs) = dvs.GetSubscribedAppDbObjects(pubsubAppDB)
+        assert len(addobjs) == 0 and len(delobjs) == 0
+
+        # Verify swss changes -- none are expected this time
+        (addobjs, delobjs) = dvs.GetSubscribedAsicDbObjects(pubsubAsicDB)
+        assert len(addobjs) == 0 and len(delobjs) == 0
+
         intf_tbl._del("{}|111.0.0.1/24".format(intfs[0]))
         intf_tbl._del("{}|1110::1/64".format(intfs[0]))
         intf_tbl._del("{}|122.0.0.1/24".format(intfs[1]))


### PR DESCRIPTION
…in fpmsyncd

Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>



**What I did**

Three PRs for adding BGP eoiu support to speed up route reconciliation in fpmsyncd

sonic-buildimage:  https://github.com/Azure/sonic-buildimage/pull/2823
sonic-swss-common: https://github.com/Azure/sonic-swss-common/pull/273
sonic-swss:  https://github.com/Azure/sonic-swss/pull/856

**Why I did it**
1.  Similar to restore_neigbors.py for neigborsyncd, start a bgp_eoiu_mark.py for bgp docker.

2. The script check bgp neighbor state via cli interface periodically (every 1 second)
It looks for explicit EOR and implicit EOR (keep alive after established) in the json output of show ip bgp neighbors A.B.C.D json


3. Once the script has collected all needed EORs, it set a EOIU flag in stateDB.

4.  fpmsyncd could hold a few seconds (3 seconds) after getting the flag before starting routing reconciliation.


5.  For any reason the script failed to set EOIU flag in stateDB, the current warm_restart bgp_timer will kick in later.

This approach may have a few more seconds delay compared with the FRR embedded EOIU solution, but simple and less risk. 


**How I verified it**

Before warm upgrade bgp docker:
```
root@ASW-C2-4-C11-A.NA61:/home/admin# vtysh -c 'show bgp sum'

IPv4 Unicast Summary:
BGP router identifier 1.1.1.1, local AS number 65021 vrf-id 0
BGP table version 1057
RIB entries 1145, using 170 KiB of memory
Peers 16, using 309 KiB of memory
Peer groups 2, using 128 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
10.0.0.2        4 4200001162      41      43        0    0    0 00:06:04          544
10.0.0.6        4 4200001162      41      43        0    0    0 00:06:05          544
10.0.0.10       4 4200001162      41      43        0    0    0 00:06:04          544
10.0.0.14       4 4200001162      41      43        0    0    0 00:06:04          544
10.0.0.18       4 4200001162      41      43        0    0    0 00:06:04          544
10.0.0.22       4 4200001162      41      43        0    0    0 00:06:04          544
10.0.0.26       4 4200001162      41      43        0    0    0 00:06:04          544
10.0.0.30       4 4200001162      41      43        0    0    0 00:06:04          544

Total number of neighbors 8

IPv6 Unicast Summary:
BGP router identifier 1.1.1.1, local AS number 65021 vrf-id 0
BGP table version 671
RIB entries 1029, using 153 KiB of memory
Peers 16, using 309 KiB of memory
Peer groups 2, using 128 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
2000::2         4 4200001162     544      43        0    0    0 00:06:04          505
2000:0:0:100::2 4 4200001162     544      43        0    0    0 00:06:04          505
2000:0:0:200::2 4 4200001162     544      43        0    0    0 00:06:04          505
2000:0:0:300::2 4 4200001162     544      43        0    0    0 00:06:04          505
2000:0:0:400::2 4 4200001162     544      43        0    0    0 00:06:04          505
2000:0:0:500::2 4 4200001162     544      43        0    0    0 00:06:04          505
2000:0:0:600::2 4 4200001162     544      43        0    0    0 00:06:04          505
2000:0:0:700::2 4 4200001162     544      43        0    0    0 00:06:04          505

Total number of neighbors 8
```

Warm upgrade bgp docker:

```
root@ASW-C2-4-C11-A.NA61:/home/admin# sonic_installer upgrade_docker bgp /tmp/docker-fpm-alibgp.gz --warm -y
Command: config warm_restart enable bgp

Stopping bgp ...
Command: docker exec -i bgp pkill -9 zebra

Command: docker exec -i bgp pkill -9 bgpd

Command: sleep 2

Command: docker exec -i database redis-cli  -n 6 -p 6379 hdel 'WARM_RESTART_TABLE|bgp' state
1

Stopped  bgp ...
Command: systemctl stop bgp

Command: docker rm bgp 
bgp

Command: docker load < /tmp/docker-fpm-alibgp.gz
Loaded image: docker-fpm-alibgp:latest

Command: docker tag docker-fpm-alibgp:latest docker-fpm-alibgp:AliNOS-rel-v2.0.4-dirty-

Command: systemctl restart bgp

[==========================]
Command: config warm_restart disable bgp

Done
```

Check bgp sum immediately: 

```
root@ASW-C2-4-C11-A.NA61:/home/admin# vtysh -c 'show bgp sum'

IPv4 Unicast Summary:
BGP router identifier 1.1.1.1, local AS number 65021 vrf-id 0
BGP table version 1057
RIB entries 1145, using 170 KiB of memory
Peers 16, using 309 KiB of memory
Peer groups 2, using 128 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
10.0.0.2        4 4200001162       7       7        0    0    0 00:00:23          544
10.0.0.6        4 4200001162       7       7        0    0    0 00:00:23          544
10.0.0.10       4 4200001162       7       7        0    0    0 00:00:23          544
10.0.0.14       4 4200001162       7       7        0    0    0 00:00:23          544
10.0.0.18       4 4200001162       7       7        0    0    0 00:00:23          544
10.0.0.22       4 4200001162       7       7        0    0    0 00:00:23          544
10.0.0.26       4 4200001162       7       7        0    0    0 00:00:23          544
10.0.0.30       4 4200001162       7       7        0    0    0 00:00:23          544

Total number of neighbors 8

IPv6 Unicast Summary:
BGP router identifier 1.1.1.1, local AS number 65021 vrf-id 0
BGP table version 766
RIB entries 1029, using 153 KiB of memory
Peers 16, using 309 KiB of memory
Peer groups 2, using 128 bytes of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
2000::2         4 4200001162     510       7        0    0    0 00:00:23          505
2000:0:0:100::2 4 4200001162     510       7        0    0    0 00:00:23          505
2000:0:0:200::2 4 4200001162     510       7        0    0    0 00:00:22          505
2000:0:0:300::2 4 4200001162     510       7        0    0    0 00:00:23          505
2000:0:0:400::2 4 4200001162     510       7        0    0    0 00:00:23          505
2000:0:0:500::2 4 4200001162     510       7        0    0    0 00:00:23          505
2000:0:0:600::2 4 4200001162     510       7        0    0    0 00:00:23          505
2000:0:0:700::2 4 4200001162     510       7        0    0    0 00:00:23          505

Total number of neighbors 8
```

**Details if related**
