### PR TITLE
[port/buffer] introduce a sync mechanism to protect port PG/queue from changes under PFC storm

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -562,6 +562,11 @@ task_process_status BufferOrch::processQueue(Consumer &consumer)
                 SWSS_LOG_ERROR("Invalid queue index specified:%zd", ind);
                 return task_process_status::task_invalid_entry;
             }
+            if (port.m_queue_lock[ind])
+            {
+                SWSS_LOG_WARN("Queue %zd on port %s is locked, will retry", ind, port_name.c_str());
+                return task_process_status::task_need_retry;
+            }
             queue_id = port.m_queue_ids[ind];
             SWSS_LOG_DEBUG("Applying buffer profile:0x%" PRIx64 " to queue index:%zd, queue sai_id:0x%" PRIx64, sai_buffer_profile, ind, queue_id);
             sai_status_t sai_status = sai_queue_api->set_queue_attribute(queue_id, &attr);
@@ -660,6 +665,11 @@ task_process_status BufferOrch::processPriorityGroup(Consumer &consumer)
             {
                 SWSS_LOG_ERROR("Invalid pg index specified:%zd", ind);
                 return task_process_status::task_invalid_entry;
+            }
+            if (port.m_priority_group_lock[ind])
+            {
+                SWSS_LOG_WARN("Priority group %zd on port %s is locked, will retry", ind, port_name.c_str());
+                return task_process_status::task_need_retry;
             }
             pg_id = port.m_priority_group_ids[ind];
             SWSS_LOG_DEBUG("Applying buffer profile:0x%" PRIx64 " to port:%s pg index:%zd, pg sai_id:0x%" PRIx64, sai_buffer_profile, port_name.c_str(), ind, pg_id);

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -441,7 +441,7 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
         return;
     }
 
-    lockUnlockPriorityGroupAndQueue(portInstance, true);
+    setPriorityGroupAndQueueLockFlag(portInstance, true);
 
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
@@ -536,18 +536,18 @@ PfcWdZeroBufferHandler::~PfcWdZeroBufferHandler(void)
         return;
     }
 
-    lockUnlockPriorityGroupAndQueue(portInstance, false);
+    setPriorityGroupAndQueueLockFlag(portInstance, false);
 }
 
-void PfcWdZeroBufferHandler::lockUnlockPriorityGroupAndQueue(Port& port, bool lock) const
+void PfcWdZeroBufferHandler::setPriorityGroupAndQueueLockFlag(Port& port, bool isLocked) const
 {
     // set lock bits on PG and queue
-    port.m_priority_group_lock[static_cast<size_t>(getQueueId())] = lock;
+    port.m_priority_group_lock[static_cast<size_t>(getQueueId())] = isLocked;
     for (size_t i = 0; i < port.m_queue_ids.size(); ++i)
     {
         if (port.m_queue_ids[i] == getQueue())
         {
-            port.m_queue_lock[i] = lock;
+            port.m_queue_lock[i] = isLocked;
         }
     }
     gPortsOrch->setPort(port.m_alias, port);

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -542,7 +542,7 @@ PfcWdZeroBufferHandler::~PfcWdZeroBufferHandler(void)
 void PfcWdZeroBufferHandler::lockUnlockPriorityGroupAndPort(Port& port, bool lock) const
 {
     // set lock bits on PG and queue
-    port.m_priority_group_lock[static_cast<size_t>(getQueueId())] = false;
+    port.m_priority_group_lock[static_cast<size_t>(getQueueId())] = lock;
     for (size_t i = 0; i < port.m_queue_ids.size(); ++i)
     {
         if (port.m_queue_ids[i] == getQueue())

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -434,6 +434,15 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
 {
     SWSS_LOG_ENTER();
 
+    Port portInstance;
+    if (!gPortsOrch->getPort(port, portInstance))
+    {
+        SWSS_LOG_ERROR("Cannot get port by ID 0x%" PRIx64, port);
+        return;
+    }
+
+    lockUnlockPriorityGroupAndPort(portInstance, true);
+
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
 
@@ -462,13 +471,6 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
     m_originalQueueBufferProfile = oldQueueProfileId;
 
     // Get PG
-    Port portInstance;
-    if (!gPortsOrch->getPort(port, portInstance))
-    {
-        SWSS_LOG_ERROR("Cannot get port by ID 0x%" PRIx64, port);
-        return;
-    }
-
     sai_object_id_t pg = portInstance.m_priority_group_ids[static_cast <size_t> (queueId)];
 
     attr.id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
@@ -533,6 +535,22 @@ PfcWdZeroBufferHandler::~PfcWdZeroBufferHandler(void)
         SWSS_LOG_ERROR("Failed to set buffer profile ID on queue 0x%" PRIx64 ": %d", getQueue(), status);
         return;
     }
+
+    lockUnlockPriorityGroupAndPort(portInstance, false);
+}
+
+void PfcWdZeroBufferHandler::lockUnlockPriorityGroupAndPort(Port& port, bool lock) const
+{
+    // set lock bits on PG and queue
+    port.m_priority_group_lock[static_cast<size_t>(getQueueId())] = false;
+    for (size_t i = 0; i < port.m_queue_ids.size(); ++i)
+    {
+        if (port.m_queue_ids[i] == getQueue())
+        {
+            port.m_queue_lock[i] = lock;
+        }
+    }
+    gPortsOrch->setPort(port.m_alias, port);
 }
 
 PfcWdZeroBufferHandler::ZeroBufferProfile::ZeroBufferProfile(void)

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -441,7 +441,7 @@ PfcWdZeroBufferHandler::PfcWdZeroBufferHandler(sai_object_id_t port,
         return;
     }
 
-    lockUnlockPriorityGroupAndPort(portInstance, true);
+    lockUnlockPriorityGroupAndQueue(portInstance, true);
 
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
@@ -536,10 +536,10 @@ PfcWdZeroBufferHandler::~PfcWdZeroBufferHandler(void)
         return;
     }
 
-    lockUnlockPriorityGroupAndPort(portInstance, false);
+    lockUnlockPriorityGroupAndQueue(portInstance, false);
 }
 
-void PfcWdZeroBufferHandler::lockUnlockPriorityGroupAndPort(Port& port, bool lock) const
+void PfcWdZeroBufferHandler::lockUnlockPriorityGroupAndQueue(Port& port, bool lock) const
 {
     // set lock bits on PG and queue
     port.m_priority_group_lock[static_cast<size_t>(getQueueId())] = lock;

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -127,7 +127,7 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
          * Sets lock bits on port's priority group and queue
          * to protect them from beeing changed by other Orch's
          */
-        void lockUnlockPriorityGroupAndQueue(Port& port, bool lock) const;
+        void setPriorityGroupAndQueueLockFlag(Port& port, bool isLocked) const;
 
         // Singletone class for keeping shared data - zero buffer profiles
         class ZeroBufferProfile

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -31,17 +31,17 @@ class PfcWdActionHandler
                 uint8_t queueId, shared_ptr<Table> countersTable);
         virtual ~PfcWdActionHandler(void);
 
-        inline sai_object_id_t getPort(void)
+        inline sai_object_id_t getPort(void) const
         {
             return m_port;
         }
 
-        inline sai_object_id_t getQueue(void)
+        inline sai_object_id_t getQueue(void) const
         {
             return m_queue;
         }
 
-        inline sai_object_id_t getQueueId(void)
+        inline uint8_t getQueueId(void) const
         {
             return m_queueId;
         }
@@ -123,6 +123,8 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
         virtual ~PfcWdZeroBufferHandler(void);
 
     private:
+        void lockUnlockPriorityGroupAndPort(Port& port, bool lock) const;
+
         // Singletone class for keeping shared data - zero buffer profiles
         class ZeroBufferProfile
         {

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -123,7 +123,11 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
         virtual ~PfcWdZeroBufferHandler(void);
 
     private:
-        void lockUnlockPriorityGroupAndPort(Port& port, bool lock) const;
+        /*
+         * Sets lock bits on port's priority group and queue
+         * to protect them from beeing changed by other Orch's
+         */
+        void lockUnlockPriorityGroupAndQueue(Port& port, bool lock) const;
 
         // Singletone class for keeping shared data - zero buffer profiles
         class ZeroBufferProfile

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -96,6 +96,16 @@ public:
     std::vector<sai_object_id_t> m_priority_group_ids;
     sai_port_priority_flow_control_mode_t m_pfc_asym = SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED;
     uint8_t m_pfc_bitmask = 0;
+    /*
+     * Following two bit vectors are used to lock
+     * the PG/queue from beeing changed in BufferOrch.
+     * The use case scenario is when PfcWdZeroBufferHandler
+     * sets zero buffer profile it should protect PG/queue
+     * from beeing overriten in BufferOrch.
+     */
+    std::vector<bool> m_queue_lock;
+    std::vector<bool> m_priority_group_lock;
+
 };
 
 }

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -98,10 +98,10 @@ public:
     uint8_t m_pfc_bitmask = 0;
     /*
      * Following two bit vectors are used to lock
-     * the PG/queue from beeing changed in BufferOrch.
+     * the PG/queue from being changed in BufferOrch.
      * The use case scenario is when PfcWdZeroBufferHandler
      * sets zero buffer profile it should protect PG/queue
-     * from beeing overriten in BufferOrch.
+     * from being overwritten in BufferOrch.
      */
     std::vector<bool> m_queue_lock;
     std::vector<bool> m_priority_group_lock;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2608,6 +2608,7 @@ void PortsOrch::initializeQueues(Port &port)
     SWSS_LOG_INFO("Get %d queues for port %s", attr.value.u32, port.m_alias.c_str());
 
     port.m_queue_ids.resize(attr.value.u32);
+    port.m_queue_lock.resize(attr.value.u32);
 
     if (attr.value.u32 == 0)
     {
@@ -2643,6 +2644,7 @@ void PortsOrch::initializePriorityGroups(Port &port)
     SWSS_LOG_INFO("Get %d priority groups for port %s", attr.value.u32, port.m_alias.c_str());
 
     port.m_priority_group_ids.resize(attr.value.u32);
+    port.m_priority_group_lock.resize(attr.value.u32);
 
     if (attr.value.u32 == 0)
     {

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -54,3 +54,4 @@ extern sai_tunnel_api_t *sai_tunnel_api;
 extern sai_next_hop_api_t *sai_next_hop_api;
 extern sai_hostif_api_t *sai_hostif_api;
 extern sai_buffer_api_t *sai_buffer_api;
+extern sai_queue_api_t *sai_queue_api;

--- a/tests/mock_tests/ut_saihelper.cpp
+++ b/tests/mock_tests/ut_saihelper.cpp
@@ -77,6 +77,7 @@ namespace ut_helper
         sai_api_query(SAI_API_ACL, (void **)&sai_acl_api);
         sai_api_query(SAI_API_HOSTIF, (void **)&sai_hostif_api);
         sai_api_query(SAI_API_BUFFER, (void **)&sai_buffer_api);
+        sai_api_query(SAI_API_QUEUE, (void **)&sai_queue_api);
 
         return SAI_STATUS_SUCCESS;
     }
@@ -99,6 +100,7 @@ namespace ut_helper
         sai_acl_api = nullptr;
         sai_hostif_api = nullptr;
         sai_buffer_api = nullptr;
+        sai_queue_api = nullptr;
     }
 
     map<string, vector<FieldValueTuple>> getInitialSaiPorts()


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I introduce a sync mechanism to protect port PG/queue from changes under PFC storm.

**Why I did it**

Under warm reboot conditions on Mellanox platform, buffermgrd starts after BufferOrch gets initialized and sets initial state to DB; after reconciliation BufferOrch reacts on those changes and sets PG profile overriding PG profile set by PfcWdOrch.

**How I verified it**
Run PFC WD + warm reboot test cases.
Mannual restart of buffermgrd when port is under PFC storm - verified PG profile was not overriten.
After storm, PG profile was set according to config db.

**Details if related**
