### PR TITLE
Enable a VLAN test case for VS platform

### DIFF
--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -166,7 +166,6 @@ class TestVlan(object):
         dvs.remove_vlan("2")
 
     def test_MultipleVlan(self, dvs, testlog):
-        return
         dvs.setup_db()
 
         # create vlan and vlan members


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Enabled test_MultipleVlan test case in test_vlan.py. 

**Why I did it**

**How I verified it**
Ran the test case in VS container
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --pdb -s -v --dvsname=vs-vp test_vlan.py -k test_MultipleVlan
[sudo] password for vapatil: 
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 25 items                                                                                                                                                 

test_vlan.py::TestVlan::test_MultipleVlan remove extra link dummy
remove extra link Vlan100@Bridge
remove extra link Vlan101@Bridge
remove extra link Vlan102@Bridge
remove extra link Vlan103@Bridge
remove extra link Vlan104@Bridge
remove extra link Vlan105@Bridge
remove extra link Vlan106@Bridge
remove extra link Vlan107@Bridge
remove extra link Vlan108@Bridge
remove extra link Vlan109@Bridge
-----rc=1 for cmd ['sh', '-c', 'ip link show Ethernet20 | grep -w master']-----

-----
-----rc=1 for cmd ['sh', '-c', 'ip link show Ethernet24 | grep -w master']-----

-----
-----rc=1 for cmd ['sh', '-c', 'ip link show Ethernet28 | grep -w master']-----

-----
PASSED                                                                                                             [100%]

======================================================================= 24 tests deselected ========================================================================
============================================================= 1 passed, 24 deselected in 72.37 seconds =============================================================
```
**Details if related**
