### PR TITLE
[sonic-swss]: Fix for FPM accept call failure in ARM arch

### DIFF
--- a/fpmsyncd/fpmlink.cpp
+++ b/fpmsyncd/fpmlink.cpp
@@ -71,7 +71,7 @@ FpmLink::~FpmLink()
 void FpmLink::accept()
 {
     struct sockaddr_in client_addr;
-    socklen_t client_len;
+    socklen_t client_len = 0;
 
     m_connection_socket = ::accept(m_server_socket, (struct sockaddr *)&client_addr,
                                    &client_len);


### PR DESCRIPTION
**What I did**
[On ARM 32-bit port]
Added fix for accept call failure in FPM.

**Why I did it**
[On the ARM 32-bit port]
FPM (to accept route updates) does not accept the client connections from Zebra (Routing manager).
Because of garbage/random socket length, accept API returns EINVALUE. Upon receiving socket error, FPM handles it as exception and closes all the open sockets and exits.

The issue, though currently seen only on ARM-32 bit, could very well be seen on other platforms as well, as the variable (client_len) is un-initialised, and the value will depend on the state of the stack.

**How I verified it**
[On the ARM 32-bit port]
With the fix, FPM works as expected.
