### PR TITLE
Add the CRM pytest tests

### DIFF
--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -15,15 +15,7 @@ def getCrmCounterValue(dvs, key, counter):
         if k[0] == counter:
             return int(k[1])
 
-<<<<<<< HEAD
-def getCrmConfigValue(dvs, key, counter):
-
-    config_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
-    crm_stats_table = swsscommon.Table(config_db, 'CRM')
-
-    for k in crm_stats_table.get(key)[1]:
-        if k[0] == counter:
-            return int(k[1])
+    return 0
 
 
 def getCrmConfigStr(dvs, key, counter):
@@ -34,10 +26,7 @@ def getCrmConfigStr(dvs, key, counter):
     for k in crm_stats_table.get(key)[1]:
         if k[0] == counter:
             return k[1]
-=======
-    return 0
-
->>>>>>> official/master
+    return "" 
 
 def setReadOnlyAttr(dvs, obj, attr, val):
 


### PR DESCRIPTION
What I did
add some CRM pytest test cases, the list is shown below for CRM test.
1.Test the mechanism for CRM threshold displaying SWSS_LOG_WARN by syslog checking.
2.Add CRM Acl Group test case.
3.Add the configuration tests of threshold and polling interval.

Why I did it
In test_crm.py, It lost test some case, which include the configuration of threshold and polling
interval, acl group case, and checking waring log.

How I verified it
Add test cases in test_crm.py to make sure the test result is correct.
the result is shown below

=============================================== test session starts ===============================================
platform linux2 -- Python 2.7.12, pytest-4.3.1, py-1.8.0, pluggy-0.9.0 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/iris/project/SONiC_Offical/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 25 items

test_crm.py::test_CrmFdbEntry PASSED [ 4%]
test_crm.py::test_CrmIpv4Route PASSED [ 8%]
test_crm.py::test_CrmIpv6Route PASSED [ 12%]
test_crm.py::test_CrmIpv4Nexthop PASSED [ 16%]
test_crm.py::test_CrmIpv6Nexthop PASSED [ 20%]
test_crm.py::test_CrmIpv4Neighbor PASSED [ 24%]
test_crm.py::test_CrmIpv6Neighbor PASSED [ 28%]
test_crm.py::test_CrmNexthopGroup PASSED [ 32%]
test_crm.py::test_CrmNexthopGroupMember PASSED [ 36%]
test_crm.py::test_CrmAcl PASSED [ 40%]
test_crm.py::test_CrmAclGroup PASSED [ 44%]
test_crm.py::test_Configure PASSED [ 48%]
test_crm.py::test_Configure_ipv4_route PASSED [ 52%]
test_crm.py::test_Configure_ipv6_route PASSED [ 56%]
test_crm.py::test_Configure_ipv4_nexthop PASSED [ 60%]
test_crm.py::test_Configure_ipv6_nexthop PASSED [ 64%]
test_crm.py::test_Configure_ipv4_neighbor PASSED [ 68%]
test_crm.py::test_Configure_ipv6_neighbor PASSED [ 72%]
test_crm.py::test_Configure_group_member PASSED [ 76%]
test_crm.py::test_Configure_group_object PASSED [ 80%]
test_crm.py::test_Configure_acl_table PASSED [ 84%]
test_crm.py::test_Configure_acl_group PASSED [ 88%]
test_crm.py::test_Configure_acl_group_entry PASSED [ 92%]
test_crm.py::test_Configure_acl_group_counter PASSED [ 96%]
test_crm.py::test_Configure_fdb PASSED [100%]

=========================================== 25 passed in 226.43 seconds ===========================================