### PR TITLE
[aclorch]: Simplify the TCP flags matching code and support exact value match

### DIFF
--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -372,19 +372,6 @@ public:
     void update(SubjectType, void *);
 };
 
-template <class Iterable>
-inline void split(string str, Iterable& out, char delim = ' ')
-{
-    string val;
-
-    istringstream input(str);
-
-    while (getline(input, val, delim))
-    {
-        out.push_back(val);
-    }
-}
-
 class AclOrch : public Orch, public Observer
 {
 public:


### PR DESCRIPTION
Use similar DSCP value parsing logic for TCP falgs value parsing.
Remove the deprecated functions.

Signed-off-by: Shu0t1an Cheng <shuche@microsoft.com>