### PR TITLE
Remove FDB entries when shutting down the interface

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -87,6 +87,7 @@ public:
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_portTable;
+    unique_ptr<Table> m_lagTable;
     unique_ptr<Table> m_queueTable;
     unique_ptr<Table> m_queuePortTable;
     unique_ptr<Table> m_queueIndexTable;
@@ -189,6 +190,8 @@ private:
 
     bool getPortOperStatus(const Port& port, sai_port_oper_status_t& status) const;
     void updatePortOperStatus(Port &port, sai_port_oper_status_t status);
+
+    void removeFDBEntriesByBridgePortID(sai_object_id_t bridge_port_id);
 };
 #endif /* SWSS_PORTSORCH_H */
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add the flushing FDB feature in PortsOrch to handle the situation when the user shut down the interface.

**How I did it**
We create the new function named 'removeFDBEntriesByBridgePortID'. 
This function is responsible for calling the SAI flush_fdb_entries() function to remove the FDB entries.

There are three situations to call the above function,

1. In **doTask** function. 
    When SONiC receives the port_state_change op event, if the interface goes down, it calls removeFDBEntriesByBridgePortID() to remove FDB entries.
2.  In **removeLag** function. 
   When SONiC removes the LAG, it also calls removeFDBEntriesByBridgePortID() to remove FDB entries.
3. In **removeLagMember** function. 
  When SONiC removes one member from the LAG, if it causes the LAG's oper_status goes DOWN ( since the total number of enabled links less than the minimum number of links), it also calls removeFDBEntriesByBridgePortID() to remove FDB entries.

**How I verified it**
We prepared two physical ports (Ethernet44) and one virtual port (PortChannel1) to test.
First, I enabled two ports and each port learned 5 different FDB entries.

```
root@SONiC-Inventec-d6556:/home/admin# show mac
  No.    Vlan  MacAddress         Port           Type
 -----  ------  -----------------  -------------  -------
    1      11  00:10:94:00:00:21  PortChannel01  Dynamic
    2      11  00:10:94:00:00:22  PortChannel01  Dynamic
    3      11  00:10:94:00:00:05  Ethernet44     Dynamic
    4      11  00:10:94:00:00:03  Ethernet44     Dynamic
    5      11  00:10:94:00:00:02  Ethernet44     Dynamic
    6      11  00:10:94:00:00:06  Ethernet44     Dynamic
    7      11  00:10:94:00:00:20  PortChannel01  Dynamic
    8      11  00:10:94:00:00:23  PortChannel01  Dynamic
    9      11  00:10:94:00:00:04  Ethernet44     Dynamic  
   10      11  00:10:94:00:00:24  PortChannel01  Dynamic
Total number of entries 10
```
**Shutting down Ethernet44**

```
root@SONiC-Inventec-d6556:/home/admin# config interface shutdown Ethernet44
root@SONiC-Inventec-d6556:/home/admin# show mac
  No.    Vlan  MacAddress         Port           Type
-----  ------  -----------------  -------------  -------
    1      11  00:10:94:00:00:21  PortChannel01  Dynamic
    2      11  00:10:94:00:00:22  PortChannel01  Dynamic
    3      11  00:10:94:00:00:20  PortChannel01  Dynamic
    4      11  00:10:94:00:00:23  PortChannel01  Dynamic
    5      11  00:10:94:00:00:24  PortChannel01  Dynamic
Total number of entries 5

root@SONiC-Inventec-d6556:/home/admin# bcmcmd "l2 show"
l2 show
mac=00:10:94:00:00:24 vlan=11 GPORT=0x0 Trunk=0 Hit
mac=00:10:94:00:00:22 vlan=11 GPORT=0x0 Trunk=0 Hit
mac=00:10:94:00:00:20 vlan=11 GPORT=0x0 Trunk=0 Hit
mac=00:8c:fa:22:5a:12 vlan=1 GPORT=0x0 modid=0 port=0/cpu0 Static CPU
mac=00:10:94:00:00:23 vlan=11 GPORT=0x0 Trunk=0 Hit
mac=00:10:94:00:00:21 vlan=11 GPORT=0x0 Trunk=0 Hit
```
**Shutting down PortChannel01**

```
root@SONiC-Inventec-d6556:/home/admin# config interface shutdown PortChannel01 

root@SONiC-Inventec-d6556:/home/admin# show mac
No.    Vlan    MacAddress    Port    Type
-----  ------  ------------  ------  ------
Total number of entries 0

root@SONiC-Inventec-d6556:/home/admin# bcmcmd "l2 show"
l2 show
mac=00:8c:fa:22:5a:12 vlan=1 GPORT=0x0 modid=0 port=0/cpu0 Static CPU
```
**Test LAG minimun links case**
In the beginning, we prepare the LAG channel which includes three ports, and the min_ports setting is 2 and we let this LAG learn 5 different FDB entries.
First, we shut down the Ethernet72 then shut down the Ethernet76, it will cause the LAG oper_status goes down.
```
root@SONiC-Inventec-d6556:/home/admin# docker exec teamd cat /etc/teamd/PortChannel01.conf
{
    "device": "PortChannel01",
    "hwaddr": "00:8c:fa:22:5a:12",
    "runner": {
        "name": "lacp",
        "active": true,
        "min_ports": 2,
        "tx_hash": ["eth", "ipv4", "ipv6"]
    },
    "link_watch": {
        "name": "ethtool"
    },
    "ports": {
        "Ethernet60": {},
        "Ethernet72": {},
        "Ethernet76": {}
    }
}

root@SONiC-Inventec-d6556:/home/admin# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev       Protocol     Ports
-----  -------------  -----------  -----------------------------------------
   01  PortChannel01  LACP(A)(Up)  Ethernet76(S) Ethernet72(S) Ethernet60(S)

root@SONiC-Inventec-d6556:/home/admin# show mac
  No.    Vlan  MacAddress         Port           Type
-----  ------  -----------------  -------------  -------
    1      11  00:10:94:00:00:22  PortChannel01  Dynamic
    2      11  00:10:94:00:00:24  PortChannel01  Dynamic
    3      11  00:10:94:00:00:23  PortChannel01  Dynamic
    4      11  00:10:94:00:00:20  PortChannel01  Dynamic
    5      11  00:10:94:00:00:21  PortChannel01  Dynamic
Total number of entries 5

root@SONiC-Inventec-d6556:/home/admin# config interface shutdown Ethernet72
root@SONiC-Inventec-d6556:/home/admin# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev       Protocol     Ports
-----  -------------  -----------  -----------------------------------------
   01  PortChannel01  LACP(A)(Up)  Ethernet76(S) Ethernet72(D) Ethernet60(S)
root@SONiC-Inventec-d6556:/home/admin# show mac
  No.    Vlan  MacAddress         Port           Type
-----  ------  -----------------  -------------  -------
    1      11  00:10:94:00:00:22  PortChannel01  Dynamic
    2      11  00:10:94:00:00:24  PortChannel01  Dynamic
    3      11  00:10:94:00:00:23  PortChannel01  Dynamic
    4      11  00:10:94:00:00:20  PortChannel01  Dynamic
    5      11  00:10:94:00:00:21  PortChannel01  Dynamic
Total number of entries 5

root@SONiC-Inventec-d6556:/home/admin# config interface shutdown Ethernet76
root@SONiC-Inventec-d6556:/home/admin# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available, S - selected, D - deselected
  No.  Team Dev       Protocol     Ports
-----  -------------  -----------  -----------------------------------------
   01  PortChannel01  LACP(A)(Dw)  Ethernet76(D) Ethernet72(D) Ethernet60(S)

root@SONiC-Inventec-d6556:/home/admin# show mac
No.    Vlan    MacAddress    Port    Type
-----  ------  -----------
```
**Details if related**
