### PR TITLE
DPB: Infra code to track dependencies on Port object

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -48,6 +48,24 @@ public:
         UNKNOWN
     } ;
 
+    enum Dependency {
+        ACL_DEP,
+        FDB_DEP,
+        INTF_DEP,
+        LAG_DEP,
+        VLAN_DEP,
+        MAX_DEP
+    };
+
+    std::unordered_map<Dependency, std::string>
+    m_dependency_string = {
+        {ACL_DEP, "ACL"},
+        {FDB_DEP, "FDB"},
+        {INTF_DEP, "INTF"},
+        {LAG_DEP, "LAG"},
+        {VLAN_DEP, "VLAN"}
+    };
+
     Port() {};
     Port(std::string alias, Type type) :
             m_alias(alias), m_type(type) {};
@@ -65,6 +83,38 @@ public:
     inline bool operator!=(const Port &o) const
     {
         return !(*this == o);
+    }
+
+    inline void set_dependency(Dependency dep)
+    {
+        m_dependency_bitmap |= (1 << dep);
+    }
+
+    inline void clear_dependency(Dependency dep)
+    {
+        m_dependency_bitmap &= ~(1 << dep);
+    }
+
+    inline bool has_dependency()
+    {
+        return (m_dependency_bitmap != 0);
+    }
+
+    std::string print_dependency()
+    {
+        std::string deps="";
+        uint32_t dep_bitmap = m_dependency_bitmap;
+
+        for (int dep = ACL_DEP; dep < MAX_DEP && dep_bitmap; ++dep)
+        {
+            uint32_t mask = (1 << dep);
+
+            if (dep_bitmap & mask) {
+                deps += m_dependency_string[static_cast<Dependency>(dep)] + " ";
+                dep_bitmap &= ~mask;
+            }
+        }
+        return deps;
     }
 
     std::string         m_alias;
@@ -89,6 +139,7 @@ public:
     sai_object_id_t     m_egress_acl_table_group_id = 0;
     vlan_members_t      m_vlan_members;
     sai_object_id_t     m_parent_port_id = 0;
+    uint32_t            m_dependency_bitmap = 0;
     sai_port_oper_status_t m_oper_status = SAI_PORT_OPER_STATUS_UNKNOWN;
     std::set<std::string> m_members;
     std::set<std::string> m_child_ports;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2110,7 +2110,14 @@ void PortsOrch::doPortTask(Consumer &consumer)
         }
         else
         {
-            SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+            if (m_portList[alias].has_dependency())
+            {
+                // Port has one or more dependencies, cannot remove
+                SWSS_LOG_WARN("Please remove port dependenc(y/ies):%s",
+                               m_portList[alias].print_dependency().c_str());
+                it++;
+                continue;
+            }
         }
 
         it = consumer.m_toSync.erase(it);
@@ -2430,6 +2437,15 @@ void PortsOrch::doLagTask(Consumer &consumer)
             if (!getPort(alias, lag))
             {
                 it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            if (m_portList[alias].has_dependency())
+            {
+                // LAG has one or more dependencies, cannot remove
+                SWSS_LOG_WARN("Please remove LAG dependenc(y/ies):%s",
+                               m_portList[alias].print_dependency().c_str());
+                it++;
                 continue;
             }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added infrastructure code to track objects dependent on Port. 

**Why I did it**

To support Dynamic PortBreakout feature, we need to support deletion of Port. But before deleting a port, we need to cleanup the objects dependent on Port. For example, VLAN members, ACL polrt list, interfaces, etc.

**How I verified it**

This code has been used with ACL and VLAN dependency handling code for DPB feature. PRs for those will raised soon. I have verified for both those PRs that existing VS test cases and feature related test cases pass.

**Details if related**

Before deleting a port, we will check if any module/feature/object is depending on port. If so, we will skip the port and pict the next one in the queue. That is until the dependency are removed, we keep looping the doPortTask. Once all dependencies are removed, we will delete the port. 
