### PR TITLE
Fix traceroute issue

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -91,7 +91,7 @@ static int cmdAddVxlanIntoVxlanIf(const swss::VxlanMgr::VxlanInfo & info, std::s
     // Change the MAC address of Vxlan bridge interface to ensure it's same with switch's.
     // Otherwise it will not response traceroute packets.
     // ip link set dev {{VXLAN_IF}} address {{MAC_ADDRESS}}
-    cmd << " && " IP_CMD "link set dev"
+    cmd << " && " IP_CMD " link set dev "
         << info.m_vxlanIf
         << " address "
         << info.m_macAddress;

--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -295,7 +295,7 @@ bool VxlanMgr::doVxlanCreateTask(const KeyOpFieldsValuesTuple & t)
     }
     
     // If the mac address has been set
-    info.m_macAddress = getSwitchMacAddress();
+    info.m_macAddress = getVxlanRouterMacAddress();
     if (info.m_macAddress.empty())
     {
         SWSS_LOG_DEBUG("Mac address is not ready");
@@ -452,7 +452,7 @@ bool VxlanMgr::isVxlanStateOk(const std::string & vxlanName)
     return false;
 }
 
-std::string VxlanMgr::getSwitchMacAddress()
+std::string VxlanMgr::getVxlanRouterMacAddress()
 {
     std::vector<FieldValueTuple> temp;
 

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -25,6 +25,7 @@ public:
         std::string m_vni;
         std::string m_vxlan;
         std::string m_vxlanIf;
+        std::string m_macAddress;
     } VxlanInfo;
     ~VxlanMgr();
 private:
@@ -47,6 +48,7 @@ private:
     */
     bool isVrfStateOk(const std::string & vrfName);
     bool isVxlanStateOk(const std::string & vxlanName);
+    std::string getSwitchMacAddress();
 
     bool createVxlan(const VxlanInfo & info);
     bool deleteVxlan(const VxlanInfo & info);
@@ -54,7 +56,7 @@ private:
     void clearAllVxlanDevices();
 
     ProducerStateTable m_appVxlanTunnelTable,m_appVxlanTunnelMapTable;
-    Table m_cfgVxlanTunnelTable,m_cfgVnetTable,m_stateVrfTable,m_stateVxlanTable;
+    Table m_cfgVxlanTunnelTable,m_cfgVnetTable,m_stateVrfTable,m_stateVxlanTable, m_appSwitchTable;
 
     /*
     * Vxlan Tunnel Cache

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace swss {
 
@@ -48,7 +49,7 @@ private:
     */
     bool isVrfStateOk(const std::string & vrfName);
     bool isVxlanStateOk(const std::string & vxlanName);
-    std::string getVxlanRouterMacAddress();
+    std::pair<bool, std::string> getVxlanRouterMacAddress();
 
     bool createVxlan(const VxlanInfo & info);
     bool deleteVxlan(const VxlanInfo & info);

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -48,7 +48,7 @@ private:
     */
     bool isVrfStateOk(const std::string & vrfName);
     bool isVxlanStateOk(const std::string & vxlanName);
-    std::string getSwitchMacAddress();
+    std::string getVxlanRouterMacAddress();
 
     bool createVxlan(const VxlanInfo & info);
     bool deleteVxlan(const VxlanInfo & info);


### PR DESCRIPTION
**What I did**

Change the MAC address of vxlan bridge to the switch's.

**Why I did it**

The vxlan device will not response the traceroute message if its MAC address isn't same with the switch's.

**How I verified it**

To compare the MAC address of switch's with the Brvxlanxxxx's. We expect that they are exactly same.


Signed-off-by: zegan@microsoft.com
