### PR TITLE
Ignore neighbor entry with BCAST MAC, check SAI status exists

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -9,6 +9,7 @@
 #include "ipaddress.h"
 #include "netmsg.h"
 #include "linkcache.h"
+#include "macaddress.h"
 
 #include "neighsync.h"
 #include "warm_restart.h"
@@ -77,6 +78,13 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     }
 
     nl_addr2str(rtnl_neigh_get_lladdr(neigh), macStr, MAX_ADDR_SIZE);
+
+    /* Ignore neighbor entries with Broadcast Mac - Trigger for directed broadcast */
+    if (!delete_key && (MacAddress(macStr) == MacAddress("ff:ff:ff:ff:ff:ff")))
+    {
+        SWSS_LOG_INFO("Broadcast Mac recieved, ignoring for %s", ipStr);
+        return;
+    }
 
     std::vector<FieldValueTuple> fvVector;
     FieldValueTuple f("family", family);

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -393,9 +393,18 @@ bool NeighOrch::addNeighbor(NeighborEntry neighborEntry, MacAddress macAddress)
         status = sai_neighbor_api->create_neighbor_entry(&neighbor_entry, 1, &neighbor_attr);
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d",
+            if (status == SAI_STATUS_ITEM_ALREADY_EXISTS)
+            {
+                SWSS_LOG_ERROR("Entry exists: neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-            return false;
+                return true;
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d",
+                           macAddress.to_string().c_str(), alias.c_str(), status);
+                return false;
+            }
         }
 
         SWSS_LOG_NOTICE("Created neighbor %s on %s", macAddress.to_string().c_str(), alias.c_str());

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -397,6 +397,7 @@ bool NeighOrch::addNeighbor(NeighborEntry neighborEntry, MacAddress macAddress)
             {
                 SWSS_LOG_ERROR("Entry exists: neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
+                /* Returning True so as to skip retry */
                 return true;
             }
             else


### PR DESCRIPTION
**What I did**
In certain cases, we get neighbor entries with BCAST MAC. This can be safely ignored from programming the hardware

**Why I did it**
Directed bcast entries are added as part of Interface IP address creation. The neighbor update is redundant. 

**How I verified it**
Configure neighbor entry with BCAST mac. 

```
sudo ip neigh add 10.1.1.255 lladdr ff:ff:ff:ff:ff:ff dev Ethernet124
NOTICE swss#neighsyncd: :- onMsg: Broadcast Mac recieved, ignoring for 10.1.1.255
```

**Details if related**
