### PR TITLE
Revert changelog that was done for passing VS test.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,5 @@
 sonic (1.0.0) stable; urgency=medium
 
-  * next-hop key add ifname
-
- -- Tyler Li <tyler.li@mediatek.com>  Thu, 19 Sep 2019 04:00:00 -0700
-
   * Initial release.
 
  -- Shuotian Cheng <shuche@microsoft.com>  Wed, 09 Mar 2016 12:00:00 -0800


### PR DESCRIPTION
**What I did**
Revert changelog that was done for passing VS test as part of https://github.com/Azure/sonic-swss/pull/977

**Why I did it**
Original issue is fixed as part of  Azure/sonic-build-tools@e9e3957

**How I verified it**

**Details if related**
