### PR TITLE
[build] Fixed TNA profiles build for BFN platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ CFLAGS_COMMON="-std=c++11 -Wall -fPIC -Wno-write-strings -I/usr/include/libnl3 -
 
 AM_CONDITIONAL(sonic_asic_platform_barefoot,   test x$CONFIGURED_PLATFORM = xbarefoot)
 AM_COND_IF([sonic_asic_platform_barefoot],
-           [CFLAGS_COMMON+=" -I/opt/bfn/install/include/switchsai"])
+           [CFLAGS_COMMON+=" -I/opt/bfn/install/include/switchsai -I/opt/bfn/install/include/bf_switch/sai"])
 
 CFLAGS_COMMON+=" -Werror"
 CFLAGS_COMMON+=" -Wno-reorder"


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>

**Why I did it**
Fix SONiC build for BFN platform with SDE package that contains TNA profiles only.

**How I verified it**
Built SONiC image with BFN A0/B0 profiles.
