### PR TITLE
[SAI] Backport SAI 1.4 to 201811

### DIFF
--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -368,13 +368,13 @@ bool PfcWdLossyHandler::getHwCounters(PfcWdHwStats& counters)
 {
     SWSS_LOG_ENTER();
 
-    static const vector<sai_queue_stat_t> queueStatIds =
+    static const vector<sai_stat_id_t> queueStatIds =
     {
         SAI_QUEUE_STAT_PACKETS,
         SAI_QUEUE_STAT_DROPPED_PACKETS,
     };
 
-    static const vector<sai_ingress_priority_group_stat_t> pgStatIds =
+    static const vector<sai_stat_id_t> pgStatIds =
     {
         SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS,
         SAI_INGRESS_PRIORITY_GROUP_STAT_DROPPED_PACKETS,


### PR DESCRIPTION
use sai_stat_id_t for new SAI header file (#769)

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Cherry-picked some changes that required to backport SAI 1.4 to 201811 branch.

**Why I did it**
Support SAI 1.4 on 201811 branch.

**How I verified it**

**Details if related**
