### PR TITLE
[debugcounterorch] Add checks for supported counter types and drop reasons

### DIFF
--- a/orchagent/debug_counter/drop_counter.h
+++ b/orchagent/debug_counter/drop_counter.h
@@ -2,7 +2,6 @@
 #define SWSS_UTIL_DROP_COUNTER_H_
 
 #include <string>
-#include <vector>
 #include <unordered_set>
 #include <unordered_map>
 #include "debug_counter.h"
@@ -33,8 +32,8 @@ class DropCounter : public DebugCounter
         static bool isIngressDropReasonValid(const std::string& drop_reason);
         static bool isEgressDropReasonValid(const std::string& drop_reason);
 
-        static std::vector<std::string> getSupportedDropReasons(sai_debug_counter_attr_t drop_reason_type);
-        static std::string serializeSupportedDropReasons(std::vector<std::string> drop_reasons);
+        static std::unordered_set<std::string> getSupportedDropReasons(sai_debug_counter_attr_t drop_reason_type);
+        static std::string serializeSupportedDropReasons(std::unordered_set<std::string> drop_reasons);
         static uint64_t getSupportedDebugCounterAmounts(sai_debug_counter_type_t counter_type);
 
     private:

--- a/orchagent/debugcounterorch.h
+++ b/orchagent/debugcounterorch.h
@@ -77,6 +77,10 @@ private:
     std::shared_ptr<swss::Table> m_counterNameToPortStatMap = nullptr;
     std::shared_ptr<swss::Table> m_counterNameToSwitchStatMap = nullptr;
 
+    std::unordered_set<std::string> supported_counter_types;
+    std::unordered_set<std::string> supported_ingress_drop_reasons;
+    std::unordered_set<std::string> supported_egress_drop_reasons;
+
     FlexCounterStatManager flex_counter_manager;
 
     std::unordered_map<std::string, std::unique_ptr<DebugCounter>> debug_counters;


### PR DESCRIPTION
- Refactor drop reason capability query to trim SAI prefixes
- Store device capabilities in orchagent to perform safety checks

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I added a check in orchagent to prevent unsupported drop counter types and drop reasons from crashing orchagent.

**Why I did it**
I did this to prevent devices from crashing due to inadvertent configuration errors.

**How I verified it**
I locally tested by:
1. Inserting a SWITCH_INGRESS counter into config DB on a device where SWITCH_INGRESS_COUNTER was not supported
2. Adding L2_ANY to a counter on a device where L2_ANY was not supported.
3. Created a valid counter on a device to ensure that normal operation was not impacted.

**Details if related**
Fixes #1136 - Rather than depending on each ASIC vendor to follow the same error handling doctrine, this PR validates HW support in orchagent, which should be more reliable.

Related to Azure/sonic-utilities#785 - In order to validate user input, we need to remove the SAI prefixes before we store the results. This removes the need for the CLI to perform these checks.