### PR TITLE
[intfmgr] Fix OA crash issue due to link local configurations

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -602,8 +602,12 @@ bool IntfMgr::doIntfAddrTask(const vector<string>& keys,
     {
         setIntfIp(alias, "del", ip_prefix);
 
-        m_appIntfTableProducer.del(appKey);
-        m_stateIntfTable.del(keys[0] + state_db_key_delimiter + keys[1]);
+        // Don't send link local config to AppDB and Orchagent
+        if (ip_prefix.getIp().getAddrScope() != IpAddress::AddrScope::LINK_SCOPE)
+        {
+            m_appIntfTableProducer.del(appKey);
+            m_stateIntfTable.del(keys[0] + state_db_key_delimiter + keys[1]);
+        }
     }
     else
     {

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -587,12 +587,16 @@ bool IntfMgr::doIntfAddrTask(const vector<string>& keys,
 
         std::vector<FieldValueTuple> fvVector;
         FieldValueTuple f("family", ip_prefix.isV4() ? IPV4_NAME : IPV6_NAME);
-        FieldValueTuple s("scope", "global");
-        fvVector.push_back(s);
-        fvVector.push_back(f);
 
-        m_appIntfTableProducer.set(appKey, fvVector);
-        m_stateIntfTable.hset(keys[0] + state_db_key_delimiter + keys[1], "state", "ok");
+        // Don't send link local config to AppDB and Orchagent
+        if (ip_prefix.getIp().getAddrScope() != IpAddress::AddrScope::LINK_SCOPE)
+        {
+            FieldValueTuple s("scope", "global");
+            fvVector.push_back(s);
+            fvVector.push_back(f);
+            m_appIntfTableProducer.set(appKey, fvVector);
+            m_stateIntfTable.hset(keys[0] + state_db_key_delimiter + keys[1], "state", "ok");
+        }
     }
     else if (op == DEL_COMMAND)
     {


### PR DESCRIPTION
[intfmgr] Fix OA crash issue due to link local configurations

Signed-off-by: Zhenggen Xu <zxu@linkedin.com>

This should be backported to 201811 and 201911.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix OA crash issue due to link local configurations. 
In this PR, it will not send the link local configurations towards AppDB as it was configured on HW by default.

**Why I did it**
In case we have ipv6 link local configuration in configDB, it will crash OA.

**How I verified it**
**configuration:**
```
    "VLAN_INTERFACE": {
        "Vlan100|10.11.10.1/26": {
            "family": "IPv4", 
            "scope": "global"
        }, 
        "Vlan100|2000:11:10::1/64": {
            "family": "IPv6", 
            "scope": "global"
        }, 
        "Vlan100|fe80::1/10": {
            "family": "IPv6", 
            "scope": "local"
        }, 
        "Vlan777|10.11.77.1/26": {
            "family": "IPv4", 
            "scope": "global"
        }, 
        "Vlan777|2000:11:77::1/64": {
            "family": "IPv6", 
            "scope": "global"
        }, 
        "Vlan777|fe80::1/10": {
            "family": "IPv6", 
            "scope": "local"
        }
    }, 
```

**Before fix:**
```
Feb 12 00:15:56.615576 sonic ERR swss#orchagent: :- meta_sai_validate_route_entry: object key SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"fe80::/10","switch_id":"oid:0x21000000000000","vr":"oid:0x300000000
0022"} already exists
Feb 12 00:15:56.615682 sonic ERR swss#orchagent: :- addSubnetRoute: Failed to create subnet route to fe80::/10 from Vlan100, rv:-6
Feb 12 00:15:56.616068 sonic INFO swss#supervisord: orchagent terminate called after throwing an instance of '
Feb 12 00:15:56.621355 sonic INFO swss#supervisord: orchagent std::runtime_error'
Feb 12 00:15:56.621534 sonic INFO swss#supervisord: orchagent   what():  Failed to create subnet route.
Feb 12 00:15:56.621625 sonic INFO swss#supervisord: orchagent 
```

```
admin@sonic:~$ redis-cli 
127.0.0.1:6379> keys INT*
1) "INTF_TABLE:Vlan100:10.11.10.1/26"
2) "INTF_TABLE:Vlan100:2000:11:10::1/64"
3) "INTF_TABLE:Vlan777:2000:11:77::1/64"
4) "INTF_TABLE:Vlan100:fe80::1/10"
5) "INTF_TABLE:lo:2000:0:1::1/128"
6) "INTF_TABLE:Vlan777:fe80::1/10"
7) "INTF_TABLE:lo:10.0.1.1/32"
8) "INTF_TABLE_KEY_SET"
9) "INTF_TABLE:Vlan777:10.11.77.1/26"
127.0.0.1:6379> 
```

**After fix:**
No crash was seen.

```
127.0.0.1:6379> keys INTF*
 1) "INTF_TABLE:Vlan100:10.11.10.1/26"
 2) "INTF_TABLE:Vlan100:2000:11:10::1/64"
 3) "INTF_TABLE:Vlan777:2000:11:77::1/64"
 4) "INTF_TABLE:Ethernet116:10.2.1.1/31"
 5) "INTF_TABLE:lo:2000:0:1::1/128"
 6) "INTF_TABLE:Ethernet112:2000:1:1::2/126"
 7) "INTF_TABLE:lo:10.0.1.1/32"
 8) "INTF_TABLE:Vlan777:10.11.77.1/26"
 9) "INTF_TABLE:Ethernet116:2000:2:1::2/126"
10) "INTF_TABLE:Ethernet112:10.1.1.1/31"

```


**Details if related**
