### PR TITLE
[aclorch]: unbind port from acltable when remove port

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1416,7 +1416,27 @@ void AclTable::update(SubjectType type, void *cntx)
     }
     else
     {
-        // TODO: deal with port removal scenario
+        if (portSet.find(port.m_alias) != portSet.end())
+        {
+            sai_object_id_t bind_port_id;
+            if (gPortsOrch->getAclBindPortId(port.m_alias, bind_port_id))
+            {
+                unbind(bind_port_id);
+                unlink(bind_port_id);
+
+                portSet.erase(port.m_alias);
+                pendingPortSet.emplace(port.m_alias);
+
+                SWSS_LOG_NOTICE("Unbound port %s from ACL table %s",
+                        port.m_alias.c_str(), id.c_str());
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Failed to get port %s bind port ID",
+                        port.m_alias.c_str());
+                return;
+            }
+        }
     }
 }
 
@@ -1449,6 +1469,7 @@ bool AclTable::unbind(sai_object_id_t portOid)
                 m_oid, member, status);
         return false;
     }
+    ports[portOid] = SAI_NULL_OBJECT_ID;
     return true;
 }
 
@@ -1483,6 +1504,13 @@ void AclTable::link(sai_object_id_t portOid)
     SWSS_LOG_ENTER();
 
     ports.emplace(portOid, SAI_NULL_OBJECT_ID);
+}
+
+void AclTable::unlink(sai_object_id_t portOid)
+{
+    SWSS_LOG_ENTER();
+
+    ports.erase(portOid);
 }
 
 bool AclTable::add(shared_ptr<AclRule> newRule)

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -354,6 +354,8 @@ public:
     bool unbind();
     // Link the ACL table with a port, for future bind or unbind
     void link(sai_object_id_t portOid);
+    // Unlink the ACL table with a port, for future bind
+    void unlink(sai_object_id_t portOid);
     // Add or overwrite a rule into the ACL table
     bool add(shared_ptr<AclRule> newRule);
     // Remove a rule from the ACL table


### PR DESCRIPTION
**What I did**
1.aclorch unbind port from acltable when process port remove notification
2.AclTable::unbind set ports[portOid] to NULL after remove_acl_table_group_member
3.add AclTable::unlink() to cleanup AclTable::ports.
4.portsorch notify PORTCHANGE when remove vlan and add vlan
5.adjust the execution sequence between m_portList erase and PORT_CHANGE notify

**Why I did it**
When the port(port/lag/vlan) is removed, the port and acltable are not unbound

**How I verified it**
debug print and sai log

**Details if related**
