### PR TITLE
Revert "Revert "[BFN] Enable m_isCombinedMirrorV6Table for BFN""

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2104,13 +2104,13 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
 
     // In Broadcom platform, V4 and V6 rules are stored in the same table
     if (platform == BRCM_PLATFORM_SUBSTRING ||
-            platform == NPS_PLATFORM_SUBSTRING) {
+        platform == NPS_PLATFORM_SUBSTRING  ||
+        platform == BFN_PLATFORM_SUBSTRING) {
         m_isCombinedMirrorV6Table = true;
     }
 
     // In Mellanox platform, V4 and V6 rules are stored in different tables
-    if (platform == MLNX_PLATFORM_SUBSTRING ||
-        platform == BFN_PLATFORM_SUBSTRING) {
+    if (platform == MLNX_PLATFORM_SUBSTRING) {
         m_isCombinedMirrorV6Table = false;
     }
 


### PR DESCRIPTION
**What I did**
Enable m_isCombinedMirrorV6Table for BFN

**Why I did it**
To fix typo in initial PR #1177


Reverts Azure/sonic-swss#1209 which reverts Azure/sonic-swss#1206 as #1206 changes requested for  201911 branch. See https://github.com/Azure/sonic-swss/pull/1212