### PR TITLE
[portsorch] Refactor portsorch to use FlexCounterManager to setup port and queue stats

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -1,4 +1,4 @@
-INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/orchagent -I $(top_srcdir)/warmrestart
+INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/orchagent -I $(top_srcdir)/warmrestart -I $(top_srcdir)/orchagent/flex_counter
 CFLAGS_SAI = -I /usr/include/sai
 LIBNL_CFLAGS = -I/usr/include/libnl3
 LIBNL_LIBS = -lnl-genl-3 -lnl-route-3 -lnl-3

--- a/orchagent/debugcounterorch.cpp
+++ b/orchagent/debugcounterorch.cpp
@@ -25,7 +25,7 @@ static const unordered_map<string, CounterType> flex_counter_type_lookup = {
 // object should only be initialized once.
 DebugCounterOrch::DebugCounterOrch(DBConnector *db, const vector<string>& table_names, int poll_interval) :
         Orch(db, table_names),
-        flex_counter_manager(DEBUG_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, poll_interval),
+        flex_counter_manager(DEBUG_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, poll_interval, true),
         m_stateDb(new DBConnector("STATE_DB", 0)),
         m_debugCapabilitiesTable(new Table(m_stateDb.get(), STATE_DEBUG_COUNTER_CAPABILITIES_NAME)),
         m_countersDb(new DBConnector("COUNTERS_DB", 0)),
@@ -34,7 +34,6 @@ DebugCounterOrch::DebugCounterOrch(DBConnector *db, const vector<string>& table_
 {
     SWSS_LOG_ENTER();
     publishDropCounterCapabilities();
-    flex_counter_manager.enableFlexCounterGroup();
 }
 
 DebugCounterOrch::~DebugCounterOrch(void)

--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -34,17 +34,19 @@ const unordered_map<CounterType, string> FlexCounterManager::counter_id_field_lo
 {
     { CounterType::PORT_DEBUG,   PORT_DEBUG_COUNTER_ID_LIST },
     { CounterType::SWITCH_DEBUG, SWITCH_DEBUG_COUNTER_ID_LIST },
+    { CounterType::PORT,         PORT_COUNTER_ID_LIST },
+    { CounterType::QUEUE,        QUEUE_COUNTER_ID_LIST }
 };
 
-// This constructor will create a group that is disabled by default.
 FlexCounterManager::FlexCounterManager(
         const string& group_name,
         const StatsMode stats_mode,
-        const uint polling_interval) :
+        const uint polling_interval,
+        const bool enabled) :
     group_name(group_name),
     stats_mode(stats_mode),
     polling_interval(polling_interval),
-    enabled(false),
+    enabled(enabled),
     flex_counter_db(new DBConnector("FLEX_COUNTER_DB", 0)),
     flex_counter_group_table(new ProducerTable(flex_counter_db.get(), FLEX_COUNTER_GROUP_TABLE)),
     flex_counter_table(new ProducerTable(flex_counter_db.get(), FLEX_COUNTER_TABLE))
@@ -72,6 +74,8 @@ FlexCounterManager::~FlexCounterManager()
 
 void FlexCounterManager::applyGroupConfiguration()
 {
+    SWSS_LOG_ENTER();
+
     vector<FieldValueTuple> field_values =
     {
         FieldValueTuple(STATS_MODE_FIELD, stats_mode_lookup.at(stats_mode)),

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -18,6 +18,8 @@ enum class StatsMode
 
 enum class CounterType
 {
+    PORT,
+    QUEUE,
     PORT_DEBUG,
     SWITCH_DEBUG
 };
@@ -33,7 +35,8 @@ class FlexCounterManager
         FlexCounterManager(
                 const std::string& group_name,
                 const StatsMode stats_mode,
-                const uint polling_interval);
+                const uint polling_interval,
+                const bool enabled);
 
         FlexCounterManager(const FlexCounterManager&) = delete;
         FlexCounterManager& operator=(const FlexCounterManager&) = delete;

--- a/orchagent/flex_counter/flex_counter_stat_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_stat_manager.cpp
@@ -13,8 +13,9 @@ using swss::FieldValueTuple;
 FlexCounterStatManager::FlexCounterStatManager(
         const string& group_name,
         const StatsMode stats_mode,
-        const int polling_interval) :
-    FlexCounterManager(group_name, stats_mode, polling_interval)
+        const int polling_interval,
+        const bool enabled) :
+    FlexCounterManager(group_name, stats_mode, polling_interval, enabled)
 {
     SWSS_LOG_ENTER();
 }

--- a/orchagent/flex_counter/flex_counter_stat_manager.h
+++ b/orchagent/flex_counter/flex_counter_stat_manager.h
@@ -11,7 +11,8 @@ class FlexCounterStatManager : public FlexCounterManager
         FlexCounterStatManager(
                 const std::string& group_name,
                 const StatsMode stats_mode,
-                const int polling_interval);
+                const int polling_interval,
+                const bool enabled);
 
         FlexCounterStatManager(const FlexCounterStatManager&) = delete;
         FlexCounterStatManager& operator=(const FlexCounterStatManager&) = delete;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -9,6 +9,7 @@
 #include "observer.h"
 #include "macaddress.h"
 #include "producertable.h"
+#include "flex_counter_manager.h"
 
 #define FCS_LEN 4
 #define VLAN_TAG_LEN 4
@@ -104,13 +105,14 @@ private:
     unique_ptr<ProducerTable> m_flexCounterTable;
     unique_ptr<ProducerTable> m_flexCounterGroupTable;
 
-    std::string getQueueFlexCounterTableKey(std::string s);
     std::string getQueueWatermarkFlexCounterTableKey(std::string s);
-    std::string getPortFlexCounterTableKey(std::string s);
     std::string getPriorityGroupWatermarkFlexCounterTableKey(std::string s);
 
     shared_ptr<DBConnector> m_counter_db;
     shared_ptr<DBConnector> m_flex_db;
+
+    FlexCounterManager port_stat_manager;
+    FlexCounterManager queue_stat_manager;
 
     std::map<sai_object_id_t, PortSupportedSpeeds> m_portSupportedSpeeds;
 


### PR DESCRIPTION
- Updates portsorch to use FlexCounterManager for port and queue stats instead of direct redis operations
- Updates FlexCounterManager to support standard Port and Queue counters
- Updates FlexCounterManager to allow clients to enable the group in the constructor, for convenience
- Updates the makefile for cfgmgr to include new flex_counter dependency from portsorch

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I refactored portsorch to use FlexCounterManager to handle flex counter operations rather than directly interacting with the FLEX_COUNTER_DB.

**Why I did it**
I did it to abstract away some of the details of flex counter setup from portsorch and make portsorch simpler. This is also makes it easier to update the flex counter implementation in the future.

**How I verified it**
I built a sonic image with the changes and verified that the FLEX_COUNTER_DB was the same as before, and that COUNTERS_DB was being updated properly. I also checked that portstat and queuestat were behaving correctly as well.
