### PR TITLE
[restore_neighbors.py] build arp packet with correct hwsrc and psrc

### DIFF
--- a/neighsyncd/restore_neighbors.py
+++ b/neighsyncd/restore_neighbors.py
@@ -194,7 +194,7 @@ def set_neigh_in_kernel(ipclass, family, intf_idx, dst_ip, dmac):
 def build_arp_ns_pkt(family, smac, src_ip, dst_ip):
     if family == 'IPv4':
         eth = Ether(src=smac, dst='ff:ff:ff:ff:ff:ff')
-        pkt = eth/ARP(op='who-has', pdst=dst_ip)
+        pkt = eth/ARP(op='who-has', pdst=dst_ip, psrc=src_ip, hwsrc=smac)
     elif family == 'IPv6':
         nsma = in6_getnsma(inet_pton(AF_INET6, dst_ip))
         mcast_dst_ip = inet_ntop(AF_INET6, nsma)


### PR DESCRIPTION
Otherwise, we can see that DUT after warm reboot sends ARP
packets with management IP (10.112.71.4)

$ sudo tcpdump -ni PortChannel0003 --direction out
16:33:40.572995 ARP, Request who-has 10.0.0.61 tell 10.112.71.4, length
28

All neighbors than are stil considered as STALE.

Signed-off-by: Stepan Blyschak <stepanb@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
