### PR TITLE
[vxlanmgrd]: Fix for vxlanmgrd cannot correctly work after config reload

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -539,7 +539,7 @@ bool VxlanMgr::deleteVxlan(const VxlanInfo & info)
 void VxlanMgr::clearAllVxlanDevices()
 {
     std::string stdout;
-    const std::string cmd = std::string("") + IP_CMD + " addr";
+    const std::string cmd = std::string("") + IP_CMD + " link";
     int ret = EXECUTE(cmd, stdout);
     if (ret != 0)
     {

--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -1,4 +1,7 @@
 #include <algorithm>
+#include <regex>
+#include <sstream>
+#include <string>
 #include <net/if.h>
 
 #include "logger.h"
@@ -155,6 +158,13 @@ VxlanMgr::VxlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb,
         m_stateVrfTable(stateDb, STATE_VRF_TABLE_NAME),
         m_stateVxlanTable(stateDb, STATE_VXLAN_TABLE_NAME)
 {
+    // Clear old vxlan devices that were created at last time.
+    clearAllVxlanDevices();
+}
+
+VxlanMgr::~VxlanMgr()
+{
+    clearAllVxlanDevices();
 }
 
 void VxlanMgr::doTask(Consumer &consumer)
@@ -526,5 +536,38 @@ bool VxlanMgr::deleteVxlan(const VxlanInfo & info)
     return true;
 }
 
-
+void VxlanMgr::clearAllVxlanDevices()
+{
+    std::string stdout;
+    const std::string cmd = std::string("") + IP_CMD + " addr";
+    int ret = EXECUTE(cmd, stdout);
+    if (ret != 0)
+    {
+        SWSS_LOG_ERROR("Cannot get devices by command : %s", cmd.c_str());
+        return;
+    }
+    std::regex device_name_pattern("^\\d+:\\s+([^:]+)");
+    std::smatch match_result;
+    auto lines = tokenize(stdout, '\n');
+    for (const std::string & line : lines)
+    {
+        if (!std::regex_search(line, match_result, device_name_pattern))
+        {
+            continue;
+        }
+        std::string res;
+        std::string device_name = match_result[1];
+        VxlanInfo info;
+        if (device_name.find(VXLAN_NAME_PREFIX) == 0)
+        {
+            info.m_vxlan = device_name;
+            cmdDeleteVxlan(info, res);
+        }
+        else if (device_name.find(VXLAN_IF_NAME_PREFIX) == 0)
+        {
+            info.m_vxlanIf = device_name;
+            cmdDeleteVxlanIf(info, res);
+        }
+    }
+}
 

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -26,7 +26,7 @@ public:
         std::string m_vxlan;
         std::string m_vxlanIf;
     } VxlanInfo;
-
+    ~VxlanMgr();
 private:
     void doTask(Consumer &consumer);
 
@@ -51,6 +51,7 @@ private:
     bool createVxlan(const VxlanInfo & info);
     bool deleteVxlan(const VxlanInfo & info);
 
+    void clearAllVxlanDevices();
 
     ProducerStateTable m_appVxlanTunnelTable,m_appVxlanTunnelMapTable;
     Table m_cfgVxlanTunnelTable,m_cfgVnetTable,m_stateVrfTable,m_stateVxlanTable;


### PR DESCRIPTION
- What I did
  Clear old vxlan devices that were created at last time

- Why I did it
  1. "config reload" command will kill the swss container, which will make the vxlanmgrd loss the cache information. And to execute "ip link add xxx " command will fail after the vxlanmgrd process restart, because the vxlan device has been created.
  2. The Vnet was deleted by modifying config_db.json, and then execute "config reload" command, which will kill vxlanmgrd process. And when vxlanmgrd restart again, it will cannot receive the delete message, because the redis database also was clear after "config reload". So those vxlan devices will become garbage until the kernel restart.

- How I verified it
  Test it in Chassis topology.

Signed-off-by: Ze Gan <ganze718@gmail.com>