### PR TITLE
[PortsOrch] Init Port paramter with port speed & an & FEC from APP DB,

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1339,7 +1339,7 @@ string PortsOrch::getPriorityGroupWatermarkFlexCounterTableKey(string key)
     return string(PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP) + ":" + key;
 }
 
-bool PortsOrch::initPort(const string &alias, const set<int> &lane_set)
+bool PortsOrch::initPort(const string &alias, const set<int> &lane_set, uint32_t speed, int an, string fec_mode)
 {
     SWSS_LOG_ENTER();
 
@@ -1359,6 +1359,12 @@ bool PortsOrch::initPort(const string &alias, const set<int> &lane_set)
 
             p.m_index = static_cast<int32_t>(m_portList.size()); // TODO: Assume no deletion of physical port
             p.m_port_id = id;
+            if (!fec_mode.empty())
+                if (fec_mode_map.find(fec_mode) != fec_mode_map.end())
+                    p.m_fec_mode = fec_mode_map[fec_mode];
+            p.m_speed = speed;
+            if (an != -1)
+                p.m_autoneg = an;
 
             /* Initialize the port and create corresponding host interface */
             if (initializePort(p))
@@ -1672,7 +1678,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                     if (port_created)
                     {
-                        if (!initPort(get<0>(it->second), it->first))
+                        if (!initPort(get<0>(it->second), it->first, get<1>(it->second), get<2>(it->second), get<3>(it->second)))
                         {
                             throw runtime_error("PortsOrch initialization failure.");
                         }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -158,7 +158,7 @@ private:
 
     bool addPort(const set<int> &lane_set, uint32_t speed, int an=0, string fec="");
     bool removePort(sai_object_id_t port_id);
-    bool initPort(const string &alias, const set<int> &lane_set);
+    bool initPort(const string &alias, const set<int> &lane_set, uint32_t speed, int an, string fec_mode);
 
     bool setPortAdminStatus(sai_object_id_t id, bool up);
     bool getPortAdminStatus(sai_object_id_t id, bool& up);


### PR DESCRIPTION
Init Port paramter with port speed & an & FEC from APP DB,  instead of default vaule of port class, make it aligned with the setting sent to ASIC DB

Signed-off-by: Richard Wu <wutong23@baidu.com>

**What I did**
Update PortsOrch::initPort to set  speed, FEC and auto neg to the Port class instance in orchagent memory

**Why I did it**
When invoking addPort, the port speed, FEC and autoneg are set via SAI, but those parameters are not set via PortsOrch::initPort. In the result, the port class instance are not aligned with ASIC if those parameters settings in port_config.ini are not same with the default value in Port class.

Before this change, if I set the FEC to RS in port_config.ini and NONE in config_db.json, those below will happed:
1. The FEC in ASIC is set to RS via SAI, while the port class instance's FEC is NONE by the default value.
2. When loading the CONFIG DB, then the orchagent will try to set the FEC to NONE.
3. in the PortsOrch::doPortTask, it will compare the fec setting with the port class instance. In this step, as the port class instance FEC is NONE, so **it will result in not updating the FEC to NONE .** 

**How I verified it**
1. Update the port_config.ini file with FEC to RS, while NONE in config_db.json. 
2. Set the peer port FEC to NONE.
3. Reboot the switch, check whether the port can up.
