### PR TITLE
[fpmsyncd] Fix memory leak bug

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -23,9 +23,7 @@ RouteSync::RouteSync(RedisPipeline *pipeline) :
     m_vnet_tunnelTable(pipeline, APP_VNET_RT_TUNNEL_TABLE_NAME, true),
     m_warmStartHelper(pipeline, &m_routeTable, APP_ROUTE_TABLE_NAME, "bgp", "bgp")
 {
-    m_nl_sock = nl_socket_alloc();
-    nl_connect(m_nl_sock, NETLINK_ROUTE);
-    rtnl_link_alloc_cache(m_nl_sock, AF_UNSPEC, &m_link_cache);
+
 }
 
 void RouteSync::onMsg(int nlmsg_type, struct nl_object *obj)
@@ -281,23 +279,67 @@ void RouteSync::onVnetRouteMsg(int nlmsg_type, struct nl_object *obj, string vne
  */
 bool RouteSync::getIfName(int if_index, char *if_name, size_t name_len)
 {
+    struct nl_sock *sk = NULL;
+    struct nl_cache *cache = NULL;
+    int err;
+
     if (!if_name || name_len == 0)
     {
         return false;
     }
 
     memset(if_name, 0, name_len);
+    
+    sk = nl_socket_alloc();
+    if (!sk) 
+    {
+        SWSS_LOG_ERROR("Unable to allocate netlink socket");
+        return false;
+    }
+
+    err = nl_connect(sk, NETLINK_ROUTE);
+    if (err < 0)
+    {
+        SWSS_LOG_ERROR("Unable to connect netlink socket: %s", nl_geterror(err));
+        nl_socket_free(sk);
+        return false;
+    }
+
+    err = rtnl_link_alloc_cache(sk, AF_UNSPEC, &cache);
+    if (err < 0)
+    {
+        SWSS_LOG_ERROR("Unable to allocate link cache: %s", nl_geterror(err));
+        nl_close(sk);
+        nl_socket_free(sk);
+        return false;
+    }
 
     /* Cannot get interface name. Possibly the interface gets re-created. */
-    if (!rtnl_link_i2name(m_link_cache, if_index, if_name, name_len))
+    if (!rtnl_link_i2name(cache, if_index, if_name, name_len))
     {
-        rtnl_link_alloc_cache(m_nl_sock, AF_UNSPEC, &m_link_cache);
-        if (!rtnl_link_i2name(m_link_cache, if_index, if_name, name_len))
+        /* Re-allocate netlink cache */
+        nl_cache_free(cache);
+        err = rtnl_link_alloc_cache(sk, AF_UNSPEC, &cache);
+        if (err < 0)
         {
+            SWSS_LOG_ERROR("Unable to allocate link cache: %s", nl_geterror(err));
+            nl_close(sk);
+            nl_socket_free(sk);
+            return false;
+        }
+
+        if (!rtnl_link_i2name(cache, if_index, if_name, name_len))
+        {
+            nl_cache_free(cache);
+            nl_close(sk);
+            nl_socket_free(sk);
             return false;
         }
     }
 
+    nl_cache_free(cache);
+    nl_close(sk);
+    nl_socket_free(sk);
     return true;
 }
 

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -23,7 +23,6 @@ RouteSync::RouteSync(RedisPipeline *pipeline) :
     m_vnet_tunnelTable(pipeline, APP_VNET_RT_TUNNEL_TABLE_NAME, true),
     m_warmStartHelper(pipeline, &m_routeTable, APP_ROUTE_TABLE_NAME, "bgp", "bgp")
 {
-
 }
 
 void RouteSync::onMsg(int nlmsg_type, struct nl_object *obj)

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -316,16 +316,8 @@ bool RouteSync::getIfName(int if_index, char *if_name, size_t name_len)
     /* Cannot get interface name. Possibly the interface gets re-created. */
     if (!rtnl_link_i2name(cache, if_index, if_name, name_len))
     {
-        /* Re-allocate netlink cache */
-        nl_cache_free(cache);
-        err = rtnl_link_alloc_cache(sk, AF_UNSPEC, &cache);
-        if (err < 0)
-        {
-            SWSS_LOG_ERROR("Unable to allocate link cache: %s", nl_geterror(err));
-            nl_close(sk);
-            nl_socket_free(sk);
-            return false;
-        }
+        /* Trying to refill cache */
+        nl_cache_refill(sk, cache);
 
         if (!rtnl_link_i2name(cache, if_index, if_name, name_len))
         {

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -29,8 +29,6 @@ private:
     ProducerStateTable  m_vnet_routeTable;
     /* vnet vxlan tunnel table */  
     ProducerStateTable  m_vnet_tunnelTable; 
-    struct nl_cache    *m_link_cache;
-    struct nl_sock     *m_nl_sock;
 
     /* Handle regular route (include VRF route) */
     void onRouteMsg(int nlmsg_type, struct nl_object *obj);

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -29,6 +29,8 @@ private:
     ProducerStateTable  m_vnet_routeTable;
     /* vnet vxlan tunnel table */  
     ProducerStateTable  m_vnet_tunnelTable; 
+    struct nl_cache    *m_link_cache;
+    struct nl_sock     *m_nl_sock;
 
     /* Handle regular route (include VRF route) */
     void onRouteMsg(int nlmsg_type, struct nl_object *obj);


### PR DESCRIPTION
fpmsyncd: Fix memory leak bug

* Allocate and free Netlink memory in RouteSync::getIfName()

Signed-off-by: Wei Bai baiwei0427@gmail.com