### PR TITLE
[vnetorch]: Set default VxLAN encap TTL value

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -465,9 +465,10 @@ VnetBridgeInfo VNetBitmapObject::getBridgeInfoByVni(uint32_t vni, string tunnelN
     vector<sai_attribute_t> bpt_attrs;
     auto* vxlan_orch = gDirectory.get<VxlanTunnelOrch*>();
     auto *tunnel = vxlan_orch->getVxlanTunnel(tunnelName);
+
     if (!tunnel->isActive())
     {
-        tunnel->createTunnel(MAP_T::BRIDGE_TO_VNI, MAP_T::VNI_TO_BRIDGE);
+        tunnel->createTunnel(MAP_T::BRIDGE_TO_VNI, MAP_T::VNI_TO_BRIDGE, VXLAN_ENCAP_TTL);
     }
 
     attr.id = SAI_BRIDGE_PORT_ATTR_TYPE;
@@ -1448,7 +1449,7 @@ bool VNetOrch::addOperation(const Request& request)
 
             VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
             if (!vxlan_orch->createVxlanTunnelMap(tunnel, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
-                                                  vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId()))
+                                                  vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
             {
                 SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
                                 vnet_name.c_str(), tunnel.c_str());

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -14,6 +14,7 @@
 #define VNET_BITMAP_SIZE 32
 #define VNET_TUNNEL_SIZE 512
 #define VNET_NEIGHBOR_MAX 0xffff
+#define VXLAN_ENCAP_TTL 128
 
 extern sai_object_id_t gVirtualRouterId;
 

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -82,7 +82,7 @@ public:
         return active_;
     }
 
-    bool createTunnel(MAP_T encap, MAP_T decap);
+    bool createTunnel(MAP_T encap, MAP_T decap, uint8_t encap_ttl=0);
     sai_object_id_t addEncapMapperEntry(sai_object_id_t obj, uint32_t vni);
     sai_object_id_t addDecapMapperEntry(sai_object_id_t obj, uint32_t vni);
 
@@ -172,7 +172,7 @@ public:
     }
 
     bool createVxlanTunnelMap(string tunnelName, tunnel_map_type_t mapType, uint32_t vni,
-                              sai_object_id_t encap, sai_object_id_t decap);
+                              sai_object_id_t encap, sai_object_id_t decap, uint8_t encap_ttl=0);
 
     bool removeVxlanTunnelMap(string tunnelName, uint32_t vni);
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Implemented logic to set default VxLAN encap TTL value
**Why I did it**
On different platforms default VxLAN encap TTL value is different, so we need to set same value for all
**How I verified it**
Executed "VNET" ansible test and verified it passed.
**Details if related**
