### PR TITLE
[cfgmgr] clear loopback and vrf in kernel if not warmstart

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -7,6 +7,7 @@
 #include "intfmgr.h"
 #include "exec.h"
 #include "shellcmd.h"
+#include "warm_restart.h"
 
 using namespace std;
 using namespace swss;
@@ -29,6 +30,10 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_stateIntfTable(stateDb, STATE_INTERFACE_TABLE_NAME),
         m_appIntfTableProducer(appDb, APP_INTF_TABLE_NAME)
 {
+    if (!WarmStart::isWarmStart())
+    {
+        flushLoopbackIntfs();
+    }
 }
 
 void IntfMgr::setIntfIp(const string &alias, const string &opCmd,
@@ -104,6 +109,27 @@ void IntfMgr::delLoopbackIntf(const string &alias)
     if (ret)
     {
         SWSS_LOG_ERROR("Command '%s' failed with rc %d", cmd.str().c_str(), ret);
+    }
+}
+
+void IntfMgr::flushLoopbackIntfs()
+{
+    stringstream cmd;
+    string res;
+
+    cmd << IP_CMD << " link show type dummy | grep -o '" << LOOPBACK_PREFIX << "[^:]*'";
+
+    int ret = swss::exec(cmd.str(), res);
+    if (ret)
+    {
+        SWSS_LOG_DEBUG("Command '%s' failed with rc %d", cmd.str().c_str(), ret);
+        return;
+    }
+
+    auto aliases = tokenize(res, '\n');
+    for (string &alias : aliases)
+    {
+        delLoopbackIntf(alias);
     }
 }
 

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -129,6 +129,7 @@ void IntfMgr::flushLoopbackIntfs()
     auto aliases = tokenize(res, '\n');
     for (string &alias : aliases)
     {
+        SWSS_LOG_NOTICE("Remove loopback device %s", alias.c_str());
         delLoopbackIntf(alias);
     }
 }

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -34,6 +34,7 @@ private:
     int getIntfIpCount(const std::string &alias);
     void addLoopbackIntf(const std::string &alias);
     void delLoopbackIntf(const std::string &alias);
+    void flushLoopbackIntfs(void);
 
     void addHostSubIntf(const std::string&intf, const std::string &subIntf, const std::string &vlan);
     void setHostSubIntfMtu(const std::string &subIntf, const std::string &mtu);

--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -8,6 +8,7 @@
 #include "intfmgr.h"
 #include <fstream>
 #include <iostream>
+#include "warm_restart.h"
 
 using namespace std;
 using namespace swss;
@@ -51,6 +52,9 @@ int main(int argc, char **argv)
         DBConnector cfgDb(CONFIG_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
         DBConnector appDb(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
         DBConnector stateDb(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+
+        WarmStart::initialize("intfmgrd", "swss");
+        WarmStart::checkWarmStart("intfmgrd", "swss");
 
         IntfMgr intfmgr(&cfgDb, &appDb, &stateDb, cfg_intf_tables);
 

--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -7,6 +7,7 @@
 #include "vrfmgr.h"
 #include "exec.h"
 #include "shellcmd.h"
+#include "warm_restart.h"
 
 #define VRF_TABLE_START 1001
 #define VRF_TABLE_END 2000
@@ -58,9 +59,23 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
                 rowType = DETAILS_ROW;
                 break;
             case DETAILS_ROW:
-                table = static_cast<uint32_t>(stoul(items[6]));
-                m_vrfTableMap[vrfName] = table;
-                m_freeTables.erase(table);
+                if (WarmStart::isWarmStart())
+                {
+                    table = static_cast<uint32_t>(stoul(items[6]));
+                    m_vrfTableMap[vrfName] = table;
+                    m_freeTables.erase(table);
+                }
+                else
+                {
+                    cmd.str("");
+                    cmd.clear();
+                    cmd << IP_CMD << " link del " << vrfName;
+                    int ret = swss::exec(cmd.str(), res);
+                    if (ret)
+                    {
+                        SWSS_LOG_ERROR("Command '%s' failed with rc %d", cmd.str().c_str(), ret);
+                    }
+                }
                 rowType = LINK_ROW;
                 break;
         }

--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -67,6 +67,7 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
                 }
                 else
                 {
+                    SWSS_LOG_NOTICE("Remove vrf device %s", vrfName.c_str());
                     cmd.str("");
                     cmd.clear();
                     cmd << IP_CMD << " link del " << vrfName;

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -8,6 +8,7 @@
 #include "vrfmgr.h"
 #include <fstream>
 #include <iostream>
+#include "warm_restart.h"
 
 using namespace std;
 using namespace swss;
@@ -48,6 +49,9 @@ int main(int argc, char **argv)
         DBConnector cfgDb(CONFIG_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
         DBConnector appDb(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
         DBConnector stateDb(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+
+        WarmStart::initialize("vrfmgrd", "swss");
+        WarmStart::checkWarmStart("vrfmgrd", "swss");
 
         VrfMgr vrfmgr(&cfgDb, &appDb, &stateDb, cfg_vrf_tables);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Clear loopback interfaces in kernel at intfmgrd starting except warmstart.
Clear vrf interfaces in kernel at vrfmgrd starting except warmstart.

**Why I did it**
After loopback moved to intfmgrd, the behavior is changed. 
[issue #3814](https://github.com/Azure/sonic-buildimage/issues/3814)

**How I verified it**
tests

**Details if related**
