### PR TITLE
[neighsyncd]: Ignore link local neighbor entries

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -61,7 +61,9 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= ":";
 
     nl_addr2str(rtnl_neigh_get_dst(neigh), ipStr, MAX_ADDR_SIZE);
-
+    /* Ignore IPv6 link-local addresses as neighbors */
+    if (family == IPV6_NAME && IN6_IS_ADDR_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
+        return;
     /* Ignore IPv6 multicast link-local addresses as neighbors */
     if (family == IPV6_NAME && IN6_IS_ADDR_MC_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
         return;


### PR DESCRIPTION
**What I did**
Revert back one change from this [PR](https://github.com/Azure/sonic-swss/pull/774) to ignore link local neighbor as there are some current limitations with handling link-local neighbors

**Why I did it**

**How I verified it**

**Details if related**
