### PR TITLE
[AclOrch]: Fix the acl mirror counter doubled by inactive mirror and …

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1133,7 +1133,7 @@ void AclRuleMirror::update(SubjectType type, void *cntx)
     else
     {
         // Store counters before deactivating ACL rule
-        counters += getCounters();
+        counters += AclRule::getCounters();
 
         SWSS_LOG_INFO("Deactivating mirroring ACL %s for session %s", m_id.c_str(), m_sessionName.c_str());
         remove();


### PR DESCRIPTION
…active again

        When disabling the mirror session, the aclorch will record
        the current counter, but it should invoke the base class
        function to get the current acl entry counter, otherwise the
        counters will be doubled by invoke the AclRuleMirror::getCounters()

Signed-off-by: Richard Wu <wutong23@baidu.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**


**Why I did it**

**How I verified it**

**Details if related**
When disable the mirror acl entry, the acl rule counter will be doubled by invoke the AclRuleMirror::getCounters(). For example, the acl mirror entry counter is 1000, it will be 2000 when disable the mirror session and enable it again.  The function of AclRuleMirror::getCounters() will return the counters + the current acl entry counter in hardware.
