### PR TITLE
Support per buffer pool watermark polling mode

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -180,7 +180,6 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
             SWSS_LOG_NOTICE("Clear watermark failed on %s, rv: %s", it.first.c_str(), sai_serialize_status(status).c_str());
             noWmClrCapability |= bitMask;
         }
-        SWSS_LOG_ERROR("%s clear_buffer_pool_stats(): %s", it.first.c_str(), sai_serialize_status(status).c_str());
 
         bitMask <<= 1;
     }
@@ -220,7 +219,7 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
         }
     }
 
-    // m_isBufferPoolWatermarkCounterIdListGenerated = true;
+    m_isBufferPoolWatermarkCounterIdListGenerated = true;
 }
 
 const object_map &BufferOrch::getBufferPoolNameOidMap(void)

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -167,8 +167,8 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
 
     // Some platforms do not support buffer pool watermark clear operation on a particular pool
     // Invoke the SAI clear_stats API per pool to query the capability from the API call return status
-    uint8_t noWmClrCapability = 0;
-    uint8_t bitMask = 1;
+    unsigned int noWmClrCapability = 0;
+    unsigned int bitMask = 1;
     for (const auto &it : *(m_buffer_type_maps[CFG_BUFFER_POOL_TABLE_NAME]))
     {
         sai_status_t status = sai_buffer_api->clear_buffer_pool_stats(

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -167,6 +167,8 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
 
     // Some platforms do not support buffer pool watermark clear operation on a particular pool
     // Invoke the SAI clear_stats API per pool to query the capability from the API call return status
+    // We use bit mask to mark the clear watermark capability of each buffer pool. We use an unsigned int to place hold
+    // these bits. This assumes the total number of buffer pools to be no greater than 32, which should satisfy all use cases.
     unsigned int noWmClrCapability = 0;
     unsigned int bitMask = 1;
     for (const auto &it : *(m_buffer_type_maps[CFG_BUFFER_POOL_TABLE_NAME]))
@@ -175,7 +177,7 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
                 it.second,
                 static_cast<uint32_t>(bufferPoolWatermarkStatIds.size()),
                 reinterpret_cast<const sai_stat_id_t *>(bufferPoolWatermarkStatIds.data()));
-        if (status !=  SAI_STATUS_SUCCESS)
+        if (status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
         {
             SWSS_LOG_NOTICE("Clear watermark failed on %s, rv: %s", it.first.c_str(), sai_serialize_status(status).c_str());
             noWmClrCapability |= bitMask;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -198,9 +198,9 @@ PortsOrch::PortsOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames)
         fieldValues.emplace_back(STATS_MODE_FIELD, STATS_MODE_READ_AND_CLEAR);
         m_flexCounterGroupTable->set(PG_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP, fieldValues);
     }
-    catch (...)
+    catch (const runtime_error &e)
     {
-        SWSS_LOG_WARN("Watermark flex counter groups were not set successfully");
+        SWSS_LOG_ERROR("Watermark flex counter groups were not set successfully: %s", e.what());
     }
 
     uint32_t i, j;

--- a/orchagent/watermarkorch.h
+++ b/orchagent/watermarkorch.h
@@ -51,7 +51,7 @@ private:
     /*
     [7-2] - unused
     [1] - pg wm status
-    [0] - queue wm status (least significant bit) 
+    [0] - queue wm status (least significant bit)
     */
     uint8_t m_wmStatus = 0;
     bool m_timerChanged = false;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Buffer pool watermark design is built on a READ_AND_CLEAR polling mode at the syncd level. We observe some SAI implementation is missing the clear_stats operation support for buffer pool watermark, either simply not coded yet or having hardware limitation. In such cases, we have mismatch between the actual polling behavior and what a user perceives from FLEX_COUNTER_DB read from FLEX_COUNTER_GROUP_TABLE.

To have a consistent view, we propose per buffer pool watermark stats polling mode at the orchagent level when not all buffer pools support clear_stats operation on a switch. The situation is detected by issuing clear_stats operation at the orchagent level to probe the capability over all pools first. If this is truly the case, we then do not set "STATS_MODE" field in "FLEX_COUNTER_GROUP_TABLE:BUFFER_POOL_WATERMARK_STAT_COUNTER", but set it to the per buffer pool table "FLEX_COUNTER_TABLE:BUFFER_POOL_WATERMARK_STAT_COUNTER:oid:<buffer_pool_oid>".






**Why I did it**

**How I verified it**
Tested on dut

```
127.0.0.1:6379[5]> hgetall "FLEX_COUNTER_TABLE:BUFFER_POOL_WATERMARK_STAT_COUNTER:oid:0x180000000005f3"
1) "BUFFER_POOL_COUNTER_ID_LIST"
2) "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"
3) "STATS_MODE"
4) "STATS_MODE_READ_AND_CLEAR"
127.0.0.1:6379[5]> hgetall "FLEX_COUNTER_TABLE:BUFFER_POOL_WATERMARK_STAT_COUNTER:oid:0x180000000005f4"
1) "BUFFER_POOL_COUNTER_ID_LIST"
2) "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"
3) "STATS_MODE"
4) "STATS_MODE_READ_AND_CLEAR"
127.0.0.1:6379[5]> hgetall "FLEX_COUNTER_TABLE:BUFFER_POOL_WATERMARK_STAT_COUNTER:oid:0x180000000005f5"
1) "BUFFER_POOL_COUNTER_ID_LIST"
2) "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"
3) "STATS_MODE"
4) "STATS_MODE_READ"
```

```
"FLEX_COUNTER_GROUP_TABLE:BUFFER_POOL_WATERMARK_STAT_COUNTER"
1) "BUFFER_POOL_PLUGIN_LIST"
2) "ca4aef2fce419033b7cd2ca9c787753198880af3"
3) "POLL_INTERVAL"
4) "10000"
5) "FLEX_COUNTER_STATUS"
6) "enable"
```

```
$ redis-cli -n 2 hgetall "COUNTERS_BUFFER_POOL_NAME_MAP"
1) "egress_lossless_pool"
2) "oid:0x180000000005f3"
3) "egress_lossy_pool"
4) "oid:0x180000000005f4"
5) "ingress_lossless_pool"
6) "oid:0x180000000005f5"
```

```
$ watermarkstat -t buffer_pool
Shared pool maximum occupancy:
                 Pool    Bytes
---------------------  -------
 egress_lossless_pool  1073904
    egress_lossy_pool        0
ingress_lossless_pool  1018160
```

**Details if related**

Depend on: https://github.com/Azure/sonic-sairedis/pull/485
