### PR TITLE
pkill -9 zebra for frr warm restart VS test fix

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -329,7 +329,7 @@ class DockerVirtualSwitch(object):
         time.sleep(5)
 
     def stop_zebra(dvs):
-        dvs.runcmd(['sh', '-c', 'pkill -x zebra'])
+        dvs.runcmd(['sh', '-c', 'pkill -9 zebra'])
         time.sleep(1)
 
     def start_fpmsyncd(dvs):

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -955,7 +955,6 @@ def set_restart_timer(dvs, db, app_name, value):
 ################################################################################
 
 
-@pytest.mark.skip(reason="Failing. Under investigation")
 def test_routing_WarmRestart(dvs, testlog):
 
     appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
@@ -1014,7 +1013,7 @@ def test_routing_WarmRestart(dvs, testlog):
     #
     dvs.runcmd("ip route add 192.168.1.100/32 nexthop via 111.0.0.2")
     dvs.runcmd("ip route add 192.168.1.200/32 nexthop via 122.0.0.2")
-    dvs.runcmd("ip route add 192.168.1.300/32 nexthop via 133.0.0.2")
+    dvs.runcmd("ip route add 192.168.1.230/32 nexthop via 133.0.0.2")
 
     #
     # Defining baseline IPv4 ecmp route-entries


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
use pkill -9 for zebra kill during warm restart test.  This is the same as warm reboot.

**Why I did it**
FRR 7.0 zebra resends all existing route to fpm channel upon receiving sigterm signal, that caused warm restart vs DB operation check failure.
 
**How I verified it**
VS
**Details if related**
