### PR TITLE
Cleanup configure.ac from BFN specific code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,10 +36,6 @@ AM_CONDITIONAL(DEBUG, test x$debug = xtrue)
 
 CFLAGS_COMMON="-std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/libnl3 -I/usr/include/swss"
 
-AM_CONDITIONAL(sonic_asic_platform_barefoot,   test x$CONFIGURED_PLATFORM = xbarefoot)
-AM_COND_IF([sonic_asic_platform_barefoot],
-           [CFLAGS_COMMON+=" -I/opt/bfn/install/include/switchsai"])
-
 CFLAGS_COMMON+=" -Werror"
 CFLAGS_COMMON+=" -Wno-reorder"
 CFLAGS_COMMON+=" -Wcast-align"


### PR DESCRIPTION
Signed-off-by: Andriy Kokhan <akokhan@barefootnetworks.com>

**What I did**
Removed BFN specific code from configure.ac

**Why I did it**
Migration from libswitchsai to libsai

**How I verified it**
Private build of BFN target