### PR TITLE
[vs tests]: Add mirror session warm reboot test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -777,15 +777,36 @@ class DockerVirtualSwitch(object):
         time.sleep(1)
 
     def remove_neighbor(self, interface, ip):
+        """
+            Removes a neighbor from the device. This method will wait 1 second
+            to allow redis updates to propagate.
+        """
         tbl = swsscommon.ProducerStateTable(self.pdb, "NEIGH_TABLE")
         tbl._del(interface + ":" + ip)
         time.sleep(1)
 
     def add_route(self, prefix, nexthop):
+        """
+            Adds a route from nexthop to prefix. This method will wait 1 second
+            to allow redis updates to propagate.
+        """
         self.runcmd("ip route add " + prefix + " via " + nexthop)
         time.sleep(1)
 
+    def update_route(self, prefix, nexthop):
+        """
+            Adds a route from nexthop to prefix, overwriting an existing route
+            to prefix. This method will wait 1 second to allow redis updates
+            to propagate.
+        """
+        self.runcmd("ip route change " + prefix + " via " + nexthop)
+        time.sleep(1)
+
     def add_route_ecmp(self, prefix, nexthops):
+        """
+            Adds an ecmp route from any of the provided nexthops to prefix.
+            This method will wait 1 second to allow redis updates to propagate.
+        """
         cmd = ""
         for nexthop in nexthops:
             cmd += " nexthop via " + nexthop
@@ -793,7 +814,24 @@ class DockerVirtualSwitch(object):
         self.runcmd("ip route add " + prefix + cmd)
         time.sleep(1)
 
+    def update_route_ecmp(self, prefix, nexthops):
+        """
+            Adds an ecmp route from any of the provided nexthops to prefix,
+            overwriting an existing ecmp route to prefix. This method will wait
+            1 second to allow redis updates to propagate.
+        """
+        cmd = ""
+        for nexthop in nexthops:
+            cmd += " nexthop via " + nexthop
+
+        self.runcmd("ip route change " + prefix + cmd)
+        time.sleep(1)
+
     def remove_route(self, prefix):
+        """
+            Removes a route to prefix. This method will wait 1 second to allow
+            redis updates to propagate.
+        """
         self.runcmd("ip route del " + prefix)
         time.sleep(1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -781,6 +781,22 @@ class DockerVirtualSwitch(object):
         tbl._del(interface + ":" + ip)
         time.sleep(1)
 
+    def add_route(self, prefix, nexthop):
+        self.runcmd("ip route add " + prefix + " via " + nexthop)
+        time.sleep(1)
+
+    def add_route_ecmp(self, prefix, nexthops):
+        cmd = ""
+        for nexthop in nexthops:
+            cmd += " nexthop via " + nexthop
+
+        self.runcmd("ip route add " + prefix + cmd)
+        time.sleep(1)
+
+    def remove_route(self, prefix):
+        self.runcmd("ip route del " + prefix)
+        time.sleep(1)
+
     def setup_db(self):
         self.pdb = swsscommon.DBConnector(0, self.redis_sock, 0)
         self.adb = swsscommon.DBConnector(1, self.redis_sock, 0)


### PR DESCRIPTION
**What I did**
Added a test case to validate that the monitor port is preserved during warm reboot.

**Why I did it**
To validate #1054 

**How I verified it**
```
daall@valhalla:~/dev/sonic-swss/tests$ sudo pytest -s -v --dvsname=vs test_warm_reboot.py::TestWarmReboot::test_MirrorSessionWarmReboot -s
=============================================================================================== test session starts ===============================================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python2
cachedir: .cache
rootdir: /home/daall/dev/sonic-swss/tests, inifile:
collected 1 item                                                                                                                                                                                                  

test_warm_reboot.py::TestWarmReboot::test_MirrorSessionWarmReboot remove extra link dummy
PASSED                                                                                                                                    [100%]

============================================================================================ 1 passed in 78.33 seconds ============================================================================================
```

**Details if related**
Continuation of #1097 