### PR TITLE
Update Route test to check for added entry

### DIFF
--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -120,10 +120,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds fdb high 90")
         dvs.runcmd("crm config thresholds fdb type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "FDB_ENTRY THRESHOLD_EXCEEDED for TH_FREE", 1)
 
         # enable ipv6 on server 2
@@ -183,10 +183,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds ipv4 route high 90")
         dvs.runcmd("crm config thresholds ipv4 route type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "IPV4_ROUTE THRESHOLD_EXCEEDED for TH_FREE",1)
 
         intf_tbl._del("Ethernet0|10.0.0.0/31")
@@ -253,10 +253,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds ipv6 route high 90")
         dvs.runcmd("crm config thresholds ipv6 route type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "IPV6_ROUTE THRESHOLD_EXCEEDED for TH_FREE",1)
 
         intf_tbl._del("Ethernet0|fc00::1/126")
@@ -308,10 +308,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds ipv4 nexthop high 90")
         dvs.runcmd("crm config thresholds ipv4 nexthop type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "IPV4_NEXTHOP THRESHOLD_EXCEEDED for TH_FREE",1)
 
         intf_tbl._del("Ethernet0|10.0.0.0/31")
@@ -367,10 +367,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds ipv6 nexthop high 90")
         dvs.runcmd("crm config thresholds ipv6 nexthop type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "IPV6_NEXTHOP THRESHOLD_EXCEEDED for TH_FREE",1)
 
         intf_tbl._del("Ethernet0|fc00::1/126")
@@ -422,10 +422,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds ipv4 neighbor high 90")
         dvs.runcmd("crm config thresholds ipv4 neighbor type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "IPV4_NEIGHBOR THRESHOLD_EXCEEDED for TH_FREE",1)
 
         intf_tbl._del("Ethernet0|10.0.0.0/31")
@@ -481,10 +481,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds ipv6 neighbor high 90")
         dvs.runcmd("crm config thresholds ipv6 neighbor type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "IPV6_NEIGHBOR THRESHOLD_EXCEEDED for TH_FREE",1)
 
         intf_tbl._del("Ethernet0|fc00::1/126")
@@ -549,10 +549,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds nexthop group member high 90")
         dvs.runcmd("crm config thresholds nexthop group object type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "NEXTHOP_GROUP THRESHOLD_EXCEEDED for TH_FREE",1)
 
         intf_tbl._del("Ethernet0|10.0.0.0/31")
@@ -624,10 +624,10 @@ class TestCrm(object):
         assert new_avail_counter == avail_counter
 
         marker = dvs.add_log_marker()
-        dvs.runcmd("crm config polling interval 2")
+        dvs.runcmd("crm config polling interval 3")
         dvs.runcmd("crm config thresholds nexthop group member high 90")
         dvs.runcmd("crm config thresholds nexthop group member type free")
-        time.sleep(2)
+        time.sleep(3)
         check_syslog(dvs, marker, "NEXTHOP_GROUP_MEMBER THRESHOLD_EXCEEDED for TH_FREE",1)
 
         intf_tbl._del("Ethernet0|10.0.0.0/31")

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -38,8 +38,16 @@ class TestRoute(object):
 
         (addobjs, delobjs) = dvs.GetSubscribedAsicDbObjects(pubsub)
 
-        assert len(addobjs) == 1
+        assert len(addobjs) >= 1
 
-        rt_key = json.loads(addobjs[0]['key'])
+        adb = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+        atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
+        keys = atbl.getKeys()
+        found = False
 
-        assert rt_key['dest'] == "2.2.2.0/24"
+        for key in keys:
+            route = json.loads(key)
+            if route['dest'] == "2.2.2.0/24":
+                found = True
+
+        assert found


### PR DESCRIPTION
**What I did**
Update Route test to check for added entry

**Why I did it**
Sometimes, default routes keeps coming on eth0 during the route add and this can result in test failure

**How I verified it**
Run VS test

**Details if related**
For CRM check log case:
```
marker = '=== start marker 2019-10-10T05:25:38.550022 ==='
err_log = 'IPV6_ROUTE THRESHOLD_EXCEEDED for TH_FREE', expected_cnt = 1

    def check_syslog(dvs, marker, err_log, expected_cnt):
        (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \"%s\" | wc -l" % (marker, err_log)])
>       assert num.strip() == str(expected_cnt)
E       AssertionError: assert '2' == '1'
E         - 2
E         + 1
```