### PR TITLE
[vstest]: report error when team kernel module is not available

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,9 @@ class DockerVirtualSwitch(object):
         self.alld  = self.basicd + self.swssd + self.syncd + self.rtd + self.teamd
         self.client = docker.from_env()
 
+        if subprocess.check_call(["/sbin/modprobe", "team"]) != 0:
+            raise NameError("cannot install kernel team module")
+
         self.ctn = None
         if keeptb:
             self.cleanup = False


### PR DESCRIPTION
make explicit failure if team kernel module is not available on the system

Signed-off-by: Guohan Lu <gulv@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
