### PR TITLE
Teamd :: fix for cleaning up the teamd processes correctly on teamd docker stop

### DIFF
--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -8,11 +8,16 @@
 
 #include <algorithm>
 #include <sstream>
+#include <fstream>
 #include <thread>
 
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <signal.h>
+
+#define PID_FILE_PATH "/var/run/teamd/"
 
 using namespace std;
 using namespace swss;
@@ -108,6 +113,77 @@ void TeamMgr::doTask(Consumer &consumer)
     }
 }
 
+
+#define MAX_PID_STRLEN 10
+int TeamMgr::getTeamPid(const string &alias)
+{
+    SWSS_LOG_ENTER();
+    int pid = 0;
+
+    string file = string(PID_FILE_PATH) + alias + string(".pid");
+    ifstream infile(file);
+    if (!infile.is_open())
+    {
+        SWSS_LOG_WARN("The LAG PID file: %s is not readable", file.c_str());
+        return 0;
+    }
+
+    string line;
+    getline(infile, line);
+    if (line.empty())
+    {
+        SWSS_LOG_WARN("The LAG PID file: %s is empty", file.c_str());
+    }
+    else 
+    {
+        /*Store the PID value */
+        pid = stoi(line, nullptr, 10);
+    }
+
+    /* Close the file and return */
+    infile.close();
+
+    return pid;
+}
+
+
+#define MAX_PID_STRLEN 10
+void TeamMgr::addLagPid(const string &alias)
+{
+    SWSS_LOG_ENTER();
+    m_lagPIDList[alias] = getTeamPid(alias);
+}
+
+void TeamMgr::removeLagPid(const string &alias)
+{
+    SWSS_LOG_ENTER();
+    m_lagPIDList.erase(alias);
+}
+
+void TeamMgr::cleanTeamProcesses(int signo)
+{
+    int pid = 0;
+
+    for (const auto& it: m_lagList)
+    {
+        pid = m_lagPIDList[it];
+        if(!pid) {
+            SWSS_LOG_WARN("Invalid PID found for LaG %s ", it.c_str());
+
+            /* Try to get the PID again */
+            pid = getTeamPid(it);
+        }
+
+        if(pid > 0)
+        {
+            SWSS_LOG_WARN("Cleaning Process(PID: %d) for LaG %s ", pid, it.c_str());
+            kill(pid, signo);
+        }
+    }
+
+    return;
+}
+
 void TeamMgr::doLagTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -171,6 +247,7 @@ void TeamMgr::doLagTask(Consumer &consumer)
                 }
 
                 m_lagList.insert(alias);
+                addLagPid(alias);
             }
 
             setLagAdminStatus(alias, admin_status);
@@ -187,6 +264,7 @@ void TeamMgr::doLagTask(Consumer &consumer)
             {
                 removeLag(alias);
                 m_lagList.erase(alias);
+                removeLagPid(alias);
             }
         }
 

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -173,12 +173,12 @@ void TeamMgr::cleanTeamProcesses(int signo)
 
         if(pid > 0)
         {
-            SWSS_LOG_WARN("Sending Signal to (PID: %d) for LaG %s ", pid, it.c_str());
+            SWSS_LOG_INFO("Sending TERM Signal to (PID: %d) for LaG %s ", pid, it.c_str());
             kill(pid, signo);
         }
         else
         {
-            SWSS_LOG_WARN("Cound not find PID corresponding to LaG %s ", it.c_str());
+            SWSS_LOG_ERROR("Can't send TERM signal to LAG %s. PID wasn't found", it.c_str());
         }
     }
 

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -14,7 +14,6 @@
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <signal.h>
 
 #define PID_FILE_PATH "/var/run/teamd/"
@@ -114,11 +113,10 @@ void TeamMgr::doTask(Consumer &consumer)
 }
 
 
-#define MAX_PID_STRLEN 10
-int TeamMgr::getTeamPid(const string &alias)
+pid_t TeamMgr::getTeamPid(const string &alias)
 {
     SWSS_LOG_ENTER();
-    int pid = 0;
+    pid_t pid = 0;
 
     string file = string(PID_FILE_PATH) + alias + string(".pid");
     ifstream infile(file);
@@ -147,7 +145,6 @@ int TeamMgr::getTeamPid(const string &alias)
 }
 
 
-#define MAX_PID_STRLEN 10
 void TeamMgr::addLagPid(const string &alias)
 {
     SWSS_LOG_ENTER();
@@ -162,7 +159,7 @@ void TeamMgr::removeLagPid(const string &alias)
 
 void TeamMgr::cleanTeamProcesses(int signo)
 {
-    int pid = 0;
+    pid_t pid = 0;
 
     for (const auto& it: m_lagList)
     {
@@ -176,8 +173,12 @@ void TeamMgr::cleanTeamProcesses(int signo)
 
         if(pid > 0)
         {
-            SWSS_LOG_WARN("Cleaning Process(PID: %d) for LaG %s ", pid, it.c_str());
+            SWSS_LOG_WARN("Sending Signal to (PID: %d) for LaG %s ", pid, it.c_str());
             kill(pid, signo);
+        }
+        else
+        {
+            SWSS_LOG_WARN("Cound not find PID corresponding to LaG %s ", it.c_str());
         }
     }
 

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -49,9 +49,9 @@ private:
     bool setLagMtu(const std::string &alias, const std::string &mtu);
     bool setLagLearnMode(const std::string &alias, const std::string &learn_mode);
  
-    int getTeamPid(const string &alias);
-    void addLagPid(const string &alias);
-    void removeLagPid(const string &alias);
+    int getTeamPid(const std::string &alias);
+    void addLagPid(const std::string &alias);
+    void removeLagPid(const std::string &alias);
 
     bool isPortEnslaved(const std::string &);
     bool findPortMaster(std::string &, const std::string &);

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -7,6 +7,7 @@
 #include "netmsg.h"
 #include "orch.h"
 #include "producerstatetable.h"
+#include <sys/types.h>
 
 namespace swss {
 
@@ -31,7 +32,7 @@ private:
     ProducerStateTable m_appLagTable;
 
     std::set<std::string> m_lagList;
-    std::map<std::string, int> m_lagPIDList;
+    std::map<std::string, pid_t> m_lagPIDList;
 
     MacAddress m_mac;
 
@@ -49,7 +50,7 @@ private:
     bool setLagMtu(const std::string &alias, const std::string &mtu);
     bool setLagLearnMode(const std::string &alias, const std::string &learn_mode);
  
-    int getTeamPid(const std::string &alias);
+    pid_t getTeamPid(const std::string &alias);
     void addLagPid(const std::string &alias);
     void removeLagPid(const std::string &alias);
 

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -17,6 +17,8 @@ public:
             const std::vector<TableConnector> &tables);
 
     using Orch::doTask;
+    void cleanTeamProcesses(int signo);
+
 private:
     Table m_cfgMetadataTable;   // To retrieve MAC address
     Table m_cfgPortTable;
@@ -29,6 +31,7 @@ private:
     ProducerStateTable m_appLagTable;
 
     std::set<std::string> m_lagList;
+    std::map<std::string, int> m_lagPIDList;
 
     MacAddress m_mac;
 
@@ -45,6 +48,10 @@ private:
     bool setLagAdminStatus(const std::string &alias, const std::string &admin_status);
     bool setLagMtu(const std::string &alias, const std::string &mtu);
     bool setLagLearnMode(const std::string &alias, const std::string &learn_mode);
+ 
+    int getTeamPid(const string &alias);
+    void addLagPid(const string &alias);
+    void removeLagPid(const string &alias);
 
     bool isPortEnslaved(const std::string &);
     bool findPortMaster(std::string &, const std::string &);

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -12,10 +12,6 @@
 #include "warm_restart.h"
 #include "teamsync.h"
 
-#include <signal.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 #include <unistd.h>
 
 using namespace std;
@@ -24,7 +20,6 @@ using namespace swss;
 
 /* Taken from drivers/net/team/team.c */
 #define TEAM_DRV_NAME "team"
-#define PID_FILE_PATH "/var/run/teamd/"
 
 TeamSync::TeamSync(DBConnector *db, DBConnector *stateDb, Select *select) :
     m_select(select),
@@ -215,56 +210,13 @@ void TeamSync::removeLag(const string &lagName)
     m_selectablesToRemove.insert(lagName);
 }
 
-#define MAX_PID_STRLEN 10
-/* This API will be called from the teamsyncd signal handler. This will 
- * do the cleanup of teamd processes and exit.
- */
-void TeamSync::cleanTeamProcesses(int signo)
+void TeamSync::cleanTeamSync()
 {
-    ssize_t sz = 0;
-    int fd, pid;
-    char *endptr = NULL;
-    string file_path;
-
     for (const auto& it: m_teamSelectables)
     {
-       /* There are PID files created for each teamd process at "/var/run/teamd" */
-       file_path = string(PID_FILE_PATH) + it.first + string(".pid");
-
-       /* Open the file, get the PID and send signal to the process */
-       fd = open(file_path.c_str(), O_RDONLY);
-       if (fd > 0)
-       {
-           char pid_str[MAX_PID_STRLEN] = {0};
-           sz = read(fd, pid_str, MAX_PID_STRLEN-1);
-           if(sz > 0)
-           {
-               errno = 0;
-               pid = (pid_t)strtol(pid_str, &endptr, 10);
-               if ((errno == ERANGE) || (errno != 0 && pid == 0))
-               {
-                   SWSS_LOG_WARN("No valid PID extracted from file %s", file_path.c_str());
-               }
-               else
-               {
-                   /* Sending the SIGNAL to the Process */
-                   SWSS_LOG_INFO("Sending SIGTERM to PID [%d]", pid);
-                   kill(pid, signo);
-               }
-           }
-           else
-           {
-               SWSS_LOG_WARN("No bytes read from the file [%s]", file_path.c_str());
-           }
-           close(fd);
-       }
-       else
-       {
-           SWSS_LOG_WARN("Could not open the file %s", file_path.c_str());
-       }
-       file_path.clear();
+        /* Cleanup LAG */
+        removeLag(it.first);
     }
-
     return;
 }
 

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -233,14 +233,18 @@ void TeamSync::cleanTeamProcesses(int signo)
        fd = open(file_path.c_str(), O_RDONLY);
        if (fd > 0)
        {
-           sz = read(fd, pid_str, MAX_PID_STRLEN);
-           if(sz) {
-               pid_str[sz] = '\0';
+           memset(pid_str, 0, MAX_PID_STRLEN);
+           sz = read(fd, pid_str, MAX_PID_STRLEN-1);
+           if(sz > 0)
+           {
                pid = (pid_t)strtol(pid_str, &endptr, 10);
-               kill(pid, signo);
+               if(pid > 0) 
+               {
+                   kill(pid, signo);
+               }
            }
+           close(fd);
        }
-       close(fd);
        file_path.clear();
     }
     return;

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -25,7 +25,7 @@ public:
     TeamSync(DBConnector *db, DBConnector *stateDb, Select *select);
 
     void periodic();
-    void cleanTeamProcesses(int signo);
+    void cleanTeamSync();
 
     /* Listen to RTM_NEWLINK, RTM_DELLINK to track team devices */
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -25,6 +25,7 @@ public:
     TeamSync(DBConnector *db, DBConnector *stateDb, Select *select);
 
     void periodic();
+    void cleanTeamProcesses(int signo);
 
     /* Listen to RTM_NEWLINK, RTM_DELLINK to track team devices */
     virtual void onMsg(int nlmsg_type, struct nl_object *obj);

--- a/teamsyncd/teamsyncd.cpp
+++ b/teamsyncd/teamsyncd.cpp
@@ -10,16 +10,12 @@
 using namespace std;
 using namespace swss;
 
-TeamSync *syncPtr = NULL;
+/* Introducing a flag to indicate the receipt of signal */
+bool received_sigterm = false;
 
 void sig_handler(int signo)
 {
-    /* Stop the teamd processes present */
-    if(syncPtr)
-    {
-        syncPtr->cleanTeamProcesses(signo);
-    }
-
+    received_sigterm = true;
     return;
 }
 
@@ -30,15 +26,12 @@ int main(int argc, char **argv)
     DBConnector stateDb("STATE_DB", 0);
     Select s;
     TeamSync sync(&db, &stateDb, &s);
-    syncPtr = &sync;
 
     NetDispatcher::getInstance().registerMessageHandler(RTM_NEWLINK, &sync);
     NetDispatcher::getInstance().registerMessageHandler(RTM_DELLINK, &sync);
 
-    /* Register the signal handler for various signals */
+    /* Register the signal handler for SIGTERM */
     signal(SIGTERM, sig_handler);
-    signal(SIGINT, sig_handler);
-    signal(SIGQUIT, sig_handler);
 
     while (1)
     {
@@ -53,6 +46,12 @@ int main(int argc, char **argv)
             s.addSelectable(&netlink);
             while (true)
             {
+                if(received_sigterm)
+                {
+                  sync.cleanTeamProcesses(SIGTERM);
+                  received_sigterm = false;
+                }
+
                 Selectable *temps;
                 s.select(&temps, 1000); // block for a second
                 sync.periodic();

--- a/teamsyncd/teamsyncd.cpp
+++ b/teamsyncd/teamsyncd.cpp
@@ -10,7 +10,6 @@
 using namespace std;
 using namespace swss;
 
-/* Introducing a flag to indicate the receipt of signal */
 bool received_sigterm = false;
 
 void sig_handler(int signo)
@@ -48,7 +47,7 @@ int main(int argc, char **argv)
             {
                 if(received_sigterm)
                 {
-                  sync.cleanTeamProcesses(SIGTERM);
+                  sync.cleanTeamSync();
                   received_sigterm = false;
                 }
 


### PR DESCRIPTION
**What I did**

The changes implemented in the final fix are, 
   (1)	In teammgrd: While adding LAG, save the mapping of lag <-> teamd PID
   (2)	In teammgrd: While removing LAG, remove the mapping of lag <-> teamd PID
   (3)	Introduce SIGTERM handlers in both teammgrd and teamsyncd

- (a) In teammgrd, send the SIGTERM to all the teamd processes. It takes just a second for teamd processes + port channel interfaces to be cleaned up
- (b) In teamsyncd, clean up the teamd resources like nl_socket etc.

**Why I did it**

    There were multiple Issues seen, in random on doing a config reload/ config loadminigraph

(i)	Teamsyncd segfault 
(ii)	Teamsyncd getting the NETLINK messages with the older IFINDEXs
    (iii) "TeamPortSync: Unable to init team socket" error messages

  Root cause

     With config reload command , the docker teamd stop and start is issued. I find that after "docker stop" the port channel interfaces remains in the linux kernel – it is not getting cleaned. There are indeed signal handlers in the teamd processes. But in this case teamd is started as a “daemon” with the “-d” option. The supervisord is not able to send the SIGTERM to the processes started in a daemon mode (http://supervisord.org/subprocess.html?highlight=daemon)

“docker stop” sends two signals 

1.	SIGTERM to the ENTRYPOINT process in our case it is supervisord process 
2.	After 10 sec send SIGKILL to all processes to stop the container.

     So when docker stop is issued, supervisord send SIGTERM to all processes ( teamsyncd/temmgrd gets the signal correctly – but I find none of the teamd processes get the signal either because they are daemonized and running in background OR because teamd is not started directly by supervisord). 

The teamd processes are killed later with SIGKILL send as a last resort to stop docker. SIGKILL cannot be handled and hence no cleanup – portchanel interfaces remains in kernel.

**How I verified it**

   Tried the config reload back to back multiple times -- verified that the Portchannel interface are cleaned up in kernel, teamd processes are killed correctly.
  When the teamd docker is started again, I don't see random NETLINK create/delete messages with the older Portchannel ifindices. ( which was seen earlier without this fix ) 

**Other possible fixes which I tried out, but decided not to take**

The other possible fix options which was tried were,

   (1)	Use the fork/exec way to spawn the teamd processes
               

- (a) Seeing instabilities in all teamd instances NOT coming up when we do “config reload” back to back.
               

- (b) Even with teamd staying in foreground, those processes were not getting the  SIGTERM on “docker stop”. So doesn’t serve the purpose of trying NOT to  daemonize the teamd.

   
(2)	In the teammgrd Signal handler directly invoke an existing API teammgrd:removeLag() which
        cleans up the teamd processes. This was working fine, but the cleanup was taking longer 
        duration like around 5sec for cleaning up all the teamd processes, which very high 
        considering it is a signal handler.

