### PR TITLE
[MultiDB]: vs test conftest.py needs copy config file to mounted path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,6 +221,10 @@ class DockerVirtualSwitch(object):
                     network_mode="container:%s" % self.ctn_sw.name,
                     volumes={ self.mount: { 'bind': '/var/run/redis', 'mode': 'rw' } })
 
+        self.dst_dbconfig_path = "{}/sonic-db".format(self.mount)
+        self.src_dbconfig_file = "/var/run/redis/sonic-db/database_config.json"
+        os.system("mkdir -p {}".format(self.dst_dbconfig_path))
+        os.system("cp {} {}".format(self.src_dbconfig_file, self.dst_dbconfig_path))
         self.appldb = None
         self.redis_sock = self.mount + '/' + "redis.sock"
         try:


### PR DESCRIPTION
* together with https://github.com/Azure/sonic-swss-common/pull/315
*vs test mount host:/var/run/redis-vs/{sw_name} to vs:var/run/redis/, so we need to copy the host:/var/run/redis/sonic-db/database_config.json to host:/var/run/redis-vs/{sw_name}/sonic-db/ and the vs can use this database_config.json file.
* I am not sure why the mount name is different from /var/run/redis/, if it is the same, then we don't need copy.  and  https://github.com/Azure/sonic-swss-common/pull/315 . is enough.

Signed-off-by: Dong Zhang d.zhang@alibaba-inc.com