### PR TITLE
[warm restart assist] assume vector values could be reordered

### DIFF
--- a/warmrestart/warmRestartAssist.cpp
+++ b/warmrestart/warmRestartAssist.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <algorithm>
 #include "logger.h"
 #include "schema.h"
 #include "warm_restart.h"
@@ -173,7 +174,7 @@ void AppRestartAssist::insertToMap(string key, vector<FieldValueTuple> fvVector,
     else if (found != appTableCacheMap.end())
     {
         // check only the original vector range (exclude cache-state field/value)
-        if(!equal(fvVector.begin(), fvVector.end(), found->second.begin()))
+        if(! contains(found->second, fvVector))
         {
             SWSS_LOG_NOTICE("%s, found key: %s, new value ", m_appTableName.c_str(), key.c_str());
 
@@ -279,4 +280,19 @@ bool AppRestartAssist::checkReconcileTimer(Selectable *s)
         return true;
     }
     return false;
+}
+
+// check if left vector contains all elements of right vector
+bool AppRestartAssist::contains(const std::vector<FieldValueTuple>& left,
+              const std::vector<FieldValueTuple>& right)
+{
+    for (auto const& rv : right)
+    {
+        if (std::find(left.begin(), left.end(), rv) == left.end())
+        {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/warmrestart/warmRestartAssist.h
+++ b/warmrestart/warmRestartAssist.h
@@ -115,6 +115,8 @@ private:
     std::string joinVectorString(const std::vector<FieldValueTuple> &fv);
     void setCacheEntryState(std::vector<FieldValueTuple> &fvVector, cache_state_t state);
     cache_state_t getCacheEntryState(const std::vector<FieldValueTuple> &fvVector);
+    bool contains(const std::vector<FieldValueTuple>& left,
+                  const std::vector<FieldValueTuple>& right);
 };
 
 }


### PR DESCRIPTION
**What I did**

When comparing 2 vectors, assume their elements could be re-ordered.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**Why I did it**
Without he change, during warm reboot, some neighbor entries will be mistakenly judged as having new value and recreated.

**How I verified it**
With the change, no neighbor entry got recreated due to having 'new value' after warm reboot.