### PR TITLE
[aclorch] if vendor does not implement ACL action capability quieries…

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -115,6 +115,20 @@ static acl_stage_type_lookup_t aclStageLookUp =
     {STAGE_EGRESS,  ACL_STAGE_EGRESS }
 };
 
+static const acl_capabilities_t defaultAclActionsSupported =
+{
+    {
+        ACL_STAGE_INGRESS,
+        {
+            SAI_ACL_ACTION_TYPE_PACKET_ACTION,
+            SAI_ACL_ACTION_TYPE_MIRROR_INGRESS
+        }
+    },
+    {
+        ACL_STAGE_EGRESS, {}
+    }
+};
+
 static acl_ip_type_lookup_t aclIpTypeLookup =
 {
     { IP_TYPE_ANY,         SAI_ACL_IP_TYPE_ANY },
@@ -2129,69 +2143,71 @@ void AclOrch::queryAclActionCapability()
     sai_status_t status {SAI_STATUS_FAILURE};
     sai_attribute_t attr;
     vector<int32_t> action_list;
-    vector<FieldValueTuple> fvVector;
 
     attr.id = SAI_SWITCH_ATTR_MAX_ACL_ACTION_COUNT;
     status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        const auto max_action_count = attr.value.u32;
+
+        for (auto stage_attr: {SAI_SWITCH_ATTR_ACL_STAGE_INGRESS, SAI_SWITCH_ATTR_ACL_STAGE_EGRESS})
+        {
+            auto stage = (stage_attr == SAI_SWITCH_ATTR_ACL_STAGE_INGRESS ? ACL_STAGE_INGRESS : ACL_STAGE_EGRESS);
+            auto stage_str = (stage_attr == SAI_SWITCH_ATTR_ACL_STAGE_INGRESS ? STAGE_INGRESS : STAGE_EGRESS);
+            action_list.resize(static_cast<size_t>(max_action_count));
+
+            attr.id = stage_attr;
+            attr.value.aclcapability.action_list.list  = action_list.data();
+            attr.value.aclcapability.action_list.count = max_action_count;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            if (status == SAI_STATUS_SUCCESS)
+            {
+
+                SWSS_LOG_INFO("Supported %s action count %d:", stage_str,
+                              attr.value.aclcapability.action_list.count);
+
+                for (size_t i = 0; i < static_cast<size_t>(attr.value.aclcapability.action_list.count); i++)
+                {
+                    auto action = static_cast<sai_acl_action_type_t>(action_list[i]);
+                    m_aclCapabilities[stage].insert(action);
+                    SWSS_LOG_INFO("    %s", sai_serialize_enum(action, &sai_metadata_enum_sai_acl_action_type_t).c_str());
+                }
+            }
+            else if (status == SAI_STATUS_NOT_IMPLEMENTED)
+            {
+                SWSS_LOG_WARN("Failed to query ACL %s action capabilities - "
+                        "API not implemented, using defaults",
+                        stage_str);
+                initDefaultAclActionCapabilities(stage);
+            }
+            else
+            {
+                SWSS_LOG_THROW("AclOrch initialization failed: "
+                               "failed to query supported %s ACL actions", stage_str);
+            }
+
+            // put capabilities in state DB
+            putAclActionCapabilityInDB(stage);
+        }
+    }
+    else if (status == SAI_STATUS_NOT_IMPLEMENTED)
+    {
+        SWSS_LOG_WARN("Failed to query maximum ACL action count - "
+                "API not implemented, using defaults capabilities for both %s and %s",
+                STAGE_INGRESS, STAGE_EGRESS);
+        for (auto stage: {ACL_STAGE_INGRESS, ACL_STAGE_EGRESS})
+        {
+            initDefaultAclActionCapabilities(stage);
+            putAclActionCapabilityInDB(stage);
+        }
+    }
+    else
     {
         SWSS_LOG_THROW("AclOrch initialization failed: "
                        "failed to query maximum ACL action count");
     }
 
-    const auto max_action_count = attr.value.u32;
-
-    for (auto stage_attr: {SAI_SWITCH_ATTR_ACL_STAGE_INGRESS, SAI_SWITCH_ATTR_ACL_STAGE_EGRESS})
-    {
-        auto stage = (stage_attr == SAI_SWITCH_ATTR_ACL_STAGE_INGRESS ? ACL_STAGE_INGRESS : ACL_STAGE_EGRESS);
-        auto stage_str = (stage_attr == SAI_SWITCH_ATTR_ACL_STAGE_INGRESS ? STAGE_INGRESS : STAGE_EGRESS);
-        action_list.resize(static_cast<size_t>(max_action_count));
-
-        attr.id = stage_attr;
-        attr.value.aclcapability.action_list.list  = action_list.data();
-        attr.value.aclcapability.action_list.count = max_action_count;
-
-        status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_THROW("AclOrch initialization failed: "
-                           "failed to query supported %s ACL actions", stage_str);
-        }
-
-        SWSS_LOG_INFO("Supported %s action count %d:", stage_str,
-                      attr.value.aclcapability.action_list.count);
-
-        for (size_t i = 0; i < static_cast<size_t>(attr.value.aclcapability.action_list.count); i++)
-        {
-            auto action = static_cast<sai_acl_action_type_t>(action_list[i]);
-            m_aclCapabilities[stage].insert(action);
-            SWSS_LOG_INFO("    %s", sai_serialize_enum(action, &sai_metadata_enum_sai_acl_action_type_t).c_str());
-        }
-
-        // put capabilities in state DB
-
-        auto field = std::string("ACL_ACTIONS") + '|' + stage_str;
-        auto& acl_action_set = m_aclCapabilities[stage];
-
-        string delimiter;
-        ostringstream acl_action_value_stream;
-
-        for (const auto& action_map: {aclL3ActionLookup, aclMirrorStageLookup, aclDTelActionLookup})
-        {
-            for (const auto& it: action_map)
-            {
-                auto saiAction = getAclActionFromAclEntry(it.second);
-                if (acl_action_set.find(saiAction) != acl_action_set.cend())
-                {
-                    acl_action_value_stream << delimiter << it.first;
-                    delimiter = comma;
-                }
-            }
-        }
-
-        fvVector.emplace_back(field, acl_action_value_stream.str());
-        m_switchTable.set("switch", fvVector);
-    }
 
     /* For those ACL action entry attributes for which acl parameter is enumeration (metadata->isenum == true)
      * we can query enum values which are implemented by vendor SAI.
@@ -2207,6 +2223,50 @@ void AclOrch::queryAclActionCapability()
     queryAclActionAttrEnumValues(ACTION_DTEL_FLOW_OP,
                                  aclDTelActionLookup,
                                  aclDTelFlowOpTypeLookup);
+}
+
+void AclOrch::putAclActionCapabilityInDB(acl_stage_type_t stage)
+{
+    vector<FieldValueTuple> fvVector;
+    auto stage_str = (stage == ACL_STAGE_INGRESS ? STAGE_INGRESS : STAGE_EGRESS);
+
+    auto field = std::string("ACL_ACTIONS") + '|' + stage_str;
+    auto& acl_action_set = m_aclCapabilities[stage];
+
+    string delimiter;
+    ostringstream acl_action_value_stream;
+
+    for (const auto& action_map: {aclL3ActionLookup, aclMirrorStageLookup, aclDTelActionLookup})
+    {
+        for (const auto& it: action_map)
+        {
+            auto saiAction = getAclActionFromAclEntry(it.second);
+            if (acl_action_set.find(saiAction) != acl_action_set.cend())
+            {
+                acl_action_value_stream << delimiter << it.first;
+                delimiter = comma;
+            }
+        }
+    }
+
+    fvVector.emplace_back(field, acl_action_value_stream.str());
+    m_switchTable.set("switch", fvVector);
+}
+
+void AclOrch::initDefaultAclActionCapabilities(acl_stage_type_t stage)
+{
+    m_aclCapabilities[stage] = defaultAclActionsSupported.at(stage);
+
+    SWSS_LOG_INFO("Assumed %s %zu actions to be supported:",
+            stage == ACL_STAGE_INGRESS ? STAGE_INGRESS : STAGE_EGRESS,
+            m_aclCapabilities[stage].size());
+
+    for (auto action: m_aclCapabilities[stage])
+    {
+        SWSS_LOG_INFO("    %s", sai_serialize_enum(action, &sai_metadata_enum_sai_acl_action_type_t).c_str());
+    }
+    // put capabilities in state DB
+    putAclActionCapabilityInDB(stage);
 }
 
 template<typename AclActionAttrLookupT>
@@ -2251,15 +2311,28 @@ void AclOrch::queryAclActionAttrEnumValues(const string &action_name,
                                                                  SAI_OBJECT_TYPE_ACL_ENTRY,
                                                                  acl_attr,
                                                                  &values);
-        if (status != SAI_STATUS_SUCCESS)
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            for (size_t i = 0; i < values.count; i++)
+            {
+                m_aclEnumActionCapabilities[acl_action].insert(values.list[i]);
+            }
+        }
+        else if (status == SAI_STATUS_NOT_IMPLEMENTED)
+        {
+            SWSS_LOG_WARN("Failed to query enum values supported for ACL action %s - ",
+                    "API is not implemented, assuming all values are supported for this action",
+                    action_name.c_str());
+            /* assume all enum values are supported */
+            for (size_t i = 0; i < meta->enummetadata->valuescount; i++)
+            {
+                m_aclEnumActionCapabilities[acl_action].insert(meta->enummetadata->values[i]);
+            }
+        }
+        else
         {
             SWSS_LOG_THROW("sai_query_attribute_enum_values_capability failed for %s",
                            action_name.c_str());
-        }
-
-        for (size_t i = 0; i < values.count; i++)
-        {
-            m_aclEnumActionCapabilities[acl_action].insert(values.list[i]);
         }
 #else
         /* assume all enum values are supported untill sai object api is available */

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2307,7 +2307,7 @@ void AclOrch::queryAclActionAttrEnumValues(const string &action_name,
                 m_aclEnumActionCapabilities[acl_action].insert(values.list[i]);
             }
         }
-        else if (status == SAI_STATUS_NOT_IMPLEMENTED)
+        else
         {
             SWSS_LOG_WARN("Failed to query enum values supported for ACL action %s - ",
                     "API is not implemented, assuming all values are supported for this action",
@@ -2317,11 +2317,6 @@ void AclOrch::queryAclActionAttrEnumValues(const string &action_name,
             {
                 m_aclEnumActionCapabilities[acl_action].insert(meta->enummetadata->values[i]);
             }
-        }
-        else
-        {
-            SWSS_LOG_THROW("sai_query_attribute_enum_values_capability failed for %s",
-                           action_name.c_str());
         }
 #else
         /* assume all enum values are supported untill sai object api is available */

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2174,27 +2174,22 @@ void AclOrch::queryAclActionCapability()
                     SWSS_LOG_INFO("    %s", sai_serialize_enum(action, &sai_metadata_enum_sai_acl_action_type_t).c_str());
                 }
             }
-            else if (status == SAI_STATUS_NOT_IMPLEMENTED)
-            {
-                SWSS_LOG_WARN("Failed to query ACL %s action capabilities - "
-                        "API not implemented, using defaults",
-                        stage_str);
-                initDefaultAclActionCapabilities(stage);
-            }
             else
             {
-                SWSS_LOG_THROW("AclOrch initialization failed: "
-                               "failed to query supported %s ACL actions", stage_str);
+                SWSS_LOG_WARN("Failed to query ACL %s action capabilities - "
+                        "API assumed to be not implemented, using defaults",
+                        stage_str);
+                initDefaultAclActionCapabilities(stage);
             }
 
             // put capabilities in state DB
             putAclActionCapabilityInDB(stage);
         }
     }
-    else if (status == SAI_STATUS_NOT_IMPLEMENTED)
+    else
     {
         SWSS_LOG_WARN("Failed to query maximum ACL action count - "
-                "API not implemented, using defaults capabilities for both %s and %s",
+                "API assumed to be not implemented, using defaults capabilities for both %s and %s",
                 STAGE_INGRESS, STAGE_EGRESS);
         for (auto stage: {ACL_STAGE_INGRESS, ACL_STAGE_EGRESS})
         {
@@ -2202,12 +2197,6 @@ void AclOrch::queryAclActionCapability()
             putAclActionCapabilityInDB(stage);
         }
     }
-    else
-    {
-        SWSS_LOG_THROW("AclOrch initialization failed: "
-                       "failed to query maximum ACL action count");
-    }
-
 
     /* For those ACL action entry attributes for which acl parameter is enumeration (metadata->isenum == true)
      * we can query enum values which are implemented by vendor SAI.

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -419,6 +419,8 @@ private:
 
     void queryMirrorTableCapability();
     void queryAclActionCapability();
+    void initDefaultAclActionCapabilities(acl_stage_type_t);
+    void putAclActionCapabilityInDB(acl_stage_type_t);
 
     template<typename AclActionAttrLookupT>
     void queryAclActionAttrEnumValues(const string& action_name,


### PR DESCRIPTION
… - use default capabilities (do not fail)

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

If ACL max action count query failed - use defaultAclActionsSupported for both INGRESS and EGRESS
If ACL actions query on INGRESS failed use defaultAclActionsSupported for INGRESS
If ACL actions query on EGRESS failed use defaultAclActionsSupported for EGRESS

Warn in any scenario that orchagent will assume defaults.

#ifdef SAI_SUPPORTS_OBJECT_API /* does not compile right now */
if enum values supported for ACL action query failed - assume all are supported
(e.g. action - PACKET_ACTION, values - DROP,FORWARD etc.)
#else
assume all values are supported
#end 


**Why I did it**

Seems to crash on many vendors because of lack of capability query support

**How I verified it**

Verify on system which supports attributes,
Simulate if system does not support and verify defaults are pushed to db

**Details if related**


