### PR TITLE
[portsyncd] Remove the port_config.ini dependency from portsyncd

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -35,9 +35,9 @@ bool g_init = false;
 
 void usage()
 {
-    cout << "Usage: portsyncd [-p port_config.ini]" << endl;
-    cout << "       -p port_config.ini: import port lane mapping" << endl;
-    cout << "                           use configDB data if not specified" << endl;
+    cout << "Usage: portsyncd" << endl;
+    cout << "       port lane mapping is from configDB" << endl;
+    cout << "       this program will exit if configDB does not contain that info" << endl;
 }
 
 void handlePortConfigFile(ProducerStateTable &p, string file, bool warm);
@@ -50,16 +50,12 @@ int main(int argc, char **argv)
 {
     Logger::linkToDbNative("portsyncd");
     int opt;
-    string port_config_file;
     map<string, KeyOpFieldsValuesTuple> port_cfg_map;
 
-    while ((opt = getopt(argc, argv, "p:v:h")) != -1 )
+    while ((opt = getopt(argc, argv, "v:h")) != -1 )
     {
         switch (opt)
         {
-        case 'p':
-            port_config_file.assign(optarg);
-            break;
         case 'h':
             usage();
             return 1;
@@ -91,11 +87,9 @@ int main(int argc, char **argv)
         if (!handlePortConfigFromConfigDB(p, cfgDb, warm))
         {
             // if port config is missing in ConfigDB
-            // attempt to use port_config.ini
-            if (!port_config_file.empty())
-            {
-                handlePortConfigFile(p, port_config_file, warm);
-            }
+            // program will exit with failure
+            SWSS_LOG_THROW("ConfigDB does not have port information, exiting...");
+            return EXIT_FAILURE;
         }
 
         LinkSync sync(&appl_db, &state_db);
@@ -220,97 +214,6 @@ bool handlePortConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb, boo
     }
 
     return true;
-}
-
-void handlePortConfigFile(ProducerStateTable &p, string file, bool warm)
-{
-    cout << "Read port configuration file..." << endl;
-
-    ifstream infile(file);
-    if (!infile.is_open())
-    {
-        usage();
-	throw runtime_error("Port configuration file not found!");
-    }
-
-    list<string> header = {"name", "lanes", "alias", "speed", "autoneg", "fec"};
-    string line;
-    while (getline(infile, line))
-    {
-        if (line.at(0) == '#')
-        {
-            // Take this line as column header line
-            istringstream iss_hdr(line.substr(1));
-            string hdr;
-
-            header.clear();
-            while (! iss_hdr.eof()) {
-                iss_hdr >> hdr;
-                cout << "Adding column header '" << hdr << "'" << endl;
-                header.push_back(hdr);
-            }
-
-            continue;
-        }
-
-        istringstream iss(line);
-        map<string, string> entry;
-
-        /* Read port configuration entry */
-        for (auto column : header)
-        {
-            iss >> entry[column];
-        }
-
-        if (!warm)
-        {
-            /* If port has no alias, then use its name as alias */
-            string alias;
-            if ((entry.find("alias") != entry.end()) && (entry["alias"] != ""))
-            {
-                alias = entry["alias"];
-            }
-            else
-            {
-                alias = entry["name"];
-            }
-
-            FieldValueTuple lanes_attr("lanes", entry["lanes"]);
-            FieldValueTuple alias_attr("alias", alias);
-
-            vector<FieldValueTuple> attrs;
-            attrs.push_back(lanes_attr);
-            attrs.push_back(alias_attr);
-
-            if ((entry.find("speed") != entry.end()) && (entry["speed"] != ""))
-            {
-                FieldValueTuple speed_attr("speed", entry["speed"]);
-                attrs.push_back(speed_attr);
-            }
-
-            if ((entry.find("autoneg") != entry.end()) && (entry["autoneg"] != ""))
-            {
-                FieldValueTuple autoneg_attr("autoneg", entry["autoneg"]);
-                attrs.push_back(autoneg_attr);
-            }
-
-            if ((entry.find("fec") != entry.end()) && (entry["fec"] != ""))
-            {
-                FieldValueTuple fec_attr("fec", entry["fec"]);
-                attrs.push_back(fec_attr);
-            }
-
-            p.set(entry["name"], attrs);
-        }
-
-        g_portSet.insert(entry["name"]);
-    }
-
-    infile.close();
-    if (!warm)
-    {
-        notifyPortConfigDone(p);
-    }
 }
 
 void handlePortConfig(ProducerStateTable &p, map<string, KeyOpFieldsValuesTuple> &port_cfg_map)


### PR DESCRIPTION
[portsyncd] Remove the port_config.ini dependency from portsyncd

portsyncd will rely on configDB port table, not from port_config.ini

port_config.ini is used when we convert minigraph to configDB, then
everything should come from configDB.

Also for the DPB feature, we are going to deprecate port_config.ini

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove the port_config.ini dependency from portsyncd

**Why I did it**
port_config.ini is used when we convert minigraph to configDB, then
everything should come from configDB.

Also for the DPB feature, we are going to deprecate port_config.ini

**How I verified it**
vs-test

**Details if related**
