### PR TITLE
Default action for Egress ACL Table not populated.

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -127,7 +127,10 @@ static const acl_capabilities_t defaultAclActionsSupported =
         }
     },
     {
-        ACL_STAGE_EGRESS, {}
+        ACL_STAGE_EGRESS, 
+        {
+            SAI_ACL_ACTION_TYPE_PACKET_ACTION
+        }
     }
 };
 


### PR DESCRIPTION
Default action for Egress ACL Table not populated. 
SAI Query for ACL Capability is not supported as of now for all
platform. This fix issue Swss Issue #1207 

**What I did**
Updated default acl action for Egress ACL Table
**Why I did it**
Refer Issue #1207 
**How I verified it**
Manually Verified Running PFC WD testcase

