### PR TITLE
[vxlanorch] Ambiguous return code for removeNextHopTunnel

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -522,7 +522,7 @@ VxlanTunnelOrch::removeNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAd
     if(!isTunnelExists(tunnelName))
     {
         SWSS_LOG_ERROR("Vxlan tunnel '%s' does not exists", tunnelName.c_str());
-        return true;
+        return false;
     }
 
     auto tunnel_obj = getVxlanTunnel(tunnelName);


### PR DESCRIPTION
**What I did**
If the tunnel is not existed, it should change to return false when remove next hop for a tunnel 

**Why I did it**
For `VxlanTunnelOrch::removeNextHopTunnel` it both checkt tunnel and nexthop existed or not. But in the checking fail case, the first return true and the second return false   

**How I verified it**
Call r`VxlanTunnelOrch::removeNextHopTunnel` for a non existed tunnel for testing.