### PR TITLE
[team sync/mgr] Add debug message before cleaning up LAGs

### DIFF
--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -163,6 +163,7 @@ void TeamMgr::cleanTeamProcesses(int signo)
 {
     pid_t pid = 0;
 
+    SWSS_LOG_ENTER();
     SWSS_LOG_NOTICE("Cleaning up LAGs during shutdown...");
     for (const auto& it: m_lagList)
     {

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -163,6 +163,7 @@ void TeamMgr::cleanTeamProcesses(int signo)
 {
     pid_t pid = 0;
 
+    SWSS_LOG_NOTICE("Cleaning up LAGs during shutdown...");
     for (const auto& it: m_lagList)
     {
         pid = m_lagPIDList[it];

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -212,7 +212,8 @@ void TeamSync::removeLag(const string &lagName)
 
 void TeamSync::cleanTeamSync()
 {
-    SWSS_LOG_NOTICE("Cleaning up kernel LAGs ...");
+    SWSS_LOG_ENTER();
+    SWSS_LOG_NOTICE("Cleaning up LAG teamd resources ...");
 
     for (const auto& it: m_teamSelectables)
     {

--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -212,6 +212,8 @@ void TeamSync::removeLag(const string &lagName)
 
 void TeamSync::cleanTeamSync()
 {
+    SWSS_LOG_NOTICE("Cleaning up kernel LAGs ...");
+
     for (const auto& it: m_teamSelectables)
     {
         /* Cleanup LAG */


### PR DESCRIPTION
**What I did**

These functions are called only once in the time of service stopping,
add events will help debug. And these messages won't be chatty.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**Why I did it**
Once the cleanup code was on radar as a suspect. If we had these debug messages, it would have cleared the suspect very quickly.
