### PR TITLE
swss: Fix sFlow sampling-rate and admin-state

### DIFF
--- a/cfgmgr/sflowmgr.h
+++ b/cfgmgr/sflowmgr.h
@@ -30,7 +30,8 @@ namespace swss {
 
 struct SflowPortInfo
 {
-    bool        local_conf;
+    bool        local_rate_cfg;
+    bool        local_admin_cfg;
     std::string speed;
     std::string rate;
     std::string admin;
@@ -50,7 +51,7 @@ private:
     Table                  m_cfgSflowSessionTable;
     ProducerStateTable     m_appSflowTable;
     ProducerStateTable     m_appSflowSessionTable;
-    SflowPortConfMap  m_sflowPortConfMap;
+    SflowPortConfMap       m_sflowPortConfMap;
     bool                   m_intfAllConf;
     bool                   m_gEnable;
 


### PR DESCRIPTION
* Fixing Add logic to allow user to revert to
         default sFlow sampling-rate on
         interface.
* Fixing Fixed incorrect interface admin-status
         when 'all' interface is disabled but
         there are local sampling-rate configurations.

Signed-off-by: Garrick He <garrick_he@dell.com>

**What I did**
Fixed a bug where the interface sFlow admin-status is not correct if the user configures a custom sFlow sampling-rate. (UT performed here)

As a side-effect of this fix, users can now restore the default sFlow sampling-rate with the `default` option using: `config sflow interface sampling-rate Ethernet4 default`
This is not tested here but will be tested when the config script update PR is submitted to sonic-utilities. The sFlow corresponding HLD and command-line reference will also be updated.

**Why I did it**
If the user ONLY configures a custom (local) sFlow sampling-rate for a interface, the interface's admin-status should still adhere to the global interface admin-status.

**How I verified it**
Ran unit-test before and after the fix. See 'details' section below.

**Details if related**
```
admin@sonic:~$ show version

SONiC Software Version: SONiC.HEAD.271-7d2ebf81
Distribution: Debian 9.12
Kernel: 4.9.0-11-2-amd64
Build commit: 7d2ebf81
Build date: Thu Mar 12 12:08:35 UTC 2020
Built by: johnar@jenkins-worker-12

Platform: x86_64-kvm_x86_64-r0
HwSKU: Force10-S6000
ASIC: vs
Serial Number: 000000
Uptime: 11:32:42 up 2 min,  1 user,  load average: 2.07, 1.49, 0.62

Docker images:
REPOSITORY                    TAG                 IMAGE ID            SIZE
docker-syncd-vs               HEAD.271-7d2ebf81   801ebba2928e        293MB
docker-syncd-vs               latest              801ebba2928e        293MB
docker-router-advertiser      HEAD.271-7d2ebf81   66a01177d5e2        283MB
docker-router-advertiser      latest              66a01177d5e2        283MB
docker-platform-monitor       HEAD.271-7d2ebf81   fe5764889f0a        335MB
docker-platform-monitor       latest              fe5764889f0a        335MB
docker-dhcp-relay             HEAD.271-7d2ebf81   6fb090883a58        293MB
docker-dhcp-relay             latest              6fb090883a58        293MB
docker-database               HEAD.271-7d2ebf81   596b4fb9f0b9        283MB
docker-database               latest              596b4fb9f0b9        283MB
docker-orchagent              HEAD.271-7d2ebf81   d7ce15f59f9a        326MB
docker-orchagent              latest              d7ce15f59f9a        326MB
docker-nat                    HEAD.271-7d2ebf81   a45757c846f1        310MB
docker-nat                    latest              a45757c846f1        310MB
docker-sonic-telemetry        HEAD.271-7d2ebf81   b62ca7d52376        345MB
docker-sonic-telemetry        latest              b62ca7d52376        345MB
docker-sonic-mgmt-framework   HEAD.271-7d2ebf81   2c9db136589e        421MB
docker-sonic-mgmt-framework   latest              2c9db136589e        421MB
docker-fpm-frr                HEAD.271-7d2ebf81   c7bab662339e        328MB
docker-fpm-frr                latest              c7bab662339e        328MB
docker-sflow                  HEAD.271-7d2ebf81   7502070966f0        308MB
docker-sflow                  latest              7502070966f0        308MB
docker-lldp-sv2               HEAD.271-7d2ebf81   ce902ae9e83c        305MB
docker-lldp-sv2               latest              ce902ae9e83c        305MB
docker-snmp-sv2               HEAD.271-7d2ebf81   e3fbc3024f19        340MB
docker-snmp-sv2               latest              e3fbc3024f19        340MB
docker-teamd                  HEAD.271-7d2ebf81   2f934886b9b1        308MB
docker-teamd                  latest              2f934886b9b1        308MB

admin@sonic:~$



UT before fix:

admin@sonic:~$ sudo -i
root@sonic:~# show sflow

sFlow Global Information:
  sFlow Admin State:          down
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  0 Collectors configured:
root@sonic:~# config sflow enable
Created symlink /etc/systemd/system/multi-user.target.wants/sflow.service → /etc/systemd/system/sflow.service.
root@sonic:~# show sflow

sFlow Global Information:
  sFlow Admin State:          up
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  0 Collectors configured:
root@sonic:~# show sflow interface

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   |   Sampling Rate |
+=============+===============+=================+
| Ethernet0   | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet4   | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet8   | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet12  | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet16  | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet20  | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet24  | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet28  | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet32  | up            |            4000 |
+-------------+---------------+-----------------+
...<OUTPUT cut out to save room > ...

root@sonic:~# config sflow interface sample-rate Ethernet0 256
root@sonic:~# config sflow interface sample-rate Ethernet4 512
root@sonic:~# show sflow interface | less

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   |   Sampling Rate |
+=============+===============+=================+
| Ethernet0   | up            |             256 |
+-------------+---------------+-----------------+
| Ethernet4   | up            |             512 |
+-------------+---------------+-----------------+


root@sonic:~# config sflow interface disable all
root@sonic:~# show sflow interface | less

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   |   Sampling Rate |
+=============+===============+=================+
| Ethernet0   | up            |             256 |
+-------------+---------------+-----------------+
| Ethernet4   | up            |             512 |
+-------------+---------------+-----------------+

Notice the two interfaces remains 'up' even though they don't have a local admin-state configured.

UT AFTER fix:
root@sonic:~# config sflow enable
root@sonic:~# show sflow interface | less

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   |   Sampling Rate |
+=============+===============+=================+
| Ethernet0   | up            |            4000 |
+-------------+---------------+-----------------+
| Ethernet4   | up            |            4000 |
+-------------+---------------+-----------------+
...<OUTPUT CUT OUT TO SAVE ROOM> ...

root@sonic:~# config sflow interface sample-rate Ethernet0 256
root@sonic:~# config sflow interface sample-rate Ethernet4 512
root@sonic:~# show sflow interface | less

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   |   Sampling Rate |
+=============+===============+=================+
| Ethernet0   | up            |             256 |
+-------------+---------------+-----------------+
| Ethernet4   | up            |             512 |
+-------------+---------------+-----------------+

root@sonic:~# config sflow interface disable all
root@sonic:~#
root@sonic:~# show sflow interface | less

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   | Sampling Rate   |
+=============+===============+=================+
+-------------+---------------+-----------------+
root@sonic:~#

Notice all interfaces are disabled as they should be since they all adhere to a global admin state.
```