### PR TITLE
[teamsyncd]: Do not update lag mtu from teamsyncd (netlink)

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -127,10 +127,8 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     std::vector<FieldValueTuple> fvVector;
     FieldValueTuple a("admin_status", admin_state ? "up" : "down");
     FieldValueTuple o("oper_status", oper_state ? "up" : "down");
-    FieldValueTuple m("mtu", to_string(mtu));
     fvVector.push_back(a);
     fvVector.push_back(o);
-    fvVector.push_back(m);
     m_lagTable.set(lagName, fvVector);
 
     SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s, mtu: %d",


### PR DESCRIPTION
**What I did**
Revert changes done as part of https://github.com/Azure/sonic-swss/pull/922

**Why I did it**
In some use-cases it is required that kernel MTU is different (may be default 1500) from the config_db value (say 9000).  In this case, if `teamsyncd `updates the MTU value via Netlink, orchagent/asic mtu value would be different from the user configured value. We want `teammgr ` which listens on config db to update the mtu value to APP_DB.

Original change was done due to a timing issue where mtu value was found to be missing in APP_DB. This resulted in orchagent creating router interface with 1492 mtu value - Logs are in details
 
**How I verified it**
Load the changes and `reboot`, `config reload` and check if `mtu `is correct in `APP_DB` as expected.

**Details if related**

```
Jun  4 01:39:58.250123 str-7260cx3-acs-1 NOTICE teamd#teammgrd: :- setLagAdminStatus: Set port channel PortChannel0001 admin status to up
Jun  4 01:39:58.260106 str-7260cx3-acs-1 NOTICE teamd#teammgrd: :- setLagMtu: Set port channel PortChannel0001 MTU to 9100
Jun  4 01:39:59.479761 str-7260cx3-acs-1 INFO teamd#teamsyncd: :- addLag: Add PortChannel0001 admin_status:up oper_status:down, mtu: 9100
Jun  4 01:40:10.860972 str-7260cx3-acs-1 NOTICE teamd#teammgrd: :- addLagMember: Add Ethernet52 to port channel PortChannel0001
Jun  4 01:40:10.889090 str-7260cx3-acs-1 INFO teamd#teamsyncd: :- addLag: Add PortChannel0001 admin_status:up oper_status:down, mtu: 9100
Jun  4 01:40:10.889173 str-7260cx3-acs-1 INFO teamd#teamsyncd: :- addLag: Add PortChannel0001 admin_status:up oper_status:up, mtu: 9100
Jun  4 01:40:10.928183 str-7260cx3-acs-1 INFO teamd#teamsyncd: :- addLag: Add PortChannel0001 admin_status:up oper_status:up, mtu: 9100
Jun  4 01:40:10.939448 str-7260cx3-acs-1 NOTICE teamd#teammgrd: :- addLagMember: Add Ethernet48 to port channel PortChannel0001
Jun  4 01:40:10.990113 str-7260cx3-acs-1 INFO teamd#teamsyncd: :- addLag: Add PortChannel0001 admin_status:up oper_status:up, mtu: 9100
Jun  4 01:40:27.189900 str-7260cx3-acs-1 NOTICE swss#orchagent: :- doLagTask: Create port: LAG PortChannel0001 mtu 0
Jun  4 01:40:27.190029 str-7260cx3-acs-1 NOTICE swss#orchagent: :- addLag: Create an empty LAG PortChannel0001 lid:200000013fff2
Jun  4 01:40:27.190489 str-7260cx3-acs-1 NOTICE swss#orchagent: :- doLagTask: --> MTU: LAG PortChannel0001 mtu 0
Jun  4 01:40:27.264062 str-7260cx3-acs-1 NOTICE swss#orchagent: :- addRouterIntfs: Create router interface PortChannel0001 MTU 1492

```

