### PR TITLE
Check RIF/Port exists only for add entries

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -317,27 +317,27 @@ void NeighOrch::doTask(Consumer &consumer)
             continue;
         }
 
-        Port p;
-        if (!gPortsOrch->getPort(alias, p))
-        {
-            SWSS_LOG_INFO("Port %s doesn't exist", alias.c_str());
-            it++;
-            continue;
-        }
-
-        if (!p.m_rif_id)
-        {
-            SWSS_LOG_INFO("Router interface doesn't exist on %s", alias.c_str());
-            it++;
-            continue;
-        }
-
         IpAddress ip_address(key.substr(found+1));
 
         NeighborEntry neighbor_entry = { ip_address, alias };
 
         if (op == SET_COMMAND)
         {
+            Port p;
+            if (!gPortsOrch->getPort(alias, p))
+            {
+                SWSS_LOG_INFO("Port %s doesn't exist", alias.c_str());
+                it++;
+                continue;
+            }
+
+            if (!p.m_rif_id)
+            {
+                SWSS_LOG_INFO("Router interface doesn't exist on %s", alias.c_str());
+                it++;
+                continue;
+            }
+
             MacAddress mac_address;
             for (auto i = kfvFieldsValues(t).begin();
                  i  != kfvFieldsValues(t).end(); i++)


### PR DESCRIPTION
**What I did**
Check RIF/Port in case of set

**Why I did it**
During warmboot, we get neighbor delete notifications for Bridge member ports. This looks to be an indexing issue and transient. As a safety fix, the check for RIF is moved in orch to set case

Logs:

```
syslog.1:Sep  6 10:41:37.362397 DSM09T0 INFO kernel: [   74.426644] Bridge: port 25(Ethernet124) entered forwarding state
syslog.1:Sep  6 10:41:43.899725 DSM09T0 NOTICE swss#orchagent: :- addVlanMember: Add member Ethernet120 to VLAN Vlan809 vid:809 pid1000000000552
syslog.1:Sep  6 10:41:43.900683 DSM09T0 NOTICE swss#orchagent: :- addBridgePort: Add bridge port Ethernet124 to default 1Q bridge
syslog.1:Sep  6 10:41:43.901039 DSM09T0 NOTICE swss#orchagent: :- addVlanMember: Add member Ethernet124 to VLAN Vlan809 vid:809 pid1000000000594
syslog.1:Sep  6 10:41:51.779855 DSM09T0 INFO swss#restore_neighbor: Add neighbor entries: family: IPv6, intf_idx: 17, ip: 2603::a7c:e402, mac: 28:16:a8:fc:da:f4
syslog.1:Sep  6 10:41:51.780952 DSM09T0 WARNING swss#restore_neighbor: Neigh exists in kernel with family: IPv6, intf_idx: 17, ip: 2603::a7c:e402, mac: 28:16:a8:fc:da:f4
syslog.1:Sep  6 10:42:32.512011 DSM09T0 NOTICE swss#neighsyncd: :- insertToMap: NEIGH_TABLE, delete key: Ethernet124:2603::a7c:e405, 

```

**How I verified it**

**Details if related**
