### PR TITLE
[mirrororch]: Add retry logic when deleting referenced mirror session

### DIFF
--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -94,7 +94,7 @@ private:
     bool m_freeze = false;
 
     void createEntry(const string&, const vector<FieldValueTuple>&);
-    void deleteEntry(const string&);
+    task_process_status deleteEntry(const string&);
 
     bool activateSession(const string&, MirrorEntry&);
     bool deactivateSession(const string&, MirrorEntry&);


### PR DESCRIPTION
When a mirror session is referenced by an ACL rule, we cannot remove
the mirror session. However, once the ACL rule gets removed, a retry
would help clean up the to-be-removed mirror session.

Signed-off-by: Shu0T1an ChenG <shuche@microsoft.com>
