### PR TITLE
[policerorch]: Add PolicerOrch to bundle with mirror session

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -49,7 +49,8 @@ orchagent_SOURCES = \
             vnetorch.cpp \
             dtelorch.cpp \
             flexcounterorch.cpp \
-            watermarkorch.cpp
+            watermarkorch.cpp \
+            policerorch.cpp
 
 orchagent_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 orchagent_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -17,23 +17,23 @@ extern sai_switch_api_t*    sai_switch_api;
 extern sai_object_id_t      gSwitchId;
 extern PortsOrch*           gPortsOrch;
 
-map<string, sai_meter_type_t> policer_meter_map = {
+static map<string, sai_meter_type_t> policer_meter_map = {
     {"packets", SAI_METER_TYPE_PACKETS},
     {"bytes", SAI_METER_TYPE_BYTES}
 };
 
-map<string, sai_policer_mode_t> policer_mode_map = {
+static map<string, sai_policer_mode_t> policer_mode_map = {
     {"sr_tcm", SAI_POLICER_MODE_SR_TCM},
     {"tr_tcm", SAI_POLICER_MODE_TR_TCM},
     {"storm",  SAI_POLICER_MODE_STORM_CONTROL}
 };
 
-map<string, sai_policer_color_source_t> policer_color_aware_map = {
+static map<string, sai_policer_color_source_t> policer_color_aware_map = {
     {"aware", SAI_POLICER_COLOR_SOURCE_AWARE},
     {"blind", SAI_POLICER_COLOR_SOURCE_BLIND}
 };
 
-map<string, sai_hostif_trap_type_t> trap_id_map = {
+static map<string, sai_hostif_trap_type_t> trap_id_map = {
     {"stp", SAI_HOSTIF_TRAP_TYPE_STP},
     {"lacp", SAI_HOSTIF_TRAP_TYPE_LACP},
     {"eapol", SAI_HOSTIF_TRAP_TYPE_EAPOL},
@@ -71,7 +71,7 @@ map<string, sai_hostif_trap_type_t> trap_id_map = {
     {"udld", SAI_HOSTIF_TRAP_TYPE_UDLD}
 };
 
-map<string, sai_packet_action_t> packet_action_map = {
+static map<string, sai_packet_action_t> packet_action_map = {
     {"drop", SAI_PACKET_ACTION_DROP},
     {"forward", SAI_PACKET_ACTION_FORWARD},
     {"copy", SAI_PACKET_ACTION_COPY},

--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -7,6 +7,7 @@
 #include "neighorch.h"
 #include "routeorch.h"
 #include "fdborch.h"
+#include "policerorch.h"
 
 #include "ipaddress.h"
 #include "ipaddresses.h"
@@ -30,6 +31,7 @@ struct MirrorEntry
     uint8_t dscp;
     uint8_t ttl;
     uint8_t queue;
+    string policer;
 
     struct
     {
@@ -65,7 +67,7 @@ class MirrorOrch : public Orch, public Observer, public Subject
 {
 public:
     MirrorOrch(TableConnector appDbConnector, TableConnector confDbConnector,
-               PortsOrch *portOrch, RouteOrch *routeOrch, NeighOrch *neighOrch, FdbOrch *fdbOrch);
+               PortsOrch *portOrch, RouteOrch *routeOrch, NeighOrch *neighOrch, FdbOrch *fdbOrch, PolicerOrch *policerOrch);
 
     void update(SubjectType, void *);
     bool sessionExists(const string&);
@@ -79,6 +81,7 @@ private:
     RouteOrch *m_routeOrch;
     NeighOrch *m_neighOrch;
     FdbOrch *m_fdbOrch;
+    PolicerOrch *m_policerOrch;
 
     Table m_mirrorTable;
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -128,9 +128,11 @@ bool OrchDaemon::init()
     };
     gBufferOrch = new BufferOrch(m_configDb, buffer_tables);
 
+    PolicerOrch *policer_orch = new PolicerOrch(m_configDb, "POLICER");
+
     TableConnector stateDbMirrorSession(m_stateDb, APP_MIRROR_SESSION_TABLE_NAME);
     TableConnector confDbMirrorSession(m_configDb, CFG_MIRROR_SESSION_TABLE_NAME);
-    MirrorOrch *mirror_orch = new MirrorOrch(stateDbMirrorSession, confDbMirrorSession, gPortsOrch, gRouteOrch, gNeighOrch, gFdbOrch);
+    MirrorOrch *mirror_orch = new MirrorOrch(stateDbMirrorSession, confDbMirrorSession, gPortsOrch, gRouteOrch, gNeighOrch, gFdbOrch, policer_orch);
 
     TableConnector confDbAclTable(m_configDb, CFG_ACL_TABLE_NAME);
     TableConnector confDbAclRuleTable(m_configDb, CFG_ACL_RULE_TABLE_NAME);
@@ -163,7 +165,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap.
      * That is ensured implicitly by the order of map key, "LAG_TABLE" is smaller than "VLAN_TABLE" in lexicographic order.
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gBufferOrch, gPortsOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, wm_orch };
+    m_orchList = { gSwitchOrch, gCrmOrch, gBufferOrch, gPortsOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, tunnel_decap_orch, qos_orch, wm_orch, policer_orch };
 
 
     bool initialize_dtel = false;

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -26,6 +26,7 @@
 #include "countercheckorch.h"
 #include "flexcounterorch.h"
 #include "watermarkorch.h"
+#include "policerorch.h"
 #include "directory.h"
 
 using namespace swss;

--- a/orchagent/policerorch.cpp
+++ b/orchagent/policerorch.cpp
@@ -1,0 +1,268 @@
+#include "sai.h"
+#include "policerorch.h"
+
+#include "converter.h"
+
+using namespace std;
+using namespace swss;
+
+extern sai_policer_api_t*   sai_policer_api;
+
+extern sai_object_id_t gSwitchId;
+extern PortsOrch* gPortsOrch;
+
+static const string meter_type_field           = "METER_TYPE";
+static const string mode_field                 = "MODE";
+static const string color_source_field         = "COLOR_SOURCE";
+static const string cbs_field                  = "CBS";
+static const string cir_field                  = "CIR";
+static const string pbs_field                  = "PBS";
+static const string pir_field                  = "PIR";
+static const string green_packet_action_field  = "GREEN_PACKET_ACTION";
+static const string red_packet_action_field    = "RED_PACKET_ACTION";
+static const string yellow_packet_action_field = "YELLOW_PACKET_ACTION";
+
+static const map<string, sai_meter_type_t> meter_type_map = {
+    {"PACKETS", SAI_METER_TYPE_PACKETS},
+    {"BYTES", SAI_METER_TYPE_BYTES}
+};
+
+static const map<string, sai_policer_mode_t> policer_mode_map = {
+    {"SR_TCM", SAI_POLICER_MODE_SR_TCM},
+    {"TR_TCM", SAI_POLICER_MODE_TR_TCM},
+    {"STORM_CONTROL", SAI_POLICER_MODE_STORM_CONTROL}
+};
+
+static const map<string, sai_policer_color_source_t> policer_color_source_map = {
+    {"AWARE", SAI_POLICER_COLOR_SOURCE_AWARE},
+    {"BLIND", SAI_POLICER_COLOR_SOURCE_BLIND}
+};
+
+static const map<string, sai_packet_action_t> packet_action_map = {
+    {"DROP", SAI_PACKET_ACTION_DROP},
+    {"FORWARD", SAI_PACKET_ACTION_FORWARD},
+    {"COPY", SAI_PACKET_ACTION_COPY},
+    {"COPY_CANCEL", SAI_PACKET_ACTION_COPY_CANCEL},
+    {"TRAP", SAI_PACKET_ACTION_TRAP},
+    {"LOG", SAI_PACKET_ACTION_LOG},
+    {"DENY", SAI_PACKET_ACTION_DENY},
+    {"TRANSIT", SAI_PACKET_ACTION_TRANSIT}
+};
+
+bool PolicerOrch::policerExists(const string &name)
+{
+    SWSS_LOG_ENTER();
+
+    return m_syncdPolicers.find(name) != m_syncdPolicers.end();
+}
+
+bool PolicerOrch::getPolicerOid(const string &name, sai_object_id_t &oid)
+{
+    SWSS_LOG_ENTER();
+
+    if (policerExists(name))
+    {
+        oid = m_syncdPolicers[name];
+        SWSS_LOG_NOTICE("Get policer %s oid:%lx", name.c_str(), oid);
+        return true;
+    }
+
+    return false;
+}
+
+bool PolicerOrch::increaseRefCount(const string &name)
+{
+    SWSS_LOG_ENTER();
+
+    if (!policerExists(name))
+    {
+        SWSS_LOG_WARN("Policer %s does not exist", name.c_str());
+        return false;
+    }
+
+    ++m_policerRefCounts[name];
+
+    SWSS_LOG_INFO("Policer %s reference count is increased to %d",
+            name.c_str(), m_policerRefCounts[name]);
+    return true;
+}
+
+bool PolicerOrch::decreaseRefCount(const string &name)
+{
+    SWSS_LOG_ENTER();
+
+    if (!policerExists(name))
+    {
+        SWSS_LOG_WARN("Policer %s does not exist", name.c_str());
+        return false;
+    }
+
+    --m_policerRefCounts[name];
+
+    SWSS_LOG_INFO("Policer %s reference count is decreased to %d",
+            name.c_str(), m_policerRefCounts[name]);
+    return true;
+}
+
+PolicerOrch::PolicerOrch(DBConnector* db, string tableName) :
+    Orch(db, tableName)
+{
+    SWSS_LOG_ENTER();
+}
+
+void PolicerOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    if (!gPortsOrch->isPortReady())
+    {
+        return;
+    }
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        auto tuple = it->second;
+
+        auto key = kfvKey(tuple);
+        auto op = kfvOp(tuple);
+
+        if (op == SET_COMMAND)
+        {
+            if (m_syncdPolicers.find(key) != m_syncdPolicers.end())
+            {
+                SWSS_LOG_ERROR("Policer %s already exists", key.c_str());
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            vector<sai_attribute_t> attrs;
+            bool meter_type = false, mode = false;
+
+            for (auto i = kfvFieldsValues(tuple).begin();
+                    i != kfvFieldsValues(tuple).end(); ++i)
+            {
+                auto field = to_upper(fvField(*i));
+                auto value = to_upper(fvValue(*i));
+
+                SWSS_LOG_DEBUG("attribute: %s value: %s", field.c_str(), value.c_str());
+
+                sai_attribute_t attr;
+
+                if (field == meter_type_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_METER_TYPE;
+                    attr.value.s32 = (sai_meter_type_t) meter_type_map.at(value);
+                    meter_type = true;
+                }
+                else if (field == mode_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_MODE;
+                    attr.value.s32 = (sai_policer_mode_t) policer_mode_map.at(value);
+                    mode = true;
+                }
+                else if (field == color_source_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_COLOR_SOURCE;
+                    attr.value.s32 = policer_color_source_map.at(value);
+                }
+                else if (field == cbs_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_CBS;
+                    attr.value.u64 = stoul(value);
+                }
+                else if (field == cir_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_CIR;
+                    attr.value.u64 = stoul(value);
+                }
+                else if (field == pbs_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_PBS;
+                    attr.value.u64 = stoul(value);
+                }
+                else if (field == pir_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_PIR;
+                    attr.value.u64 = stoul(value);
+                }
+                else if (field == red_packet_action_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_RED_PACKET_ACTION;
+                    attr.value.s32 = packet_action_map.at(value);
+                }
+                else if (field == green_packet_action_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_GREEN_PACKET_ACTION;
+                    attr.value.s32 = packet_action_map.at(value);
+                }
+                else if (field == yellow_packet_action_field)
+                {
+                    attr.id = SAI_POLICER_ATTR_YELLOW_PACKET_ACTION;
+                    attr.value.s32 = packet_action_map.at(value);
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Unknown policer attribute %s specified",
+                            field.c_str());
+                    continue;
+                }
+
+                attrs.push_back(attr);
+            }
+
+            if (!meter_type || !mode)
+            {
+                SWSS_LOG_ERROR("Failed to create policer %s,\
+                        missing madatory fields", key.c_str());
+            }
+
+            sai_object_id_t policer_id;
+            sai_status_t status = sai_policer_api->create_policer(
+                &policer_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to create policer %s, rv:%d",
+                        key.c_str(), status);
+                it++;
+                continue;
+            }
+
+            SWSS_LOG_NOTICE("Created policer %s", key.c_str());
+            m_syncdPolicers[key] = policer_id;
+            m_policerRefCounts[key] = 0;
+            it = consumer.m_toSync.erase(it);
+        }
+        else if (op == DEL_COMMAND)
+        {
+            if (m_syncdPolicers.find(key) == m_syncdPolicers.end())
+            {
+                SWSS_LOG_ERROR("Policer %s does not exists", key.c_str());
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            if (m_policerRefCounts[key] > 0)
+            {
+                SWSS_LOG_INFO("Policer %s is still referenced", key.c_str());
+                it++;
+                continue;
+            }
+
+            sai_status_t status = sai_policer_api->remove_policer(
+                    m_syncdPolicers.at(key));
+            if (status == SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to remove policer %s, rv:%d",
+                        key.c_str(), status);
+                it++;
+                continue;
+            }
+
+            SWSS_LOG_NOTICE("Removed policer %s", key.c_str());
+            m_syncdPolicers.erase(key);
+            m_policerRefCounts.erase(key);
+            it = consumer.m_toSync.erase(it);
+        }
+    }
+}

--- a/orchagent/policerorch.h
+++ b/orchagent/policerorch.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "orch.h"
+#include "portsorch.h"
+
+using namespace std;
+
+typedef map<string, sai_object_id_t> PolicerTable;
+typedef map<string, int> PolicerRefCountTable;
+
+class PolicerOrch : public Orch
+{
+public:
+    PolicerOrch(DBConnector* db, string tableName);
+
+    bool policerExists(const string &name);
+    bool getPolicerOid(const string &name, sai_object_id_t &oid);
+
+    bool increaseRefCount(const string &name);
+    bool decreaseRefCount(const string &name);
+private:
+    virtual void doTask(Consumer& consumer);
+
+    PolicerTable m_syncdPolicers;
+    PolicerRefCountTable m_policerRefCounts;
+};

--- a/tests/test_mirror_policer.py
+++ b/tests/test_mirror_policer.py
@@ -1,0 +1,239 @@
+# This test suite covers the functionality of mirror feature in SwSS
+
+import platform
+import pytest
+import time
+from distutils.version import StrictVersion
+
+from swsscommon import swsscommon
+
+
+class TestMirror(object):
+    def setup_db(self, dvs):
+        self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+        self.cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        self.sdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+
+    def set_port_status(self, port, admin_status):
+        tbl = swsscommon.Table(self.cdb, "PORT")
+        fvs = swsscommon.FieldValuePairs([("admin_status", "up")])
+        tbl.set(port, fvs)
+        time.sleep(1)
+
+    def add_ip_address(self, interface, ip):
+        tbl = swsscommon.Table(self.cdb, "INTERFACE")
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set(interface + "|" + ip, fvs)
+        time.sleep(1)
+
+    def remove_ip_address(self, interface, ip):
+        tbl = swsscommon.Table(self.cdb, "INTERFACE")
+        tbl._del(interface + "|" + ip)
+        time.sleep(1)
+
+    def add_neighbor(self, interface, ip, mac):
+        tbl = swsscommon.ProducerStateTable(self.pdb, "NEIGH_TABLE")
+        fvs = swsscommon.FieldValuePairs([("neigh", mac),
+                                          ("family", "IPv4")])
+        tbl.set(interface + ":" + ip, fvs)
+        time.sleep(1)
+
+    def remove_neighbor(self, interface, ip):
+        tbl = swsscommon.ProducerStateTable(self.pdb, "NEIGH_TABLE")
+        tbl._del(interface + ":" + ip)
+        time.sleep(1)
+
+    def add_route(self, dvs, prefix, nexthop):
+        dvs.runcmd("ip route add " + prefix + " via " + nexthop)
+        time.sleep(1)
+
+    def remove_route(self, dvs, prefix):
+        dvs.runcmd("ip route del " + prefix)
+        time.sleep(1)
+
+    def create_mirror_session(self, name, src, dst, gre, dscp, ttl, queue, policer):
+        tbl = swsscommon.Table(self.cdb, "MIRROR_SESSION")
+        fvs = swsscommon.FieldValuePairs([("src_ip", src),
+                                          ("dst_ip", dst),
+                                          ("gre_type", gre),
+                                          ("dscp", dscp),
+                                          ("ttl", ttl),
+                                          ("queue", queue),
+                                          ("policer", policer)])
+        tbl.set(name, fvs)
+        time.sleep(1)
+
+    def remove_mirror_session(self, name):
+        tbl = swsscommon.Table(self.cdb, "MIRROR_SESSION")
+        tbl._del(name)
+        time.sleep(1)
+
+    def create_policer(self, name):
+        tbl = swsscommon.Table(self.cdb, "POLICER")
+        fvs = swsscommon.FieldValuePairs([("meter_type", "packets"),
+                                          ("mode", "sr_tcm"),
+                                          ("cir", "600"),
+                                          ("cbs", "600"),
+                                          ("red_packet_action", "drop")])
+        tbl.set(name, fvs)
+        time.sleep(1)
+
+    def remove_policer(self, name):
+        tbl = swsscommon.Table(self.cdb, "POLICER")
+        tbl._del(name)
+        time.sleep(1)
+
+    def test_MirrorPolicer(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        policer= "POLICER"
+
+        # create policer
+        self.create_policer(policer)
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "2.2.2.2", "0x6558", "8", "100", "0", policer)
+        self.set_port_status("Ethernet16", "up")
+        self.add_ip_address("Ethernet16", "10.0.0.0/31")
+        self.add_neighbor("Ethernet16", "10.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "2.2.2.2", "10.0.0.1")
+
+        # check asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
+        policer_entries = tbl.getKeys()
+        assert len(policer_entries) == 1
+        policer_oid = policer_entries[0]
+
+        # check asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        mirror_entries = tbl.getKeys()
+        assert len(mirror_entries) == 1
+
+        (status, fvs) = tbl.get(mirror_entries[0])
+        assert status == True
+        assert len(fvs) == 12
+        for fv in fvs:
+            if fv[0] == "SAI_MIRROR_SESSION_ATTR_MONITOR_PORT":
+                assert dvs.asicdb.portoidmap[fv[1]] == "Ethernet16"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_TYPE":
+                assert fv[1] == "SAI_MIRROR_SESSION_TYPE_ENHANCED_REMOTE"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_ERSPAN_ENCAPSULATION_TYPE":
+                assert fv[1] == "SAI_ERSPAN_ENCAPSULATION_TYPE_MIRROR_L3_GRE_TUNNEL"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_IPHDR_VERSION":
+                assert fv[1] == "4"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_TOS":
+                assert fv[1] == "32"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_TTL":
+                assert fv[1] == "100"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS":
+                assert fv[1] == "3.3.3.3"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_DST_IP_ADDRESS":
+                assert fv[1] == "2.2.2.2"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_SRC_MAC_ADDRESS":
+                assert fv[1] == dvs.runcmd("bash -c \"ip link show eth0 | grep ether | awk '{print $2}'\"")[1].strip().upper()
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS":
+                assert fv[1] == "02:04:06:08:10:12"
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_GRE_PROTOCOL_TYPE":
+                assert fv[1] == "25944" # 0x6558
+            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_POLICER":
+                assert fv[1] == policer_oid
+            else:
+                assert False
+
+        # remove mirror session
+        self.remove_route(dvs, "2.2.2.2")
+        self.remove_neighbor("Ethernet16", "10.0.0.1")
+        self.remove_ip_address("Ethernet16", "10.0.0.0/31")
+        self.set_port_status("Ethernet16", "down")
+        self.remove_mirror_session(session)
+
+        # remove policer
+        self.remove_policer(policer)
+
+
+    def create_acl_table(self, table, interfaces):
+        tbl = swsscommon.Table(self.cdb, "ACL_TABLE")
+        fvs = swsscommon.FieldValuePairs([("policy_desc", "mirror_test"),
+                                          ("type", "mirror"),
+                                          ("ports", ",".join(interfaces))])
+        tbl.set(table, fvs)
+        time.sleep(1)
+
+    def remove_acl_table(self, table):
+        tbl = swsscommon.Table(self.cdb, "ACL_TABLE")
+        tbl._del(table)
+        time.sleep(1)
+
+    def create_mirror_acl_dscp_rule(self, table, rule, dscp, session):
+        tbl = swsscommon.Table(self.cdb, "ACL_RULE")
+        fvs = swsscommon.FieldValuePairs([("priority", "1000"),
+                                          ("mirror_action", session),
+                                          ("DSCP", dscp)])
+        tbl.set(table + "|" + rule, fvs)
+        time.sleep(1)
+
+    def remove_mirror_acl_dscp_rule(self, table, rule):
+        tbl = swsscommon.Table(self.cdb, "ACL_RULE")
+        tbl._del(table + "|" + rule)
+        time.sleep(1)
+
+    def test_MirrorPolicerWithAcl(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        session = "MIRROR_SESSION"
+        policer= "POLICER"
+        acl_table = "MIRROR_TABLE"
+        acl_rule = "MIRROR_RULE"
+
+        # create policer
+        self.create_policer(policer)
+
+        # create mirror session
+        self.create_mirror_session(session, "3.3.3.3", "2.2.2.2", "0x6558", "8", "100", "0", policer)
+        self.set_port_status("Ethernet16", "up")
+        self.add_ip_address("Ethernet16", "10.0.0.0/31")
+        self.add_neighbor("Ethernet16", "10.0.0.1", "02:04:06:08:10:12")
+        self.add_route(dvs, "2.2.2.2", "10.0.0.1")
+
+        # check asic database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+        mirror_entries = tbl.getKeys()
+        assert len(mirror_entries) == 1
+        mirror_oid = mirror_entries[0]
+
+        # create acl table
+        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"])
+
+        # create acl rule with dscp value and mask
+        self.create_mirror_acl_dscp_rule(acl_table, acl_rule, "8/56", session)
+
+        # assert acl rule is created
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+        assert len(rule_entries) == 1
+
+        (status, fvs) = tbl.get(rule_entries[0])
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_ACL_ENTRY_ATTR_FIELD_DSCP":
+                assert fv[1] == "8&mask:0x38"
+            if fv[0] == "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS":
+                assert fv[1] == "1:" + mirror_oid
+
+        # remove acl rule
+        self.remove_mirror_acl_dscp_rule(acl_table, acl_rule)
+
+        # remove acl table
+        self.remove_acl_table(acl_table)
+
+        # remove mirror session
+        self.remove_route(dvs, "2.2.2.2")
+        self.remove_neighbor("Ethernet16", "10.0.0.1")
+        self.remove_ip_address("Ethernet16", "10.0.0.0/31")
+        self.set_port_status("Ethernet16", "down")
+        self.remove_mirror_session(session)
+
+        # remove policer
+        self.remove_policer(policer)


### PR DESCRIPTION
Now that we could create a policer for the mirror session to
throttle the mirroring traffic.

configuration:

POLICER|NAME:
 meter_type:packets|bytes
 mode:sr_tcm|tr_tcm|storm_control
 cir|DIGITS
 cbs|DIGITS
 pir|DIGITS
 pbs|DIGITS
 corlor_source:aware|blind
 red_action:drop
 yellow_action:drop
 green_action:drop

MIRROR_SESSION|NAME:
 policer:policer_name

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>