### PR TITLE
[teammgrd]during warm-reboot teamd need to recover system-id from saved lacp-pdu

### DIFF
--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -378,11 +378,13 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
 
     const string dump_path = "/var/warmboot/teamd/";
     MacAddress mac_boot = m_mac;
-    /*set portchannel mac same with mac before warmStart ,when warmStart there is a file written by teamd*/
+
+    // set portchannel mac same with mac before warmStart, when warmStart and there
+    // is a file written by teamd.
     ifstream aliasfile(dump_path + alias);
     if (WarmStart::isWarmStart() && aliasfile.is_open())
     {
-# define PARTNER_SYSTEM_ID_OFFSET 40
+        const int partner_system_id_offset = 40;
         string line;
 
         while (getline(aliasfile, line))
@@ -393,8 +395,8 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
             if (!memberfile.is_open())
                 continue;
 
-            memberfile.seekg(PARTNER_SYSTEM_ID_OFFSET, std::ios::beg);
-            memberfile.read((char *)mac_temp, ETHER_ADDR_LEN);
+            memberfile.seekg(partner_system_id_offset, std::ios::beg);
+            memberfile.read(reinterpret_cast<char*>(mac_temp), ETHER_ADDR_LEN);
             mac_boot = MacAddress(mac_temp);
             break;
         }

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -7,6 +7,8 @@
 #include "portmgr.h"
 
 #include <algorithm>
+#include <iostream>
+#include <fstream>
 #include <sstream>
 #include <thread>
 
@@ -373,8 +375,33 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
     string res;
 
     stringstream conf;
+
+    const string dump_path = "/var/warmboot/teamd/";
+    MacAddress mac_boot = m_mac;
+    /*set portchannel mac same with mac before warmStart ,when warmStart there is a file written by teamd*/
+    ifstream aliasfile(dump_path + alias);
+    if (WarmStart::isWarmStart() && aliasfile.is_open())
+    {
+# define PARTNER_SYSTEM_ID_OFFSET 40
+        string line;
+
+        while (getline(aliasfile, line))
+        {
+            ifstream memberfile(dump_path + line, ios::binary);
+            uint8_t mac_temp[ETHER_ADDR_LEN];
+
+            if (!memberfile.is_open())
+                continue;
+
+            memberfile.seekg(PARTNER_SYSTEM_ID_OFFSET, std::ios::beg);
+            memberfile.read((char *)mac_temp, ETHER_ADDR_LEN);
+            mac_boot = MacAddress(mac_temp);
+            break;
+        }
+    }
+
     conf << "'{\"device\":\"" << alias << "\","
-         << "\"hwaddr\":\"" << m_mac.to_string() << "\","
+         << "\"hwaddr\":\"" << mac_boot.to_string() << "\","
          << "\"runner\":{"
          << "\"active\":true,"
          << "\"name\":\"lacp\"";
@@ -395,7 +422,6 @@ task_process_status TeamMgr::addLag(const string &alias, int min_links, bool fal
             alias.c_str(), conf.str().c_str());
 
     string warmstart_flag = WarmStart::isWarmStart() ? " -w -o " : " -r ";
-    const string dump_path = "/var/warmboot/teamd/";
 
     cmd << TEAMD_CMD
         << warmstart_flag


### PR DESCRIPTION
Signed-off-by: shine.chen <shine.chen@nephosinc.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- When creating new portchannel, teammgrd gets the MAC from the saved LACP PDU and updates the port-channel MAC accordingly.
- Pls refer to [MCLAG-HLD](https://github.com/Azure/SONiC/pull/325) for details.

**Why I did it**
- In MC-LAG scenario, two peer devices form one end point of a LAG, these two devices must have the same MAC address since it’s used for LACP. During warm-reboot, this MAC must not be changed. 

**How I verified it**
- test it on nephos lab. With this approach we observe zero packet loss during mclag warm-reboot procedure.

**Details if related**
