### PR TITLE
Fix compilation issue to ignore neighbor entries with Broadcast Mac

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -63,7 +63,7 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     nl_addr2str(rtnl_neigh_get_lladdr(neigh), macStr, MAX_ADDR_SIZE);
 
     /* Ignore neighbor entries with Broadcast Mac - Trigger for directed broadcast */
-    if (!delete_key && (MacAddress(macStr) == MacAddress("ff:ff:ff:ff:ff:ff")))
+    if (MacAddress(macStr) == MacAddress("ff:ff:ff:ff:ff:ff"))
     {
         SWSS_LOG_INFO("Broadcast Mac recieved, ignoring for %s", ipStr);
         return;


### PR DESCRIPTION
**What I did**
Fix compilation issue. For delete case, this code will not be executed as it gets returned earlier

**Why I did it**

**How I verified it**

**Details if related**
