### PR TITLE
Handle default VLAN create and delete

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -110,7 +110,8 @@ private:
     Port m_cpuPort;
     // TODO: Add Bridge/Vlan class
     sai_object_id_t m_default1QBridge;
-    sai_object_id_t m_defaultVlan;
+    sai_object_id_t m_defaultVlan_ObjId;
+    sai_vlan_id_t   m_defaultVlan_Id;
 
     bool m_portConfigDone = false;
     sai_uint32_t m_portCount;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Handle default VLAN creation/deletion in SWSS orch agent. 

**Why I did it**
The default VLAN is created in SAI/driver  during switch initialization. When user tries to create the default VLAN, OrchAgent detects error from SyncD and terminates. Reason is the VLAN already exists. To avoid that, handling the case of default VLAN creation/deletion and skipped the driver call.

**How I verified it**

1.	Create/Delete VLAN 1 
2.	Add/Remove physical ports from VLAN 1
3.	Tagged/Untagged membership for VLAN 1
4.	Add/Remove PortChannel from VLAN 1
5.	Save/Reload VLAN 1 configuration
6.	Ensure that VLAN membership is updated as per config (in driver/SDK)
7.	L2 MAC learning/flushing on VLAN 1
8.	L3 interface configuration on VLAN 1 (ipv4)
9.	ARP learning on VLAN 1 interface
10.	CPU Tx/Rx with VLAN tag 1

**Details if related**
