### PR TITLE
[sub intf] Use m_lag_id to be the parent port object id when parent port is LAG

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -588,7 +588,7 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
     }
     if (vlan_id > MAX_VALID_VLAN_ID)
     {
-        SWSS_LOG_ERROR("sub interface %s Port object creation: invalid VLAN id %u", alias.c_str(), vlan_id);
+        SWSS_LOG_ERROR("sub interface %s Port object creation failed: invalid VLAN id %u", alias.c_str(), vlan_id);
         return false;
     }
 
@@ -614,7 +614,19 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
         p.m_mtu = parentPort.m_mtu;
     }
 
-    p.m_parent_port_id = parentPort.m_port_id;
+    switch (parentPort.m_type)
+    {
+        case Port::PHY:
+            p.m_parent_port_id = parentPort.m_port_id;
+            break;
+        case Port::LAG:
+            p.m_parent_port_id = parentPort.m_lag_id;
+            break;
+        default:
+            SWSS_LOG_ERROR("Sub interface %s Port object creation failed: \
+                    parent port %s of invalid type (must be physical port or LAG)", alias.c_str(), parentAlias.c_str());
+            return false;
+    }
     p.m_vlan_info.vlan_id = vlan_id;
 
     parentPort.m_child_ports.insert(p.m_alias);

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -348,29 +348,31 @@ class TestSubPortIntf(object):
         self._test_sub_port_intf_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
         self._test_sub_port_intf_admin_status_change(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
-    def test_sub_port_intf_remove_ip_addrs(self, dvs):
-        self.connect_dbs(dvs)
+    def _test_sub_port_intf_remove_ip_addrs(self, dvs, sub_port_intf_name):
+        substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
+        parent_port = substrs[0]
+        vlan_id = substrs[1]
 
         old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
 
-        self.set_parent_port_admin_status(dvs, self.PHYSICAL_PORT_UNDER_TEST, "up")
-        self.create_sub_port_intf_profile(self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+        self.create_sub_port_intf_profile(sub_port_intf_name)
 
-        self.add_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV4_ADDR_UNDER_TEST)
-        self.add_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV6_ADDR_UNDER_TEST)
+        self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
 
         rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
 
         # Remove IPv4 address
-        self.remove_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV4_ADDR_UNDER_TEST)
+        self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
 
         # Verify that IPv4 address state ok is removed from STATE_DB INTERFACE_TABLE by Intfmgrd
         self.check_sub_port_intf_key_removal(self.state_db, STATE_INTERFACE_TABLE_NAME, \
-                self.SUB_PORT_INTERFACE_UNDER_TEST + "|" + self.IPV4_ADDR_UNDER_TEST)
+                sub_port_intf_name + "|" + self.IPV4_ADDR_UNDER_TEST)
 
         # Verify that IPv4 address configuration is removed from APPL_DB INTF_TABLE by Intfmgrd
         self.check_sub_port_intf_key_removal(self.appl_db, APP_INTF_TABLE_NAME, \
-                self.SUB_PORT_INTERFACE_UNDER_TEST + ":" + self.IPV4_ADDR_UNDER_TEST)
+                sub_port_intf_name + ":" + self.IPV4_ADDR_UNDER_TEST)
 
         # Verify that IPv4 subnet route entry is removed from ASIC_DB
         # Verify that IPv4 ip2me route entry is removed from ASIC_DB
@@ -378,15 +380,15 @@ class TestSubPortIntf(object):
         self.check_sub_port_intf_route_entries_removal(removed_route_entries)
 
         # Remove IPv6 address
-        self.remove_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV6_ADDR_UNDER_TEST)
+        self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
 
         # Verify that IPv6 address state ok is removed from STATE_DB INTERFACE_TABLE by Intfmgrd
         self.check_sub_port_intf_key_removal(self.state_db, STATE_INTERFACE_TABLE_NAME, \
-                self.SUB_PORT_INTERFACE_UNDER_TEST + "|" + self.IPV6_ADDR_UNDER_TEST)
+                sub_port_intf_name + "|" + self.IPV6_ADDR_UNDER_TEST)
 
         # Verify that IPv6 address configuration is removed from APPL_DB INTF_TABLE by Intfmgrd
         self.check_sub_port_intf_key_removal(self.appl_db, APP_INTF_TABLE_NAME, \
-                self.SUB_PORT_INTERFACE_UNDER_TEST + ":" + self.IPV6_ADDR_UNDER_TEST)
+                sub_port_intf_name + ":" + self.IPV6_ADDR_UNDER_TEST)
 
         # Verify that IPv6 subnet route entry is removed from ASIC_DB
         # Verify that IPv6 ip2me route entry is removed from ASIC_DB
@@ -397,7 +399,13 @@ class TestSubPortIntf(object):
         self.check_sub_port_intf_key_existence(self.asic_db, ASIC_RIF_TABLE, rif_oid)
 
         # Remove a sub port interface
-        self.remove_sub_port_intf_profile(self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.remove_sub_port_intf_profile(sub_port_intf_name)
+
+    def test_sub_port_intf_remove_ip_addrs(self, dvs):
+        self.connect_dbs(dvs)
+
+        self._test_sub_port_intf_remove_ip_addrs(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self._test_sub_port_intf_remove_ip_addrs(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
     def test_sub_port_intf_removal(self, dvs):
         self.connect_dbs(dvs)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -274,21 +274,23 @@ class TestSubPortIntf(object):
         self._test_sub_port_intf_add_ip_addrs(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
         self._test_sub_port_intf_add_ip_addrs(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
-    def test_sub_port_intf_admin_status_change(self, dvs):
-        self.connect_dbs(dvs)
+    def _test_sub_port_intf_admin_status_change(self, dvs, sub_port_intf_name):
+        substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
+        parent_port = substrs[0]
+        vlan_id = substrs[1]
 
         old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
 
-        self.set_parent_port_admin_status(dvs, self.PHYSICAL_PORT_UNDER_TEST, "up")
-        self.create_sub_port_intf_profile(self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+        self.create_sub_port_intf_profile(sub_port_intf_name)
 
-        self.add_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV4_ADDR_UNDER_TEST)
-        self.add_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV6_ADDR_UNDER_TEST)
+        self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
 
         fv_dict = {
             ADMIN_STATUS: "up",
         }
-        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST, fv_dict)
+        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
 
         fv_dict = {
             "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true",
@@ -299,13 +301,13 @@ class TestSubPortIntf(object):
         self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
 
         # Change sub port interface admin status to down
-        self.set_sub_port_intf_admin_status(self.SUB_PORT_INTERFACE_UNDER_TEST, "down")
+        self.set_sub_port_intf_admin_status(sub_port_intf_name, "down")
 
         # Verify that sub port interface admin status change is synced to APPL_DB INTF_TABLE by Intfmgrd
         fv_dict = {
             ADMIN_STATUS: "down",
         }
-        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST, fv_dict)
+        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
 
         # Verify that sub port router interface entry in ASIC_DB has the updated admin status
         fv_dict = {
@@ -317,13 +319,13 @@ class TestSubPortIntf(object):
         self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
 
         # Change sub port interface admin status to up
-        self.set_sub_port_intf_admin_status(self.SUB_PORT_INTERFACE_UNDER_TEST, "up")
+        self.set_sub_port_intf_admin_status(sub_port_intf_name, "up")
 
         # Verify that sub port interface admin status change is synced to APPL_DB INTF_TABLE by Intfmgrd
         fv_dict = {
             ADMIN_STATUS: "up",
         }
-        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST, fv_dict)
+        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
 
         # Verify that sub port router interface entry in ASIC_DB has the updated admin status
         fv_dict = {
@@ -335,10 +337,16 @@ class TestSubPortIntf(object):
         self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
 
         # Remove IP addresses
-        self.remove_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV4_ADDR_UNDER_TEST)
-        self.remove_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV6_ADDR_UNDER_TEST)
+        self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
         # Remove a sub port interface
-        self.remove_sub_port_intf_profile(self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.remove_sub_port_intf_profile(sub_port_intf_name)
+
+    def test_sub_port_intf_admin_status_change(self, dvs):
+        self.connect_dbs(dvs)
+
+        self._test_sub_port_intf_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self._test_sub_port_intf_admin_status_change(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
     def test_sub_port_intf_remove_ip_addrs(self, dvs):
         self.connect_dbs(dvs)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -3,11 +3,15 @@ import time
 import json
 
 from swsscommon import swsscommon
+import sys
 
 CFG_VLAN_SUB_INTF_TABLE_NAME = "VLAN_SUB_INTERFACE"
 CFG_PORT_TABLE_NAME = "PORT"
+CFG_LAG_TABLE_NAME = "PORTCHANNEL"
+CFG_LAG_MEMBER_TABLE_NAME = "PORTCHANNEL_MEMBER"
 
 STATE_PORT_TABLE_NAME = "PORT_TABLE"
+STATE_LAG_TABLE_NAME = "LAG_TABLE"
 STATE_INTERFACE_TABLE_NAME = "INTERFACE_TABLE"
 
 APP_INTF_TABLE_NAME = "INTF_TABLE"
@@ -17,10 +21,18 @@ ASIC_ROUTE_ENTRY_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"
 
 ADMIN_STATUS = "admin_status"
 
+ETHERNET_PREFIX = "Ethernet"
+LAG_PREFIX = "PortChannel"
+
+VLAN_SUB_INTERFACE_SEPARATOR = "."
+
 
 class TestSubPortIntf(object):
-    PHYSICAL_PORT_UNDER_TEST = "Ethernet64"
     SUB_PORT_INTERFACE_UNDER_TEST = "Ethernet64.10"
+    PHYSICAL_PORT_UNDER_TEST = SUB_PORT_INTERFACE_UNDER_TEST.split('.')[0]
+
+    LAG_SUB_PORT_INTERFACE_UNDER_TEST = "PortChannel1.20"
+    LAG_UNDER_TEST = LAG_SUB_PORT_INTERFACE_UNDER_TEST.split('.')[0]
 
     IPV4_ADDR_UNDER_TEST = "10.0.0.33/31"
     IPV4_TOME_UNDER_TEST = "10.0.0.33/32"
@@ -39,10 +51,20 @@ class TestSubPortIntf(object):
     def set_parent_port_admin_status(self, port_name, status):
         fvs = swsscommon.FieldValuePairs([(ADMIN_STATUS, status)])
 
-        tbl = swsscommon.Table(self.config_db, CFG_PORT_TABLE_NAME)
+        tbl_name = CFG_PORT_TABLE_NAME
+        if port_name.startswith('PortChannel'):
+            tbl_name = CFG_LAG_TABLE_NAME
+        else:
+            assert port_name.startswith('Ethernet')
+        tbl = swsscommon.Table(self.config_db, tbl_name)
         tbl.set(port_name, fvs)
-
         time.sleep(1)
+
+        #if tbl_name == CFG_LAG_MEMBER_TABLE_NAME
+        #    tbl = swsscommon.Table(self.config_db, CFG_LAG_MEMBER_TABLE_NAME)
+        #    fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        #    tbl.set("{}|Ethernet4".format(port_name), fvs)
+        #    time.sleep(1)
 
     def create_sub_port_intf_profile(self, sub_port_intf_name):
         fvs = swsscommon.FieldValuePairs([(ADMIN_STATUS, "up")])
@@ -146,30 +168,37 @@ class TestSubPortIntf(object):
             route_entry = json.loads(raw_route_entry)
             assert route_entry["dest"] not in removed_route_entries
 
-    def test_sub_port_intf_creation(self, dvs):
-        self.connect_dbs(dvs)
+    def _test_sub_port_intf_creation(self, dvs, sub_port_intf_name):
+        substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
+        parent_port = substrs[0]
+        vlan_id = substrs[1]
+        if parent_port.startswith(ETHERNET_PREFIX):
+            state_tbl_name = STATE_PORT_TABLE_NAME
+        else:
+            assert parent_port.startswith(LAG_PREFIX)
+            state_tbl_name = STATE_LAG_TABLE_NAME
 
         old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
 
-        self.set_parent_port_admin_status(self.PHYSICAL_PORT_UNDER_TEST, "up")
-        self.create_sub_port_intf_profile(self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.set_parent_port_admin_status(parent_port, "up")
+        self.create_sub_port_intf_profile(sub_port_intf_name)
 
         # Verify that sub port interface state ok is pushed to STATE_DB by Intfmgrd
         fv_dict = {
             "state": "ok",
         }
-        self.check_sub_port_intf_fvs(self.state_db, STATE_PORT_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST, fv_dict)
+        self.check_sub_port_intf_fvs(self.state_db, state_tbl_name, sub_port_intf_name, fv_dict)
 
         # Verify that sub port interface configuration is synced to APPL_DB INTF_TABLE by Intfmgrd
         fv_dict = {
             ADMIN_STATUS: "up",
         }
-        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST, fv_dict)
+        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
 
         # Verify that a sub port router interface entry is created in ASIC_DB
         fv_dict = {
             "SAI_ROUTER_INTERFACE_ATTR_TYPE": "SAI_ROUTER_INTERFACE_TYPE_SUB_PORT",
-            "SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID": "10",
+            "SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID": "{}".format(vlan_id),
             "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true",
             "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "true",
             "SAI_ROUTER_INTERFACE_ATTR_MTU": "9100",
@@ -178,7 +207,13 @@ class TestSubPortIntf(object):
         self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
 
         # Remove a sub port interface
-        self.remove_sub_port_intf_profile(self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.remove_sub_port_intf_profile(sub_port_intf_name)
+
+    def test_sub_port_intf_creation(self, dvs):
+        self.connect_dbs(dvs)
+
+        self._test_sub_port_intf_creation(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self._test_sub_port_intf_creation(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
     def test_sub_port_intf_add_ip_addrs(self, dvs):
         self.connect_dbs(dvs)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -407,41 +407,54 @@ class TestSubPortIntf(object):
         self._test_sub_port_intf_remove_ip_addrs(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
         self._test_sub_port_intf_remove_ip_addrs(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
 
-    def test_sub_port_intf_removal(self, dvs):
-        self.connect_dbs(dvs)
+    def _test_sub_port_intf_removal(self, dvs, sub_port_intf_name):
+        substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
+        parent_port = substrs[0]
+        vlan_id = substrs[1]
+        if parent_port.startswith(ETHERNET_PREFIX):
+            state_tbl_name = STATE_PORT_TABLE_NAME
+        else:
+            assert parent_port.startswith(LAG_PREFIX)
+            state_tbl_name = STATE_LAG_TABLE_NAME
 
         old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
 
-        self.set_parent_port_admin_status(dvs, self.PHYSICAL_PORT_UNDER_TEST, "up")
-        self.create_sub_port_intf_profile(self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+        self.create_sub_port_intf_profile(sub_port_intf_name)
 
-        self.add_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV4_ADDR_UNDER_TEST)
-        self.add_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV6_ADDR_UNDER_TEST)
+        self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
 
         rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
 
         fv_dict = {
             "state": "ok",
         }
-        self.check_sub_port_intf_fvs(self.state_db, STATE_PORT_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST, fv_dict)
+        self.check_sub_port_intf_fvs(self.state_db, state_tbl_name, sub_port_intf_name, fv_dict)
 
         fv_dict = {
             ADMIN_STATUS: "up",
         }
-        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST, fv_dict)
+        self.check_sub_port_intf_fvs(self.appl_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
 
         # Remove IP addresses
-        self.remove_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV4_ADDR_UNDER_TEST)
-        self.remove_sub_port_intf_ip_addr(self.SUB_PORT_INTERFACE_UNDER_TEST, self.IPV6_ADDR_UNDER_TEST)
+        self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
 
         # Remove a sub port interface
-        self.remove_sub_port_intf_profile(self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.remove_sub_port_intf_profile(sub_port_intf_name)
 
         # Verify that sub port interface state ok is removed from STATE_DB by Intfmgrd
-        self.check_sub_port_intf_key_removal(self.state_db, STATE_PORT_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.check_sub_port_intf_key_removal(self.state_db, state_tbl_name, sub_port_intf_name)
 
         # Verify that sub port interface configuration is removed from APPL_DB INTF_TABLE by Intfmgrd
-        self.check_sub_port_intf_key_removal(self.appl_db, APP_INTF_TABLE_NAME, self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self.check_sub_port_intf_key_removal(self.appl_db, APP_INTF_TABLE_NAME, sub_port_intf_name)
 
         # Verify that sub port router interface entry is removed from ASIC_DB
         self.check_sub_port_intf_key_removal(self.asic_db, ASIC_RIF_TABLE, rif_oid)
+
+    def test_sub_port_intf_removal(self, dvs):
+        self.connect_dbs(dvs)
+
+        self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -3,12 +3,10 @@ import time
 import json
 
 from swsscommon import swsscommon
-import sys
 
 CFG_VLAN_SUB_INTF_TABLE_NAME = "VLAN_SUB_INTERFACE"
 CFG_PORT_TABLE_NAME = "PORT"
 CFG_LAG_TABLE_NAME = "PORTCHANNEL"
-CFG_LAG_MEMBER_TABLE_NAME = "PORTCHANNEL_MEMBER"
 
 STATE_PORT_TABLE_NAME = "PORT_TABLE"
 STATE_LAG_TABLE_NAME = "LAG_TABLE"
@@ -29,10 +27,7 @@ VLAN_SUB_INTERFACE_SEPARATOR = "."
 
 class TestSubPortIntf(object):
     SUB_PORT_INTERFACE_UNDER_TEST = "Ethernet64.10"
-    PHYSICAL_PORT_UNDER_TEST = SUB_PORT_INTERFACE_UNDER_TEST.split('.')[0]
-
     LAG_SUB_PORT_INTERFACE_UNDER_TEST = "PortChannel1.20"
-    LAG_UNDER_TEST = LAG_SUB_PORT_INTERFACE_UNDER_TEST.split('.')[0]
 
     IPV4_ADDR_UNDER_TEST = "10.0.0.33/31"
     IPV4_TOME_UNDER_TEST = "10.0.0.33/32"
@@ -65,12 +60,6 @@ class TestSubPortIntf(object):
             dvs.runcmd("bash -c 'echo " + ("1" if status == "up" else "0") + \
                     " > /sys/class/net/" + port_name + "/carrier'")
         time.sleep(1)
-
-        #if tbl_name == CFG_LAG_MEMBER_TABLE_NAME
-        #    tbl = swsscommon.Table(self.config_db, CFG_LAG_MEMBER_TABLE_NAME)
-        #    fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
-        #    tbl.set("{}|Ethernet4".format(port_name), fvs)
-        #    time.sleep(1)
 
     def create_sub_port_intf_profile(self, sub_port_intf_name):
         fvs = swsscommon.FieldValuePairs([(ADMIN_STATUS, "up")])

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -89,7 +89,7 @@ class TestSubPortIntf(object):
         tbl = swsscommon.Table(self.config_db, CFG_VLAN_SUB_INTF_TABLE_NAME)
         tbl._del(sub_port_intf_name)
 
-        time.sleep(1)
+        time.sleep(2)
 
     def remove_sub_port_intf_ip_addr(self, sub_port_intf_name, ip_addr):
         tbl = swsscommon.Table(self.config_db, CFG_VLAN_SUB_INTF_TABLE_NAME)


### PR DESCRIPTION
Fix to https://github.com/Azure/sonic-buildimage/issues/4142

Add vs test on lag sub interface based on unconventional lag naming "PortChannel1.20" to fit the interface name within 15 characters


Signed-off-by: Wenda Ni <wonda.ni@gmail.com>

```
$ sudo pytest -s test_sub_port_intf.py::TestSubPortIntf --dvsname=vs
====================================================================== test session starts =======================================================================
platform linux2 -- Python 2.7.13, pytest-4.6.9, py-1.8.0, pluggy-0.13.1
rootdir: /data01/home/wendani/sonic-buildimage-201911/src/sonic-swss/tests
plugins: flaky-3.6.1
collected 5 items                                                                                                                                                

test_sub_port_intf.py .....

=================================================================== 5 passed in 134.21 seconds ===================================================================
```
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
