### PR TITLE
[copporch]: fix the endless loop problem when removing copp table group.

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -626,6 +626,7 @@ void CoppOrch::doTask(Consumer &consumer)
                 it = consumer.m_toSync.erase(it);
                 break;
             case task_process_status::task_failed:
+                it = consumer.m_toSync.erase(it);
                 SWSS_LOG_ERROR("Processing copp task item failed, exiting. ");
                 return;
             case task_process_status::task_need_retry:
@@ -633,6 +634,7 @@ void CoppOrch::doTask(Consumer &consumer)
                 it++;
                 break;
             default:
+                it = consumer.m_toSync.erase(it);
                 SWSS_LOG_ERROR("Invalid task status:%d", task_status);
                 return;
         }


### PR DESCRIPTION
Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
fix the endless loop problem when removing copp table group.
**Why I did it**
When removing copp table group, the copp orchangent trapped into endless loop.
**How I verified it**
1.remove the copp table group, as follows:
00-copp.config_back.json :
[
    {
        "COPP_TABLE:trap.group.bgp.lacp": {
            "trap_ids": "bgp,bgpv6,lacp",
            "trap_action":"trap",
            "trap_priority":"4",
            "queue": "4"
        },
        "OP": "DEL"
    }
]
swssconfig  00-copp.config_back.json
2.check the syslog, as follows
Aug 27 15:40:02.982399 48S-sdd NOTICE swss#orchagent: :- processCoppRule: processCoppRule OP DEL trap_group_name trap.group.bgp.lacp 
Aug 27 15:40:03.982379 48S-sdd NOTICE swss#orchagent: :- processCoppRule: processCoppRule OP DEL trap_group_name trap.group.bgp.lacp 
Aug 27 15:40:04.982412 48S-sdd NOTICE swss#orchagent: :- processCoppRule: processCoppRule OP DEL trap_group_name trap.group.bgp.lacp 
Aug 27 15:40:05.982404 48S-sdd NOTICE swss#orchagent: :- processCoppRule: processCoppRule OP DEL trap_group_name trap.group.bgp.lacp 
Aug 27 15:40:06.982367 48S-sdd NOTICE swss#orchagent: :- processCoppRule: processCoppRule OP DEL trap_group_name trap.group.bgp.lacp
.....
CoppOrch::doTask enter into endless loop.
When 'task_status' equals to 'task_process_status::task_failed' , the doTask function just return without erasing the map list element.

**Details if related**
