### PR TITLE
Return 0 for CRM counter instead of None if no match

### DIFF
--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -15,6 +15,8 @@ def getCrmCounterValue(dvs, key, counter):
         if k[0] == counter:
             return int(k[1])
 
+    return 0
+
 
 def setReadOnlyAttr(dvs, obj, attr, val):
 


### PR DESCRIPTION
**What I did**
if stats (used/available) is not present, the function returns None. Modified to return 0 if no stats match.

**Why I did it**
Fixing an issue introduced as part of https://github.com/Azure/sonic-swss/pull/830

**How I verified it**
N/A

**Details if related**
