### PR TITLE
[MirrorOrch]: Init the next hop ip with 0 instead of default constructor

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -786,7 +786,7 @@ void MirrorOrch::updateNextHop(const NextHopUpdate& update)
         }
         else
         {
-            session.nexthopInfo.nexthop = IpAddress();
+            session.nexthopInfo.nexthop = IpAddress(0);
         }
 
         // Resolve the neighbor of the new next hop


### PR DESCRIPTION
              Otherwise, in the getgetNeighborInfo function, it will check whether
              the nexthop is zero, but it will return false according to
              IpAddress::isZero(), then it will try to query the
              neighbor orch about this invalid ip address.

Signed-off-by: Richard Wu <wutong23@baidu.com>


**What I did**

**Why I did it**

**How I verified it**

**Details if related**
In current implement， in the getgetNeighborInfo function, it will check whether the nexthop is zero, but it will return false according to  IpAddress::isZero(), then it will try to query the neighbor orch about this invalid ip address.