### PR TITLE
Remove the platform check for remove/add port action at init phase

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1636,19 +1636,10 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     if (m_lanesAliasSpeedMap.find(it->first) == m_lanesAliasSpeedMap.end())
                     {
-                        char *platform = getenv("platform");
-                        if (platform && (strstr(platform, BFN_PLATFORM_SUBSTRING) || strstr(platform, MLNX_PLATFORM_SUBSTRING)))
+                        if (!removePort(it->second))
                         {
-                            if (!removePort(it->second))
-                            {
-                                throw runtime_error("PortsOrch initialization failure.");
-                            }
+                            throw runtime_error("PortsOrch initialization failure.");
                         }
-                        else
-                        {
-                            SWSS_LOG_NOTICE("Failed to remove Port %" PRIx64 " due to missing SAI remove_port API.", it->second);
-                        }
-
                         it = m_portListLaneMap.erase(it);
                     }
                     else
@@ -1663,22 +1654,11 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                     if (m_portListLaneMap.find(it->first) == m_portListLaneMap.end())
                     {
-                        // work around to avoid syncd termination on SAI error due missing create_port SAI API
-                        // can be removed when SAI redis return NotImplemented error
-                        char *platform = getenv("platform");
-                        if (platform && (strstr(platform, BFN_PLATFORM_SUBSTRING) || strstr(platform, MLNX_PLATFORM_SUBSTRING)))
+                        if (!addPort(it->first, get<1>(it->second), get<2>(it->second), get<3>(it->second)))
                         {
-                            if (!addPort(it->first, get<1>(it->second), get<2>(it->second), get<3>(it->second)))
-                            {
-                                throw runtime_error("PortsOrch initialization failure.");
-                            }
-
-                            port_created = true;
+                            throw runtime_error("PortsOrch initialization failure.");
                         }
-                        else
-                        {
-                            SWSS_LOG_NOTICE("Failed to create Port %s due to missing SAI create_port API.", get<0>(it->second).c_str());
-                        }
+                        port_created = true;
                     }
                     else
                     {
@@ -2742,7 +2722,7 @@ bool PortsOrch::removeVlan(Port vlan)
     SWSS_LOG_ENTER();
     if (m_port_ref_count[vlan.m_alias] > 0)
     {
-        SWSS_LOG_ERROR("Failed to remove ref count %d VLAN %s", 
+        SWSS_LOG_ERROR("Failed to remove ref count %d VLAN %s",
                        m_port_ref_count[vlan.m_alias],
                        vlan.m_alias.c_str());
         return false;
@@ -2926,8 +2906,8 @@ bool PortsOrch::removeLag(Port lag)
 
     if (m_port_ref_count[lag.m_alias] > 0)
     {
-        SWSS_LOG_ERROR("Failed to remove ref count %d LAG %s", 
-                        m_port_ref_count[lag.m_alias], 
+        SWSS_LOG_ERROR("Failed to remove ref count %d LAG %s",
+                        m_port_ref_count[lag.m_alias],
                         lag.m_alias.c_str());
         return false;
     }


### PR DESCRIPTION
Remove the platform check for remove/add port action at init phase.

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove the platform check so all platform can remove/add port based on the configDB or port_config.ini during the init time. 

**Why I did it**
BRCM is now supporting this. Also we should expect all platforms support this.

**How I verified it**
Along with sonic-buildimage PR: https://github.com/Azure/sonic-buildimage/pull/3240,  see the test results on that PR.

**Details if related**
