### PR TITLE
[vlan] Add pytest case to add max vlan.

### DIFF
--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -13,16 +13,16 @@ class TestVlan(object):
         self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
 
-    def create_vlan(self, vlan, sleep=1):
+    def create_vlan(self, vlan):
         tbl = swsscommon.Table(self.cdb, "VLAN")
         fvs = swsscommon.FieldValuePairs([("vlanid", vlan)])
         tbl.set("Vlan" + vlan, fvs)
-        time.sleep(sleep)
+        time.sleep(1)
 
-    def remove_vlan(self, vlan, sleep=1):
+    def remove_vlan(self, vlan):
         tbl = swsscommon.Table(self.cdb, "VLAN")
         tbl._del("Vlan" + vlan)
-        time.sleep(sleep)
+        time.sleep(1)
 
     def create_vlan_member(self, vlan, interface):
         tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
@@ -260,9 +260,8 @@ class TestVlan(object):
         # create max vlan
         vlan = min_vid
         while vlan <= max_vid:
-            self.create_vlan(str(vlan), 0)
+            self.create_vlan(str(vlan))
             vlan += 1
-        time.sleep(150)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
@@ -272,9 +271,8 @@ class TestVlan(object):
         # remove all vlan
         vlan = min_vid
         while vlan <= max_vid:
-            self.remove_vlan(str(vlan), 0)
+            self.remove_vlan(str(vlan))
             vlan += 1
-        time.sleep(200)
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
[vlan] Add pytest cases to add max vlan.

**Why I did it**

**How I verified it**
Add test case:
1. Add max vlan (2-4094) and remove it. => succeed

**Details if related**
==================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.15rc1, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/ubuntu/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 25 items

test_vlan.py::TestVlan::test_VlanAddRemove PASSED 										[  4%]
test_vlan.py::TestVlan::test_MultipleVlan PASSED										[  8%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input0-0] PASSED		[ 12%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input1-0] PASSED		[ 16%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input2-0] PASSED		[ 20%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectKeyPrefix[test_input3-1] PASSED		[ 24%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input0-0] PASSED		[ 28%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input1-0] PASSED		[ 32%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input2-0] PASSED		[ 36%]
test_vlan.py::TestVlan::test_AddVlanWithIncorrectValueType[test_input3-1] PASSED		[ 40%]
test_vlan.py::TestVlan::test_AddVlanMemberWithIncorrectKeyPrefix[test_input0-0] PASSED	[ 44%]
test_vlan.py::TestVlan::test_AddVlanMemberWithIncorrectKeyPrefix[test_input1-0] PASSED	[ 48%]
test_vlan.py::TestVlan::test_AddVlanMemberWithIncorrectKeyPrefix[test_input2-0] PASSED	[ 52%]
test_vlan.py::TestVlan::test_AddVlanMemberWithIncorrectValueType[test_input0-0] PASSED	[ 56%]
test_vlan.py::TestVlan::test_AddVlanMemberWithIncorrectValueType[test_input1-0] PASSED	[ 60%]
test_vlan.py::TestVlan::test_AddVlanMemberWithIncorrectValueType[test_input2-0] PASSED	[ 64%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input0-expected0] PASSED		[ 68%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input1-expected1] PASSED		[ 72%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input2-expected2] PASSED		[ 76%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input3-expected3] PASSED		[ 80%]
test_vlan.py::TestVlan::test_VlanMemberTaggingMode[test_input4-expected4] PASSED		[ 84%]
test_vlan.py::TestVlan::test_AddVlanMemberWithNonExistVlan PASSED						[ 88%]
test_vlan.py::TestVlan::test_RemoveNonexistentVlan PASSED								[ 92%]
test_vlan.py::TestVlan::test_AddPortChannelToVlan PASSED								[ 96%]
test_vlan.py::TestVlan::test_AddMaxVlan PASSED 											[100%]

================================================================= 25 passed in 453.56 seconds =================================================================

Signed-off-by: Emma Lin <emma_lin@edge-core.com>