### PR TITLE
[vxlanorch] Fix Logic of Vxlan tunnel removal 

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -376,7 +376,7 @@ remove_tunnel_termination(sai_object_id_t term_table_id)
         sai_status_t status = sai_tunnel_api->remove_tunnel_term_table_entry(term_table_id);
         if (status != SAI_STATUS_SUCCESS)
         {
-        throw std::runtime_error("Can't remove a tunnel term table object");
+            throw std::runtime_error("Can't remove a tunnel term table object");
         }
     }
     else

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -295,7 +295,7 @@ create_tunnel(
 void
 remove_tunnel(sai_object_id_t tunnel_id)
 {
-    if(tunnel_id != SAI_NULL_OBJECT_ID)
+    if (tunnel_id != SAI_NULL_OBJECT_ID)
     {
         sai_status_t status = sai_tunnel_api->remove_tunnel(tunnel_id);
         if (status != SAI_STATUS_SUCCESS)
@@ -371,7 +371,7 @@ create_tunnel_termination(
 void
 remove_tunnel_termination(sai_object_id_t term_table_id)
 {
-    if(term_table_id != SAI_NULL_OBJECT_ID)
+    if (term_table_id != SAI_NULL_OBJECT_ID)
     {
         sai_status_t status = sai_tunnel_api->remove_tunnel_term_table_entry(term_table_id);
         if (status != SAI_STATUS_SUCCESS)

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -295,10 +295,17 @@ create_tunnel(
 void
 remove_tunnel(sai_object_id_t tunnel_id)
 {
-    sai_status_t status = sai_tunnel_api->remove_tunnel(tunnel_id);
-    if (status != SAI_STATUS_SUCCESS)
+    if(tunnel_id != SAI_NULL_OBJECT_ID)
     {
-        throw std::runtime_error("Can't remove a tunnel object");
+        sai_status_t status = sai_tunnel_api->remove_tunnel(tunnel_id);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            throw std::runtime_error("Can't remove a tunnel object");
+        }
+    }
+    else
+    {
+        SWSS_LOG_DEBUG("Tunnel id is NULL.");
     }
 }
 
@@ -364,10 +371,17 @@ create_tunnel_termination(
 void
 remove_tunnel_termination(sai_object_id_t term_table_id)
 {
-    sai_status_t status = sai_tunnel_api->remove_tunnel_term_table_entry(term_table_id);
-    if (status != SAI_STATUS_SUCCESS)
+    if(term_table_id != SAI_NULL_OBJECT_ID)
     {
+        sai_status_t status = sai_tunnel_api->remove_tunnel_term_table_entry(term_table_id);
+        if (status != SAI_STATUS_SUCCESS)
+        {
         throw std::runtime_error("Can't remove a tunnel term table object");
+        }
+    }
+    else
+    {
+        SWSS_LOG_DEBUG("Tunnel term table id is NULL.");
     }
 }
 

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -121,7 +121,7 @@ private:
     string tunnel_name_;
     bool active_ = false;
 
-    tunnel_ids_t ids_;
+    tunnel_ids_t ids_ = {0, 0, 0, 0};
     std::pair<MAP_T, MAP_T> tunnel_map_ = { MAP_T::MAP_TO_INVALID, MAP_T::MAP_TO_INVALID };
 
     TunnelMapEntries tunnel_map_entries_;


### PR DESCRIPTION
 **What I did**
Add the validity checking before we call sai_api to remove tunnel_id and tunnel_term_id.

**Why I did it**
As the vxlan tunnel_id and tunnel_term_id are not created until the map entrys are added, in case of configuring the vxlan tunnel without map entry, and then it is invalid to remove it without validity checking.

**How I verified it**
Applied Vxlan tunnel configure without the map entry and then remove the tunnel, there are no errors.

**Details if related**
