### PR TITLE
[switchorch] Populate COUNTERS_SWITCH_NAME_MAP in COUNTERS_DB

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -6,6 +6,8 @@
 #include "notifier.h"
 #include "notificationproducer.h"
 #include "macaddress.h"
+#include "rediscommand.h"
+#include "sai_serialize.h"
 
 using namespace std;
 using namespace swss;
@@ -35,11 +37,14 @@ const map<string, sai_packet_action_t> packet_action_map =
 
 SwitchOrch::SwitchOrch(DBConnector *db, string tableName) :
         Orch(db, tableName),
-        m_db(db)
+        m_db(db),
+        m_countersDb(new DBConnector(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0)),
+        m_switchNameMap(new Table(m_countersDb.get(), COUNTERS_SWITCH_NAME_MAP))
 {
     m_restartCheckNotificationConsumer = new NotificationConsumer(db, "RESTARTCHECK");
     auto restartCheckNotifier = new Notifier(m_restartCheckNotificationConsumer, this, "RESTARTCHECK");
     Orch::addExecutor(restartCheckNotifier);
+    m_switchNameMap->set("", { FieldValueTuple("switch", sai_serialize_object_id(gSwitchId)) });
 }
 
 void SwitchOrch::doTask(Consumer &consumer)

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "orch.h"
+#include "producertable.h"
 
 struct WarmRestartCheck
 {
@@ -26,6 +27,9 @@ private:
     swss::NotificationConsumer* m_restartCheckNotificationConsumer;
     void doTask(swss::NotificationConsumer& consumer);
     swss::DBConnector *m_db;
+
+    std::shared_ptr<swss::DBConnector> m_countersDb;
+    std::shared_ptr<swss::Table> m_switchNameMap;
 
     // Information contained in the request from
     // external program for orchagent pre-shutdown state check


### PR DESCRIPTION
[switchorch] Populate COUNTERS_SWITCH_NAME_MAP in COUNTERS_DB

Signed-off-by: Danny Allen <daall@microsoft.com>

**Details if related**
Related to/spun off from: Azure/sonic-swss#1075