### PR TITLE
[portsorch] Enable port-level buffer drop counters

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -114,6 +114,8 @@ const vector<sai_port_stat_t> port_stat_ids =
     SAI_PORT_STAT_ETHER_STATS_TX_NO_ERRORS,
     SAI_PORT_STAT_IP_IN_UCAST_PKTS,
     SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS,
+    SAI_PORT_STAT_IN_DROPPED_PKTS,
+    SAI_PORT_STAT_OUT_DROPPED_PKTS,
 };
 
 static const vector<sai_queue_stat_t> queue_stat_ids =


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added the SAI buffer drop counters to the list of port stats to be polled.

**Why I did it**
To enable stats for MMU related drops.

**How I verified it**
Loaded the modified SWSS onto a physical DUT and verified that 1) the stat was added to the flex counter polling list and 2) that the flex counter had added the stat to the COUNTERS_DB for each port.
