### PR TITLE
Set LAG mtu value based on kernel netlink msg

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -130,6 +130,7 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     FieldValueTuple m("mtu", to_string(mtu));
     fvVector.push_back(a);
     fvVector.push_back(o);
+    fvVector.push_back(m);
     m_lagTable.set(lagName, fvVector);
 
     SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s, mtu: %d",

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -114,24 +114,26 @@ void TeamSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
+    unsigned int mtu = rtnl_link_get_mtu(link);
     addLag(lagName, rtnl_link_get_ifindex(link),
            rtnl_link_get_flags(link) & IFF_UP,
-           rtnl_link_get_flags(link) & IFF_LOWER_UP);
+           rtnl_link_get_flags(link) & IFF_LOWER_UP, mtu);
 }
 
 void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
-                      bool oper_state)
+                      bool oper_state, unsigned int mtu)
 {
     /* Set the LAG */
     std::vector<FieldValueTuple> fvVector;
     FieldValueTuple a("admin_status", admin_state ? "up" : "down");
     FieldValueTuple o("oper_status", oper_state ? "up" : "down");
+    FieldValueTuple m("mtu", to_string(mtu));
     fvVector.push_back(a);
     fvVector.push_back(o);
     m_lagTable.set(lagName, fvVector);
 
-    SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s",
-                   lagName.c_str(), admin_state ? "up" : "down", oper_state ? "up" : "down");
+    SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s, mtu: %d",
+                   lagName.c_str(), admin_state ? "up" : "down", oper_state ? "up" : "down", mtu);
 
     /* Return when the team instance has already been tracked */
     if (m_teamSelectables.find(lagName) != m_teamSelectables.end())

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -56,7 +56,7 @@ public:
 
 protected:
     void addLag(const std::string &lagName, int ifindex, bool admin_state,
-                bool oper_state);
+                bool oper_state, unsigned int mtu);
     void removeLag(const std::string &lagName);
 
     /* valid only in WR mode */


### PR DESCRIPTION
**What I did**
Set LAG `mtu `value based on kernel netlink msg along with `admin `and `oper `status 

**Why I did it**
During initialization, the `mtu `attribute is not always present in `LAG_TABLE`. This change ensures that MTU is always set to APP DB as  the same value as configured in kernel. 

**How I verified it**
Check APP DB entry and verify syslog config

**Details if related**
