### PR TITLE
Add/Del lag_name_map item when adding and removing lag.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -148,6 +148,12 @@ PortsOrch::PortsOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames)
     m_counter_db = shared_ptr<DBConnector>(new DBConnector(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0));
     m_counterTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_PORT_NAME_MAP));
 
+    m_counterLagTable = unique_ptr<Table>(new Table(m_counter_db.get(), COUNTERS_LAG_NAME_MAP));
+    FieldValueTuple tuple("", "");
+    vector<FieldValueTuple> defaultLagFv;
+    defaultLagFv.push_back(tuple);
+    m_counterLagTable->set("", defaultLagFv);
+
     /* Initialize port table */
     m_portTable = unique_ptr<Table>(new Table(db, APP_PORT_TABLE_NAME));
 
@@ -2943,6 +2949,11 @@ bool PortsOrch::addLag(string lag_alias)
     PortUpdate update = { lag, true };
     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
 
+    FieldValueTuple tuple(lag_alias, sai_serialize_object_id(lag_id));
+    vector<FieldValueTuple> fields;
+    fields.push_back(tuple);
+    m_counterLagTable->set("", fields);
+
     return true;
 }
 
@@ -2986,6 +2997,8 @@ bool PortsOrch::removeLag(Port lag)
 
     PortUpdate update = { lag, false };
     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
+
+    m_counterLagTable->hdel("", lag.m_alias);
 
     return true;
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -90,6 +90,7 @@ public:
     bool removeAclTableGroup(const Port &p);
 private:
     unique_ptr<Table> m_counterTable;
+    unique_ptr<Table> m_counterLagTable;
     unique_ptr<Table> m_portTable;
     unique_ptr<Table> m_queueTable;
     unique_ptr<Table> m_queuePortTable;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
The code is to add/del items in LAG_NAME_MAP_TABLE in COUNTERS_DB if a lag is added or removed. 
The code need the below pull request:
#51 in Azure/sonic-py-swsssdk 
read portchannel name from LAG_NAME_MAP_TABLE in COUNTERS_DB #51

**Why I did it**
For use of LAG_NAME_MAP_TABLE in COUNTERS_DB just like fdbshow.
I have create another pull request in Azure/sonic-utilities:
Show mac learned on lag interface #730

**How I verified it**

**Details if related**
