### PR TITLE
[aclorch]: Check for existing mirror table only when creating a new table

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2459,7 +2459,7 @@ bool AclOrch::addAclTable(AclTable &newTable, string table_id)
                 mirror_type = TABLE_TYPE_MIRROR;
             }
 
-            if (table_type == ACL_TABLE_MIRRORV6 && !m_mirrorV6TableId.empty()))
+            if (table_type == ACL_TABLE_MIRRORV6 && !m_mirrorV6TableId.empty())
             {
                 mirror_type = TABLE_TYPE_MIRRORV6;
             }

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2446,6 +2446,21 @@ bool AclOrch::addAclTable(AclTable &newTable, string table_id)
             return false;
         }
     }
+    else
+    {
+        // If ACL table is new, check for the existence of current mirror tables
+        // Note: only one table per mirror type can be created
+        auto table_type = newTable.type;
+        if (table_type == ACL_TABLE_MIRROR || table_type == ACL_TABLE_MIRRORV6)
+        {
+            if ((table_type == ACL_TABLE_MIRROR && !m_mirrorTableId.empty()) ||
+                    (table_type == ACL_TABLE_MIRRORV6 && !m_mirrorV6TableId.empty()))
+            {
+                SWSS_LOG_ERROR("Mirror table has already been created");
+                return false;
+            }
+        }
+    }
 
     // Check if a separate mirror table is needed or not based on the platform
     if (newTable.type == ACL_TABLE_MIRROR || newTable.type == ACL_TABLE_MIRRORV6)
@@ -2876,15 +2891,6 @@ bool AclOrch::processAclTableType(string type, acl_table_type_t &table_type)
         if (!m_mirrorTableCapabilities[table_type])
         {
             SWSS_LOG_ERROR("Mirror table type %s is not supported", type.c_str());
-            return false;
-        }
-
-        // Check the existence of current mirror tables
-        // Note: only one table per type could be created
-        if ((table_type == ACL_TABLE_MIRROR && !m_mirrorTableId.empty()) ||
-                (table_type == ACL_TABLE_MIRRORV6 && !m_mirrorV6TableId.empty()))
-        {
-            SWSS_LOG_ERROR("Mirror table table_type %s has already been created", type.c_str());
             return false;
         }
     }

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2453,10 +2453,20 @@ bool AclOrch::addAclTable(AclTable &newTable, string table_id)
         auto table_type = newTable.type;
         if (table_type == ACL_TABLE_MIRROR || table_type == ACL_TABLE_MIRRORV6)
         {
-            if ((table_type == ACL_TABLE_MIRROR && !m_mirrorTableId.empty()) ||
-                    (table_type == ACL_TABLE_MIRRORV6 && !m_mirrorV6TableId.empty()))
+            string mirror_type;
+            if ((table_type == ACL_TABLE_MIRROR && !m_mirrorTableId.empty()))
             {
-                SWSS_LOG_ERROR("Mirror table has already been created");
+                mirror_type = TABLE_TYPE_MIRROR;
+            }
+
+            if (table_type == ACL_TABLE_MIRRORV6 && !m_mirrorV6TableId.empty()))
+            {
+                mirror_type = TABLE_TYPE_MIRRORV6;
+            }
+
+            if (!mirror_type.empty())
+            {
+                SWSS_LOG_ERROR("Mirror table %s has already been created", mirror_type.c_str());
                 return false;
             }
         }


### PR DESCRIPTION
[aclorch]: Check for existing mirror table only when creating a new table

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I modified aclorch to check for existing mirror tables only when creating new tables, not when modifying/replacing an existing table.

**Why I did it**
Configlets may modify the bindings for MIRROR tables, this change makes it easier to do so. It also makes the behavior for updates to MIRROR tables consistent with the behavior with updates for other table types.

**How I verified it**
I updated the bindings for the EVERFLOW ACL table and verified that the group was deleted and created, as expected.