### PR TITLE
upon cold reboot, skip remove mgmt vrf table from the kernel

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -68,7 +68,8 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
                 else
                 {
                     // No deletion of mgmt table from kernel
-                    if (vrfName.compare("mgmt") ==0) {
+                    if (vrfName.compare("mgmt") ==0)
+                    { 
                         SWSS_LOG_NOTICE("Skipping remove vrf device %s", vrfName.c_str());
                         rowType = LINK_ROW;
                         break;

--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -67,6 +67,13 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
                 }
                 else
                 {
+                    // No deletion of mgmt table from kernel
+                    if (vrfName.compare("mgmt") ==0) {
+                        SWSS_LOG_NOTICE("Skipping remove vrf device %s", vrfName.c_str());
+                        rowType = LINK_ROW;
+                        break;
+                    }
+
                     SWSS_LOG_NOTICE("Remove vrf device %s", vrfName.c_str());
                     cmd.str("");
                     cmd.clear();

--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -68,7 +68,7 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
                 else
                 {
                     // No deletion of mgmt table from kernel
-                    if (vrfName.compare("mgmt") ==0)
+                    if (vrfName.compare("mgmt") == 0)
                     { 
                         SWSS_LOG_NOTICE("Skipping remove vrf device %s", vrfName.c_str());
                         rowType = LINK_ROW;


### PR DESCRIPTION

**What I did**
In vrfmgr.cpp, for non-warm reboot case, skip removal of mgmt vrf table from the kernel.

**Why I did it**
mgmt vrf table in the kernel is installed via /etc/network/interfaces upon reboot, if vrfmgrd removes it after that, mgmt vrf table is missing in the kernel even though it is in the config db.

**How I verified it**
configure mgmt vrf and data VRF, save the configurations and do node reboot. After reboot, check mgmt vrf table is in the kernel.
Also check data VRFs are also present in the kernel.

**Details if related**
root@sonic:~# ip vrf show
Name              Table
-----------------------
Vrf_red           1001
Vrf_green         1002
mgmt              5000   <<<<<<<<
