### PR TITLE
[aclorch]: Fix table name in counter table for mirror rules

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3000,7 +3000,8 @@ void AclOrch::doTask(SelectableTimer &timer)
             swss::FieldValueTuple fvtb("Bytes", to_string(cnt.bytes));
             values.push_back(fvtb);
 
-            AclOrch::getCountersTable().set(table_it.second.id + ":" + rule_it.second->getId(), values, "");
+            AclOrch::getCountersTable().set(rule_it.second->getTableId() + ":"
+                    + rule_it.second->getId(), values, "");
         }
         values.clear();
     }


### PR DESCRIPTION
In ACL combined mode, v4 and v6 rules are sharing the same
physical table while having separated configuration tables.
The daemon needs to use the configuration table name to store
the counter information.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>