### PR TITLE
Apply buffer profiles: not wait till kernel net_devices are created for all physical ports

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -806,7 +806,7 @@ void BufferOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
-    if (!gPortsOrch->isInitDone())
+    if (!gPortsOrch->isConfigDone())
     {
         return;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -394,12 +394,22 @@ bool PortsOrch::allPortsReady()
     return m_initDone && m_pendingPortSet.empty();
 }
 
-/* Upon receiving PortInitDone, all the configured ports have been created*/
+/* Upon receiving PortInitDone, all the configured ports have been created in both hardware and kernel*/
 bool PortsOrch::isInitDone()
 {
     return m_initDone;
 }
 
+// Upon m_portConfigState transiting to PORT_CONFIG_DONE state, all physical ports have been "created" in hardware.
+// Because of the asynchronous nature of sairedis calls, "create" in the strict sense means that the SAI create_port()
+// function is called and the create port event has been pushed to the sairedis pipeline. Because sairedis pipeline
+// preserves the order of the events received, any event that depends on the physical port being created first, e.g.,
+// buffer profile apply, will be popped in the FIFO fashion, processed in the right order after the physical port is
+// physically created in the ASIC, and thus can be issued safely when this function call returns true.
+bool PortsOrch::isConfigDone()
+{
+    return m_portConfigState == PORT_CONFIG_DONE;
+}
 
 map<string, Port>& PortsOrch::getAllPorts()
 {
@@ -1492,14 +1502,14 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
         if (alias == "PortConfigDone")
         {
-            if (m_portConfigDone)
+            if (m_portConfigState != PORT_CONFIG_MISSING)
             {
-                // Already done, ignore this task
+                // Already received, ignore this task
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
 
-            m_portConfigDone = true;
+            m_portConfigState = PORT_CONFIG_RECEIVED;
 
             for (auto i : kfvFieldsValues(t))
             {
@@ -1631,7 +1641,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
              * 2. Create new ports
              * 3. Initialize all ports
              */
-            if (m_portConfigDone && (m_lanesAliasSpeedMap.size() == m_portCount))
+            if (m_portConfigState == PORT_CONFIG_RECEIVED && (m_lanesAliasSpeedMap.size() == m_portCount))
             {
                 for (auto it = m_portListLaneMap.begin(); it != m_portListLaneMap.end();)
                 {
@@ -1676,9 +1686,11 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                     it = m_lanesAliasSpeedMap.erase(it);
                 }
+
+                m_portConfigState = PORT_CONFIG_DONE;
             }
 
-            if (!m_portConfigDone)
+            if (m_portConfigState != PORT_CONFIG_DONE)
             {
                 // Not yet receive PortConfigDone. Save it for future retry
                 it++;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -57,6 +57,7 @@ public:
 
     bool allPortsReady();
     bool isInitDone();
+    bool isConfigDone();
 
     map<string, Port>& getAllPorts();
     bool bake() override;
@@ -115,7 +116,14 @@ private:
     sai_object_id_t m_default1QBridge;
     sai_object_id_t m_defaultVlan;
 
-    bool m_portConfigDone = false;
+    typedef enum
+    {
+        PORT_CONFIG_MISSING,
+        PORT_CONFIG_RECEIVED,
+        PORT_CONFIG_DONE,
+    } port_config_state_t;
+
+    port_config_state_t m_portConfigState = PORT_CONFIG_MISSING;
     sai_uint32_t m_portCount;
     map<set<int>, sai_object_id_t> m_portListLaneMap;
     map<set<int>, tuple<string, uint32_t, int, string>> m_lanesAliasSpeedMap;


### PR DESCRIPTION
Apply buffer profiles when hardware physical ports are created

Introduce a mini state machine to track the portConfigState transition on receiving event from APPL_DB PORT_TABLE 

Signed-off-by: Wenda Ni <wenni@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**
On brcm dut

### Cold reboot
```
Oct 30 03:46:13.403689 str-dx010-acs-1 ERR swss#orchagent: :- doPortTask: m_portConfigState: key PortConfigDone received, transit to state PORT_CONFIG_RECEIVED*

Oct 30 03:46:14.346703 str-dx010-acs-1 ERR swss#orchagent: :- doPortTask: m_portConfigState: transit to state PORT_CONFIG_DONE

Oct 30 03:46:14.566002 str-dx010-acs-1 ERR swss#orchagent: :- doPortTask: admin up port Ethernet112
Oct 30 03:46:14.566813 str-dx010-acs-1 ERR swss#orchagent: :- doPortTask: m_portConfigState: state PORT_CONFIG_DONE

Oct 30 03:46:14.570333 str-dx010-acs-1 ERR swss#orchagent: :- doPortTask: admin up port Ethernet116
Oct 30 03:46:14.570545 str-dx010-acs-1 ERR swss#orchagent: :- doPortTask: m_portConfigState: state PORT_CONFIG_DONE
```
**Details if related**
