### PR TITLE
Add a neighbor entry with BCAST MAC and verify its ignored

### DIFF
--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -82,6 +82,8 @@ def test_DirectedBroadcast(dvs, testlog):
     # Explicitly add a neighbor entry with BCAST MAC and check if its in ASIC_DB
     dvs.runcmd("ip neigh replace 192.169.0.30 lladdr FF:FF:FF:FF:FF:FF dev Vlan100")
 
+    time.sleep(1)
+
     keys = atbl.getKeys()
     for key in keys:
         neigh = json.loads(key)

--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -78,3 +78,13 @@ def test_DirectedBroadcast(dvs, testlog):
                 assert fvs[0][1] == "FF:FF:FF:FF:FF:FF"
 
     assert dir_bcast
+
+    # Explicitly add a neighbor entry with BCAST MAC and check if its in ASIC_DB
+    dvs.runcmd("ip neigh replace 192.169.0.30 lladdr FF:FF:FF:FF:FF:FF dev Vlan100")
+
+    keys = atbl.getKeys()
+    for key in keys:
+        neigh = json.loads(key)
+
+        if neigh['ip'] == "192.169.0.30":
+            assert False


### PR DESCRIPTION
**What I did**
Add VS test for verifying neighbor entry with BCAST MAC

**Why I did it**

**How I verified it**
Run VS tests

```
sudo pytest -v test_dirbcast.py --dvsname=vs
============================================================================= test session starts ==============================================================================
platform linux2 -- Python 2.7.12, pytest-3.3.0, py-1.5.2, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /datadrive/sonic/build/vnet/sonic-swss/tests, inifile:
collected 1 item                                                                                                                                                               

test_dirbcast.py::test_DirectedBroadcast PASSED
```

**Details if related**
