### PR TITLE
teamsyncd::Additional checks put inplace to make sure the netlink message is valid

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -12,6 +12,10 @@
 #include "warm_restart.h"
 #include "teamsync.h"
 
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include <unistd.h>
 
 using namespace std;
@@ -20,6 +24,7 @@ using namespace swss;
 
 /* Taken from drivers/net/team/team.c */
 #define TEAM_DRV_NAME "team"
+#define PID_FILE_PATH "/var/run/teamd/"
 
 TeamSync::TeamSync(DBConnector *db, DBConnector *stateDb, Select *select) :
     m_select(select),
@@ -193,6 +198,22 @@ void TeamSync::onMsg(int nlmsg_type, struct nl_object *obj)
                        nlmsg_type, lagName.c_str(), admin, oper, ifindex);
     }
 
+    unsigned int flags = rtnl_link_get_flags(link);
+    bool admin = flags & IFF_UP;
+    bool oper = flags & IFF_LOWER_UP;
+    unsigned int ifindex = rtnl_link_get_ifindex(link);
+
+    if (type)
+    {
+        SWSS_LOG_INFO(" nlmsg type:%d key:%s admin:%d oper:%d ifindex:%d type:%s",
+                       nlmsg_type, lagName.c_str(), admin, oper, ifindex, type);
+    }
+    else
+    {
+        SWSS_LOG_INFO(" nlmsg type:%d key:%s admin:%d oper:%d ifindex:%d",
+                       nlmsg_type, lagName.c_str(), admin, oper, ifindex);
+    }
+
     if (nlmsg_type == RTM_DELLINK)
     {
         if (m_teamSelectables.find(lagName) != m_teamSelectables.end())
@@ -283,6 +304,37 @@ void TeamSync::removeLag(const string &lagName)
     }
 
     m_selectablesToRemove.insert(lagName);
+}
+
+#define MAX_PID_STRLEN 10
+void TeamSync::cleanTeamProcesses(int signo)
+{
+    ssize_t sz = 0;
+    int fd, pid;
+    char pid_str[MAX_PID_STRLEN] = {0};
+    char *endptr = NULL;
+    string file_path;
+
+    for (auto it=m_teamSelectables.begin(); it!=m_teamSelectables.end(); ++it)
+    {
+       /* There are PID files created for each teamd process in /var/run/teamd DIR */
+       file_path = string(PID_FILE_PATH) + it->first + string(".pid");
+
+       /* Open the file, get the PID and send signal to the process */
+       fd = open(file_path.c_str(), O_RDONLY);
+       if (fd > 0)
+       {
+           sz = read(fd, pid_str, MAX_PID_STRLEN);
+           if(sz) {
+               pid_str[sz] = '\0';
+               pid = (pid_t)strtol(pid_str, &endptr, 10);
+               kill(pid, signo);
+           }
+       }
+       close(fd);
+       file_path.clear();
+    }
+    return;
 }
 
 const struct team_change_handler TeamSync::TeamPortSync::gPortChangeHandler = {

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -65,11 +65,16 @@ protected:
     /* Handle all selectables add/removal events */
     void doSelectableTask();
 
+    /* Get the interface name for ifindex */
+    std::string ifindexToName(int ifindex);
+
 private:
     Select *m_select;
     ProducerStateTable m_lagTable;
     ProducerStateTable m_lagMemberTable;
     Table m_stateLagTable;
+    nl_cache *m_link_cache;
+    nl_sock *m_nl_sock;
 
     bool m_warmstart;
     std::unordered_map<std::string, std::vector<FieldValueTuple>> m_stateLagTablePreserved;

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -65,8 +65,8 @@ protected:
     /* Handle all selectables add/removal events */
     void doSelectableTask();
 
-    /* Get the interface name for ifindex */
-    std::string ifindexToName(int ifindex);
+    /* Compare the interface name with that retrieved with ifindex */
+    bool checkIfindexToName(int ifindex, const std::string &name);
 
 private:
     Select *m_select;

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -25,6 +25,7 @@ public:
     TeamSync(DBConnector *db, DBConnector *stateDb, Select *select);
 
     void periodic();
+    void cleanTeamProcesses(int signo);
 
     /* Listen to RTM_NEWLINK, RTM_DELLINK to track team devices */
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);


### PR DESCRIPTION
**What I did**

Added additional checks in the netlink message handling of teamsyncd to make sure the message is for a valid interface with ifindex and name. This is using the netlink cache infrastructure to check if the interface name retrieved from cache with the ifindex is matching with the interfaceName in the netlink NEW LINK create message. If the interface name is not same, we drop the message.

**Why I did it**

Have seen random cases where teamsyncd fails and the stack trace was showing interface name as NULL and the ifindex an incorrect one.

**How I verified it**

Could not get the exact reproduction scenario, but induced these errors manually and found the teamsyncd staying up.

**Details if related**
