### PR TITLE
[bitmap_vnet]: Fix removal flow for tunnel route

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1102,7 +1102,7 @@ bool VNetBitmapObject::removeTunnelRoute(IpPrefix& ipPrefix)
         throw std::runtime_error("VNET tunnel route removal failed");
     }
 
-    auto endpointInfo = endpointMap_.at(endpoint);
+    auto& endpointInfo = endpointMap_.at(endpoint);
 
     sai_status_t status;
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed removal flow for BITMAP VNET tunnel route

**Why I did it**

There was a mistake in BITMAP VNET code that caused ```used_count``` for endpoints not to be decremented during removing tunnel route. As a result some SDK resources were not fully removed in case one endpoint is shared between two or more tunnel routes.

**How I verified it**
* Configured multiple VNET tunnel routes with the one shared endpoint
* Removed all the configured tunnel routes
* Verified that all CRM counters are updated as expected

**Details if related**
N/A