### PR TITLE
Move away sairedis logrotate from signal handler

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -47,6 +47,7 @@ int gBatchSize = DEFAULT_BATCH_SIZE;
 bool gSairedisRecord = true;
 bool gSwssRecord = true;
 bool gLogRotate = false;
+bool gSaiRedisLogRotate = false;
 bool gSyncMode = false;
 
 ofstream gRecordOfs;
@@ -73,15 +74,7 @@ void sighup_handler(int signo)
      * Don't do any logging since they are using mutexes.
      */
     gLogRotate = true;
-
-    sai_attribute_t attr;
-    attr.id = SAI_REDIS_SWITCH_ATTR_PERFORM_LOG_ROTATE;
-    attr.value.booldata = true;
-
-    if (sai_switch_api != NULL)
-    {
-        sai_switch_api->set_switch_attribute(gSwitchId, &attr);
-    }
+    gSaiRedisLogRotate = true;
 }
 
 void syncd_apply_view()

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -19,6 +19,7 @@ using namespace swss;
 
 extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
+extern bool                        gSaiRedisLogRotate;
 
 extern void syncd_apply_view();
 /*
@@ -399,6 +400,19 @@ void OrchDaemon::flush()
     {
         SWSS_LOG_ERROR("Failed to flush redis pipeline %d", status);
         exit(EXIT_FAILURE);
+    }
+
+    // check if logroate is requested
+    if (gSaiRedisLogRotate)
+    {
+        SWSS_LOG_NOTICE("performing log rotate");
+
+        gSaiRedisLogRotate = false;
+
+        attr.id = SAI_REDIS_SWITCH_ATTR_PERFORM_LOG_ROTATE;
+        attr.value.booldata = true;
+
+        sai_switch_api->set_switch_attribute(gSwitchId, &attr);
     }
 }
 

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -18,6 +18,7 @@ int gBatchSize = DEFAULT_BATCH_SIZE;
 bool gSairedisRecord = true;
 bool gSwssRecord = true;
 bool gLogRotate = false;
+bool gSaiRedisLogRotate = false;
 ofstream gRecordOfs;
 string gRecordFile;
 

--- a/tests/mock_tests/mock_orchagent_main.h
+++ b/tests/mock_tests/mock_orchagent_main.h
@@ -19,6 +19,7 @@ extern int gBatchSize;
 extern bool gSwssRecord;
 extern bool gSairedisRecord;
 extern bool gLogRotate;
+extern bool gSaiRedisLogRotate;
 extern ofstream gRecordOfs;
 extern string gRecordFile;
 


### PR DESCRIPTION
**What I did**
Move away logrotate from signal handler to main orch loop, to not execute any sairedis library code which potentially can be under mutex and cause deadlock when signal handler occur

**Why I did it**
to not execute sai_switch_api->set_attribute() under signal handler, just to set logrotate flag

**How I verified it**
running orchagent against vs switch and sending HUP signal to orch process

**Details if related**
Since flush method is executed every time that select is returning object from orchdaemon main/start loop, this is good point to check if logrotate is needed