### PR TITLE
Fix VLAN error introduced with new 4.9 kernel behavior

### DIFF
--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -155,6 +155,14 @@ class TestVlan(object):
         vlan_member_entries = tbl.getKeys()
         assert len(vlan_member_entries) == 0
 
+        # member ports should have been detached from bridge master properly
+        exitcode, output = dvs.runcmd(['sh', '-c', "ip link show Ethernet20 | grep -w master"])
+        assert exitcode != 0
+        exitcode, output = dvs.runcmd(['sh', '-c', "ip link show Ethernet24 | grep -w master"])
+        assert exitcode != 0
+        exitcode, output = dvs.runcmd(['sh', '-c', "ip link show Ethernet28 | grep -w master"])
+        assert exitcode != 0
+
         # remove vlans
         dvs.remove_vlan("18")
         dvs.remove_vlan("188")


### PR DESCRIPTION
Signed-off-by: Jipan Yang <jipan.yang@alibaba-inc.com>

**What I did**
The change includes two parts:

<1> Bring member out of default VLAN 1 upon putting port/lag in a VLAN

<2>  Second part was done by @tieguoevan ( https://github.com/tieguoevan) and incorporated here to avoid test error that would follow change <1>.

```
Summary:
The Bridge interface needs to be up all the time. Otherwise, the command bridge vlan will fail.
Not sure it is a kernel bug, but it cause error when clear all vlan members and reconfigure it.

create a dummy interface in the Bridge to keep it up all the time
```

Without change <2>
```
root@bc133f3f180f:/var/log# /sbin/bridge vlan add vid 2 dev Bridge self
RTNETLINK answers: Invalid argument
root@bc133f3f180f:/var/log# echo $?
255
root@bc133f3f180f:/var/log# bridge vlan 
port	vlan ids
Bridge	None
root@bc133f3f180f:/var/log# bridge vlan  add vid 2 dev Bridge self
RTNETLINK answers: Invalid argument
root@bc133f3f180f:/var/log# bridge vlan
port	vlan ids
Bridge	None
root@bc133f3f180f:/var/log# bridge vlan  add vid 2 dev Bridge self
RTNETLINK answers: Invalid argument
root@bc133f3f180f:/var/log# bridge vlan  add vid 2 dev Bridge      
RTNETLINK answers: Operation not supported
root@bc133f3f180f:/var/log# bridge vlan  add vid 2 dev Bridge self
RTNETLINK answers: Invalid argument
root@bc133f3f180f:/var/log# bridge vlan  add vid 2 dev Bridge self
RTNETLINK answers: Invalid argument
root@bc133f3f180f:/var/log# 
root@bc133f3f180f:/var/log# 
root@bc133f3f180f:/var/log# bridge vlan  add vid 2 dev Bridge self
RTNETLINK answers: Invalid argument
root@bc133f3f180f:/var/log# bridge vlan
port	vlan ids
Bridge	None
root@bc133f3f180f:/var/log# bridge vlan del vid 2 dev Bridge self
root@bc133f3f180f:/var/log# echo $?
0
root@bc133f3f180f:/var/log# bridge vlan  add vid 2 dev Bridge self
RTNETLINK answers: Invalid argument
```
```
jipan@jipan_sonic_vm_150:~/upstream/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -v --dvsname=vs  test_vlan.py  -x
===================================================================== test session starts =====================================================================
platform linux2 -- Python 2.7.15rc1, pytest-3.3.0, py-1.5.3, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/jipan/upstream/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 15 items                                                                                                                                            

test_vlan.py::TestVlan::test_VlanAddRemove PASSED                                                                                                       [  6%]
test_vlan.py::TestVlan::test_MultipleVlan PASSED                                                                                                        [ 13%]
test_vlan.py::TestVlan::test_VlanIncrementalConfig FAILED                                                                                               [ 20%]

========================================================================== FAILURES ===========================================================================
_____________________________________________________________ TestVlan.test_VlanIncrementalConfig _____________________________________________________________

self = <test_vlan.TestVlan object at 0x7f11214c2e50>, dvs = <conftest.DockerVirtualSwitch object at 0x7f11214e05d0>
testlog = <function testlog at 0x7f1122e3f7d0>

    def test_VlanIncrementalConfig(self, dvs, testlog):
        dvs.setup_db()
    
        # create vlan
        dvs.create_vlan("2")
    
        # check asic database
        tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
        vlan_entries = [k for k in tbl.getKeys() if k != dvs.asicdb.default_vlan_id]
>       assert len(vlan_entries) == 1
E       assert 0 == 1
E        +  where 0 = len([])

test_vlan.py:184: AssertionError

```
**Why I did it**

Fix 
https://github.com/Azure/sonic-swss/issues/998 
https://github.com/Azure/sonic-buildimage/issues/2658

and 
**How I verified it**

**Details if related**
