### PR TITLE
Removed the xfail mark for NAT test cases.

### DIFF
--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -7,9 +7,6 @@ import os
 
 from swsscommon import swsscommon
 
-
-# FIXME: https://github.com/Azure/sonic-swss/issues/1199
-@pytest.mark.xfail(reason="DVS crashes during NAT test execution")
 class TestNat(object):
     def setup_db(self, dvs):
         self.appdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -81,8 +81,14 @@ class TestNat(object):
         keys  = tbl.getKeys()
 
         (status, fvs) = tbl.get("Ethernet0")
-
-        assert fvs==(('NULL', 'NULL'), ('nat_zone', '1'))
+        assert status == True
+        assert len(fvs) > 0
+        zone = False
+        for fv in fvs:
+            if fv[0] == 'nat_zone' and fv[1] == '1':
+               zone = True
+               break
+        assert zone == True
 
 
     def test_AddNatStaticEntry(self, dvs, testlog):


### PR DESCRIPTION
The NAT test cases are failed due to NAT commands are not present at time of issue (https://github.com/Azure/sonic-swss/issues/1199) was reported.

Later on sonic-utilities submodule got updated to master "sonic-buildimage" branch and after this update all NAT test cases are passed.

And also fixed a failure seen in test case "test_NatInterfaceZone".

So removing the xfail mark for NAT test cases.

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>

