### PR TITLE
[copporch]: Fix polymorphic type error

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -604,7 +604,7 @@ void CoppOrch::doTask(Consumer &consumer)
         {
             task_status = processCoppRule(consumer);
         }
-        catch(const out_of_range e)
+        catch(const out_of_range& e)
         {
             SWSS_LOG_ERROR("processing copp rule threw out_of_range exception:%s", e.what());
             task_status = task_process_status::task_invalid_entry;


### PR DESCRIPTION
copporch.cpp: In member function ‘virtual void CoppOrch::doTask(Consumer&)’:
copporch.cpp:607:34: error: catching polymorphic type ‘const class std::out_of_range’ by value [-Werror=catch-value=]
         catch(const out_of_range e)
                                  ^
cc1plus: all warnings being treated as errors

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>