### PR TITLE
[Orchagent]: Fixbug segmentfault at routeorch

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -156,15 +156,14 @@ void RouteOrch::attach(Observer *observer, const IpAddress& dstAddr)
 
     observerEntry->second.observers.push_back(observer);
 
-    SWSS_LOG_NOTICE("Attached next hop observer of route %s for destination IP %s",
-            observerEntry->second.routeTable.rbegin()->first.to_string().c_str(),
-            dstAddr.to_string().c_str());
-
     // Trigger next hop change for the first time the observer is attached
     // Note that rbegin() is pointing to the entry with longest prefix match
     auto route = observerEntry->second.routeTable.rbegin();
     if (route != observerEntry->second.routeTable.rend())
     {
+        SWSS_LOG_NOTICE("Attached next hop observer of route %s for destination IP %s",
+                observerEntry->second.routeTable.rbegin()->first.to_string().c_str(),
+                dstAddr.to_string().c_str());
         NextHopUpdate update = { dstAddr, route->first, route->second };
         observer->update(SUBJECT_TYPE_NEXTHOP_CHANGE, static_cast<void *>(&update));
     }


### PR DESCRIPTION
The log statement will cause segmentfault if `observerEntry->second.routeTable` is empty.

Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
