### PR TITLE
[sonic-swss]: Added flap counter and last flap time functionality.

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -194,6 +194,9 @@ private:
 
     bool setPortSerdesAttribute(sai_object_id_t port_id, sai_attr_id_t attr_id,
                                 vector<uint32_t> &serdes_val);
+
+    void updateDbPortFlapCounter(const Port& port, vector<FieldValueTuple>& old_tuples, vector<FieldValueTuple>& new_tuples) const;
+    void updateDbPortLastFlapTime(vector<FieldValueTuple>& new_tuples) const;
+
 };
 #endif /* SWSS_PORTSORCH_H */
-


### PR DESCRIPTION
Number of times a link got reset(up/down) has been added under this change, also the last flap timestamp for the link has also been added, they will be updated once the oper status of any port changes. 2 additional fields have been added to appl_db i.e. "flap_counter" and "last_flap_time" which willbe updated when "oper_status" is updated.

Signed-off-by: Prem Prakash prprakash@linkedin.com


**What I did**
Added flap counter and last flap timestamp feature 

**Why I did it**
This would help in solving operational issues faster. Instead of relying on the logs to figure out a bad flapper we can see this feature under status command.

**How I verified it**
Tested it by building up the **docker-orchagent.gz** after my change, changes were required on **sonic-utilities** repo as well to see the output, I will raise a parallel PR for that.

[flap_output.txt](https://github.com/Azure/sonic-swss/files/3279928/flap_output.txt)

