### PR TITLE
Fix crash during orchagent process exit

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -45,8 +45,20 @@ OrchDaemon::OrchDaemon(DBConnector *applDb, DBConnector *configDb, DBConnector *
 OrchDaemon::~OrchDaemon()
 {
     SWSS_LOG_ENTER();
-    for (Orch *o : m_orchList)
-        delete(o);
+    
+    /*
+     * Some orchagents call other agents in their destructor.
+     * To avoid accessing deleted agent, do deletion in reverse order.
+     * NOTE: This is stil not a robust solution, as order in this list
+     *       does not strictly match the order of construction of agents. 
+     * For a robust solution, first some cleaning/house-keeping in 
+     * orchagents management is in order.
+     * For now it fixes, possible crash during process exit.
+     */
+    auto it = m_orchList.rbegin();
+    for(; it != m_orchList.rend(); ++it) {
+        delete(*it);
+    }
 }
 
 bool OrchDaemon::init()


### PR DESCRIPTION
Avoid crash due to accessing deleted pointer, during process exit.
In this case, FdbOrch was calling detach on PortsOrch which is already deleted
and the memory got returned to Kernel, which resulted in kernel exception.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
