### PR TITLE
Don't remove RIF for Vnet interface when ip prefix is deleted

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -821,7 +821,10 @@ bool VNetBitmapObject::removeIntf(const string& alias, const IpPrefix *prefix)
             SWSS_LOG_ERROR("Failed to remove VNET table entry, SAI rc: %d", status);
             throw std::runtime_error("VNET interface removal failed");
         }
+    }
 
+    if (!prefix)
+    {
         intfMap_.erase(alias);
 
         if (!gIntfsOrch->removeIntf(alias, gVirtualRouterId, nullptr))


### PR DESCRIPTION
**What I did**
Vnet RIF interface must be deleted when interface delete happens and not when IP is removed. Logic is made same as VRF implementation

**Why I did it**

**How I verified it**

**Details if related**
