### PR TITLE
Define lacp key to make possible creation of two lacp channels between couple of switches

### DIFF
--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -36,6 +36,9 @@ private:
 
     MacAddress m_mac;
 
+    unsigned short m_lacp_key = 0;
+    std::map<std::string, unsigned short> m_lagKeys;
+
     void doTask(Consumer &consumer);
     void doLagTask(Consumer &consumer);
     void doLagMemberTask(Consumer &consumer);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Fix: https://github.com/Azure/sonic-buildimage/issues/4009

**What I did**
Added `teamdctl port config update` command to set lacp key. Also check [why I install configuration before we add interface to a channel](https://lists.fedorahosted.org/archives/list/libteam@lists.fedorahosted.org/message/57SCT3BDPBCWO5ZMJUKHBKYZ37VJFS26/)

**Why I did it**
Otherwise it's impossible to set more than 1 channel between two systems.

**How I verified it**
Build an image and run on my dut. Check tcpdump of lacp packets. Also portchannels must be up.

**Details if related**
