### PR TITLE
[vs]: Fix bitmap VNET virtual switch test

### DIFF
--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -922,7 +922,6 @@ class TestVnetOrch(object):
     '''
     Test 1 - Create Vlan Interface, Tunnel and Vnet
     '''
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_vnet_orch_1(self, dvs, testlog):
         vnet_obj = self.get_vnet_obj()
 
@@ -944,6 +943,7 @@ class TestVnetOrch(object):
         vid = create_vlan_interface(dvs, "Vlan101", "Ethernet28", "Vnet_2000", "100.100.4.1/24")
         vnet_obj.check_router_interface(dvs, 'Vnet_2000', vid)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "100.100.1.1/32", 'Vnet_2000', '10.10.10.1')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_2000', '10.10.10.1', tunnel_name)
 
@@ -963,6 +963,7 @@ class TestVnetOrch(object):
         create_phy_interface(dvs, "Ethernet4", "Vnet_2001", "100.102.1.1/24")
         vnet_obj.check_router_interface(dvs, 'Vnet_2001')
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "100.100.2.1/32", 'Vnet_2001', '10.10.10.2', "00:12:34:56:78:9A")
         vnet_obj.check_vnet_routes(dvs, 'Vnet_2001', '10.10.10.2', tunnel_name, "00:12:34:56:78:9A")
 
@@ -1004,7 +1005,6 @@ class TestVnetOrch(object):
     '''
     Test 2 - Two VNets, One HSMs per VNet
     '''
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_vnet_orch_2(self, dvs, testlog):
         vnet_obj = self.get_vnet_obj()
 
@@ -1023,15 +1023,19 @@ class TestVnetOrch(object):
         vid = create_vlan_interface(dvs, "Vlan1001", "Ethernet0", "Vnet_1", "1.1.10.1/24")
         vnet_obj.check_router_interface(dvs, 'Vnet_1', vid)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "1.1.1.10/32", 'Vnet_1', '100.1.1.10')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_1', '100.1.1.10', tunnel_name)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "1.1.1.11/32", 'Vnet_1', '100.1.1.10')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_1', '100.1.1.10', tunnel_name)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "1.1.1.12/32", 'Vnet_1', '200.200.1.200')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_1', '200.200.1.200', tunnel_name)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "1.1.1.14/32", 'Vnet_1', '200.200.1.201')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_1', '200.200.1.201', tunnel_name)
 
@@ -1046,9 +1050,11 @@ class TestVnetOrch(object):
         vid = create_vlan_interface(dvs, "Vlan1002", "Ethernet4", "Vnet_2", "2.2.10.1/24")
         vnet_obj.check_router_interface(dvs, 'Vnet_2', vid)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "2.2.2.10/32", 'Vnet_2', '100.1.1.20')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_2', '100.1.1.20', tunnel_name)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "2.2.2.11/32", 'Vnet_2', '100.1.1.20')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_2', '100.1.1.20', tunnel_name)
 
@@ -1096,7 +1102,6 @@ class TestVnetOrch(object):
     '''
     Test 3 - Two VNets, One HSMs per VNet, Peering
     '''
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_vnet_orch_3(self, dvs, testlog):
         vnet_obj = self.get_vnet_obj()
 
@@ -1124,9 +1129,11 @@ class TestVnetOrch(object):
         vid = create_vlan_interface(dvs, "Vlan2002", "Ethernet12", "Vnet_20", "8.8.10.1/24")
         vnet_obj.check_router_interface(dvs, 'Vnet_20', vid)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "5.5.5.10/32", 'Vnet_10', '50.1.1.10')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_10', '50.1.1.10', tunnel_name)
 
+        vnet_obj.fetch_exist_entries(dvs)
         create_vnet_routes(dvs, "8.8.8.10/32", 'Vnet_20', '80.1.1.20')
         vnet_obj.check_vnet_routes(dvs, 'Vnet_10', '80.1.1.20', tunnel_name)
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed bitmap VNET virtual switch test failures related to extra FDB entries learned
**Why I did it**
Bitmap VNET vs test fails due to some FDB entries learnt during test execution
**How I verified it**
Executed virtual switch tests
**Details if related**
N/A