### PR TITLE
[fdb]fdborch: fdb entries are deleted according to vlan or port or vlan&&port

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -685,6 +685,10 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
     std::string op;
     std::string data;
     std::vector<swss::FieldValueTuple> values;
+    string alias;
+    string vlan;
+    Port port;
+    Port vlanPort;
 
     consumer.pop(op, data, values);
 
@@ -706,14 +710,76 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
         }
         else if (op == "PORT")
         {
-            /*place holder for flush port fdb*/
-            SWSS_LOG_ERROR("Received unsupported flush port fdb request");
+            alias = data;
+            if (alias.empty())
+            {
+                SWSS_LOG_ERROR("Receive wrong port to flush fdb!");
+                return;
+            }
+            if (!gPortsOrch->getPort(alias, port))
+            {
+                SWSS_LOG_ERROR("Get Port from port(%s) failed!", alias.c_str());
+                return;
+            }
+            if (port.m_bridge_port_id == SAI_NULL_OBJECT_ID)
+            {
+                return;
+            }
+            flushFDBEntries(port.m_bridge_port_id, SAI_NULL_OBJECT_ID);
+            SWSS_LOG_NOTICE("Clear fdb by port(%s)", alias.c_str());
             return;
         }
         else if (op == "VLAN")
         {
-            /*place holder for flush vlan fdb*/
-            SWSS_LOG_ERROR("Received unsupported flush vlan fdb request");
+            vlan = data;
+            if (vlan.empty())
+            {
+                SWSS_LOG_ERROR("Receive wrong vlan to flush fdb!");
+                return;
+            }
+            if (!gPortsOrch->getPort(vlan, vlanPort))
+            {
+                SWSS_LOG_ERROR("Get Port from vlan(%s) failed!", vlan.c_str());
+                return;
+            }
+            if (vlanPort.m_vlan_info.vlan_oid == SAI_NULL_OBJECT_ID)
+            {
+                return;
+            }
+            flushFDBEntries(SAI_NULL_OBJECT_ID, vlanPort.m_vlan_info.vlan_oid);
+            SWSS_LOG_NOTICE("Clear fdb by vlan(%s)", vlan.c_str());
+            return;
+        }
+        else if (op == "PORTVLAN")
+        {
+            size_t found = data.find('|');
+            if (found != string::npos)
+            {
+                alias = data.substr(0, found);
+                vlan = data.substr(found+1);
+            }
+            if (alias.empty() || vlan.empty())
+            {
+                SWSS_LOG_ERROR("Receive wrong port or vlan to flush fdb!");
+                return;
+            }
+            if (!gPortsOrch->getPort(alias, port))
+            {
+                SWSS_LOG_ERROR("Get Port from port(%s) failed!", alias.c_str());
+                return;
+            }
+            if (!gPortsOrch->getPort(vlan, vlanPort))
+            {
+                SWSS_LOG_ERROR("Get Port from vlan(%s) failed!", vlan.c_str());
+                return;
+            }
+            if (port.m_bridge_port_id == SAI_NULL_OBJECT_ID ||
+                vlanPort.m_vlan_info.vlan_oid == SAI_NULL_OBJECT_ID)
+            {
+                return;
+            }
+            flushFDBEntries(port.m_bridge_port_id, vlanPort.m_vlan_info.vlan_oid); 
+            SWSS_LOG_NOTICE("Clear fdb by port(%s)+vlan(%s)", alias.c_str(), vlan.c_str());
             return;
         }
         else


### PR DESCRIPTION
Fdb entries can be deleted with user specifying vlan or port or vlan&&port.The secifying vlan or port can be configured by cli at another issue#565 in Azure / sonic-utilities.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
