### PR TITLE
sonic-swss/orchagent:  Add new protocol trap name support

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -69,7 +69,9 @@ static map<string, sai_hostif_trap_type_t> trap_id_map = {
     {"router_custom_range", SAI_HOSTIF_TRAP_TYPE_ROUTER_CUSTOM_RANGE_BASE},
     {"l3_mtu_error", SAI_HOSTIF_TRAP_TYPE_L3_MTU_ERROR},
     {"ttl_error", SAI_HOSTIF_TRAP_TYPE_TTL_ERROR},
-    {"udld", SAI_HOSTIF_TRAP_TYPE_UDLD}
+    {"udld", SAI_HOSTIF_TRAP_TYPE_UDLD},
+    {"bfd", SAI_HOSTIF_TRAP_TYPE_BFD},
+    {"bfdv6", SAI_HOSTIF_TRAP_TYPE_BFDV6}
 };
 
 static map<string, sai_packet_action_t> packet_action_map = {


### PR DESCRIPTION
sonic-swss/orchagent:  Add new protocol trap name support in CoPP

Added new protocol name support so these names can be used in copp_config.json file and properly parsed.

This is to support new feature requirement.

Verified Sonic image on Broadcom target by specifying these new traps in copp_config.json file and verified these new protocols are trapped and policed as they are configured in the copp_config.json file.

Signed-off-by: jingping.xie@broadcom.com



