### PR TITLE
[test]: Do not remove vEthernet* interfaces

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,7 +299,7 @@ class DockerVirtualSwitch(object):
             fds = re_space.split(l)
             if len(fds) > 1:
                 pname = fds[1].rstrip(":")
-                m = re.compile("(eth|lo|Bridge|Ethernet)").match(pname)
+                m = re.compile("(eth|lo|Bridge|Ethernet|vEthernet)").match(pname)
                 if not m:
                     self.ctn.exec_run("ip link del {}".format(pname))
                     print "remove extra link {}".format(pname)


### PR DESCRIPTION
These interfaces are explicitly created for sending packets between
docker and outisde.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
