### PR TITLE
Fix test_vnet_orch_4 test case for vnet pytest.

### DIFF
--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -1280,7 +1280,7 @@ class TestVnetOrch(object):
         delete_vnet_entry(dvs, 'Vnet3004')
         vnet_obj.check_del_vnet_entry(dvs, 'Vnet3004')
 
-        delete_vnet_routes(dvs, "100.100.2.1/24", 'Vnet3002')
+        delete_vnet_routes(dvs, "100.100.2.1/32", 'Vnet3002')
         vnet_obj.check_del_vnet_routes(dvs, 'Vnet3002')
 
         delete_vnet_local_routes(dvs, "100.102.1.0/24", 'Vnet3002')


### PR DESCRIPTION
**What I did**
modify "100.100.2.1/24" to "100.100.2.1/32" for test_vnet_orch_4  test case.

**Why I did it**
I trace the code, the prefix set to "100.100.2.1/32" when it create the vnet route.

create_vnet_routes(dvs, "100.100.2.1/32", 'Vnet3002', 'fd:2::34', "00:12:34:56:78:9A")
 vnet_obj.check_vnet_routes(dvs, 'Vnet3002', 'fd:2::34', tunnel_name, "00:12:34:56:78:9A")

so the delete prefix para should set to  100.100.2.1/32, not 100.100.2.1/24.
 
**How I verified it**
test by unittest.
**Details if related**
