### PR TITLE
Undo skipping Vnet tests, Vrf check before enslaving

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -144,7 +144,10 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
         // Set Interface VRF except for lo
         if (!is_lo)
         {
-            setIntfVrf(alias, vrf_name);
+            if (!vrf_name.empty())
+            {
+                setIntfVrf(alias, vrf_name);
+            }
             m_appIntfTableProducer.set(alias, data);
         }
         else

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -799,8 +799,6 @@ class TestVnetOrch(object):
     '''
     Test 1 - Create Vlan Interface, Tunnel and Vnet
     '''
-    # TODO: Please fix this test case.
-    @pytest.mark.skip(reason="Starting Vxlanmgr to be merged")
     def test_vnet_orch_1(self, dvs, testlog):
         vnet_obj = self.get_vnet_obj()
 
@@ -850,8 +848,6 @@ class TestVnetOrch(object):
     '''
     Test 2 - Two VNets, One HSMs per VNet
     '''
-    # TODO: Please fix this test case.
-    @pytest.mark.skip(reason="Starting Vxlanmgr to be merged")
     def test_vnet_orch_2(self, dvs, testlog):
         vnet_obj = self.get_vnet_obj()
 
@@ -905,8 +901,6 @@ class TestVnetOrch(object):
     '''
     Test 3 - Two VNets, One HSMs per VNet, Peering
     '''
-    # TODO: Please fix this test case.
-    @pytest.mark.skip(reason="Starting Vxlanmgr to be merged")
     def test_vnet_orch_3(self, dvs, testlog):
         vnet_obj = self.get_vnet_obj()
 


### PR DESCRIPTION
**What I did**
Re-enable Vnet Vxlan tests. 
Check VRF name before setting it as master. It is possible to have INTERFACE table without the `vrfname `for the `default ` VRF case. Check added to handle this. 

**Why I did it**
Dependency with https://github.com/Azure/sonic-buildimage/pull/2705 resolved

**How I verified it**
N/A

**Details if related**
N/A