### PR TITLE
[aclorch] Enable DSCP rules on IPv6 mirror tables

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1427,7 +1427,7 @@ bool AclTable::create()
     attr.value.s32 = acl_stage;
     table_attrs.push_back(attr);
 
-    if (type == ACL_TABLE_MIRROR)
+    if (type == ACL_TABLE_MIRROR || type == ACL_TABLE_MIRRORV6)
     {
         attr.id = SAI_ACL_TABLE_ATTR_FIELD_DSCP;
         attr.value.booldata = true;


### PR DESCRIPTION
- Enable DSCP field for MIRRORV6 tables
- Add vs test for MIRRORV6 table initialization

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I enabled the DSCP field for MIRRORV6 tables.

**Why I did it**
I did it to allow users to add DSCP ACL rules to MIRRORV6 tables.

**How I verified it**
I added a virtual switch test "test_MirrorV6TableCreation" to validate that ASIC DB is updated correctly.
```
daall@valhalla:~/dev/sonic-swss/tests$ sudo pytest -s -v --dvsname=vs test_mirror_ipv6_separate.py::TestMirror
============================================= test session starts ==============================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python2
cachedir: .cache
rootdir: /home/daall/dev/sonic-swss/tests, inifile:
collected 5 items                                                                                              

test_mirror_ipv6_separate.py::TestMirror::test_MirrorV6TableCreation PASSED [ 20%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorSeparated PASSED [ 40%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6Reorder1 PASSED [ 60%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6Reorder2 PASSED [ 80%]
test_mirror_ipv6_separate.py::TestMirror::test_AclBindMirrorV6WrongConfig PASSED [100%]

========================== 5 passed in 122.29 seconds ==========================
```

**Details if related**
N/A