### PR TITLE
[test]: Fix set interface in configuration database

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -718,8 +718,8 @@ class DockerVirtualSwitch(object):
             tbl_name = "INTERFACE"
         tbl = swsscommon.Table(self.cdb, tbl_name)
         fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
-        tbl.set(interface + "|" + ip, fvs)
         tbl.set(interface, fvs)
+        tbl.set(interface + "|" + ip, fvs)
         time.sleep(1)
 
     def remove_ip_address(self, interface, ip):

--- a/tests/test_mirror_ipv6_combined.py
+++ b/tests/test_mirror_ipv6_combined.py
@@ -44,6 +44,7 @@ class TestMirror(object):
             tbl_name = "INTERFACE"
         tbl = swsscommon.Table(self.cdb, tbl_name)
         fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set(interface, fvs)
         tbl.set(interface + "|" + ip, fvs)
         time.sleep(1)
 
@@ -56,6 +57,7 @@ class TestMirror(object):
             tbl_name = "INTERFACE"
         tbl = swsscommon.Table(self.cdb, tbl_name)
         tbl._del(interface + "|" + ip)
+        tbl._del(interface)
         time.sleep(1)
 
     def add_neighbor(self, interface, ip, mac):

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -38,6 +38,7 @@ class TestMirror(object):
             tbl_name = "INTERFACE"
         tbl = swsscommon.Table(self.cdb, tbl_name)
         fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set(interface, fvs)
         tbl.set(interface + "|" + ip, fvs)
         time.sleep(1)
 
@@ -50,6 +51,7 @@ class TestMirror(object):
             tbl_name = "INTERFACE"
         tbl = swsscommon.Table(self.cdb, tbl_name)
         tbl._del(interface + "|" + ip)
+        tbl._del(interface)
         time.sleep(1)
 
     def add_neighbor(self, interface, ip, mac):

--- a/tests/test_mirror_policer.py
+++ b/tests/test_mirror_policer.py
@@ -24,12 +24,14 @@ class TestMirror(object):
     def add_ip_address(self, interface, ip):
         tbl = swsscommon.Table(self.cdb, "INTERFACE")
         fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set(interface, fvs)
         tbl.set(interface + "|" + ip, fvs)
         time.sleep(1)
 
     def remove_ip_address(self, interface, ip):
         tbl = swsscommon.Table(self.cdb, "INTERFACE")
         tbl._del(interface + "|" + ip)
+        tbl._del(interface)
         time.sleep(1)
 
     def add_neighbor(self, interface, ip, mac):


### PR DESCRIPTION
INTF_NAME entry is needed besides INTF_NAME|PREFIX
This change is introduced in commit 185e9a184 #794

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
