### PR TITLE
[vs tests] Mark VLAN and warm reboot tests as xfail

### DIFF
--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -7,10 +7,6 @@ import platform
 from distutils.version import StrictVersion
 
 
-# FIXME: This test is extremely unstable and requires several retries
-# for it to pass - we need to stabilize this test before putting it back
-# into the pipeline.
-@pytest.mark.xfail(reason="VLAN test unstable")
 class TestVlan(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
@@ -428,6 +424,10 @@ class TestVlan(object):
             #remove vlan
             dvs.remove_vlan(vlan)
 
+    # FIXME: This test is extremely unstable and requires several retries
+    # for it to pass - we need to stabilize this test before putting it back
+    # into the pipeline.
+    @pytest.mark.xfail(reason="test case is unstable")
     def test_AddPortChannelToVlan(self, dvs, testlog):
         self.setup_db(dvs)
         marker = dvs.add_log_marker()
@@ -648,6 +648,10 @@ class TestVlan(object):
         vlan_entries = [k for k in tbl.getKeys() if k != dvs.asicdb.default_vlan_id]
         assert len(vlan_entries) == 0
 
+    # FIXME: This test is extremely unstable and requires several retries
+    # for it to pass - we need to stabilize this test before putting it back
+    # into the pipeline.
+    @pytest.mark.xfail(reason="test case is unstable")
     def test_RemoveVlanWithRouterInterface(self, dvs, testlog):
         dvs.setup_db()
         marker = dvs.add_log_marker()

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -7,6 +7,10 @@ import platform
 from distutils.version import StrictVersion
 
 
+# FIXME: This test is extremely unstable and requires several retries
+# for it to pass - we need to stabilize this test before putting it back
+# into the pipeline.
+@pytest.mark.xfail(reason="VLAN test unstable")
 class TestVlan(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -235,10 +235,6 @@ def ping_new_ips(dvs):
             dvs.runcmd(['sh', '-c', "ping6 -c 1 -W 0 -q {}00::{} > /dev/null 2>&1".format(i*4,j+NUM_NEIGH_PER_INTF+2)])
 
 
-# FIXME: This test is extremely unstable and requires several retries
-# for it to pass - we need to stabilize this test before putting it back
-# into the pipeline.
-@pytest.mark.xfail(reason="warm reboot test unstable")
 class TestWarmReboot(object):
     def test_PortSyncdWarmRestart(self, dvs, testlog):
 
@@ -1799,6 +1795,10 @@ class TestWarmReboot(object):
         intf_tbl._del("{}".format(intfs[2]))
         time.sleep(2)
 
+    # FIXME: This test is extremely unstable and requires several retries
+    # for it to pass - we need to stabilize this test before putting it back
+    # into the pipeline.
+    @pytest.mark.xfail(reason="test case is unstable")
     def test_system_warmreboot_neighbor_syncup(self, dvs, testlog):
 
         appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -234,6 +234,11 @@ def ping_new_ips(dvs):
             dvs.runcmd(['sh', '-c', "ping -c 1 -W 0 -q {}.0.0.{} > /dev/null 2>&1".format(i*4,j+NUM_NEIGH_PER_INTF+2)])
             dvs.runcmd(['sh', '-c', "ping6 -c 1 -W 0 -q {}00::{} > /dev/null 2>&1".format(i*4,j+NUM_NEIGH_PER_INTF+2)])
 
+
+# FIXME: This test is extremely unstable and requires several retries
+# for it to pass - we need to stabilize this test before putting it back
+# into the pipeline.
+@pytest.mark.xfail(reason="warm reboot test unstable")
 class TestWarmReboot(object):
     def test_PortSyncdWarmRestart(self, dvs, testlog):
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

**What I did**
I marked the VLAN and warm reboot vs tests as xfail, which means that test failures in those tests will not cause the entire test suite to fail.

**Why I did it**
I did it to try to reduce the number of test suite failures so that we don't have to spam "retest this please" to unblock PRs.

**Details if related**
Opened #1181 and #1182 to track test stabilization.