### PR TITLE
[vxlamgr]: Change default return value to true in doTask() to avoid retry the unknown table request

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -165,7 +165,7 @@ void VxlanMgr::doTask(Consumer &consumer)
     auto it = consumer.m_toSync.begin();
     while (it != consumer.m_toSync.end())
     {
-        bool task_result = false;
+        bool task_result = true;
         auto t = it->second;
         const std::string & op = kfvOp(t);
 


### PR DESCRIPTION
**What I did**
[vxlamgr]: Change default return value to true in doTask() to avoid retry the unknown table request

**Why I did it**
If the default value is false, the request will be retied next time. But those cases which cause return value be false are unknown table request, I thought this kind of requests should only write LOG instead of doing retry 

**How I verified it**
Send incorrect table name request to doTask for vxlanmgr.cpp 
