### PR TITLE
change direct-route(AKA subnet-route) issuer from intfsorch to routeorch

### DIFF
--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -32,7 +32,9 @@ public:
     IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch);
 
     sai_object_id_t getRouterIntfsId(const string&);
-
+    sai_object_id_t getVrId(const string&);
+    std::string getRouterIntfsByIpaddress(const IpAddress&);
+    bool isPrefixSubnet(const IpPrefix&, const string& );
     void increaseRouterIntfsRefCount(const string&);
     void decreaseRouterIntfsRefCount(const string&);
 
@@ -81,8 +83,8 @@ private:
     bool addRouterIntfs(sai_object_id_t vrf_id, Port &port);
     bool removeRouterIntfs(Port &port);
 
-    void addSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
-    void removeSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
+    /*void addSubnetRoute(const Port &port, const IpPrefix &ip_prefix);
+    void removeSubnetRoute(const Port &port, const IpPrefix &ip_prefix);*/
 
     void addDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix);
     void removeDirectedBroadcast(const Port &port, const IpPrefix &ip_prefix);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -94,7 +94,7 @@ bool OrchDaemon::init()
 
     gIntfsOrch = new IntfsOrch(m_applDb, APP_INTF_TABLE_NAME, vrf_orch);
     gNeighOrch = new NeighOrch(m_applDb, APP_NEIGH_TABLE_NAME, gIntfsOrch);
-    gRouteOrch = new RouteOrch(m_applDb, APP_ROUTE_TABLE_NAME, gNeighOrch);
+    gRouteOrch = new RouteOrch(m_applDb, APP_ROUTE_TABLE_NAME, gNeighOrch, gIntfsOrch);
     CoppOrch  *copp_orch  = new CoppOrch(m_applDb, APP_COPP_TABLE_NAME);
     TunnelDecapOrch *tunnel_decap_orch = new TunnelDecapOrch(m_applDb, APP_TUNNEL_DECAP_TABLE_NAME);
 

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -49,7 +49,7 @@ struct NextHopObserverEntry
 class RouteOrch : public Orch, public Subject
 {
 public:
-    RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch);
+    RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch, IntfsOrch *intfsOrch);
 
     bool hasNextHopGroup(const IpAddresses&) const;
     sai_object_id_t getNextHopGroupId(const IpAddresses&);
@@ -60,7 +60,7 @@ public:
     void increaseNextHopRefCount(IpAddresses);
     void decreaseNextHopRefCount(IpAddresses);
     bool isRefCounterZero(const IpAddresses&) const;
-
+    bool intfsRemoveUpdate(const string&, const IpPrefix&);
     bool addNextHopGroup(IpAddresses);
     bool removeNextHopGroup(IpAddresses);
 
@@ -70,7 +70,7 @@ public:
     void notifyNextHopChangeObservers(IpPrefix, IpAddresses, bool);
 private:
     NeighOrch *m_neighOrch;
-
+    IntfsOrch *m_intfsOrch;
     int m_nextHopGroupCount;
     int m_maxNextHopGroupCount;
     bool m_resync;
@@ -81,6 +81,7 @@ private:
     NextHopObserverTable m_nextHopObservers;
 
     void addTempRoute(IpPrefix, IpAddresses);
+    bool addSubnetRoute(string&, IpPrefix);
     bool addRoute(IpPrefix, IpAddresses);
     bool removeRoute(IpPrefix);
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -115,6 +115,8 @@ class TestRouterInterface(object):
         # assign IP to interface
         self.add_ip_address("Ethernet8", "10.0.0.4/31")
 
+        self.set_admin_status("Ethernet8", "up")
+
         # check application database
         tbl = swsscommon.Table(self.pdb, "INTF_TABLE:Ethernet8")
         intf_entries = tbl.getKeys()
@@ -309,7 +311,10 @@ class TestLagRouterInterfaceIpv4(object):
             if route["dest"] == "30.0.0.4/32":
                 ip2me_found = True
 
-        assert subnet_found and ip2me_found
+        #assert subnet_found and ip2me_found
+        #subnet can be found only when the portchannel is up
+        #but portchannel is always down in vs test (no partner to aggregate)
+        assert ip2me_found
 
         # remove IP from interface
         self.remove_ip_address("PortChannel001", "30.0.0.4/31")


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
change direct route( AKA subnet-route) issuer from intfsorch to routeorch

**Why I did it**
    intfsOrch add directed route by ip address configuration, but routes from 
fpmsyncd got data from routing protocol, which can refer to the state of 
interfaces. When the interface is down intfsorch still adds subnet route . 
It will result in a wrong situation, route with same prefix from route
protocol will be refused to be added to SAI. 
So we change direct route issuer from infsorch to routeorch.

**How I verified it**
Test it on nephos lab

**Details if related**
