### PR TITLE
[qosorch]: Add cir and pir parameters for scheduler

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -869,6 +869,30 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
                 // TODO: The meaning is to be able to adjus priority of the given scheduler group.
                 // However currently SAI model does not provide such ability.
             }
+            else if (fvField(*i) == scheduler_min_bandwidth_rate_field_name)
+            {
+                attr.id = SAI_SCHEDULER_ATTR_MIN_BANDWIDTH_RATE;
+                attr.value.u64 = (uint64_t)stoi(fvValue(*i));
+                sai_attr_list.push_back(attr);
+            }
+            else if (fvField(*i) == scheduler_min_bandwidth_burst_rate_field_name)
+            {
+                attr.id = SAI_SCHEDULER_ATTR_MIN_BANDWIDTH_BURST_RATE;
+                attr.value.u64 = (uint64_t)stoi(fvValue(*i));
+                sai_attr_list.push_back(attr);
+            }
+            else if (fvField(*i) == scheduler_max_bandwidth_rate_field_name)
+            {
+                attr.id = SAI_SCHEDULER_ATTR_MAX_BANDWIDTH_RATE;
+                attr.value.u64 = (uint64_t)stoi(fvValue(*i));
+                sai_attr_list.push_back(attr);
+            }
+            else if (fvField(*i) == scheduler_max_bandwidth_burst_rate_field_name)
+            {
+                attr.id = SAI_SCHEDULER_ATTR_MAX_BANDWIDTH_BURST_RATE;
+                attr.value.u64 = (uint64_t)stoi(fvValue(*i));
+                sai_attr_list.push_back(attr);
+            }
             else {
                 SWSS_LOG_ERROR("Unknown field:%s", fvField(*i).c_str());
                 return task_process_status::task_invalid_entry;

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -36,10 +36,14 @@ const string scheduler_algo_STRICT              = "STRICT";
 const string scheduler_weight_field_name        = "weight";
 const string scheduler_priority_field_name      = "priority";
 
-const string scheduler_min_bandwidth_rate_field_name        = "cir";
-const string scheduler_min_bandwidth_burst_rate_field_name  = "cbs";
-const string scheduler_max_bandwidth_rate_field_name        = "pir";
-const string scheduler_max_bandwidth_burst_rate_field_name  = "pbs";
+const string scheduler_min_bandwidth_rate_field_name
+                                                = "cir";
+const string scheduler_min_bandwidth_burst_rate_field_name  
+                                                = "cbs";
+const string scheduler_max_bandwidth_rate_field_name        
+                                                = "pir";
+const string scheduler_max_bandwidth_burst_rate_field_name  
+                                                = "pbs";
 
 const string ecn_field_name                     = "ecn";
 const string ecn_none                           = "ecn_none";

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -36,6 +36,11 @@ const string scheduler_algo_STRICT              = "STRICT";
 const string scheduler_weight_field_name        = "weight";
 const string scheduler_priority_field_name      = "priority";
 
+const string scheduler_min_bandwidth_rate_field_name      = "cir";
+const string scheduler_min_bandwidth_burst_rate_field_name      = "cbs";
+const string scheduler_max_bandwidth_rate_field_name      = "pir";
+const string scheduler_max_bandwidth_burst_rate_field_name      = "pbs";
+
 const string ecn_field_name                     = "ecn";
 const string ecn_none                           = "ecn_none";
 const string ecn_red                            = "ecn_red";

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -36,10 +36,10 @@ const string scheduler_algo_STRICT              = "STRICT";
 const string scheduler_weight_field_name        = "weight";
 const string scheduler_priority_field_name      = "priority";
 
-const string scheduler_min_bandwidth_rate_field_name      = "cir";
-const string scheduler_min_bandwidth_burst_rate_field_name      = "cbs";
-const string scheduler_max_bandwidth_rate_field_name      = "pir";
-const string scheduler_max_bandwidth_burst_rate_field_name      = "pbs";
+const string scheduler_min_bandwidth_rate_field_name        = "cir";
+const string scheduler_min_bandwidth_burst_rate_field_name  = "cbs";
+const string scheduler_max_bandwidth_rate_field_name        = "pir";
+const string scheduler_max_bandwidth_burst_rate_field_name  = "pbs";
 
 const string ecn_field_name                     = "ecn";
 const string ecn_none                           = "ecn_none";

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -36,14 +36,10 @@ const string scheduler_algo_STRICT              = "STRICT";
 const string scheduler_weight_field_name        = "weight";
 const string scheduler_priority_field_name      = "priority";
 
-const string scheduler_min_bandwidth_rate_field_name
-                                                = "cir";
-const string scheduler_min_bandwidth_burst_rate_field_name  
-                                                = "cbs";
-const string scheduler_max_bandwidth_rate_field_name        
-                                                = "pir";
-const string scheduler_max_bandwidth_burst_rate_field_name  
-                                                = "pbs";
+const string scheduler_min_bandwidth_rate_field_name       = "cir";//Committed Information Rate
+const string scheduler_min_bandwidth_burst_rate_field_name = "cbs";//Committed Burst Size
+const string scheduler_max_bandwidth_rate_field_name       = "pir";//Peak Information Rate
+const string scheduler_max_bandwidth_burst_rate_field_name = "pbs";//Peak Burst Size
 
 const string ecn_field_name                     = "ecn";
 const string ecn_none                           = "ecn_none";


### PR DESCRIPTION
Signed-off-by: tengfei <tengfei@asterfusion.com>

**What I did**
   Add  cir, pir, cbs, pbs parameters for scheduler 
**Why I did it**
   SAI interface supports cir, pir, cbs, pbs parameters for scheduler, but these parameters were not in orchagent 
**How I verified it**
   I wrote these parameters to redis database by json, and then verified by redis-cli 
