### PR TITLE
swss-orchagent: add new orch for vnet routes/tunnel routes tables in CONFIG_DB 

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -77,6 +77,12 @@ bool OrchDaemon::init()
             APP_VNET_RT_TABLE_NAME,
             APP_VNET_RT_TUNNEL_TABLE_NAME
     };
+
+    vector<string> cfg_vnet_tables = {
+            CFG_VNET_RT_TABLE_NAME,
+            CFG_VNET_RT_TUNNEL_TABLE_NAME
+    };
+
     VNetOrch *vnet_orch;
     if (platform == MLNX_PLATFORM_SUBSTRING)
     {
@@ -87,6 +93,8 @@ bool OrchDaemon::init()
         vnet_orch = new VNetOrch(m_applDb, APP_VNET_TABLE_NAME);
     }
     gDirectory.set(vnet_orch);
+    VNetCfgRouteOrch *cfg_vnet_rt_orch = new VNetCfgRouteOrch(m_configDb, m_applDb, cfg_vnet_tables);
+    gDirectory.set(cfg_vnet_rt_orch);
     VNetRouteOrch *vnet_rt_orch = new VNetRouteOrch(m_applDb, vnet_tables, vnet_orch);
     gDirectory.set(vnet_rt_orch);
     VRFOrch *vrf_orch = new VRFOrch(m_applDb, APP_VRF_TABLE_NAME);
@@ -202,6 +210,7 @@ bool OrchDaemon::init()
     m_orchList.push_back(gFdbOrch);
     m_orchList.push_back(mirror_orch);
     m_orchList.push_back(gAclOrch);
+    m_orchList.push_back(cfg_vnet_rt_orch);
     m_orchList.push_back(vnet_orch);
     m_orchList.push_back(vnet_rt_orch);
     m_orchList.push_back(vrf_orch);

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1991,7 +1991,7 @@ void VNetCfgRouteOrch::doTask(Consumer &consumer)
     {
         bool task_result = false;
         auto t = it->second;
-        const std::string & op = kfvOp(t);
+        const string & op = kfvOp(t);
         if (table_name == CFG_VNET_RT_TABLE_NAME)
         {
             task_result = doVnetRouteTask(t, op);
@@ -2016,21 +2016,21 @@ void VNetCfgRouteOrch::doTask(Consumer &consumer)
     }
 }
 
-bool VNetCfgRouteOrch::doVnetTunnelRouteTask(const KeyOpFieldsValuesTuple & t, const std::string & op)
+bool VNetCfgRouteOrch::doVnetTunnelRouteTask(const KeyOpFieldsValuesTuple & t, const string & op)
 {
     SWSS_LOG_ENTER();
 
-    std::string vnetRouteTunnelName = kfvKey(t);
-    std::replace(vnetRouteTunnelName.begin(), vnetRouteTunnelName.end(), config_db_key_delimiter, delimiter);
+    string vnetRouteTunnelName = kfvKey(t);
+    replace(vnetRouteTunnelName.begin(), vnetRouteTunnelName.end(), config_db_key_delimiter, delimiter);
     if (op == SET_COMMAND)
     {
         m_appVnetRouteTunnelTable.set(vnetRouteTunnelName, kfvFieldsValues(t));
-        SWSS_LOG_NOTICE("Create vnet route tunnel %s", vnetRouteTunnelName.c_str());
+        SWSS_LOG_INFO("Create vnet route tunnel %s", vnetRouteTunnelName.c_str());
     }
     else if (op == DEL_COMMAND)
     {
         m_appVnetRouteTunnelTable.del(vnetRouteTunnelName);
-        SWSS_LOG_NOTICE("Delete vnet route tunnel %s", vnetRouteTunnelName.c_str());
+        SWSS_LOG_INFO("Delete vnet route tunnel %s", vnetRouteTunnelName.c_str());
     }
     else
     {
@@ -2041,21 +2041,21 @@ bool VNetCfgRouteOrch::doVnetTunnelRouteTask(const KeyOpFieldsValuesTuple & t, c
     return true;
 }
 
-bool VNetCfgRouteOrch::doVnetRouteTask(const KeyOpFieldsValuesTuple & t, const std::string & op)
+bool VNetCfgRouteOrch::doVnetRouteTask(const KeyOpFieldsValuesTuple & t, const string & op)
 {
     SWSS_LOG_ENTER();
 
-    std::string vnetRouteName = kfvKey(t);
-    std::replace(vnetRouteName.begin(), vnetRouteName.end(), config_db_key_delimiter, delimiter);
+    string vnetRouteName = kfvKey(t);
+    replace(vnetRouteName.begin(), vnetRouteName.end(), config_db_key_delimiter, delimiter);
     if (op == SET_COMMAND)
     {
         m_appVnetRouteTable.set(vnetRouteName, kfvFieldsValues(t));
-        SWSS_LOG_NOTICE("Create vnet route %s", vnetRouteName.c_str());
+        SWSS_LOG_INFO("Create vnet route %s", vnetRouteName.c_str());
     }
     else if (op == DEL_COMMAND)
     {
         m_appVnetRouteTable.del(vnetRouteName);
-        SWSS_LOG_NOTICE("Delete vnet route %s", vnetRouteName.c_str());
+        SWSS_LOG_INFO("Delete vnet route %s", vnetRouteName.c_str());
     }
     else
     {

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -9,7 +9,6 @@
 
 #include "request_parser.h"
 #include "ipaddresses.h"
-
 #include "producerstatetable.h"
 
 #define VNET_BITMAP_SIZE 32
@@ -377,11 +376,8 @@ public:
 private:
     void doTask(Consumer &consumer);
 
-    bool doVnetTunnelRouteCreateTask(const KeyOpFieldsValuesTuple & t);
-    bool doVnetTunnelRouteDeleteTask(const KeyOpFieldsValuesTuple & t);
-
-    bool doVnetRouteCreateTask(const KeyOpFieldsValuesTuple & t);
-    bool doVnetRouteDeleteTask(const KeyOpFieldsValuesTuple & t);
+    bool doVnetTunnelRouteTask(const KeyOpFieldsValuesTuple & t, const std::string & op);
+    bool doVnetRouteTask(const KeyOpFieldsValuesTuple & t, const std::string & op);
 
     ProducerStateTable m_appVnetRouteTable, m_appVnetRouteTunnelTable;
 };

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -10,6 +10,8 @@
 #include "request_parser.h"
 #include "ipaddresses.h"
 
+#include "producerstatetable.h"
+
 #define VNET_BITMAP_SIZE 32
 #define VNET_TUNNEL_SIZE 512
 #define VNET_NEIGHBOR_MAX 0xffff
@@ -364,6 +366,24 @@ private:
     VNetOrch *vnet_orch_;
     VNetRouteRequest request_;
     handler_map handler_map_;
+};
+
+class VNetCfgRouteOrch : public Orch
+{
+public:
+    VNetCfgRouteOrch(DBConnector *db, DBConnector *appDb, vector<string> &tableNames);
+    using Orch::doTask;
+
+private:
+    void doTask(Consumer &consumer);
+
+    bool doVnetTunnelRouteCreateTask(const KeyOpFieldsValuesTuple & t);
+    bool doVnetTunnelRouteDeleteTask(const KeyOpFieldsValuesTuple & t);
+
+    bool doVnetRouteCreateTask(const KeyOpFieldsValuesTuple & t);
+    bool doVnetRouteDeleteTask(const KeyOpFieldsValuesTuple & t);
+
+    ProducerStateTable m_appVnetRouteTable, m_appVnetRouteTunnelTable;
 };
 
 #endif // __VNETORCH_H

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -85,11 +85,11 @@ def check_object(db, table, key, expected_attributes):
 
 
 def create_vnet_local_routes(dvs, prefix, vnet_name, ifname):
-    app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+    conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
 
-    create_entry_pst(
-        app_db,
-        "VNET_ROUTE_TABLE", ':', "%s:%s" % (vnet_name, prefix),
+    create_entry_tbl(
+        conf_db,
+        "VNET_ROUTE", '|', "%s|%s" % (vnet_name, prefix),
         [
             ("ifname", ifname),
         ]
@@ -99,7 +99,7 @@ def create_vnet_local_routes(dvs, prefix, vnet_name, ifname):
 
 
 def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0):
-    app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+    conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
 
     attrs = [
             ("endpoint", endpoint),
@@ -111,11 +111,12 @@ def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0):
     if mac:
         attrs.append(('mac_address', mac))
 
-    create_entry_pst(
-        app_db,
-        "VNET_ROUTE_TUNNEL_TABLE", ':', "%s:%s" % (vnet_name, prefix),
+    create_entry_tbl(
+        conf_db,
+        "VNET_ROUTE_TUNNEL", '|', "%s|%s" % (vnet_name, prefix),
         attrs,
     )
+
 
     time.sleep(2)
 

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -117,7 +117,6 @@ def create_vnet_routes(dvs, prefix, vnet_name, endpoint, mac="", vni=0):
         attrs,
     )
 
-
     time.sleep(2)
 
 


### PR DESCRIPTION
Signed-off-by: Weixi Chen <Weixi.Chen@microsoft.com>

**What I did**
1. Add VNET_ROUTE and VNET_ROUTE_TUNNEL tables in CONFIG_DB so that VNET routes get persistent after reboot if a config_save is performed. 
2. Add a new orchagent VnetRouteCfgOrch that listens for newly exposed tables in CONFIG_DB which have a one to one relation with existing APP_DB tables. 

**Why I did it**
Static vnet routes provisioned in sonic are not persistence. Switch reboot leads to the loss of static routes. Tables in CONFIG_DB will be persistent if a config save is manually performed.

**How I verified it**
run vs test: sudo pytest test_vnet.py -s -v --dvsname=vs
output:
/usr/local/lib/python2.7/dist-packages/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
======================================================================== test session starts ========================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/weixi-vs/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 3 items

test_vnet.py::TestVnetOrch::test_vnet_orch_2 PASSED                                                                                                           [ 33%]
test_vnet.py::TestVnetOrch::test_vnet_orch_3 PASSED                                                                                                           [ 66%]
test_vnet.py::TestVnetOrch::test_vnet_orch_1 PASSED                                                                                                           [100%]

==================================================================== 3 passed in 174.11 seconds =====================================================================