### PR TITLE
Trap DHCPv6 packets for supporting ZTP over in-band interfaces using …

### DIFF
--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -34,8 +34,8 @@
         "OP": "SET"
     },
     {
-        "COPP_TABLE:trap.group.lldp.dhcp.udld": {
-            "trap_ids": "lldp,dhcp,udld",
+        "COPP_TABLE:trap.group.lldp.dhcp.dhcpv6.udld": {
+            "trap_ids": "lldp,dhcp,dhcpv6,udld",
             "trap_action":"trap",
             "trap_priority":"4",
             "queue": "4"
@@ -50,8 +50,8 @@
             "queue": "1",
             "meter_type":"packets",
             "mode":"sr_tcm",
-            "cir":"600",
-            "cbs":"600",
+            "cir":"6000",
+            "cbs":"6000",
             "red_action":"drop"
         },
         "OP": "SET"

--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -50,8 +50,8 @@
             "queue": "1",
             "meter_type":"packets",
             "mode":"sr_tcm",
-            "cir":"6000",
-            "cbs":"6000",
+            "cir":"600",
+            "cbs":"600",
             "red_action":"drop"
         },
         "OP": "SET"


### PR DESCRIPTION
…DHCPv6 discovery

Also increase incoming packet rate on in-band interfaces to support faster
download of large files. SONiC firmware image download over in-band can
take a lot of time if the incoming packet rate is limited to 600pps. This,
change increases it to 6000pps.

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Increased packet rate for traffic destined to CPU. 

Added DHCPv6 to trap list to support ZTP over IPv6 transport.

**Why I did it**
This is required for ZTP to download large files over in-band interface.
Support ZTP over IPv6 transport.


**How I verified it**
ZTP over in-band interface

**Details if related**
