### PR TITLE
[intfsorch]rifFlexCounter hasn't removed when rif removed, syncd runt…

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -821,7 +821,6 @@ void IntfsOrch::addRifToFlexCounter(const string &id, const string &name, const 
     }
 
     /* check the state of intf, if registering the intf to FC will result in runtime error */
-    vector<FieldValueTuple> fvt;
     vector<FieldValueTuple> fieldValues;
     fieldValues.emplace_back(RIF_COUNTER_ID_LIST, counters_stream.str());
 
@@ -839,10 +838,7 @@ void IntfsOrch::removeRifFromFlexCounter(const string &id, const string &name)
     /* remove it from FLEX_COUNTER_DB */
     string key = getRifFlexCounterTableKey(id);
 
-    vector<FieldValueTuple> fieldValues;
-    fieldValues.emplace_back(RIF_COUNTER_ID_LIST, "");
-
-    m_flexCounterTable->set(key, fieldValues);
+    m_flexCounterTable->del(key);
     SWSS_LOG_DEBUG("Unregistered interface %s from Flex counter", name.c_str());
 }
 


### PR DESCRIPTION
…ime error happens.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Delete RIF FlexCounter entry when RIF deleted. 

**Why I did it**
Find syncd runtime error when delete router interface.

**How I verified it**
test

**Details if related**
LOG:
ERR syncd#syncd: :- translate_vid_to_rid: unable to get RID for VID: 0x60000000007bd
ERR syncd#syncd: :- syncd_main: Runtime error: :- translate_vid_to_rid: unable to get RID for VID: 0x600000000007bd


