### PR TITLE
Increase ip2me CIR/CBS for faster in-band file transfers

### DIFF
--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -50,8 +50,8 @@
             "queue": "1",
             "meter_type":"packets",
             "mode":"sr_tcm",
-            "cir":"600",
-            "cbs":"600",
+            "cir":"6000",
+            "cbs":"6000",
             "red_action":"drop"
         },
         "OP": "SET"


### PR DESCRIPTION
Increase incoming packet rate on in-band interfaces to support faster
download of large files. SONiC firmware image download over in-band can
take a lot of time if the incoming packet rate is limited to 600pps. This,
change increases it to 6000pps. Especially when used by Zero Touch Provisioning
or by sonic_installer for firmware upgrade over in-band interfaces.

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Increased packet rate for traffic destined to CPU.

**Why I did it**
This is required for ZTP or sonic_installer to download large files (firmware image) over in-band interface.

**How I verified it**
sonic_installer install -y "url" over in-band network

**Details if related**
