### PR TITLE
[restore_neighbors] fix restore_neighbors crash

### DIFF
--- a/neighsyncd/restore_neighbors.py
+++ b/neighsyncd/restore_neighbors.py
@@ -161,7 +161,7 @@ def set_neigh_in_kernel(ipclass, family, intf_idx, dst_ip, dmac):
 def build_arp_ns_pkt(family, smac, src_ip, dst_ip):
     if family == 'IPv4':
         eth = Ether(src=smac, dst='ff:ff:ff:ff:ff:ff')
-        pkt = eth/ARP(op=ARP.who_has, pdst=dst_ip)
+        pkt = eth/ARP(op='who-has', pdst=dst_ip)
     elif family == 'IPv6':
         nsma = in6_getnsma(inet_pton(AF_INET6, dst_ip))
         mcast_dst_ip = inet_ntop(AF_INET6, nsma)


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix crash https://github.com/Azure/sonic-swss/issues/861

**Why I did it**
To fix a restore_neighbors.py crash

**How I verified it**
```
Apr 26 09:13:09.165635 arc-switch1025 INFO swss#supervisord: start.sh restore_neighbors: started
Apr 26 09:13:11.388802 arc-switch1025 INFO swss#supervisord: restore_neighbors WARNING:__main__:Neigh exists in kernel with family: IPv4, intf_idx: 2, ip: 10.210.25.32, mac: 14:18:77:33:f0:50
Apr 26 09:13:15.180388 arc-switch1025 INFO swss#supervisord 2019-04-26 09:13:09,135 INFO spawned: 'restore_neighbors' with pid 47
Apr 26 09:13:15.180388 arc-switch1025 INFO swss#supervisord 2019-04-26 09:13:09,140 INFO success: restore_neighbors entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
Apr 26 09:14:16.622282 arc-switch1025 INFO swss#supervisord: restore_neighbors WARNING:__main__:Neigh exists in kernel with family: IPv4, intf_idx: 5, ip: 10.0.0.57, mac: 52:54:00:83:2f:8f
Apr 26 09:14:16.918406 arc-switch1025 INFO swss#supervisord: restore_neighbors restore_neighbors service is started
Apr 26 09:14:16.918573 arc-switch1025 INFO swss#supervisord: restore_neighbors restore_neighbor service is done for system warmreboot
Apr 26 09:14:25.248860 arc-switch1025 INFO swss#supervisord 2019-04-26 09:14:16,926 INFO exited: restore_neighbors (exit status 0; expected)
admin@arc-switch1025:~$ show warm_restart state
name             restore_count  state
-------------  ---------------  ----------------------
warm-shutdown                0  pre-shutdown-succeeded
syncd                        1
orchagent                    1  reconciled
teammgrd                     1
vlanmgrd                     1
neighsyncd                   1  reconciled
teamsyncd                    1
bgp                          1  reconciled
portsyncd                    1

```

**Details if related**
