### PR TITLE
[dvs] Stabilize warm reboot neighbor syncup test

### DIFF
--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1973,9 +1973,6 @@ class TestWarmReboot(object):
         check_kernel_reachable_v4_neigh_num(dvs, NUM_OF_NEIGHS)
         check_kernel_reachable_v6_neigh_num(dvs, NUM_OF_NEIGHS)
 
-        #check_kernel_stale_v4_neigh_num(dvs, NUM_OF_NEIGHS/2)
-        #check_kernel_stale_v6_neigh_num(dvs, NUM_OF_NEIGHS/2)
-
         check_redis_neigh_entries(dvs, tbl, 2*(NUM_OF_NEIGHS+NUM_OF_NEIGHS/2))
 
         (nadd, ndel) = dvs.CountSubscribedObjects(pubsub)

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -2,7 +2,6 @@ import os
 import re
 import time
 import json
-import pytest
 
 from swsscommon import swsscommon
 
@@ -2027,7 +2026,6 @@ class TestWarmReboot(object):
             dvs.runcmd("ip link set down dev Ethernet{}".format(i*4))
 
         # start neighsyncd and restore_neighbors
-        marker = dvs.add_log_marker()
         start_neighsyncd(dvs)
         start_restore_neighbors(dvs)
 


### PR DESCRIPTION
Signed-off-by: Sangita Maity <sangitamaity0211@gmail.com>

**What I did**
Modified the test_warm_reboot.py script to **stabilize the test case** and also, started using **swsscommon dbconnector** instead of **redis-cli** command in one of the functions.

**Why I did it**
To stabilize the test case. 

**How I verified it**
```
samaity@server09:~/REPO_FACTORY/GIT_REPO/vs_swss_test/sonic-buildimage/src/sonic-swss$ sudo pytest -v --dvsname=vs-sang tests/test_warm_reboot.py -k "test_system_warmreboot_neighbor_syncup"
============================================================================================================ test session starts =============================================================================================================
platform linux2 -- Python 2.7.15+, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/vs_swss_test/sonic-buildimage/src/sonic-swss
plugins: repeat-0.8.0
collected 8 items / 7 deselected / 1 selected

tests/test_warm_reboot.py::TestWarmReboot::test_system_warmreboot_neighbor_syncup PASSED                                                                                                                                               [100%]

================================================================================================== 1 passed, 7 deselected in 452.22 seconds ==================================================================================================
samaity@server09:~/REPO_FACTORY/GIT_REPO/vs_swss_test/sonic-buildimage/src/sonic-swss$
```

[jenkins result](https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/sonic-swss-build-pr/1413/testReport/test_warm_reboot/TestWarmReboot/test_system_warmreboot_neighbor_syncup/)
