### PR TITLE
[dvs] Add NAT tests back to test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,10 +157,8 @@ class DockerVirtualSwitch(object):
         self.syncd = ['syncd']
         self.rtd   = ['fpmsyncd', 'zebra', 'staticd']
         self.teamd = ['teamsyncd', 'teammgrd']
-        # FIXME: We need to verify that NAT processes are running, once the
-        # appropriate changes are merged into sonic-buildimage
-        # self.natd = ['natsyncd', 'natmgrd']
-        self.alld  = self.basicd + self.swssd + self.syncd + self.rtd + self.teamd # + self.natd
+        self.natd = ['natsyncd', 'natmgrd']
+        self.alld  = self.basicd + self.swssd + self.syncd + self.rtd + self.teamd + self.natd
         self.client = docker.from_env()
         self.appldb = None
 

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -8,10 +8,9 @@ import os
 from swsscommon import swsscommon
 
 
-# FIXME: These tests depend on changes in sonic-buildimage, we need to reenable
-# them once those changes are merged.
-@pytest.mark.skip(reason="Depends on changes in sonic-buildimage")
-class TestNatFeature(object):
+# FIXME: https://github.com/Azure/sonic-swss/issues/1199
+@pytest.mark.xfail(reason="DVS crashes during NAT test execution")
+class TestNat(object):
     def setup_db(self, dvs):
         self.appdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
         self.asicdb = swsscommon.DBConnector(1, dvs.redis_sock, 0)


### PR DESCRIPTION
- Validate that NAT processes are running on dvs
- Mark tests as xfail so results can be monitored

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Fixes #1178 
Introduces #1199 