### PR TITLE
[portsyncd]: Add default catch block in portsyncd

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -230,7 +230,7 @@ void handlePortConfigFile(ProducerStateTable &p, string file, bool warm)
     if (!infile.is_open())
     {
         usage();
-        throw "Port configuration file not found!";
+	throw(std::runtime_error("Port configuration file not found!"));
     }
 
     list<string> header = {"name", "lanes", "alias", "speed", "autoneg", "fec"};

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -230,7 +230,7 @@ void handlePortConfigFile(ProducerStateTable &p, string file, bool warm)
     if (!infile.is_open())
     {
         usage();
-	throw(std::runtime_error("Port configuration file not found!"));
+	throw runtime_error("Port configuration file not found!");
     }
 
     list<string> header = {"name", "lanes", "alias", "speed", "autoneg", "fec"};

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -166,6 +166,12 @@ int main(int argc, char **argv)
         cerr << "Exception \"" << e.what() << "\" had been thrown in deamon" << endl;
         return EXIT_FAILURE;
     }
+    catch (...)
+    {
+        cerr << "Exception had been thrown in deamon" << endl;
+        return EXIT_FAILURE;
+    }
+
 
     return 1;
 }

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -163,12 +163,12 @@ int main(int argc, char **argv)
     }
     catch (const std::exception& e)
     {
-        cerr << "Exception \"" << e.what() << "\" had been thrown in deamon" << endl;
+        cerr << "Exception \"" << e.what() << "\" was thrown in daemon" << endl;
         return EXIT_FAILURE;
     }
     catch (...)
     {
-        cerr << "Exception had been thrown in deamon" << endl;
+        cerr << "Exception was thrown in daemon" << endl;
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added a default catch block in portsyncd code as current catch block only accepts parameter of type Exception. In the throw currently, a const char * is passed which leads to a core dumped scenario.

**Why I did it**
Added a default catch block.

**How I verified it**
To test, Build a sonic-Broadcom image. 
Loaded the image in a DUT, rebooted the DUT without a minigraph.xml or config_db.json in /etc/sonic. 
While booting up, when systemd tries to start portsyncd process, it passes the parameter port_config.ini. The right port_config.ini is selected and placed in the right directory in swss docker before starting portsyncd process. The right port_config.ini is selected based HW SKU and platform type which is obtained from DEVICE_METADATA. If the device configuration is not loaded correctly, then DEVICE_METADATA will not be read, and port_config.ini is not picked up. With this, if portsyncd is started without the right port_config.ini, the portsyncd process will throw and exception. 

Before the fix error looked like:

<14>Aug  5 22:20:40 MWH01-0101-0334-13T0 supervisord: portsyncd terminate called after throwing an instance of 'char const*'
<30>Aug  5 22:20:40 MWH01-0101-0334-13T0 swss.sh[1901]: 2019-08-05 22:20:40,806 INFO exited: portsyncd (terminated by SIGABRT (core dumped); not expected)

After fix the error will look like:
Aug 14 23:24:55.845720 sonic INFO supervisord: portsyncd Exception had been thrown in deamon

**Details if related**
