### PR TITLE
[DPB:orchagent:portsorch] Rework port dependency  (#23)

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -49,14 +49,6 @@ public:
         UNKNOWN
     } ;
 
-    enum Dependency {
-            ACL_DEP,
-            FDB_DEP,
-            INTF_DEP,
-            LAG_DEP,
-            VLAN_DEP
-    };
-
     Port() {};
     Port(std::string alias, Type type) :
             m_alias(alias), m_type(type) {};
@@ -121,19 +113,6 @@ public:
 
     std::unordered_set<sai_object_id_t> m_ingress_acl_tables_uset;
     std::unordered_set<sai_object_id_t> m_egress_acl_tables_uset;
-
-    inline void set_dependency(Dependency dep)
-    {
-        m_dependency_bitmap |= (1 << dep);
-    }
-    inline void clear_dependency(Dependency dep)
-    {
-        m_dependency_bitmap &= ~(1 << dep);
-    }
-    inline bool has_dependency()
-    {
-        return (m_dependency_bitmap != 0);
-    }
 };
 
 }

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -84,6 +84,7 @@ public:
     std::string         m_learn_mode = "hardware";
     bool                m_autoneg = false;
     bool                m_admin_state_up = false;
+    bool                m_init = false;
     sai_object_id_t     m_port_id = 0;
     sai_port_fec_mode_t m_fec_mode = SAI_PORT_FEC_MODE_NONE;
     VlanInfo            m_vlan_info;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1667,6 +1667,7 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     RedisClient redisClient(m_counter_db.get());
     redisClient.hdel(COUNTERS_PORT_NAME_MAP, alias);
 
+    m_portList[alias].m_init = false;
     SWSS_LOG_NOTICE("De-Initialized port %s", alias.c_str());
 }
 
@@ -2275,7 +2276,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     throw runtime_error("Remove hostif for the port failed");
                 }
-                m_portList[alias].m_init = false;
 
                 Port p;
                 if (getPort(port_id, p))

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -194,7 +194,7 @@ private:
     void getLagMember(Port &lag, vector<Port> &portv);
 
     bool addPort(const set<int> &lane_set, uint32_t speed, int an=0, string fec="");
-    bool removePort(sai_object_id_t port_id);
+    sai_status_t removePort(sai_object_id_t port_id);
     bool initPort(const string &alias, const set<int> &lane_set);
     void deInitPort(string alias, sai_object_id_t port_id);
 


### PR DESCRIPTION
* Use SAI REDIS return code to track dependency on port.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
While deleting a port, if SAI call return OBJECT_IN_USE error code, we will continue to wait/loop in orchagent to delete the port. Once all the dependencies are removed, we will go-ahead remove the port. Note that dependency tracking itself is done in SAI REDIS layer. Also note that identifying dependencies and removing the dependencies is done in config mgmt layer.

**Why I did it**
As part Dynamic Port Breakout feature, we need to delete and re-create ports. During deletion of a port, we need to ensure that all dependencies are also removed. For example, port being part of ACL, VLAN, QoS, etc. Initial approach was to track these dependencies in orchagent itself. But after discussion with Microsoft team, we decided that we can use the dependency check that is already being done at the SAI REDIS layer. So, here we are going to check the return error code of SAI call to deduce if the port has any dependency. 

**How I verified it**
Tested Dynamic Port Breakout code with port in VLAN and ACL tables. Verified from syslog that we SAI redis call to remove/delete the port succeeds when the dependencies are removed.

**Details if related**
