### PR TITLE
Removing the erase action for DEL_COMMAND option.

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -215,7 +215,6 @@ void CrmOrch::doTask(Consumer &consumer)
         else if (op == DEL_COMMAND)
         {
             SWSS_LOG_ERROR("Unsupported operation type %s\n", op.c_str());
-            it = consumer.m_toSync.erase(it);
         }
         else
         {


### PR DESCRIPTION
What I did
Fix issue: If  the op of attr is "del", CRM consumer dotask will cause infinite loop or  delete next operation cmd.

Why I did it
We can't erase any cmd only for del case. We should ignore it, and integrate erasing the operation cmd in the last.

How I verified it
I add only one del attr parameter to check whether consumer dotask will cause infinite loop or not. 
Here is the del attr parameter.
KeyOpFieldsValuesTuple Attr("CRM", "DEL", {{ "polling_interval", "20" }});