### PR TITLE
[qosorch] converting shaper bandwidth value to unsigned long instead …

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -947,25 +947,25 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
             else if (fvField(*i) == scheduler_min_bandwidth_rate_field_name)
             {
                 attr.id = SAI_SCHEDULER_ATTR_MIN_BANDWIDTH_RATE;
-                attr.value.u64 = (uint64_t)stoi(fvValue(*i));
+                attr.value.u64 = stoul(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
             else if (fvField(*i) == scheduler_min_bandwidth_burst_rate_field_name)
             {
                 attr.id = SAI_SCHEDULER_ATTR_MIN_BANDWIDTH_BURST_RATE;
-                attr.value.u64 = (uint64_t)stoi(fvValue(*i));
+                attr.value.u64 = stoul(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
             else if (fvField(*i) == scheduler_max_bandwidth_rate_field_name)
             {
                 attr.id = SAI_SCHEDULER_ATTR_MAX_BANDWIDTH_RATE;
-                attr.value.u64 = (uint64_t)stoi(fvValue(*i));
+                attr.value.u64 = stoul(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
             else if (fvField(*i) == scheduler_max_bandwidth_burst_rate_field_name)
             {
                 attr.id = SAI_SCHEDULER_ATTR_MAX_BANDWIDTH_BURST_RATE;
-                attr.value.u64 = (uint64_t)stoi(fvValue(*i));
+                attr.value.u64 = stoul(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
             else {


### PR DESCRIPTION
…of int

Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I have changed the conversion of shaper bandwidth str to unsigned long instead of int.
**Why I did it**
For higher shaper rates greater than 20Gbps, integer is not sufficient. So I changed the conversion function to stoul()
**How I verified it**
Verified by using shaper rates greater than 20Gbps.
**Details if related**
