### PR TITLE
Don't try to remove a vxlan tunnel if it has associated tunnel maps

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -548,6 +548,13 @@ bool VxlanTunnelOrch::delOperation(const Request& request)
         return true;
     }
 
+    VxlanTunnelMapOrch* tunnel_map_orch = gDirectory.get<VxlanTunnelMapOrch*>();
+    if (tunnel_map_orch->anyMapForTunnel(tunnel_name))
+    {
+        SWSS_LOG_WARN("Can't remove vxlan tunnel '%s'. There are active tunnel maps for the tunnel.", tunnel_name.c_str());
+        return false;
+    }
+
     auto tunnel_term_id = vxlan_tunnel_table_[tunnel_name].get()->getTunnelTermId();
     try
     {

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -3,6 +3,7 @@
 #include <map>
 #include <set>
 #include <memory>
+#include <algorithm>
 #include "request_parser.h"
 #include "portsorch.h"
 #include "vrforch.h"
@@ -151,6 +152,17 @@ public:
     bool isTunnelMapExists(const std::string& name) const
     {
         return vxlan_tunnel_map_table_.find(name) != std::end(vxlan_tunnel_map_table_);
+    }
+    bool anyMapForTunnel(const std::string& tunnel_name) const
+    {
+        return std::any_of(
+            vxlan_tunnel_map_table_.cbegin(),
+            vxlan_tunnel_map_table_.cend(),
+            [&tunnel_name](std::pair<std::string, sai_object_id_t> p)
+            {
+                return p.first.rfind(tunnel_name, 0) == 0;
+            }
+        );
     }
 private:
     virtual bool addOperation(const Request& request);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Check vxlan tunnel maps before removing a vxlan tunnel which is used by the tunnel maps.
Don't remove the tunnel if it has associated tunnel maps.

**Why I did it**
Otherwise we got swss crash

**How I verified it**
Build the code, install it, restart dut. Create a tunnel and a tunnel map. Then Try to remove a tunnel.
```
Sep 11 19:23:56.103135 dut-acs-1 NOTICE swss#orchagent: :- addOperation: Vxlan tunnel 'tunnel1000' was added
Sep 11 19:24:02.214602 dut-acs-1 NOTICE swss#orchagent: :- createTunnel: Vxlan tunnel 'tunnel1000' was created
Sep 11 19:24:02.215066 dut-acs-1 NOTICE swss#orchagent: :- addOperation: Vxlan tunnel map entry 'map1' for tunnel 'tunnel1000' was created
Sep 11 19:24:08.861319 dut-acs-1 NOTICE swss#orchagent: :- addOperation: Vxlan tunnel map entry 'map2' for tunnel 'tunnel1000' was created
Sep 11 19:24:16.890276 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:16.890276 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:17.526108 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:18.526164 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:19.526077 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:20.526087 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:21.526117 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:22.526086 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:23.526144 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:24.526119 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:25.526112 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:26.518517 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:26.526114 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:27.526073 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:28.526135 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:28.551131 dut-acs-1 NOTICE swss#orchagent: :- delOperation: Vxlan tunnel map entry 'map1' for tunnel 'tunnel1000' was removed
Sep 11 19:24:28.551131 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:29.526124 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:30.526106 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:31.526112 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:32.526112 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:33.526096 dut-acs-1 WARNING swss#orchagent: :- delOperation: Can't remove vxlan tunnel 'tunnel1000'. There are active tunnel maps for the tunnel.
Sep 11 19:24:34.498839 dut-acs-1 NOTICE swss#orchagent: :- delOperation: Vxlan tunnel map entry 'map2' for tunnel 'tunnel1000' was removed
Sep 11 19:24:34.498839 dut-acs-1 NOTICE swss#orchagent: :- delOperation: Vxlan tunnel 'tunnel1000' was removed
```
**Details if related**
