### PR TITLE
[vs tests] Remove class-level flaky fixtures

### DIFF
--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -4,7 +4,6 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
 class BaseTestAcl(object):
@@ -188,7 +187,6 @@ class BaseTestAcl(object):
                 assert False
 
 
-@pytest.mark.flaky
 class TestAcl(BaseTestAcl):
     def test_AclTableCreation(self, dvs, testlog):
         self.setup_db(dvs)
@@ -1375,7 +1373,6 @@ class TestAcl(BaseTestAcl):
         dvs.set_interface_status("Ethernet4", "down")
 
 
-@pytest.mark.flaky
 class TestAclRuleValidation(BaseTestAcl):
     """ Test class for cases that check if orchagent corectly validates
     ACL rules input

--- a/tests/test_acl_ctrl.py
+++ b/tests/test_acl_ctrl.py
@@ -2,10 +2,8 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestPortChannelAcl(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_acl_egress_table.py
+++ b/tests/test_acl_egress_table.py
@@ -2,10 +2,8 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestEgressAclTable(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_acl_portchannel.py
+++ b/tests/test_acl_portchannel.py
@@ -2,10 +2,8 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestPortChannelAcl(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_admin_status.py
+++ b/tests/test_admin_status.py
@@ -2,10 +2,8 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestAdminStatus(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -6,7 +6,6 @@ import redis
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 def getCrmCounterValue(dvs, key, counter):
 
@@ -65,7 +64,6 @@ def check_syslog(dvs, marker, err_log, expected_cnt):
     assert num.strip() >= str(expected_cnt)
 
 
-@pytest.mark.flaky
 class TestCrm(object):
     def test_CrmFdbEntry(self, dvs, testlog):
 

--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -4,10 +4,8 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestDirectedBroadcast(object):
     def test_DirectedBroadcast(self, dvs, testlog):
 

--- a/tests/test_drop_counters.py
+++ b/tests/test_drop_counters.py
@@ -2,7 +2,6 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 # Supported drop counters
 PORT_INGRESS_DROPS = 'PORT_INGRESS_DROPS'
@@ -59,7 +58,6 @@ EXPECTED_NUM_ASIC_FIELDS = 2
 # FIXME: It is really annoying to have to re-run tests due to inconsistent timing, should
 # implement some sort of polling interface for checking ASIC/flex counter tables after
 # applying changes to config DB
-@pytest.mark.flaky
 class TestDropCounters(object):
     def setup_db(self, dvs):
         self.asic_db = swsscommon.DBConnector(1, dvs.redis_sock, 0)

--- a/tests/test_dtel.py
+++ b/tests/test_dtel.py
@@ -4,10 +4,8 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestDtel(object):
     def test_DtelGlobalAttribs(self, dvs, testlog):
 

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -5,7 +5,6 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 from distutils.version import StrictVersion
 
 def create_entry(tbl, key, pairs):
@@ -28,7 +27,6 @@ def how_many_entries_exist(db, table):
     return len(tbl.getKeys())
 
 
-@pytest.mark.flaky
 class TestFdb(object):
     def test_FdbWarmRestartNotifications(self, dvs, testlog):
         dvs.setup_db()

--- a/tests/test_fdb_update.py
+++ b/tests/test_fdb_update.py
@@ -5,11 +5,9 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 from distutils.version import StrictVersion
 
 
-@pytest.mark.flaky
 class TestFdbUpdate(object):
     def create_entry(self, tbl, key, pairs):
         fvs = swsscommon.FieldValuePairs(pairs)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -3,10 +3,8 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestRouterInterface(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -4,11 +4,9 @@ import pytest
 import time
 
 from swsscommon import swsscommon
-from flaky import flaky
 from distutils.version import StrictVersion
 
 
-@pytest.mark.flaky
 class TestMirror(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_mirror_ipv6_combined.py
+++ b/tests/test_mirror_ipv6_combined.py
@@ -4,13 +4,11 @@ import pytest
 import time
 
 from swsscommon import swsscommon
-from flaky import flaky
 from distutils.version import StrictVersion
 
 DVS_FAKE_PLATFORM = "broadcom"
 
 
-@pytest.mark.flaky
 class TestMirror(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -5,12 +5,10 @@ import time
 from distutils.version import StrictVersion
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 DVS_FAKE_PLATFORM = "mellanox"
 
 
-@pytest.mark.flaky
 class TestMirror(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_mirror_policer.py
+++ b/tests/test_mirror_policer.py
@@ -4,11 +4,9 @@ import pytest
 import time
 
 from swsscommon import swsscommon
-from flaky import flaky
 from distutils.version import StrictVersion
 
 
-@pytest.mark.flaky
 class TestMirror(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -6,7 +6,6 @@ import pdb
 import os
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
 # FIXME: These tests depend on changes in sonic-buildimage, we need to reenable

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -3,10 +3,8 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestNeighbor(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -5,10 +5,8 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestNextHopGroup(object):
     def test_route_nhg(self, dvs, testlog):
         config_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)

--- a/tests/test_pfc.py
+++ b/tests/test_pfc.py
@@ -2,7 +2,6 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 def getBitMaskStr(bits):
 
@@ -60,7 +59,6 @@ def getPortAttr(dvs, port_oid, port_attr):
     return ''
 
 
-@pytest.mark.flaky
 class TestPfc(object):
     def test_PfcAsymmetric(self, dvs, testlog):
 

--- a/tests/test_policer.py
+++ b/tests/test_policer.py
@@ -3,10 +3,8 @@ import pytest
 import time
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestPolicer(object):
     def test_PolicerBasic(self, dvs, testlog):
         dvs.setup_db()

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -3,10 +3,8 @@ import os
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestPort(object):
     def test_PortMtu(self, dvs, testlog):
         pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -3,10 +3,8 @@ import os
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestPortAutoNeg(object):
     def test_PortAutoNegCold(self, dvs, testlog):
 

--- a/tests/test_port_buffer_rel.py
+++ b/tests/test_port_buffer_rel.py
@@ -2,11 +2,9 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
 # The test check that the ports will be up, when the admin state is UP by conf db.
-@pytest.mark.flaky
 class TestPortBuffer(object):
     def test_PortsAreUpAfterBuffers(self, dvs, testlog):
         num_ports = 32

--- a/tests/test_port_config.py
+++ b/tests/test_port_config.py
@@ -4,7 +4,6 @@ import os
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
 @pytest.yield_fixture
@@ -15,7 +14,6 @@ def port_config(request, dvs):
     dvs.runcmd("mv %s.bak %s" % (file_name, file_name))
 
 
-@pytest.mark.flaky
 class TestPortConfig(object):
 
     def getPortName(self, dvs, port_vid):

--- a/tests/test_port_mac_learn.py
+++ b/tests/test_port_mac_learn.py
@@ -3,10 +3,8 @@ import os
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestPortMacLearn(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -4,10 +4,8 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestPortchannel(object):
     def test_Portchannel(self, dvs, testlog):
 

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -4,7 +4,6 @@ import sys
 import time
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 CFG_DOT1P_TO_TC_MAP_TABLE_NAME =  "DOT1P_TO_TC_MAP"
 CFG_DOT1P_TO_TC_MAP_KEY = "AZURE"
@@ -24,7 +23,6 @@ CFG_PORT_QOS_MAP_FIELD = "dot1p_to_tc_map"
 CFG_PORT_TABLE_NAME = "PORT"
 
 
-@pytest.mark.flaky
 class TestDot1p(object):
     def connect_dbs(self, dvs):
         self.asic_db = swsscommon.DBConnector(1, dvs.redis_sock, 0)

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -5,10 +5,8 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestRoute(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_setro.py
+++ b/tests/test_setro.py
@@ -5,10 +5,8 @@ import pytest
 
 from pprint import pprint
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestSetRo(object):
     def test_SetReadOnlyAttribute(self, dvs, testlog):
 

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -3,10 +3,8 @@ import os
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestSflow(object):
     speed_rate_table = {
         "400000":"40000",

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -9,10 +9,8 @@ import os
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
-@pytest.mark.flaky
 class TestSpeedSet(object):
     num_ports = 32
     def test_SpeedAndBufferSet(self, dvs, testlog):

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -3,7 +3,6 @@ import time
 import json
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 CFG_VLAN_SUB_INTF_TABLE_NAME = "VLAN_SUB_INTERFACE"
 CFG_PORT_TABLE_NAME = "PORT"
@@ -19,7 +18,6 @@ ASIC_ROUTE_ENTRY_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"
 ADMIN_STATUS = "admin_status"
 
 
-@pytest.mark.flaky
 class TestSubPortIntf(object):
     PHYSICAL_PORT_UNDER_TEST = "Ethernet64"
     SUB_PORT_INTERFACE_UNDER_TEST = "Ethernet64.10"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,7 +2,6 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
 def create_entry(tbl, key, pairs):
@@ -62,7 +61,6 @@ def vxlan_switch_test(dvs, oid, port, mac):
     )
 
 
-@pytest.mark.flaky
 class TestSwitch(object):
     '''
     Test- Check switch attributes

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -2,14 +2,12 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
 def create_fvs(**kwargs):
     return swsscommon.FieldValuePairs(kwargs.items())
 
 
-@pytest.mark.flaky
 class TestTunnelBase(object):
     APP_TUNNEL_DECAP_TABLE_NAME = "TUNNEL_DECAP_TABLE"
     ASIC_TUNNEL_TABLE           = "ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL"

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -5,11 +5,9 @@ import pytest
 import platform
 
 from swsscommon import swsscommon
-from flaky import flaky
 from distutils.version import StrictVersion
 
 
-@pytest.mark.flaky
 class TestVlan(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -5,7 +5,6 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 from pprint import pprint
 
 
@@ -952,7 +951,6 @@ class VnetBitmapVxlanTunnel(object):
         self.vnet_bitmap_route_ids.remove(old_bitmap_route[0])
 
 
-@pytest.mark.flaky
 class TestVnetOrch(object):
 
     def get_vnet_obj(self):

--- a/tests/test_vnet_bitmap.py
+++ b/tests/test_vnet_bitmap.py
@@ -4,7 +4,6 @@ import pytest
 import test_vnet as vnet
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
 # Define fake platform for "DVS" fixture, so it will set "platform" environment variable for "orchagent".
@@ -18,7 +17,6 @@ Test cases are inherited from "test_vnet.py::TestVnetOrch" since they are the sa
 Difference between these two implementations is in set SAI attributes, so different values should be checked in ASIC_DB.
 This class should override "get_vnet_obj()" method in order to return object with appropriate implementation of "check" APIs.
 '''
-@pytest.mark.flaky
 class TestVnetBitmapOrch(vnet.TestVnetOrch):
 
     '''

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -4,11 +4,9 @@ import random
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 from pprint import pprint
 
 
-@pytest.mark.flaky
 class TestVrf(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -5,7 +5,6 @@ import time
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 from pprint import pprint
 
 
@@ -244,7 +243,6 @@ def get_lo(dvs):
     return lo_id
 
 
-@pytest.mark.flaky
 class TestVxlan(object):
     def test_vxlan_term_orch(self, dvs, testlog):
         tunnel_map_ids       = set()

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -5,7 +5,6 @@ import json
 import pytest
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 
 # macros for number of interfaces and number of neighbors
@@ -236,7 +235,6 @@ def ping_new_ips(dvs):
             dvs.runcmd(['sh', '-c', "ping6 -c 1 -W 0 -q {}00::{} > /dev/null 2>&1".format(i*4,j+NUM_NEIGH_PER_INTF+2)])
 
 
-@pytest.mark.flaky
 class TestWarmReboot(object):
     def test_PortSyncdWarmRestart(self, dvs, testlog):
 

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -6,7 +6,6 @@ import pytest
 import redis
 
 from swsscommon import swsscommon
-from flaky import flaky
 
 class SaiWmStats:
     queue_shared = "SAI_QUEUE_STAT_SHARED_WATERMARK_BYTES"
@@ -20,7 +19,6 @@ class WmTables:
     user = "USER_WATERMARKS"
 
 
-@pytest.mark.flaky
 class TestWatermark(object):
 
     DEFAULT_TELEMETRY_INTERVAL = 120


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I removed the flaky fixtures from the vs tests.

**Why I did it**
We've enabled flaky for all tests via the command line on the Jenkins side. This is a more stable solution to enabling test retries than the annotations as we don't have to police new test cases for the flaky fixtures.

**How I verified it**
I ran the VS tests locally and observed that the retries were occuring when I passed the `--force_flaky` flag.

**Details if related**
It is still possible to use flaky to add more precise parameters to specific test cases if the need arises. class and method level flaky fixtures will override the default passed by the command line.