### PR TITLE
[dvs] Mark unstable test cases as xfail

### DIFF
--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -4,7 +4,7 @@ import pytest
 
 from swsscommon import swsscommon
 
-
+@pytest.mark.xfail(reason="vs image issue: Azure/sonic-sairedis#574")
 class TestRouterInterface(object):
     def setup_db(self, dvs):
         self.pdb = swsscommon.DBConnector(0, dvs.redis_sock, 0)
@@ -490,7 +490,6 @@ class TestRouterInterface(object):
             if route["dest"] == "fc00::1/128":
                 assert False
 
-
     def test_PortInterfaceAddRemoveIpv4AddressWithVrf(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -939,7 +938,6 @@ class TestRouterInterface(object):
         # remove port channel
         self.remove_port_channel("PortChannel001")
 
-
     def test_LagInterfaceSetMtu(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -1115,7 +1113,6 @@ class TestRouterInterface(object):
 
         # remove port channel
         self.remove_port_channel("PortChannel001")
-
 
     def test_LagInterfaceAddRemoveIpv4AddressWithVrf(self, dvs, testlog):
         self.setup_db(dvs)

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -90,7 +90,6 @@ class TestNat(object):
                break
         assert zone == True
 
-
     def test_AddNatStaticEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)
@@ -152,6 +151,7 @@ class TestNat(object):
         key = tbl.getKeys()
         assert key == ()
 
+    @pytest.mark.xfail(reason="vs image issue: Azure/sonic-sairedis#575")
     def test_AddNaPtStaticEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)
@@ -193,6 +193,7 @@ class TestNat(object):
             else:
                  assert False
 
+    @pytest.mark.xfail(reason="vs image issue: Azure/sonic-sairedis#575")
     def test_DelNaPtStaticEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)
@@ -215,6 +216,7 @@ class TestNat(object):
         key = tbl.getKeys()
         assert key == ()
 
+    @pytest.mark.xfail(reason="vs image issue: Azure/sonic-sairedis#575")
     def test_AddTwiceNatEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)
@@ -263,6 +265,7 @@ class TestNat(object):
            else:
                assert False
 
+    @pytest.mark.xfail(reason="vs image issue: Azure/sonic-sairedis#575")
     def test_DelTwiceNatStaticEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)
@@ -286,6 +289,7 @@ class TestNat(object):
         key = tbl.getKeys()
         assert key == ()
 
+    @pytest.mark.xfail(reason="vs image issue: Azure/sonic-sairedis#575")
     def test_AddTwiceNaPtEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)
@@ -335,6 +339,7 @@ class TestNat(object):
            else:
                assert False
 
+    @pytest.mark.xfail(reason="vs image issue: Azure/sonic-sairedis#575")
     def test_DelTwiceNaPtStaticEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)

--- a/tests/test_port_dpb.py
+++ b/tests/test_port_dpb.py
@@ -73,6 +73,7 @@ class TestPortDPB(object):
     '''
     @pytest.mark.skip()
     '''
+    @pytest.mark.xfail(reason="test stability issue: Azure/sonic-swss#1222")
     def test_port_breakout_multiple(self, dvs):
         dpb = DPB()
         port_names = ["Ethernet0", "Ethernet12", "Ethernet64", "Ethernet112"]


### PR DESCRIPTION
- Disable VRF and NAT test cases due to VS image issues
- Disable DPB test case due to instability

Signed-off-by: Danny Allen

**Why I did it**
To unblock PRs in sonic-swss and sonic-utilities.

**Details if related**
Azure/sonic-sairedis#574 to track VRF image issue
Azure/sonic-sairedis#575 to track NAT image issue
Azure/sonic-swss#1222 to track DPB stability issue