### PR TITLE
[VLAN] Fix issue: vlanmgrd will crashed if there has incorrect key of "vlan member" on cfg_db.json

### DIFF
--- a/cfgmgr/vlanmgr.h
+++ b/cfgmgr/vlanmgr.h
@@ -39,6 +39,7 @@ private:
     bool isVlanStateOk(const string &alias);
     bool isVlanMacOk();
     bool isVlanMemberStateOk(const string &vlanMemberKey);
+    bool vlanIdToInt(const string vid_str, int *vid);
 };
 
 }

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -251,16 +251,16 @@ class TestVlan(object):
             #remove vlan
             self.remove_vlan(vlan)
 
-    @pytest.mark.parametrize("xtest_input, expected", [
+    @pytest.mark.parametrize("test_input, expected", [
         (["Vla",  "2"], 0),
         (["VLAN", "3"], 0),
         (["vlan", "4"], 0),
     ])
-    def test_AddVlanMemberWithIncorrectKeyPrefix(self, dvs, testlog, xtest_input, expected):
+    def test_AddVlanMemberWithIncorrectKeyPrefix(self, dvs, testlog, test_input, expected):
         self.setup_db(dvs)
         marker = dvs.add_log_marker()
-        vlan_prefix = xtest_input[0]
-        vlan = xtest_input[1]
+        vlan_prefix = test_input[0]
+        vlan = test_input[1]
 
         # add vlan member
         tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
@@ -280,16 +280,16 @@ class TestVlan(object):
             #remove vlan member
             self.remove_vlan_member(vlan, "Ethernet0")
 
-    @pytest.mark.parametrize("xtest_input, expected", [
+    @pytest.mark.parametrize("test_input, expected", [
         (["Vlan", "abc"], 0),
         (["Vlan", "a3"],  0),
         (["Vlan", ""],    0),
     ])
-    def test_AddVlanMemberWithIncorrectValueType(self, dvs, testlog, xtest_input, expected):
+    def test_AddVlanMemberWithIncorrectValueType(self, dvs, testlog, test_input, expected):
         self.setup_db(dvs)
         marker = dvs.add_log_marker()
-        vlan_prefix = xtest_input[0]
-        vlan = xtest_input[1]
+        vlan_prefix = test_input[0]
+        vlan = test_input[1]
 
         # add vlan member
         tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -246,18 +246,17 @@ class TestVlan(object):
 
         if len(vlan_entries) == 0:
             # check error log
-            self.check_syslog(dvs, marker, "Invalid key format. Not a number after \'Vlan\' prefix:", vlan_prefix+vlan, 1)
+            self.check_syslog(dvs, marker, "Invalid key format. Not a number after 'Vlan' prefix:", vlan_prefix+vlan, 1)
         else:
             #remove vlan
             self.remove_vlan(vlan)
-
 
     @pytest.mark.parametrize("xtest_input, expected", [
         (["Vla",  "2"], 0),
         (["VLAN", "3"], 0),
         (["vlan", "4"], 0),
     ])
-    def xtest_AddVlanMemberWithIncorrectKeyPrefix(self, dvs, testlog, xtest_input, expected):
+    def test_AddVlanMemberWithIncorrectKeyPrefix(self, dvs, testlog, xtest_input, expected):
         self.setup_db(dvs)
         marker = dvs.add_log_marker()
         vlan_prefix = xtest_input[0]
@@ -286,7 +285,7 @@ class TestVlan(object):
         (["Vlan", "a3"],  0),
         (["Vlan", ""],    0),
     ])
-    def xtest_AddVlanMemberWithIncorrectValueType(self, dvs, testlog, xtest_input, expected):
+    def test_AddVlanMemberWithIncorrectValueType(self, dvs, testlog, xtest_input, expected):
         self.setup_db(dvs)
         marker = dvs.add_log_marker()
         vlan_prefix = xtest_input[0]

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -35,6 +35,10 @@ class TestVlan(object):
         tbl._del("Vlan" + vlan + "|" + interface)
         time.sleep(1)
 
+    def check_syslog(self, dvs, marker, err_log, vlan_str, expected_cnt):
+        (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep vlanmgrd | grep \"%s\" | grep -i \"%s\" | wc -l" % (marker, err_log, vlan_str)])
+        assert num.strip() == str(expected_cnt)
+
     def test_VlanAddRemove(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -186,3 +190,62 @@ class TestVlan(object):
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
         vlan_entries = [k for k in tbl.getKeys() if k != dvs.asicdb.default_vlan_id]
         assert len(vlan_entries) == 0
+
+    @pytest.mark.parametrize("test_input, expected", [
+        (["Vla",  "2"], 0),
+        (["VLAN", "3"], 0),
+        (["vlan", "4"], 0),
+    ])
+    def test_AddVlanMemberWithIncorrectKeyPrefix(self, dvs, testlog, test_input, expected):
+        self.setup_db(dvs)
+        marker = dvs.add_log_marker()
+        vlan_prefix = test_input[0]
+        vlan = test_input[1]
+
+        # add vlan member
+        tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
+        fvs = swsscommon.FieldValuePairs([("tagging_mode", "untagged")])
+        tbl.set(vlan_prefix + vlan + "|" + "Ethernet0", fvs)
+        time.sleep(1)
+
+        # check asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN_MEMBER")
+        vlan_member_entries = tbl.getKeys()
+        assert len(vlan_member_entries) == expected
+
+        if len(vlan_member_entries) == 0:
+            # check error log
+            self.check_syslog(dvs, marker, "Invalid key format. No 'Vlan' prefix:", vlan_prefix + vlan, 1)
+        else:
+            #remove vlan member
+            self.remove_vlan_member(vlan, "Ethernet0")
+
+    @pytest.mark.parametrize("test_input, expected", [
+        (["Vlan", "abc"], 0),
+        (["Vlan", "a3"],  0),
+        (["Vlan", ""],    0),
+    ])
+    def test_AddVlanMemberWithIncorrectValueType(self, dvs, testlog, test_input, expected):
+        self.setup_db(dvs)
+        marker = dvs.add_log_marker()
+        vlan_prefix = test_input[0]
+        vlan = test_input[1]
+
+        # add vlan member
+        tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
+        fvs = swsscommon.FieldValuePairs([("tagging_mode", "untagged")])
+        tbl.set(vlan_prefix + vlan + "|" + "Ethernet0", fvs)
+        time.sleep(1)
+
+        # check asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN_MEMBER")
+        vlan_member_entries = tbl.getKeys()
+        assert len(vlan_member_entries) == expected
+
+        if len(vlan_member_entries) == 0:
+            # check error log
+            self.check_syslog(dvs, marker, "Invalid key format. Not a number after 'Vlan' prefix:",
+                vlan_prefix + vlan + "|" + "Ethernet0", 1)
+        else:
+            #remove vlan member
+            self.remove_vlan_member(vlan, "Ethernet0")


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix issue: vlanmgrd will crashed if there has incorrect key of "vlan member" on cfg_db.json
For example, load json file with following content via sonic-cfggen:
```
{
    "VLAN_MEMBER": {
    	"Vlanabc|Ethernet0": {
    		"tagging_mode": "untagged"
    	}
    }
}
```
The "Vlanabc" is incorrect.

**Why I did it**

**How I verified it**
1. Add test cases in test_vlan.py to make sure the bug fixed.
  - Add vlan member with incorrect key prefix
    - shall not succeed
    - shall not cause vlanmgrd crashed
  - Add vlan member with incorrect value type
    - shall not succeed
    - shall not cause vlanmgrd crashed
2. After load json file with incorrect content via sonic-cfggen, the vlanmgrd shall not crashed.

**Details if related**

Signed-off-by: Emma Lin <emma_lin@edge-core.com>