### PR TITLE
[PortsOrch] add reference count of port, make sure the port/LAG/VLAN …

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -150,6 +150,7 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
     {
         if (addRouterIntfs(vrf_id, port))
         {
+            gPortsOrch->increasePortRefCount(alias);
             IntfsEntry intfs_entry;
             intfs_entry.ref_count = 0;
             m_syncdIntfses[alias] = intfs_entry;
@@ -234,6 +235,7 @@ bool IntfsOrch::removeIntf(const string& alias, sai_object_id_t vrf_id, const Ip
     {
         if (removeRouterIntfs(port))
         {
+            gPortsOrch->decreasePortRefCount(alias);
             m_syncdIntfses.erase(alias);
             return true;
         }
@@ -322,7 +324,6 @@ void IntfsOrch::doTask(Consumer &consumer)
                 auto it_intfs = m_syncdIntfses.find(alias);
                 if (it_intfs == m_syncdIntfses.end())
                 {
-                    gPortsOrch->increasePortRefCount(alias);
                     IntfsEntry intfs_entry;
 
                     intfs_entry.ref_count = 0;
@@ -412,7 +413,6 @@ void IntfsOrch::doTask(Consumer &consumer)
                     }
                     if (m_syncdIntfses[alias].ip_addresses.size() == 0)
                     {
-                        gPortsOrch->decreasePortRefCount(alias);
                         m_syncdIntfses.erase(alias);
                     }
                 }

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -322,6 +322,7 @@ void IntfsOrch::doTask(Consumer &consumer)
                 auto it_intfs = m_syncdIntfses.find(alias);
                 if (it_intfs == m_syncdIntfses.end())
                 {
+                    gPortsOrch->increasePortRefCount(alias);
                     IntfsEntry intfs_entry;
 
                     intfs_entry.ref_count = 0;
@@ -411,6 +412,7 @@ void IntfsOrch::doTask(Consumer &consumer)
                     }
                     if (m_syncdIntfses[alias].ip_addresses.size() == 0)
                     {
+                        gPortsOrch->decreasePortRefCount(alias);
                         m_syncdIntfses.erase(alias);
                     }
                 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -220,6 +220,7 @@ PortsOrch::PortsOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames)
     m_cpuPort = Port("CPU", Port::CPU);
     m_cpuPort.m_port_id = attr.value.oid;
     m_portList[m_cpuPort.m_alias] = m_cpuPort;
+    m_port_ref_count[m_cpuPort.m_alias] = 0;
 
     /* Get port number */
     attr.id = SAI_SWITCH_ATTR_PORT_NUMBER;
@@ -456,6 +457,20 @@ bool PortsOrch::getPort(sai_object_id_t id, Port &port)
     return false;
 }
 
+
+void PortsOrch::increasePortRefCount(const string &alias)
+{
+    assert (m_port_ref_count.find(alias) != m_port_ref_count.end());
+    m_port_ref_count[alias]++;
+    
+}
+
+
+void PortsOrch::decreasePortRefCount(const string &alias)
+{
+    assert (m_port_ref_count.find(alias) != m_port_ref_count.end());
+    m_port_ref_count[alias]--;
+}
 bool PortsOrch::getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port)
 {
     SWSS_LOG_ENTER();
@@ -1365,6 +1380,7 @@ bool PortsOrch::initPort(const string &alias, const set<int> &lane_set)
             {
                 /* Add port to port list */
                 m_portList[alias] = p;
+                m_port_ref_count[alias] = 0;
                 /* Add port name map to counter table */
                 FieldValueTuple tuple(p.m_alias, sai_serialize_object_id(p.m_port_id));
                 vector<FieldValueTuple> fields;
@@ -2717,6 +2733,7 @@ bool PortsOrch::addVlan(string vlan_alias)
     vlan.m_vlan_info.vlan_id = vlan_id;
     vlan.m_members = set<string>();
     m_portList[vlan_alias] = vlan;
+    m_port_ref_count[vlan_alias] = 0;
 
     return true;
 }
@@ -2724,6 +2741,13 @@ bool PortsOrch::addVlan(string vlan_alias)
 bool PortsOrch::removeVlan(Port vlan)
 {
     SWSS_LOG_ENTER();
+    if (m_port_ref_count[vlan.m_alias] > 0)
+    {
+        SWSS_LOG_ERROR("Failed to remove ref count %d VLAN %s", 
+                       m_port_ref_count[vlan.m_alias],
+                       vlan.m_alias.c_str());
+        return false;
+    }
 
     /* Vlan removing is not allowed when the VLAN still has members */
     if (vlan.m_members.size() > 0)
@@ -2746,6 +2770,7 @@ bool PortsOrch::removeVlan(Port vlan)
             vlan.m_vlan_info.vlan_id);
 
     m_portList.erase(vlan.m_alias);
+    m_port_ref_count.erase(vlan.m_alias);
 
     return true;
 }
@@ -2888,6 +2913,7 @@ bool PortsOrch::addLag(string lag_alias)
     lag.m_lag_id = lag_id;
     lag.m_members = set<string>();
     m_portList[lag_alias] = lag;
+    m_port_ref_count[lag_alias] = 0;
 
     PortUpdate update = { lag, true };
     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
@@ -2898,6 +2924,14 @@ bool PortsOrch::addLag(string lag_alias)
 bool PortsOrch::removeLag(Port lag)
 {
     SWSS_LOG_ENTER();
+
+    if (m_port_ref_count[lag.m_alias] > 0)
+    {
+        SWSS_LOG_ERROR("Failed to remove ref count %d LAG %s", 
+                        m_port_ref_count[lag.m_alias], 
+                        lag.m_alias.c_str());
+        return false;
+    }
 
     /* Retry when the LAG still has members */
     if (lag.m_members.size() > 0)
@@ -2923,6 +2957,7 @@ bool PortsOrch::removeLag(Port lag)
     SWSS_LOG_NOTICE("Remove LAG %s lid:%lx", lag.m_alias.c_str(), lag.m_lag_id);
 
     m_portList.erase(lag.m_alias);
+    m_port_ref_count.erase(lag.m_alias);
 
     PortUpdate update = { lag, false };
     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -457,20 +457,18 @@ bool PortsOrch::getPort(sai_object_id_t id, Port &port)
     return false;
 }
 
-
 void PortsOrch::increasePortRefCount(const string &alias)
 {
     assert (m_port_ref_count.find(alias) != m_port_ref_count.end());
     m_port_ref_count[alias]++;
-    
 }
-
 
 void PortsOrch::decreasePortRefCount(const string &alias)
 {
     assert (m_port_ref_count.find(alias) != m_port_ref_count.end());
     m_port_ref_count[alias]--;
 }
+
 bool PortsOrch::getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -65,6 +65,8 @@ public:
     bool setBridgePortLearningFDB(Port &port, sai_bridge_port_fdb_learning_mode_t mode);
     bool getPort(string alias, Port &port);
     bool getPort(sai_object_id_t id, Port &port);
+    void increasePortRefCount(const string &alias);
+    void decreasePortRefCount(const string &alias);
     bool getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port);
     void setPort(string alias, Port port);
     void getCpuPort(Port &port);
@@ -118,6 +120,7 @@ private:
     map<set<int>, sai_object_id_t> m_portListLaneMap;
     map<set<int>, tuple<string, uint32_t, int, string>> m_lanesAliasSpeedMap;
     map<string, Port> m_portList;
+    map<string, uint32_t> m_port_ref_count;
 
     unordered_set<string> m_pendingPortSet;
 


### PR DESCRIPTION
…can NOT be deleted when there are interface using this port/LAG/VLAN.

Signed-off-by: Richard Wu <wutong23@baidu.com>



**What I did**
Currently,  there is no reference count in port orch, so we can delete the VLAN & LAG even there are L3 interface using this VLAN & LAG. It will result in SAI use reference count check error in syslog.
So I add a use reference count in port orch, so that the LAG & VLAN & PORT can not be deleted when there are L3 interface using it.

**Why I did it**
Add a use reference count in port orch for PORT, VLAN and LAG.

**How I verified it**
1. Create a VLAN/LAG/PORT.
2. Create a L3 interface by this VLAN/LAG/PORT.
3. Delete this VLAN/LAG/PORT, it can not be deleted until the L3 interface is deleted. The delete commands are cached in the redis channel.

