### PR TITLE
Single VRF for ingress and egress flows, skip route replication

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -643,9 +643,17 @@ void IntfsOrch::removeSubnetRoute(const Port &port, const IpPrefix &ip_prefix)
     sai_status_t status = sai_route_api->remove_route_entry(&unicast_route_entry);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to remove subnet route to %s from %s, rv:%d",
-                       ip_prefix.to_string().c_str(), port.m_alias.c_str(), status);
-        throw runtime_error("Failed to remove subnet route.");
+        if (status == SAI_STATUS_ITEM_NOT_FOUND)
+        {
+            SWSS_LOG_ERROR("No subnet route found for %s", ip_prefix.to_string().c_str());
+            return;
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to remove subnet route to %s from %s, rv:%d",
+                           ip_prefix.to_string().c_str(), port.m_alias.c_str(), status);
+            throw runtime_error("Failed to remove subnet route.");
+        }
     }
 
     SWSS_LOG_NOTICE("Remove subnet route to %s from %s",

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1329,7 +1329,7 @@ VNetOrch::VNetOrch(DBConnector *db, const std::string& tableName, VNET_EXEC op)
 
     if (op == VNET_EXEC::VNET_EXEC_VRF)
     {
-        vr_cntxt = { VR_TYPE::ING_VR_VALID, VR_TYPE::EGR_VR_VALID };
+        vr_cntxt = { VR_TYPE::ING_VR_VALID, VR_TYPE::VR_INVALID };
     }
     else
     {
@@ -1647,8 +1647,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
 
     if (!vnet_orch_->isVnetExists(vnet))
     {
-        SWSS_LOG_WARN("VNET %s doesn't exist", vnet.c_str());
-        return false;
+        SWSS_LOG_WARN("VNET %s doesn't exist for prefix %s, op %s",
+                      vnet.c_str(), ipPrefix.to_string().c_str(), op.c_str());
+        return (op == DEL_COMMAND)?true:false;
     }
 
     set<sai_object_id_t> vr_set;
@@ -1710,8 +1711,9 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
 
     if (!vnet_orch_->isVnetExists(vnet))
     {
-        SWSS_LOG_WARN("VNET %s doesn't exist", vnet.c_str());
-        return false;
+        SWSS_LOG_WARN("VNET %s doesn't exist for prefix %s, op %s",
+                      vnet.c_str(), ipPrefix.to_string().c_str(), op.c_str());
+        return (op == DEL_COMMAND)?true:false;
     }
 
     auto *vrf_obj = vnet_orch_->getTypePtr<VNetVrfObject>(vnet);
@@ -1799,14 +1801,18 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
 
     for (auto vr_id : vr_set)
     {
+        if (vr_id == SAI_NULL_OBJECT_ID)
+        {
+            continue;
+        }
         if (op == SET_COMMAND && !add_route(vr_id, pfx, nh_id))
         {
-            SWSS_LOG_ERROR("Route add failed for %s", ipPrefix.to_string().c_str());
+            SWSS_LOG_INFO("Route add failed for %s", ipPrefix.to_string().c_str());
             break;
         }
         else if (op == DEL_COMMAND && !del_route(vr_id, pfx))
         {
-            SWSS_LOG_ERROR("Route del failed for %s", ipPrefix.to_string().c_str());
+            SWSS_LOG_INFO("Route del failed for %s", ipPrefix.to_string().c_str());
             break;
         }
     }

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1329,7 +1329,7 @@ VNetOrch::VNetOrch(DBConnector *db, const std::string& tableName, VNET_EXEC op)
 
     if (op == VNET_EXEC::VNET_EXEC_VRF)
     {
-        vr_cntxt = { VR_TYPE::ING_VR_VALID, VR_TYPE::VR_INVALID };
+        vr_cntxt = { VR_TYPE::ING_VR_VALID };
     }
     else
     {

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -142,7 +142,14 @@ public:
 
     sai_object_id_t getDecapMapId() const
     {
-        return getVRidEgress();
+        if (std::find(vr_cntxt.begin(), vr_cntxt.end(), VR_TYPE::EGR_VR_VALID) != vr_cntxt.end())
+        {
+            return getVRidEgress();
+        }
+        else
+        {
+            return getVRidIngress();
+        }
     }
 
     sai_object_id_t getVRid() const


### PR DESCRIPTION
**What I did**
Change the model from creating two different VRFs (ingress and egress) as captured [here ](https://github.com/opencomputeproject/SAI/blob/master/doc/SAI-Proposal-QinQ-VXLAN.md
)and use only one VRF

**Why I did it**
To avoid potential scaling issues with replicating routes to multiple VRFs.

**How I verified it**
Run ansible test (vnet_vxlan) and the pytest.

**Details if related**
