### PR TITLE
[vnetorch]: Fix tunnel route removal flow for bitmap VNET

### DIFF
--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -184,8 +184,10 @@ struct TunnelRouteInfo
 {
     sai_object_id_t tunnelRouteTableEntryId;
     sai_object_id_t nexthopId;
+    sai_object_id_t tunnelId;
     uint32_t vni;
     MacAddress mac;
+    IpAddress ip;
     uint32_t offset;
 };
 
@@ -199,6 +201,14 @@ struct VnetIntfInfo
 {
     sai_object_id_t vnetTableEntryId;
     map<IpPrefix, RouteInfo> pfxMap;
+};
+
+
+struct TunnelEndpointInfo
+{
+    sai_object_id_t metaTunnelEntryId;
+    uint16_t tunnelIndex;
+    uint32_t use_count;
 };
 
 class VNetBitmapObject: public VNetObject
@@ -256,7 +266,7 @@ private:
     static std::bitset<VNET_TUNNEL_SIZE> tunnelIdOffsets_;
     static map<uint32_t, VnetBridgeInfo> bridgeInfoMap_;
     static map<tuple<MacAddress, sai_object_id_t>, VnetNeighInfo> neighInfoMap_;
-    static map<tuple<IpAddress, sai_object_id_t>, uint16_t> endpointMap_;
+    static map<tuple<IpAddress, sai_object_id_t>, TunnelEndpointInfo> endpointMap_;
 
     map<IpPrefix, RouteInfo> routeMap_;
     map<IpPrefix, TunnelRouteInfo> tunnelRouteMap_;


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed tunnel route removal flow for bitmap VNET by adding remove logic for newly added ```meta tunnel``` entry.
**Why I did it**
Some time ago, when ```encap``` flow was changed for bitmap VNET, only ```create``` flow was added for new ```meta tunnel``` entry and ```remove``` was missed. As a result if remove tunnel route ```meta tunnel``` entry still exists in HW, which is incorrect.
**How I verified it**
Ran ansible and VS tests.
**Details if related**
N/A