### PR TITLE
[aclorch]: Allow DTEL drop actions in DTEL flow watchlist

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1554,7 +1554,9 @@ bool AclRuleDTelFlowWatchListEntry::validateAddAction(string attr_name, string a
         (attr_name != ACTION_DTEL_FLOW_OP &&
         attr_name != ACTION_DTEL_INT_SESSION &&
         attr_name != ACTION_DTEL_FLOW_SAMPLE_PERCENT &&
-        attr_name != ACTION_DTEL_REPORT_ALL_PACKETS))
+        attr_name != ACTION_DTEL_REPORT_ALL_PACKETS &&
+        attr_name != ACTION_DTEL_DROP_REPORT_ENABLE &&
+        attr_name != ACTION_DTEL_TAIL_DROP_REPORT_ENABLE))
     {
         return false;
     }
@@ -1611,7 +1613,9 @@ bool AclRuleDTelFlowWatchListEntry::validateAddAction(string attr_name, string a
 
     value.aclaction.enable = true;
 
-    if (attr_name == ACTION_DTEL_REPORT_ALL_PACKETS)
+    if (attr_name == ACTION_DTEL_REPORT_ALL_PACKETS ||
+        attr_name == ACTION_DTEL_DROP_REPORT_ENABLE ||
+        attr_name == ACTION_DTEL_TAIL_DROP_REPORT_ENABLE)
     {
         value.aclaction.parameter.booldata = (attr_value == DTEL_ENABLED) ? true : false;
         value.aclaction.enable = (attr_value == DTEL_ENABLED) ? true : false;
@@ -1766,7 +1770,8 @@ bool AclRuleDTelDropWatchListEntry::validateAddAction(string attr_name, string a
     string attr_value = to_upper(attr_val);
 
     if (attr_name != ACTION_DTEL_DROP_REPORT_ENABLE &&
-        attr_name != ACTION_DTEL_TAIL_DROP_REPORT_ENABLE)
+        attr_name != ACTION_DTEL_TAIL_DROP_REPORT_ENABLE &&
+        attr_name != ACTION_DTEL_REPORT_ALL_PACKETS)
     {
         return false;
     }


### PR DESCRIPTION
In order to simplify operations, it may be desirable to combine the
DTEL flow and drop watchlists into one single watchlist that contains
both flow and drop actions. This change adds the drop actions to the
flow watchlist, allowing the combination of flow and drop actions in
a single ACL table.

This change also allows ACTION_DTEL_REPORT_ALL_PACKETS in drop
watchlists.

Signed-off-by: Mickey Spiegel <mspiegel@barefootnetworks.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This change adds the drop actions to the flow watchlist, allowing the combination of flow and drop actions in a single ACL table.
This change also allows ACTION_DTEL_REPORT_ALL_PACKETS in drop watchlists.

**Why I did it**
In order to simplify operations, it may be desirable to combine the DTEL flow and drop watchlists into one single watchlist that contains both flow and drop actions.

**How I verified it**
Tested on a Barefoot switch, showing that an ACL entry can be created with the combined watch flow and drops action. Verified that the hardware was programmed with the combined action. Verified that both DTEL flow and drop reports are generated for packets matching the ACL entry.

**Details if related**
