### PR TITLE
[vnet]: Correct VNET route table size for BITMAP implementation

### DIFF
--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -14,7 +14,7 @@
 #include "observer.h"
 
 #define VNET_BITMAP_SIZE 32
-#define VNET_TUNNEL_SIZE 512
+#define VNET_TUNNEL_SIZE 3072
 #define VNET_NEIGHBOR_MAX 0xffff
 #define VXLAN_ENCAP_TTL 128
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Corrected VNET route table size for BITMAP implementation
**Why I did it**
It wasn't updated according to current supported value which is 3K BITMAP VNET routes
**How I verified it**
Ran VNET ansible test for 3K BITMAP VNET routes
**Details if related**
N/A