### PR TITLE
Adjust stale timer for warm-reboot neighborsync test cases

### DIFF
--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1823,8 +1823,8 @@ class TestWarmReboot(object):
             # bring servers' interface up, save the macs
             dvs.runcmd("sysctl -w net.ipv4.neigh.Ethernet{}.base_reachable_time_ms=1800000".format(i*4))
             dvs.runcmd("sysctl -w net.ipv6.neigh.Ethernet{}.base_reachable_time_ms=1800000".format(i*4))
-            dvs.runcmd("sysctl -w net.ipv4.neigh.Ethernet{}.gc_stale_time=180".format(i*4))
-            dvs.runcmd("sysctl -w net.ipv6.neigh.Ethernet{}.gc_stale_time=180".format(i*4))
+            dvs.runcmd("sysctl -w net.ipv4.neigh.Ethernet{}.gc_stale_time=600".format(i*4))
+            dvs.runcmd("sysctl -w net.ipv6.neigh.Ethernet{}.gc_stale_time=600".format(i*4))
             dvs.runcmd("ip addr flush dev Ethernet{}".format(i*4))
             intf_tbl.set("Ethernet{}|{}.0.0.1/24".format(i*4, i*4), fvs)
             intf_tbl.set("Ethernet{}|{}00::1/64".format(i*4, i*4), fvs)


### PR DESCRIPTION
Adjust stale timer for warm-reboot neighborsync test cases

Increase the stale timer to "600" seconds so it won't be aged
out in case the test server is busy or slow

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
