### PR TITLE
Changing the DPB fixure to get breakout cfg table

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -836,3 +836,30 @@ def testlog(request, dvs):
     dvs.runcmd("logger === start test %s ===" % request.node.name)
     yield testlog
     dvs.runcmd("logger === finish test %s ===" % request.node.name)
+
+##################### DPB fixtures ###########################################
+
+HWSKU="Force10-S6000"
+
+@pytest.yield_fixture(scope="module")
+def create_dpb_config_file(dvs):
+    cmd = "sonic-cfggen -p /usr/share/sonic/hwsku/platform.json -k {} --print-data > /tmp/ports.json".format(HWSKU)
+    dvs.runcmd(['sh', '-c', cmd])
+    cmd = "sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/ports.json --print-data > /tmp/dpb_config_db.json"
+    dvs.runcmd(['sh', '-c', cmd])
+    cmd = "mv /etc/sonic/config_db.json /etc/sonic/config_db.json.bak"
+    dvs.runcmd(cmd)
+    cmd = "cp /tmp/dpb_config_db.json /etc/sonic/config_db.json"
+    dvs.runcmd(cmd)
+
+@pytest.yield_fixture(scope="module")
+def remove_dpb_config_file(dvs):
+    cmd = "mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json"
+    dvs.runcmd(cmd)
+
+@pytest.yield_fixture(scope="module")
+def dpb_setup_fixture(dvs):
+    create_dpb_config_file(dvs)
+    dvs.restart()
+    yield
+    remove_dpb_config_file(dvs)


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**What I did**
Generating "BREAKOUT_CFG" table in config DB for running DPB test case.

**Why I did it**

This PR is needed for [DPB TEST PR](https://github.com/Azure/sonic-buildimage/pull/3910)


**How to verify it**
Verified using VS test case mentioned [here](https://github.com/Azure/sonic-buildimage/pull/3910)
```
samaity@server09:~/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests/breakout$ sudo pytest -s -v --dvsname=vs-sang test_breakout_cli.py
========================================================================================= test session starts =========================================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/DPB/sonic-buildimage/platform/vs/tests/breakout, inifile:
collected 2 items

test_breakout_cli.py::TestBreakoutCli::test_InitialBreakoutMode remove extra link dummy
PASSED                                                                                      [ 50%]
test_breakout_cli.py::TestBreakoutCli::test_mode_1X100G **** Breakout Cli test Starts ****
**** 1X100G --> 2x50G passed ****
**** 2x50G --> 1x100G[40G] passed ****
**** 1X100G --> 4x25G[10G] passed ****
**** 4x25G[10G] --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 2x25G(2)+1x50G(2) passed ****
**** 2x25G(2)+1x50G(2) --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 1x50G(2)+2x25G(2)  passed ****
**** 1x50G(2)+2x25G(2) --> 1x100G[40G] passed ****
**** 1x100G[40G] --> 2x50G  passed ****
**** 2x50G --> 2x25G(2)+1x50G(2)  passed ****
**** 1x50G(2)+2x25G(2) --> 2x25G(2)+1x50G(2)  passed ****
**** 2x25G(2)+1x50G(2)  --> 1x100G[40G]  passed ****
PASSED                                                                                      [100%]
```