### PR TITLE
[vs tests] Activate flaky plugin for virtual switch pytests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -8,8 +8,9 @@ SWSS Integration tests runs on docker-sonic-vs which runs on top of SAI virtual 
 
 - Install docker and pytest on your dev machine
     ```
-    sudo pip install --system docker==3.5.0
-    sudo pip install --system pytest==3.3.0 docker redis
+    sudo pip install docker==3.5.0
+    sudo pip install pytest==3.3.0
+    sudo pip install flaky docker redis
     ```
 - Compile and install swss common library. Follow instructions [here](https://github.com/Azure/sonic-swss-common/blob/master/README.md) to first install prerequisites to build swss common library. 
     ```

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1,7 +1,10 @@
-from swsscommon import swsscommon
 import time
 import re
 import json
+import pytest
+
+from swsscommon import swsscommon
+from flaky import flaky
 
 
 class BaseTestAcl(object):
@@ -185,6 +188,7 @@ class BaseTestAcl(object):
                 assert False
 
 
+@pytest.mark.flaky
 class TestAcl(BaseTestAcl):
     def test_AclTableCreation(self, dvs, testlog):
         self.setup_db(dvs)
@@ -1370,6 +1374,8 @@ class TestAcl(BaseTestAcl):
         # bring down interface
         dvs.set_interface_status("Ethernet4", "down")
 
+
+@pytest.mark.flaky
 class TestAclRuleValidation(BaseTestAcl):
     """ Test class for cases that check if orchagent corectly validates
     ACL rules input

--- a/tests/test_acl_ctrl.py
+++ b/tests/test_acl_ctrl.py
@@ -1,7 +1,11 @@
-from swsscommon import swsscommon
-
 import time
+import pytest
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestPortChannelAcl(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_acl_egress_table.py
+++ b/tests/test_acl_egress_table.py
@@ -1,7 +1,11 @@
-from swsscommon import swsscommon
-
 import time
+import pytest
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestEgressAclTable(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_acl_portchannel.py
+++ b/tests/test_acl_portchannel.py
@@ -1,7 +1,11 @@
-from swsscommon import swsscommon
-
 import time
+import pytest
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestPortChannelAcl(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_admin_status.py
+++ b/tests/test_admin_status.py
@@ -1,6 +1,11 @@
-from swsscommon import swsscommon
 import time
+import pytest
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestAdminStatus(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -1,10 +1,11 @@
-from swsscommon import swsscommon
 import os
 import re
 import time
 import json
 import redis
 
+from swsscommon import swsscommon
+from flaky import flaky
 
 def getCrmCounterValue(dvs, key, counter):
 
@@ -62,6 +63,8 @@ def check_syslog(dvs, marker, err_log, expected_cnt):
     (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \"%s\" | wc -l" % (marker, err_log)])
     assert num.strip() >= str(expected_cnt)
 
+
+@pytest.mark.flaky
 class TestCrm(object):
     def test_CrmFdbEntry(self, dvs, testlog):
 

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -3,6 +3,7 @@ import re
 import time
 import json
 import redis
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -1,8 +1,12 @@
-from swsscommon import swsscommon
 import time
 import re
 import json
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestDirectedBroadcast(object):
     def test_DirectedBroadcast(self, dvs, testlog):
 

--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -1,6 +1,7 @@
 import time
 import re
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_drop_counters.py
+++ b/tests/test_drop_counters.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_drop_counters.py
+++ b/tests/test_drop_counters.py
@@ -1,6 +1,7 @@
-from swsscommon import swsscommon
-
 import time
+
+from swsscommon import swsscommon
+from flaky import flaky
 
 # Supported drop counters
 PORT_INGRESS_DROPS = 'PORT_INGRESS_DROPS'
@@ -53,9 +54,11 @@ ASIC_COUNTER_SWITCH_OUT_TYPE = 'SAI_DEBUG_COUNTER_TYPE_SWITCH_OUT_DROP_REASONS'
 EXPECTED_ASIC_FIELDS = [ASIC_COUNTER_TYPE_FIELD, ASIC_COUNTER_INGRESS_REASON_LIST_FIELD, ASIC_COUNTER_EGRESS_REASON_LIST_FIELD]
 EXPECTED_NUM_ASIC_FIELDS = 2
 
+
 # FIXME: It is really annoying to have to re-run tests due to inconsistent timing, should
 # implement some sort of polling interface for checking ASIC/flex counter tables after
 # applying changes to config DB
+@pytest.mark.flaky
 class TestDropCounters(object):
     def setup_db(self, dvs):
         self.asic_db = swsscommon.DBConnector(1, dvs.redis_sock, 0)

--- a/tests/test_dtel.py
+++ b/tests/test_dtel.py
@@ -1,16 +1,18 @@
-from swsscommon import swsscommon
-
-
 import time
 import re
 import json
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestDtel(object):
     def test_DtelGlobalAttribs(self, dvs, testlog):
-    
+
         db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
-    
+
         # create DTel global attributes in config db
         tbl = swsscommon.Table(db, "DTEL")
 

--- a/tests/test_dtel.py
+++ b/tests/test_dtel.py
@@ -1,6 +1,7 @@
 import time
 import re
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -1,8 +1,10 @@
-from swsscommon import swsscommon
 import os
 import sys
 import time
 import json
+
+from swsscommon import swsscommon
+from flaky import flaky
 from distutils.version import StrictVersion
 
 def create_entry(tbl, key, pairs):
@@ -24,6 +26,8 @@ def how_many_entries_exist(db, table):
     tbl =  swsscommon.Table(db, table)
     return len(tbl.getKeys())
 
+
+@pytest.mark.flaky
 class TestFdb(object):
     def test_FdbWarmRestartNotifications(self, dvs, testlog):
         dvs.setup_db()

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_fdb_update.py
+++ b/tests/test_fdb_update.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_fdb_update.py
+++ b/tests/test_fdb_update.py
@@ -1,11 +1,14 @@
-from swsscommon import swsscommon
 import os
 import sys
 import time
 import json
+
+from swsscommon import swsscommon
+from flaky import flaky
 from distutils.version import StrictVersion
 
 
+@pytest.mark.flaky
 class TestFdbUpdate(object):
     def create_entry(self, tbl, key, pairs):
         fvs = swsscommon.FieldValuePairs(pairs)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,5 +1,6 @@
 import time
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,8 +1,11 @@
-from swsscommon import swsscommon
-
 import time
 import json
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestRouterInterface(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -1,13 +1,14 @@
 # This test suite covers the functionality of mirror feature in SwSS
-
 import platform
 import pytest
 import time
-from distutils.version import StrictVersion
 
 from swsscommon import swsscommon
+from flaky import flaky
+from distutils.version import StrictVersion
 
 
+@pytest.mark.flaky
 class TestMirror(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_mirror_ipv6_combined.py
+++ b/tests/test_mirror_ipv6_combined.py
@@ -1,15 +1,16 @@
 # This test suite covers the functionality of mirror feature in SwSS
-
 import platform
 import pytest
 import time
-from distutils.version import StrictVersion
 
 from swsscommon import swsscommon
+from flaky import flaky
+from distutils.version import StrictVersion
 
 DVS_FAKE_PLATFORM = "broadcom"
 
 
+@pytest.mark.flaky
 class TestMirror(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -1,15 +1,16 @@
 # This test suite covers the functionality of mirror feature in SwSS
-
 import platform
 import pytest
 import time
 from distutils.version import StrictVersion
 
 from swsscommon import swsscommon
+from flaky import flaky
 
 DVS_FAKE_PLATFORM = "mellanox"
 
 
+@pytest.mark.flaky
 class TestMirror(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_mirror_policer.py
+++ b/tests/test_mirror_policer.py
@@ -1,13 +1,14 @@
 # This test suite covers the functionality of mirror feature in SwSS
-
 import platform
 import pytest
 import time
-from distutils.version import StrictVersion
 
 from swsscommon import swsscommon
+from flaky import flaky
+from distutils.version import StrictVersion
 
 
+@pytest.mark.flaky
 class TestMirror(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -1,10 +1,13 @@
-from swsscommon import swsscommon
 import time
 import re
 import json
 import pytest
 import pdb
 import os
+
+from swsscommon import swsscommon
+from flaky import flaky
+
 
 # FIXME: These tests depend on changes in sonic-buildimage, we need to reenable
 # them once those changes are merged.

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -1,5 +1,6 @@
 import time
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -1,8 +1,11 @@
-from swsscommon import swsscommon
-
 import time
 import json
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestNeighbor(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -1,9 +1,13 @@
-from swsscommon import swsscommon
 import os
 import re
 import time
 import json
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestNextHopGroup(object):
     def test_route_nhg(self, dvs, testlog):
         config_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_pfc.py
+++ b/tests/test_pfc.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_pfc.py
+++ b/tests/test_pfc.py
@@ -1,6 +1,7 @@
 import time
-from swsscommon import swsscommon
 
+from swsscommon import swsscommon
+from flaky import flaky
 
 def getBitMaskStr(bits):
 
@@ -57,6 +58,8 @@ def getPortAttr(dvs, port_oid, port_attr):
 
     return ''
 
+
+@pytest.mark.flaky
 class TestPfc(object):
     def test_PfcAsymmetric(self, dvs, testlog):
 

--- a/tests/test_policer.py
+++ b/tests/test_policer.py
@@ -3,7 +3,10 @@ import pytest
 import time
 
 from swsscommon import swsscommon
+from flaky import flaky
 
+
+@pytest.mark.flaky
 class TestPolicer(object):
     def test_PolicerBasic(self, dvs, testlog):
         dvs.setup_db()

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,5 +1,6 @@
 import time
 import os
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -1,8 +1,11 @@
-from swsscommon import swsscommon
-
 import time
 import os
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestPort(object):
     def test_PortMtu(self, dvs, testlog):
         pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -1,5 +1,6 @@
 import time
 import os
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -1,7 +1,11 @@
-from swsscommon import swsscommon
 import time
 import os
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestPortAutoNeg(object):
     def test_PortAutoNegCold(self, dvs, testlog):
 

--- a/tests/test_port_buffer_rel.py
+++ b/tests/test_port_buffer_rel.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_port_buffer_rel.py
+++ b/tests/test_port_buffer_rel.py
@@ -1,7 +1,11 @@
-from swsscommon import swsscommon
 import time
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
 # The test check that the ports will be up, when the admin state is UP by conf db.
+@pytest.mark.flaky
 class TestPortBuffer(object):
     def test_PortsAreUpAfterBuffers(self, dvs, testlog):
         num_ports = 32

--- a/tests/test_port_config.py
+++ b/tests/test_port_config.py
@@ -1,8 +1,11 @@
-from swsscommon import swsscommon
 import redis
 import time
 import os
 import pytest
+
+from swsscommon import swsscommon
+from flaky import flaky
+
 
 @pytest.yield_fixture
 def port_config(request, dvs):
@@ -11,6 +14,8 @@ def port_config(request, dvs):
     yield file_name
     dvs.runcmd("mv %s.bak %s" % (file_name, file_name))
 
+
+@pytest.mark.flaky
 class TestPortConfig(object):
 
     def getPortName(self, dvs, port_vid):

--- a/tests/test_port_mac_learn.py
+++ b/tests/test_port_mac_learn.py
@@ -1,5 +1,6 @@
 import time
 import os
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_port_mac_learn.py
+++ b/tests/test_port_mac_learn.py
@@ -1,8 +1,11 @@
-from swsscommon import swsscommon
-
 import time
 import os
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestPortMacLearn(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -1,6 +1,7 @@
 import time
 import re
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -1,8 +1,12 @@
-from swsscommon import swsscommon
 import time
 import re
 import json
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestPortchannel(object):
     def test_Portchannel(self, dvs, testlog):
 

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -2,7 +2,9 @@ import pytest
 import json
 import sys
 import time
+
 from swsscommon import swsscommon
+from flaky import flaky
 
 CFG_DOT1P_TO_TC_MAP_TABLE_NAME =  "DOT1P_TO_TC_MAP"
 CFG_DOT1P_TO_TC_MAP_KEY = "AZURE"
@@ -22,6 +24,7 @@ CFG_PORT_QOS_MAP_FIELD = "dot1p_to_tc_map"
 CFG_PORT_TABLE_NAME = "PORT"
 
 
+@pytest.mark.flaky
 class TestDot1p(object):
     def connect_dbs(self, dvs):
         self.asic_db = swsscommon.DBConnector(1, dvs.redis_sock, 0)

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import json
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,9 +1,13 @@
-from swsscommon import swsscommon
 import os
 import re
 import time
 import json
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestRoute(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_setro.py
+++ b/tests/test_setro.py
@@ -1,8 +1,9 @@
 import time
 import json
 import redis
-from pprint import pprint
+import pytest
 
+from pprint import pprint
 from swsscommon import swsscommon
 from flaky import flaky
 

--- a/tests/test_setro.py
+++ b/tests/test_setro.py
@@ -1,9 +1,13 @@
-from swsscommon import swsscommon
 import time
 import json
 import redis
 from pprint import pprint
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestSetRo(object):
     def test_SetReadOnlyAttribute(self, dvs, testlog):
 

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -1,5 +1,6 @@
 import time
 import os
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -1,9 +1,11 @@
-from swsscommon import swsscommon
-
 import time
 import os
 
+from swsscommon import swsscommon
+from flaky import flaky
 
+
+@pytest.mark.flaky
 class TestSflow(object):
     speed_rate_table = {
         "400000":"40000",

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -6,6 +6,7 @@ import time
 import re
 import json
 import os
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,18 +1,17 @@
 """
     test_speed.py implements list of tests to check speed set on
     interfaces and correct buffer manager behavior on speed change
-
-    These tests need to be run in prepared environment and with the
-    SONiC version compiled for PLATFORM=vs
-
-    See README.md for details
 """
-from swsscommon import swsscommon
 import time
 import re
 import json
 import os
 
+from swsscommon import swsscommon
+from flaky import flaky
+
+
+@pytest.mark.flaky
 class TestSpeedSet(object):
     num_ports = 32
     def test_SpeedAndBufferSet(self, dvs, testlog):

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -1,7 +1,9 @@
 import pytest
 import time
 import json
+
 from swsscommon import swsscommon
+from flaky import flaky
 
 CFG_VLAN_SUB_INTF_TABLE_NAME = "VLAN_SUB_INTERFACE"
 CFG_PORT_TABLE_NAME = "PORT"
@@ -17,6 +19,7 @@ ASIC_ROUTE_ENTRY_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"
 ADMIN_STATUS = "admin_status"
 
 
+@pytest.mark.flaky
 class TestSubPortIntf(object):
     PHYSICAL_PORT_UNDER_TEST = "Ethernet64"
     SUB_PORT_INTERFACE_UNDER_TEST = "Ethernet64.10"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,5 +1,7 @@
-from swsscommon import swsscommon
 import time
+
+from swsscommon import swsscommon
+from flaky import flaky
 
 
 def create_entry(tbl, key, pairs):
@@ -59,15 +61,14 @@ def vxlan_switch_test(dvs, oid, port, mac):
     )
 
 
+@pytest.mark.flaky
 class TestSwitch(object):
-    
     '''
     Test- Check switch attributes
     '''
     def test_switch_attribute(self, dvs, testlog):
         switch_oid = get_exist_entry(dvs, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")
-        
-        vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05")
-        
-        vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E")
 
+        vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05")
+
+        vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E")

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -1,9 +1,14 @@
-from swsscommon import swsscommon
 import time
+
+from swsscommon import swsscommon
+from flaky import flaky
+
 
 def create_fvs(**kwargs):
     return swsscommon.FieldValuePairs(kwargs.items())
 
+
+@pytest.mark.flaky
 class TestTunnelBase(object):
     APP_TUNNEL_DECAP_TABLE_NAME = "TUNNEL_DECAP_TABLE"
     ASIC_TUNNEL_TABLE           = "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL"

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -1,12 +1,15 @@
-from swsscommon import swsscommon
 import time
 import re
 import json
 import pytest
 import platform
+
+from swsscommon import swsscommon
+from flaky import flaky
 from distutils.version import StrictVersion
 
 
+@pytest.mark.flaky
 class TestVlan(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -1,9 +1,11 @@
-from swsscommon import swsscommon
 import time
 import json
 import random
 import time
 import pytest
+
+from swsscommon import swsscommon
+from flaky import flaky
 from pprint import pprint
 
 
@@ -950,6 +952,7 @@ class VnetBitmapVxlanTunnel(object):
         self.vnet_bitmap_route_ids.remove(old_bitmap_route[0])
 
 
+@pytest.mark.flaky
 class TestVnetOrch(object):
 
     def get_vnet_obj(self):

--- a/tests/test_vnet_bitmap.py
+++ b/tests/test_vnet_bitmap.py
@@ -1,6 +1,9 @@
-from swsscommon import swsscommon
 import time
+
 import test_vnet as vnet
+
+from swsscommon import swsscommon
+from flaky import flaky
 
 
 # Define fake platform for "DVS" fixture, so it will set "platform" environment variable for "orchagent".
@@ -14,6 +17,7 @@ Test cases are inherited from "test_vnet.py::TestVnetOrch" since they are the sa
 Difference between these two implementations is in set SAI attributes, so different values should be checked in ASIC_DB.
 This class should override "get_vnet_obj()" method in order to return object with appropriate implementation of "check" APIs.
 '''
+@pytest.mark.flaky
 class TestVnetBitmapOrch(vnet.TestVnetOrch):
 
     '''

--- a/tests/test_vnet_bitmap.py
+++ b/tests/test_vnet_bitmap.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 import test_vnet as vnet
 

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -1,9 +1,13 @@
-from swsscommon import swsscommon
 import time
 import json
 import random
+
+from swsscommon import swsscommon
+from flaky import flaky
 from pprint import pprint
 
+
+@pytest.mark.flaky
 class TestVrf(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -1,6 +1,7 @@
 import time
 import json
 import random
+import pytest
 
 from swsscommon import swsscommon
 from flaky import flaky

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -1,9 +1,11 @@
-from swsscommon import swsscommon
 import time
 import json
 import random
 import time
 import pytest
+
+from swsscommon import swsscommon
+from flaky import flaky
 from pprint import pprint
 
 
@@ -241,6 +243,8 @@ def get_lo(dvs):
 
     return lo_id
 
+
+@pytest.mark.flaky
 class TestVxlan(object):
     def test_vxlan_term_orch(self, dvs, testlog):
         tunnel_map_ids       = set()

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1,10 +1,11 @@
-
-from swsscommon import swsscommon
 import os
 import re
 import time
 import json
 import pytest
+
+from swsscommon import swsscommon
+from flaky import flaky
 
 
 # macros for number of interfaces and number of neighbors
@@ -235,6 +236,7 @@ def ping_new_ips(dvs):
             dvs.runcmd(['sh', '-c', "ping6 -c 1 -W 0 -q {}00::{} > /dev/null 2>&1".format(i*4,j+NUM_NEIGH_PER_INTF+2)])
 
 
+@pytest.mark.flaky
 class TestWarmReboot(object):
     def test_PortSyncdWarmRestart(self, dvs, testlog):
 

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -1,4 +1,3 @@
-from swsscommon import swsscommon
 import os
 import re
 import time
@@ -6,6 +5,8 @@ import json
 import pytest
 import redis
 
+from swsscommon import swsscommon
+from flaky import flaky
 
 class SaiWmStats:
     queue_shared = "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES"
@@ -19,6 +20,7 @@ class WmTables:
     user = "USER_WATERMARKS"
 
 
+@pytest.mark.flaky
 class TestWatermark(object):
 
     DEFAULT_TELEMETRY_INTERVAL = 120


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I turned on the "flaky" pytest plugin for the vs tests. This plugin will automatically retry failed test cases one time before failing the test suite altogether.

**Why I did it**
Currently, because of the async nature of the vs tests, any given test case has about a ~5% chance of failing, which will fail the entire build. This forces them to re-run the entire test suite to get a passing result. Rather than making people re-run the entire 2 hour process, this fix will simply retry failed test cases when they fail, which should save all of us a lot of time.

**Details if related**
This is **not** a permanent solution, simply a means to un-block people until we can get all of the virtual switch tests stabilized.