### PR TITLE
[vnet]: Fix continues warning messages after config reload

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1074,7 +1074,7 @@ bool VNetBitmapObject::removeTunnelRoute(IpPrefix& ipPrefix)
     if (tunnelRouteMap_.find(ipPrefix) == tunnelRouteMap_.end())
     {
         SWSS_LOG_WARN("VNET tunnel route %s doesn't exist", ipPrefix.to_string().c_str());
-        return false;
+        return true;
     }
 
     auto tunnelRouteInfo = tunnelRouteMap_.at(ipPrefix);
@@ -1273,7 +1273,7 @@ bool VNetBitmapObject::removeRoute(IpPrefix& ipPrefix)
     if (routeMap_.find(ipPrefix) == routeMap_.end())
     {
         SWSS_LOG_WARN("VNET route %s doesn't exist", ipPrefix.to_string().c_str());
-        return false;
+        return true;
     }
 
     sai_status_t status = sai_bmtor_api->remove_table_bitmap_router_entry(routeMap_.at(ipPrefix).routeTableEntryId);
@@ -1838,7 +1838,7 @@ bool VNetRouteOrch::doRouteTask<VNetBitmapObject>(const string& vnet, IpPrefix& 
     if (!vnet_orch_->isVnetExists(vnet))
     {
         SWSS_LOG_WARN("VNET %s doesn't exist", vnet.c_str());
-        return false;
+        return (op == DEL_COMMAND) ? true : false;
     }
 
     auto *vnet_obj = vnet_orch_->getTypePtr<VNetBitmapObject>(vnet);
@@ -1863,7 +1863,7 @@ bool VNetRouteOrch::doRouteTask<VNetBitmapObject>(const string& vnet, IpPrefix& 
     if (!vnet_orch_->isVnetExists(vnet))
     {
         SWSS_LOG_WARN("VNET %s doesn't exist", vnet.c_str());
-        return false;
+        return (op == DEL_COMMAND) ? true : false;
     }
 
     auto *vnet_obj = vnet_orch_->getTypePtr<VNetBitmapObject>(vnet);


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
In VNET route remove handler return ```true``` instead of ```false``` if route is not found in the internal vnetorch cache. It is needed because vnetorch might receive double ```remove``` event and it causes endless warning messages since event will be forever in a message queue. In order to remove it from the queue just need to return ```true``` to the caller (Orch2::doTask).
**Why I did it**
To fix continues warning messages (shown below) after config reload with the saved VNETs and VNET routes.
```WARNING swss#orchagent: :- removeTunnelRoute: VNET tunnel route 172.2.10.0/24 doesn't exist```
**How I verified it**
Added VNET config with the different routes to the config_db.json, perform config reload and verified there are no endless warnings in the log.
**Details if related**
N/A