### PR TITLE
DPB-ACL scale tests (#30)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -989,7 +989,6 @@ class DockerVirtualSwitch(object):
                                           self.get_counters_db())
         return self.dvs_acl
 
-
 @pytest.yield_fixture(scope="module")
 def dvs(request):
     name = request.config.getoption("--dvsname")
@@ -1009,6 +1008,13 @@ def testlog(request, dvs):
     dvs.runcmd("logger === start test %s ===" % request.node.name)
     yield testlog
     dvs.runcmd("logger === finish test %s ===" % request.node.name)
+
+@pytest.yield_fixture(scope="class")
+def dvs_acl_manager(request, dvs):
+    request.cls.dvs_acl = dvs_acl.DVSAcl(dvs.get_asic_db(),
+                                         dvs.get_config_db(),
+                                         dvs.get_state_db(),
+                                         dvs.get_counters_db())
 
 ##################### DPB fixtures ###########################################
 @pytest.yield_fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import subprocess
 from datetime import datetime
 from swsscommon import swsscommon
 from dvslib import dvs_database as dvs_db
+from dvslib import dvs_acl
 
 def ensure_system(cmd):
     (rc, output) = commands.getstatusoutput(cmd)
@@ -242,6 +243,8 @@ class DockerVirtualSwitch(object):
         self.config_db = None
         self.flex_db = None
         self.state_db = None
+
+        self.dvs_acl = None
 
     def destroy(self):
         if self.appldb:
@@ -953,30 +956,39 @@ class DockerVirtualSwitch(object):
             self.asic_db = db
 
         return self.asic_db
-    
+
     def get_counters_db(self):
         if not self.counters_db:
             self.counters_db = dvs_db.DVSDatabase(self.COUNTERS_DB_ID, self.redis_sock)
 
         return self.counters_db
-    
+
     def get_config_db(self):
         if not self.config_db:
             self.config_db = dvs_db.DVSDatabase(self.CONFIG_DB_ID, self.redis_sock)
 
         return self.config_db
-    
+
     def get_flex_db(self):
         if not self.flex_db:
             self.flex_db = dvs_db.DVSDatabase(self.FLEX_COUNTER_DB_ID, self.redis_sock)
 
         return self.flex_db
-    
+
     def get_state_db(self):
         if not self.state_db:
             self.state_db = dvs_db.DVSDatabase(self.STATE_DB_ID, self.redis_sock)
 
         return self.state_db
+
+    def get_dvs_acl(self):
+        if not self.dvs_acl:
+            self.dvs_acl = dvs_acl.DVSAcl(self.get_asic_db(),
+                                          self.get_config_db(),
+                                          self.get_state_db(),
+                                          self.get_counters_db())
+        return self.dvs_acl
+
 
 @pytest.yield_fixture(scope="module")
 def dvs(request):

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -1,6 +1,3 @@
-import time
-from swsscommon import swsscommon
-
 class DVSAcl(object):
     def __init__(self, adb, cdb, sdb, cntrdb):
         self.asic_db = adb
@@ -47,7 +44,7 @@ class DVSAcl(object):
         acl_tables = self.get_acl_table_ids()
         return acl_tables[0]
 
-    def verify_acl_tables(self, expt):
+    def verify_acl_table_count(self, expt):
         num_keys = len(self.asic_db.default_acl_tables) + expt
         keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
         for k in self.asic_db.default_acl_tables:
@@ -56,11 +53,6 @@ class DVSAcl(object):
         acl_tables = [k for k in keys if k not in self.asic_db.default_acl_tables]
 
         assert len(acl_tables) == expt
-
-    def verify_no_acl_tables(self):
-        num_keys = len(self.asic_db.default_acl_tables)
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
-        assert set(keys) == set(self.asic_db.default_acl_tables)
 
     def verify_acl_group_num(self, expt):
         acl_table_groups = self.get_acl_table_group_ids(expt)

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -1,0 +1,239 @@
+import time
+from swsscommon import swsscommon
+
+class DVSAcl(object):
+    def __init__(self, adb, cdb, sdb, cntrdb):
+        self.asic_db = adb
+        self.config_db = cdb
+        self.state_db = sdb
+        self.counters_db = cntrdb
+
+    def create_acl_table(self, table_name, table_type, ports, stage=None):
+        table_attrs = {
+            "policy_desc": "DVS acl table test",
+            "type": table_type,
+            "ports": ",".join(ports)
+        }
+
+        if stage:
+            table_attrs["stage"] = stage
+
+        self.config_db.create_entry("ACL_TABLE", table_name, table_attrs)
+
+    def update_acl_table(self, acl_table_name, ports):
+        table_attrs = {
+            "ports": ",".join(ports)
+        }
+        self.config_db.update_entry("ACL_TABLE", acl_table_name, table_attrs)
+
+    def remove_acl_table(self, table_name):
+        self.config_db.delete_entry("ACL_TABLE", table_name)
+
+    def get_acl_table_group_ids(self, expt):
+        acl_table_groups = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", expt)
+        return acl_table_groups
+
+    def get_acl_table_ids(self, expt=1):
+        num_keys = len(self.asic_db.default_acl_tables) + expt
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
+        for k in self.asic_db.default_acl_tables:
+            assert k in keys
+
+        acl_tables = [k for k in keys if k not in self.asic_db.default_acl_tables]
+
+        return acl_tables
+
+    def get_acl_table_id(self):
+        acl_tables = self.get_acl_table_ids()
+        return acl_tables[0]
+
+    def verify_acl_tables(self, expt):
+        num_keys = len(self.asic_db.default_acl_tables) + expt
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
+        for k in self.asic_db.default_acl_tables:
+            assert k in keys
+
+        acl_tables = [k for k in keys if k not in self.asic_db.default_acl_tables]
+
+        assert len(acl_tables) == expt
+
+    def verify_no_acl_tables(self):
+        num_keys = len(self.asic_db.default_acl_tables)
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
+        assert set(keys) == set(self.asic_db.default_acl_tables)
+
+    def verify_acl_group_num(self, expt):
+        acl_table_groups = self.get_acl_table_group_ids(expt)
+
+        for group in acl_table_groups:
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", group)
+            for k, v in fvs.items():
+                if k == "SAI_ACL_TABLE_GROUP_ATTR_ACL_STAGE":
+                    assert v == "SAI_ACL_STAGE_INGRESS"
+                elif k == "SAI_ACL_TABLE_GROUP_ATTR_ACL_BIND_POINT_TYPE_LIST":
+                    assert v == "1:SAI_ACL_BIND_POINT_TYPE_PORT"
+                elif k == "SAI_ACL_TABLE_GROUP_ATTR_TYPE":
+                    assert v == "SAI_ACL_TABLE_GROUP_TYPE_PARALLEL"
+                else:
+                    assert False
+
+    def verify_acl_table_group_member(self, acl_table_group_id, acl_table_id):
+        self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", acl_table_group_id)
+        self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", acl_table_id)
+        members = self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER")
+        for m in members:
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", m)
+            fvs = dict(fvs)
+            if (fvs.pop("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_GROUP_ID") == acl_table_group_id and
+                    fvs.pop("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID") == acl_table_id) :
+                return True
+        assert False
+
+    def verify_acl_group_member(self, acl_group_ids, acl_table_id):
+        members = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", len(acl_group_ids))
+
+        member_groups = []
+        for member in members:
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", member)
+            for k, v in fvs.items():
+                if k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_GROUP_ID":
+                    assert v in acl_group_ids
+                    member_groups.append(v)
+                elif k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID":
+                    assert v == acl_table_id
+                elif k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY":
+                    assert True
+                else:
+                    assert False
+
+        assert set(member_groups) == set(acl_group_ids)
+
+    def verify_acl_table_ports_binding(self, ports, acl_table_id):
+        for p in ports:
+            # TBD: Introduce new API in dvs_databse.py to read by field
+            fvs = self.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
+            fvs = dict(fvs)
+            port_oid = fvs.pop(p)
+            #port_oid = self.counters_db.hget_entry("COUNTERS_PORT_NAME_MAP", "", p)
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+            fvs = dict(fvs)
+            acl_table_group_id = fvs.pop("SAI_PORT_ATTR_INGRESS_ACL")
+            self.verify_acl_table_group_member(acl_table_group_id, acl_table_id)
+
+    def verify_acl_port_binding(self, bind_ports):
+        acl_table_groups = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
+
+        port_groups = []
+        for port in [self.asic_db.port_name_map[p] for p in bind_ports]:
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port)
+            acl_table_group = fvs.pop("SAI_PORT_ATTR_INGRESS_ACL", None)
+            assert acl_table_group in acl_table_groups
+            port_groups.append(acl_table_group)
+
+        assert len(port_groups) == len(bind_ports)
+        assert set(port_groups) == set(acl_table_groups)
+
+    def create_acl_rule(self, table_name, rule_name, qualifiers, action="FORWARD", priority="2020"):
+        fvs = {
+            "priority": priority,
+            "PACKET_ACTION": action
+        }
+
+        for k, v in qualifiers.items():
+            fvs[k] = v
+
+        self.config_db.create_entry("ACL_RULE", "{}|{}".format(table_name, rule_name), fvs)
+
+    def remove_acl_rule(self, table_name, rule_name):
+        self.config_db.delete_entry("ACL_RULE", "{}|{}".format(table_name, rule_name))
+
+    def get_acl_rule_id(self):
+        num_keys = len(self.asic_db.default_acl_entries) + 1
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
+
+        acl_entries = [k for k in keys if k not in self.asic_db.default_acl_entries]
+        return acl_entries[0]
+
+    def verify_no_acl_rules(self):
+        num_keys = len(self.asic_db.default_acl_entries)
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
+        assert set(keys) == set(self.asic_db.default_acl_entries)
+
+    def verify_acl_rule(self, qualifiers, action="FORWARD", priority="2020"):
+        acl_rule_id = self.get_acl_rule_id()
+
+        fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
+        self._check_acl_entry(fvs, qualifiers, action, priority)
+
+    def verify_acl_rule_set(self, priorities, in_actions, expected):
+        num_keys = len(self.asic_db.default_acl_entries) + len(priorities)
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
+
+        acl_entries = [k for k in keys if k not in self.asic_db.default_acl_entries]
+        for entry in acl_entries:
+            rule = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", entry)
+            priority = rule.get("SAI_ACL_ENTRY_ATTR_PRIORITY", None)
+            assert priority in priorities
+            self._check_acl_entry(rule, expected[priority],
+                                  action=in_actions[priority], priority=priority)
+
+    def _check_acl_entry(self, entry, qualifiers, action, priority):
+        acl_table_id = self.get_acl_table_id()
+
+        for k, v in entry.items():
+            if k == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
+                assert v == acl_table_id
+            elif k == "SAI_ACL_ENTRY_ATTR_ADMIN_STATE":
+                assert v == "true"
+            elif k == "SAI_ACL_ENTRY_ATTR_PRIORITY":
+                assert v == priority
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_COUNTER":
+                assert True
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION":
+                if action == "FORWARD":
+                    assert v == "SAI_PACKET_ACTION_FORWARD"
+                elif action == "DROP":
+                    assert v == "SAI_PACKET_ACTION_DROP"
+                else:
+                    assert False
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT":
+                if "REDIRECT" not in action:
+                    assert False
+            elif k in qualifiers:
+                assert qualifiers[k](v)
+            else:
+                assert False
+
+    def get_simple_qualifier_comparator(self, expected_qualifier):
+        def _match_qualifier(sai_qualifier):
+            return expected_qualifier == sai_qualifier
+
+        return _match_qualifier
+
+    def get_port_list_comparator(self, expected_ports):
+        def _match_port_list(sai_port_list):
+            if not sai_port_list.startswith("{}:".format(len(expected_ports))):
+                return False
+            for port in expected_ports:
+                if self.asic_db.port_name_map[port] not in sai_port_list:
+                    return False
+
+            return True
+
+        return _match_port_list
+
+    def get_acl_range_comparator(self, expected_type, expected_ports):
+        def _match_acl_range(sai_acl_range):
+            range_id = sai_acl_range.split(":", 1)[1]
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_RANGE", range_id)
+            for k, v in fvs.items():
+                if k == "SAI_ACL_RANGE_ATTR_TYPE" and v == expected_type:
+                    continue
+                elif k == "SAI_ACL_RANGE_ATTR_LIMIT" and v == expected_ports:
+                    continue
+                else:
+                    return False
+
+            return True
+
+        return _match_acl_range

--- a/tests/dvslib/dvs_database.py
+++ b/tests/dvslib/dvs_database.py
@@ -43,6 +43,20 @@ class DVSDatabase(object):
         formatted_entry = swsscommon.FieldValuePairs(entry.items())
         table.set(key, formatted_entry)
 
+    def update_entry(self, table_name, key, entry):
+        """
+            Updates entries of an existing key in the specified table.
+
+            Args:
+                table_name (str): The name of the table.
+                key (str): The key that needs to be updated.
+                entry (Dict[str, str]): A set of key-value pairs to be updated.
+        """
+
+        table = swsscommon.Table(self.db_connection, table_name)
+        formatted_entry = swsscommon.FieldValuePairs(entry.items())
+        table.set(key, formatted_entry)
+
     def get_entry(self, table_name, key):
         """
             Gets the entry stored at `key` in the specified table.

--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -154,7 +154,7 @@ class Port():
                                           ("speed", speed_str),
                                           ("index", index_str)])
         self._cfg_db_ptbl.set(self.get_name(), fvs)
-        time.sleep(1)
+        time.sleep(2)
 
     def get_fvs_dict(self, fvs):
         fvs_dict = {}
@@ -221,8 +221,6 @@ class DPB():
             #dvs.runcmd("ip link delete " + cp.get_name())
         #print "Deleted child ports:%s from config DB"%port_names
 
-        time.sleep(6)
-
         for cp in child_ports:
             assert(cp.exists_in_config_db() == False)
         for cp in child_ports:
@@ -235,7 +233,6 @@ class DPB():
         p.port_merge(child_ports)
         p.write_to_config_db()
         #print "Added port:%s to config DB"%p.get_name()
-        time.sleep(2)
 
         p.verify_config_db()
         #print "Config DB verification passed!"
@@ -254,7 +251,6 @@ class DPB():
             cp.write_to_config_db()
             child_port_names.append(cp.get_name())
         #print "Added child ports:%s to config DB"%child_port_names
-        time.sleep(6)
 
         for cp in child_ports:
             assert(cp.exists_in_config_db() == True)
@@ -279,7 +275,7 @@ class DPB():
         # TBD, need vs lib to support hostif removal
         #dvs.runcmd("ip link delete " + p.get_name())
         #print "Deleted port:%s from config DB"%port_name
-        time.sleep(6)
+        time.sleep(2)
 
         # Verify port is deleted from all DBs
         assert(p.exists_in_config_db() == False)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1,216 +1,37 @@
 import time
 
 class BaseTestAcl(object):
-    def setup_db(self, dvs):
-        self.asic_db = dvs.get_asic_db()
-        self.config_db = dvs.get_config_db()
-        self.state_db = dvs.get_state_db()
-
-    def create_acl_table(self, table_name, table_type, ports, stage=None):
-        table_attrs = {
-            "policy_desc": "DVS acl table test",
-            "type": table_type,
-            "ports": ",".join(ports)
-        }
-
-        if stage:
-            table_attrs["stage"] = stage
-
-        self.config_db.create_entry("ACL_TABLE", table_name, table_attrs)
-
-    def remove_acl_table(self, table_name):
-        self.config_db.delete_entry("ACL_TABLE", table_name)
-
-    def get_acl_table_id(self):
-        num_keys = len(self.asic_db.default_acl_tables) + 1
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
-
-        acl_tables = [k for k in keys if k not in self.asic_db.default_acl_tables]
-        return acl_tables[0]
-
-    def verify_no_acl_tables(self):
-        num_keys = len(self.asic_db.default_acl_tables)
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
-        assert set(keys) == set(self.asic_db.default_acl_tables)
-
-    def verify_acl_group_num(self, expt):
-        acl_table_groups = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", expt)
-
-        for group in acl_table_groups:
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", group)
-            for k, v in fvs.items():
-                if k == "SAI_ACL_TABLE_GROUP_ATTR_ACL_STAGE":
-                    assert v == "SAI_ACL_STAGE_INGRESS"
-                elif k == "SAI_ACL_TABLE_GROUP_ATTR_ACL_BIND_POINT_TYPE_LIST":
-                    assert v == "1:SAI_ACL_BIND_POINT_TYPE_PORT"
-                elif k == "SAI_ACL_TABLE_GROUP_ATTR_TYPE":
-                    assert v == "SAI_ACL_TABLE_GROUP_TYPE_PARALLEL"
-                else:
-                    assert False
-
-    def verify_acl_group_member(self, acl_group_ids, acl_table_id):
-        members = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", len(acl_group_ids))
-
-        member_groups = []
-        for member in members:
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", member)
-            for k, v in fvs.items():
-                if k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_GROUP_ID":
-                    assert v in acl_group_ids
-                    member_groups.append(v)
-                elif k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID":
-                    assert v == acl_table_id
-                elif k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY":
-                    assert True
-                else:
-                    assert False
-
-        assert set(member_groups) == set(acl_group_ids)
-
-    def verify_acl_port_binding(self, bind_ports):
-        acl_table_groups = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
-
-        port_groups = []
-        for port in [self.asic_db.port_name_map[p] for p in bind_ports]:
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port)
-            acl_table_group = fvs.pop("SAI_PORT_ATTR_INGRESS_ACL", None)
-            assert acl_table_group in acl_table_groups
-            port_groups.append(acl_table_group)
-
-        assert len(port_groups) == len(bind_ports)
-        assert set(port_groups) == set(acl_table_groups)
-
-    def create_acl_rule(self, table_name, rule_name, qualifiers, action="FORWARD", priority="2020"):
-        fvs = {
-            "priority": priority,
-            "PACKET_ACTION": action
-        }
-
-        for k, v in qualifiers.items():
-            fvs[k] = v
-
-        self.config_db.create_entry("ACL_RULE", "{}|{}".format(table_name, rule_name), fvs)
-
-    def remove_acl_rule(self, table_name, rule_name):
-        self.config_db.delete_entry("ACL_RULE", "{}|{}".format(table_name, rule_name))
-
-    def get_acl_rule_id(self):
-        num_keys = len(self.asic_db.default_acl_entries) + 1
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
-
-        acl_entries = [k for k in keys if k not in self.asic_db.default_acl_entries]
-        return acl_entries[0]
-
-    def verify_no_acl_rules(self):
-        num_keys = len(self.asic_db.default_acl_entries)
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
-        assert set(keys) == set(self.asic_db.default_acl_entries)
-
-    def verify_acl_rule(self, qualifiers, action="FORWARD", priority="2020"):
-        acl_rule_id = self.get_acl_rule_id()
-
-        fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
-        self._check_acl_entry(fvs, qualifiers, action, priority)
-
-    def verify_acl_rule_set(self, priorities, in_actions, expected):
-        num_keys = len(self.asic_db.default_acl_entries) + len(priorities)
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
-
-        acl_entries = [k for k in keys if k not in self.asic_db.default_acl_entries]
-        for entry in acl_entries:
-            rule = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", entry)
-            priority = rule.get("SAI_ACL_ENTRY_ATTR_PRIORITY", None)
-            assert priority in priorities
-            self._check_acl_entry(rule, expected[priority],
-                                  action=in_actions[priority], priority=priority)
-
-    def _check_acl_entry(self, entry, qualifiers, action, priority):
-        acl_table_id = self.get_acl_table_id()
-
-        for k, v in entry.items():
-            if k == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
-                assert v == acl_table_id
-            elif k == "SAI_ACL_ENTRY_ATTR_ADMIN_STATE":
-                assert v == "true"
-            elif k == "SAI_ACL_ENTRY_ATTR_PRIORITY":
-                assert v == priority
-            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_COUNTER":
-                assert True
-            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION":
-                if action == "FORWARD":
-                    assert v == "SAI_PACKET_ACTION_FORWARD"
-                elif action == "DROP":
-                    assert v == "SAI_PACKET_ACTION_DROP"
-                else:
-                    assert False
-            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT":
-                if "REDIRECT" not in action:
-                    assert False
-            elif k in qualifiers:
-                assert qualifiers[k](v)
-            else:
-                assert False
-
-    def get_simple_qualifier_comparator(self, expected_qualifier):
-        def _match_qualifier(sai_qualifier):
-            return expected_qualifier == sai_qualifier
-
-        return _match_qualifier
-
-    def get_port_list_comparator(self, expected_ports):
-        def _match_port_list(sai_port_list):
-            if not sai_port_list.startswith("{}:".format(len(expected_ports))):
-                return False
-            for port in expected_ports:
-                if self.asic_db.port_name_map[port] not in sai_port_list:
-                    return False
-
-            return True
-
-        return _match_port_list
-
-    def get_acl_range_comparator(self, expected_type, expected_ports):
-        def _match_acl_range(sai_acl_range):
-            range_id = sai_acl_range.split(":", 1)[1]
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_RANGE", range_id)
-            for k, v in fvs.items():
-                if k == "SAI_ACL_RANGE_ATTR_TYPE" and v == expected_type:
-                    continue
-                elif k == "SAI_ACL_RANGE_ATTR_LIMIT" and v == expected_ports:
-                    continue
-                else:
-                    return False
-
-            return True
-
-        return _match_acl_range
+    def setup_dvs_acl(self, dvs):
+        self.dvs_acl = dvs.get_dvs_acl()
 
 class TestAcl(BaseTestAcl):
     def test_AclTableCreation(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
-        self.create_acl_table("test", "L3", bind_ports)
+        self.dvs_acl.create_acl_table("test", "L3", bind_ports)
 
-        self.verify_acl_group_num(len(bind_ports))
-        acl_group_ids = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
-        self.verify_acl_group_member(acl_group_ids, self.get_acl_table_id())
-        self.verify_acl_port_binding(bind_ports)
+        self.dvs_acl.verify_acl_group_num(len(bind_ports))
+        acl_group_ids = self.dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
+        self.dvs_acl.verify_acl_group_member(acl_group_ids, self.dvs_acl.get_acl_table_id())
+        self.dvs_acl.verify_acl_port_binding(bind_ports)
 
+    #fails
     def test_AclRuleL4SrcPort(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_SRC_PORT": "65000"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.get_simple_qualifier_comparator("65000&mask:0xffff")}
+        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
 
-        self.create_acl_rule("test", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
+    #fails
     def test_AclRuleInOutPorts(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {
             "IN_PORTS": "Ethernet0,Ethernet4",
@@ -218,200 +39,202 @@ class TestAcl(BaseTestAcl):
         }
 
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": self.get_port_list_comparator(["Ethernet0", "Ethernet4"]),
-            "SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORTS": self.get_port_list_comparator(["Ethernet8", "Ethernet12"])
+            "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": self.dvs_acl.get_port_list_comparator(["Ethernet0", "Ethernet4"]),
+            "SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORTS": self.dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
         }
 
-        self.create_acl_rule("test", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleInPortsNonExistingInterface(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {
             "IN_PORTS": "FOO_BAR_BAZ"
         }
 
-        self.create_acl_rule("test", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.create_acl_rule("test", "acl_test_rule", config_qualifiers)
 
-        self.verify_no_acl_rules()
-        self.remove_acl_rule("test", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
 
     def test_AclRuleOutPortsNonExistingInterface(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {
             "OUT_PORTS": "FOO_BAR_BAZ"
         }
 
-        self.create_acl_rule("test", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.create_acl_rule("test", "acl_test_rule", config_qualifiers)
 
-        self.verify_no_acl_rules()
-        self.remove_acl_rule("test", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
 
     def test_AclTableDeletion(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
-        self.remove_acl_table("test")
-        self.verify_no_acl_tables()
+        self.dvs_acl.remove_acl_table("test")
+        self.dvs_acl.verify_no_acl_tables()
 
     def test_V6AclTableCreation(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4", "Ethernet8"]
-        self.create_acl_table("test_aclv6", "L3V6", bind_ports)
+        self.dvs_acl.create_acl_table("test_aclv6", "L3V6", bind_ports)
 
-        self.verify_acl_group_num(len(bind_ports))
-        acl_group_ids = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
-        self.verify_acl_group_member(acl_group_ids, self.get_acl_table_id())
-        self.verify_acl_port_binding(bind_ports)
+        self.dvs_acl.verify_acl_group_num(len(bind_ports))
+        acl_group_ids = self.dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
+        self.dvs_acl.verify_acl_group_member(acl_group_ids, self.dvs_acl.get_acl_table_id())
+        self.dvs_acl.verify_acl_port_binding(bind_ports)
 
+    # fails
     def test_V6AclRuleIPv6Any(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"IP_TYPE": "IPv6ANY"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE": self.get_simple_qualifier_comparator("SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE": self.dvs_acl.get_simple_qualifier_comparator("SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff")
         }
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
+    # fails
     def test_V6AclRuleIPv6AnyDrop(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"IP_TYPE": "IPv6ANY"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE": self.get_simple_qualifier_comparator("SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE": self.dvs_acl.get_simple_qualifier_comparator("SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff")
         }
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers, action="DROP")
-        self.verify_acl_rule(expected_sai_qualifiers, action="DROP")
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers, action="DROP")
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers, action="DROP")
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleIpProtocol(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"IP_PROTOCOL": "6"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL": self.get_simple_qualifier_comparator("6&mask:0xff")}
+        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL": self.dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")}
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleSrcIPv6(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"SRC_IPV6": "2777::0/64"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6": self.get_simple_qualifier_comparator("2777::&mask:ffff:ffff:ffff:ffff::")
+            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6": self.dvs_acl.get_simple_qualifier_comparator("2777::&mask:ffff:ffff:ffff:ffff::")
         }
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleDstIPv6(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"DST_IPV6": "2002::2/128"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6": self.get_simple_qualifier_comparator("2002::2&mask:ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6": self.dvs_acl.get_simple_qualifier_comparator("2002::2&mask:ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
         }
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4SrcPort(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_SRC_PORT": "65000"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.get_simple_qualifier_comparator("65000&mask:0xffff")}
+        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4DstPort(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_DST_PORT": "65001"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT": self.get_simple_qualifier_comparator("65001&mask:0xffff")}
+        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT": self.dvs_acl.get_simple_qualifier_comparator("65001&mask:0xffff")}
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleTCPFlags(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"TCP_FLAGS": "0x07/0x3f"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS": self.get_simple_qualifier_comparator("7&mask:0x3f")}
+        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS": self.dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f")}
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4SrcPortRange(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_SRC_PORT_RANGE": "1-100"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_RANGE_TYPE": self.get_acl_range_comparator("SAI_ACL_RANGE_TYPE_L4_SRC_PORT_RANGE", "1,100")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_RANGE_TYPE": self.dvs_acl.get_acl_range_comparator("SAI_ACL_RANGE_TYPE_L4_SRC_PORT_RANGE", "1,100")
         }
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4DstPortRange(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_DST_PORT_RANGE": "101-200"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_RANGE_TYPE": self.get_acl_range_comparator("SAI_ACL_RANGE_TYPE_L4_DST_PORT_RANGE", "101,200")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_RANGE_TYPE": self.dvs_acl.get_acl_range_comparator("SAI_ACL_RANGE_TYPE_L4_DST_PORT_RANGE", "101,200")
         }
 
-        self.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclTableDeletion(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
-        self.remove_acl_table("test_aclv6")
-        self.verify_no_acl_tables()
+        self.dvs_acl.remove_acl_table("test_aclv6")
+        self.dvs_acl.verify_no_acl_tables()
 
     def test_InsertAclRuleBetweenPriorities(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
-        self.create_acl_table("test_priorities", "L3", bind_ports)
+        self.dvs_acl.create_acl_table("test_priorities", "L3", bind_ports)
 
         rule_priorities = ["10", "20", "30", "40"]
 
@@ -430,43 +253,43 @@ class TestAcl(BaseTestAcl):
         }
 
         expected_sai_qualifiers = {
-            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.get_simple_qualifier_comparator("10.0.0.0&mask:255.255.255.255")},
-            "20": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.get_simple_qualifier_comparator("104.44.94.0&mask:255.255.254.0")},
-            "30": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.get_simple_qualifier_comparator("192.168.0.16&mask:255.255.255.255")},
-            "40": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.get_simple_qualifier_comparator("100.64.0.0&mask:255.192.0.0")},
+            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.dvs_acl.get_simple_qualifier_comparator("10.0.0.0&mask:255.255.255.255")},
+            "20": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("104.44.94.0&mask:255.255.254.0")},
+            "30": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("192.168.0.16&mask:255.255.255.255")},
+            "40": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("100.64.0.0&mask:255.192.0.0")},
         }
 
         for rule in rule_priorities:
-            self.create_acl_rule("test_priorities", "acl_test_rule_{}".format(rule),
+            self.dvs_acl.create_acl_rule("test_priorities", "acl_test_rule_{}".format(rule),
                                  config_qualifiers[rule], action=config_actions[rule],
                                  priority=rule)
 
-        self.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
+        self.dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
         odd_priority = "21"
         odd_rule = {"ETHER_TYPE": "4660"}
-        odd_sai_qualifier = {"SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE": self.get_simple_qualifier_comparator("4660&mask:0xffff")}
+        odd_sai_qualifier = {"SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE": self.dvs_acl.get_simple_qualifier_comparator("4660&mask:0xffff")}
 
         rule_priorities.append(odd_priority)
         config_actions[odd_priority] = "DROP"
         expected_sai_qualifiers[odd_priority] = odd_sai_qualifier
 
-        self.create_acl_rule("test_priorities", "acl_test_rule_{}".format(odd_priority),
+        self.dvs_acl.create_acl_rule("test_priorities", "acl_test_rule_{}".format(odd_priority),
                              odd_rule, action="DROP", priority=odd_priority)
-        self.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
+        self.dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
         for rule in rule_priorities:
-            self.remove_acl_rule("test_priorities", "acl_test_rule_{}".format(rule))
-        self.verify_no_acl_rules()
+            self.dvs_acl.remove_acl_rule("test_priorities", "acl_test_rule_{}".format(rule))
+        self.dvs_acl.verify_no_acl_rules()
 
-        self.remove_acl_table("test_priorities")
-        self.verify_no_acl_tables()
+        self.dvs_acl.remove_acl_table("test_priorities")
+        self.dvs_acl.verify_no_acl_tables()
 
     def test_RulesWithDiffMaskLengths(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
-        self.create_acl_table("test_masks", "L3", bind_ports)
+        self.dvs_acl.create_acl_table("test_masks", "L3", bind_ports)
 
         rule_priorities = ["10", "20", "30", "40", "50", "60"]
 
@@ -489,32 +312,32 @@ class TestAcl(BaseTestAcl):
         }
 
         expected_sai_qualifiers = {
-            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.get_simple_qualifier_comparator("23.103.0.0&mask:255.255.192.0")},
-            "20": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.get_simple_qualifier_comparator("104.44.94.0&mask:255.255.254.0")},
-            "30": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.get_simple_qualifier_comparator("172.16.0.0&mask:255.240.0.0")},
-            "40": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.get_simple_qualifier_comparator("100.64.0.0&mask:255.192.0.0")},
-            "50": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.get_simple_qualifier_comparator("104.146.32.0&mask:255.255.224.0")},
-            "60": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.get_simple_qualifier_comparator("21.0.0.0&mask:255.0.0.0")},
+            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.dvs_acl.get_simple_qualifier_comparator("23.103.0.0&mask:255.255.192.0")},
+            "20": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.dvs_acl.get_simple_qualifier_comparator("104.44.94.0&mask:255.255.254.0")},
+            "30": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("172.16.0.0&mask:255.240.0.0")},
+            "40": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("100.64.0.0&mask:255.192.0.0")},
+            "50": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("104.146.32.0&mask:255.255.224.0")},
+            "60": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.dvs_acl.get_simple_qualifier_comparator("21.0.0.0&mask:255.0.0.0")},
         }
 
         for rule in rule_priorities:
-            self.create_acl_rule("test_masks", "acl_test_rule_{}".format(rule),
+            self.dvs_acl.create_acl_rule("test_masks", "acl_test_rule_{}".format(rule),
                                  config_qualifiers[rule], action=config_actions[rule],
                                  priority=rule)
-        self.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
+        self.dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
         for rule in rule_priorities:
-            self.remove_acl_rule("test_masks", "acl_test_rule_{}".format(rule))
-        self.verify_no_acl_rules()
+            self.dvs_acl.remove_acl_rule("test_masks", "acl_test_rule_{}".format(rule))
+        self.dvs_acl.verify_no_acl_rules()
 
-        self.remove_acl_table("test_masks")
-        self.verify_no_acl_tables()
+        self.dvs_acl.remove_acl_table("test_masks")
+        self.dvs_acl.verify_no_acl_tables()
 
     def test_AclRuleIcmp(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
-        self.create_acl_table("test_icmp", "L3", bind_ports)
+        self.dvs_acl.create_acl_table("test_icmp", "L3", bind_ports)
 
         config_qualifiers = {
             "ICMP_TYPE": "8",
@@ -522,24 +345,24 @@ class TestAcl(BaseTestAcl):
         }
 
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE": self.get_simple_qualifier_comparator("8&mask:0xff"),
-            "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_CODE": self.get_simple_qualifier_comparator("9&mask:0xff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE": self.dvs_acl.get_simple_qualifier_comparator("8&mask:0xff"),
+            "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_CODE": self.dvs_acl.get_simple_qualifier_comparator("9&mask:0xff")
         }
 
-        self.create_acl_rule("test_icmp", "test_icmp_fields", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_icmp", "test_icmp_fields", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_icmp", "test_icmp_fields")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_icmp", "test_icmp_fields")
+        self.dvs_acl.verify_no_acl_rules()
 
-        self.remove_acl_table("test_icmp")
-        self.verify_no_acl_tables()
+        self.dvs_acl.remove_acl_table("test_icmp")
+        self.dvs_acl.verify_no_acl_tables()
 
     def test_AclRuleIcmpV6(self, dvs):
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
-        self.create_acl_table("test_icmpv6", "L3V6", bind_ports)
+        self.dvs_acl.create_acl_table("test_icmpv6", "L3V6", bind_ports)
 
         config_qualifiers = {
             "ICMPV6_TYPE": "8",
@@ -547,50 +370,50 @@ class TestAcl(BaseTestAcl):
         }
 
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ICMPV6_TYPE": self.get_simple_qualifier_comparator("8&mask:0xff"),
-            "SAI_ACL_ENTRY_ATTR_FIELD_ICMPV6_CODE": self.get_simple_qualifier_comparator("9&mask:0xff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ICMPV6_TYPE": self.dvs_acl.get_simple_qualifier_comparator("8&mask:0xff"),
+            "SAI_ACL_ENTRY_ATTR_FIELD_ICMPV6_CODE": self.dvs_acl.get_simple_qualifier_comparator("9&mask:0xff")
         }
 
-        self.create_acl_rule("test_icmpv6", "test_icmpv6_fields", config_qualifiers)
-        self.verify_acl_rule(expected_sai_qualifiers)
+        self.dvs_acl.create_acl_rule("test_icmpv6", "test_icmpv6_fields", config_qualifiers)
+        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.remove_acl_rule("test_icmpv6", "test_icmpv6_fields")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_icmpv6", "test_icmpv6_fields")
+        self.dvs_acl.verify_no_acl_rules()
 
-        self.remove_acl_table("test_icmpv6")
-        self.verify_no_acl_tables()
+        self.dvs_acl.remove_acl_table("test_icmpv6")
+        self.dvs_acl.verify_no_acl_tables()
 
     def test_AclRuleRedirectToNextHop(self, dvs):
         # NOTE: set_interface_status has a dependency on cdb within dvs,
         # so we still need to setup the db. This should be refactored.
         dvs.setup_db()
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         # Bring up an IP interface with a neighbor
         dvs.set_interface_status("Ethernet4", "up")
         dvs.add_ip_address("Ethernet4", "10.0.0.1/24")
         dvs.add_neighbor("Ethernet4", "10.0.0.2", "00:01:02:03:04:05")
 
-        next_hop_id = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", 1)[0]
+        next_hop_id = self.dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", 1)[0]
 
         bind_ports = ["Ethernet0"]
-        self.create_acl_table("test_redirect", "L3", bind_ports)
+        self.dvs_acl.create_acl_table("test_redirect", "L3", bind_ports)
 
         config_qualifiers = {"L4_SRC_PORT": "65000"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.get_simple_qualifier_comparator("65000&mask:0xffff")}
+        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
 
-        self.create_acl_rule("test_redirect", "redirect_rule", config_qualifiers, action="REDIRECT:10.0.0.2@Ethernet4", priority="20")
+        self.dvs_acl.create_acl_rule("test_redirect", "redirect_rule", config_qualifiers, action="REDIRECT:10.0.0.2@Ethernet4", priority="20")
 
-        acl_rule_id = self.get_acl_rule_id()
-        entry = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
-        self._check_acl_entry(entry, expected_sai_qualifiers, "REDIRECT:10.0.0.2@Ethernet4", "20")
+        acl_rule_id = self.dvs_acl.get_acl_rule_id()
+        entry = self.dvs_acl.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
+        self.dvs_acl._check_acl_entry(entry, expected_sai_qualifiers, "REDIRECT:10.0.0.2@Ethernet4", "20")
         assert entry.get("SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT", None) == next_hop_id
 
-        self.remove_acl_rule("test_redirect", "redirect_rule")
-        self.verify_no_acl_rules()
+        self.dvs_acl.remove_acl_rule("test_redirect", "redirect_rule")
+        self.dvs_acl.verify_no_acl_rules()
 
-        self.remove_acl_table("test_redirect")
-        self.verify_no_acl_tables()
+        self.dvs_acl.remove_acl_table("test_redirect")
+        self.dvs_acl.verify_no_acl_tables()
 
         # Clean up the IP interface and neighbor
         dvs.remove_neighbor("Ethernet4", "10.0.0.2")
@@ -607,8 +430,8 @@ class TestAclRuleValidation(BaseTestAcl):
     SWITCH_CAPABILITY_TABLE = "SWITCH_CAPABILITY"
 
     def get_acl_actions_supported(self, stage):
-        switch_id = self.state_db.wait_for_n_keys(self.SWITCH_CAPABILITY_TABLE, 1)[0]
-        switch = self.state_db.wait_for_entry(self.SWITCH_CAPABILITY_TABLE, switch_id)
+        switch_id = self.dvs_acl.state_db.wait_for_n_keys(self.SWITCH_CAPABILITY_TABLE, 1)[0]
+        switch = self.dvs_acl.state_db.wait_for_entry(self.SWITCH_CAPABILITY_TABLE, switch_id)
 
         field = "ACL_ACTIONS|{}".format(stage.upper())
 
@@ -627,7 +450,7 @@ class TestAclRuleValidation(BaseTestAcl):
             to check the case when orchagent refuses to process rules with action that is not
             supported by the ASIC.
         """
-        self.setup_db(dvs)
+        self.setup_dvs_acl(dvs)
 
         stage_name_map = {
             "ingress": "SAI_SWITCH_ATTR_ACL_STAGE_INGRESS",
@@ -669,17 +492,17 @@ class TestAclRuleValidation(BaseTestAcl):
 
             bind_ports = ["Ethernet0", "Ethernet4"]
 
-            self.create_acl_table(acl_table, "L3", bind_ports, stage=stage)
+            self.dvs_acl.create_acl_table(acl_table, "L3", bind_ports, stage=stage)
 
             config_qualifiers = {
                 "ICMP_TYPE": "8"
             }
 
-            self.create_acl_rule(acl_table, acl_rule, config_qualifiers)
-            self.verify_no_acl_rules()
-            self.remove_acl_rule(acl_table, acl_rule)
+            self.dvs_acl.create_acl_rule(acl_table, acl_rule, config_qualifiers)
+            self.dvs_acl.verify_no_acl_rules()
+            self.dvs_acl.remove_acl_rule(acl_table, acl_rule)
 
-            self.remove_acl_table(acl_table)
+            self.dvs_acl.remove_acl_table(acl_table)
 
             dvs.runcmd("supervisorctl restart syncd")
             dvs.stop_swss()

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1,12 +1,9 @@
 import time
+import pytest
 
-class BaseTestAcl(object):
-    def setup_dvs_acl(self, dvs):
-        self.dvs_acl = dvs.get_dvs_acl()
-
-class TestAcl(BaseTestAcl):
+@pytest.mark.usefixtures('dvs_acl_manager')
+class TestAcl():
     def test_AclTableCreation(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
         self.dvs_acl.create_acl_table("test", "L3", bind_ports)
@@ -16,9 +13,7 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_acl_group_member(acl_group_ids, self.dvs_acl.get_acl_table_id())
         self.dvs_acl.verify_acl_port_binding(bind_ports)
 
-    #fails
     def test_AclRuleL4SrcPort(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_SRC_PORT": "65000"}
         expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
@@ -29,9 +24,7 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
         self.dvs_acl.verify_no_acl_rules()
 
-    #fails
     def test_AclRuleInOutPorts(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {
             "IN_PORTS": "Ethernet0,Ethernet4",
@@ -50,7 +43,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleInPortsNonExistingInterface(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {
             "IN_PORTS": "FOO_BAR_BAZ"
@@ -62,7 +54,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
 
     def test_AclRuleOutPortsNonExistingInterface(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {
             "OUT_PORTS": "FOO_BAR_BAZ"
@@ -74,13 +65,11 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
 
     def test_AclTableDeletion(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         self.dvs_acl.remove_acl_table("test")
-        self.dvs_acl.verify_no_acl_tables()
+        self.dvs_acl.verify_acl_table_count(0)
 
     def test_V6AclTableCreation(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4", "Ethernet8"]
         self.dvs_acl.create_acl_table("test_aclv6", "L3V6", bind_ports)
@@ -90,9 +79,7 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_acl_group_member(acl_group_ids, self.dvs_acl.get_acl_table_id())
         self.dvs_acl.verify_acl_port_binding(bind_ports)
 
-    # fails
     def test_V6AclRuleIPv6Any(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"IP_TYPE": "IPv6ANY"}
         expected_sai_qualifiers = {
@@ -105,9 +92,7 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
         self.dvs_acl.verify_no_acl_rules()
 
-    # fails
     def test_V6AclRuleIPv6AnyDrop(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"IP_TYPE": "IPv6ANY"}
         expected_sai_qualifiers = {
@@ -121,7 +106,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleIpProtocol(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"IP_PROTOCOL": "6"}
         expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL": self.dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")}
@@ -133,7 +117,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleSrcIPv6(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"SRC_IPV6": "2777::0/64"}
         expected_sai_qualifiers = {
@@ -147,7 +130,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleDstIPv6(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"DST_IPV6": "2002::2/128"}
         expected_sai_qualifiers = {
@@ -161,7 +143,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4SrcPort(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_SRC_PORT": "65000"}
         expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
@@ -173,7 +154,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4DstPort(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_DST_PORT": "65001"}
         expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT": self.dvs_acl.get_simple_qualifier_comparator("65001&mask:0xffff")}
@@ -185,7 +165,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleTCPFlags(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"TCP_FLAGS": "0x07/0x3f"}
         expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS": self.dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f")}
@@ -197,7 +176,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4SrcPortRange(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_SRC_PORT_RANGE": "1-100"}
         expected_sai_qualifiers = {
@@ -211,7 +189,6 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclRuleL4DstPortRange(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         config_qualifiers = {"L4_DST_PORT_RANGE": "101-200"}
         expected_sai_qualifiers = {
@@ -225,13 +202,11 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
     def test_V6AclTableDeletion(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         self.dvs_acl.remove_acl_table("test_aclv6")
-        self.dvs_acl.verify_no_acl_tables()
+        self.dvs_acl.verify_acl_table_count(0)
 
     def test_InsertAclRuleBetweenPriorities(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
         self.dvs_acl.create_acl_table("test_priorities", "L3", bind_ports)
@@ -283,10 +258,9 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
         self.dvs_acl.remove_acl_table("test_priorities")
-        self.dvs_acl.verify_no_acl_tables()
+        self.dvs_acl.verify_acl_table_count(0)
 
     def test_RulesWithDiffMaskLengths(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
         self.dvs_acl.create_acl_table("test_masks", "L3", bind_ports)
@@ -331,10 +305,9 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
         self.dvs_acl.remove_acl_table("test_masks")
-        self.dvs_acl.verify_no_acl_tables()
+        self.dvs_acl.verify_acl_table_count(0)
 
     def test_AclRuleIcmp(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
         self.dvs_acl.create_acl_table("test_icmp", "L3", bind_ports)
@@ -356,10 +329,9 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
         self.dvs_acl.remove_acl_table("test_icmp")
-        self.dvs_acl.verify_no_acl_tables()
+        self.dvs_acl.verify_acl_table_count(0)
 
     def test_AclRuleIcmpV6(self, dvs):
-        self.setup_dvs_acl(dvs)
 
         bind_ports = ["Ethernet0", "Ethernet4"]
         self.dvs_acl.create_acl_table("test_icmpv6", "L3V6", bind_ports)
@@ -381,13 +353,12 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
         self.dvs_acl.remove_acl_table("test_icmpv6")
-        self.dvs_acl.verify_no_acl_tables()
+        self.dvs_acl.verify_acl_table_count(0)
 
     def test_AclRuleRedirectToNextHop(self, dvs):
         # NOTE: set_interface_status has a dependency on cdb within dvs,
         # so we still need to setup the db. This should be refactored.
         dvs.setup_db()
-        self.setup_dvs_acl(dvs)
 
         # Bring up an IP interface with a neighbor
         dvs.set_interface_status("Ethernet4", "up")
@@ -413,7 +384,7 @@ class TestAcl(BaseTestAcl):
         self.dvs_acl.verify_no_acl_rules()
 
         self.dvs_acl.remove_acl_table("test_redirect")
-        self.dvs_acl.verify_no_acl_tables()
+        self.dvs_acl.verify_acl_table_count(0)
 
         # Clean up the IP interface and neighbor
         dvs.remove_neighbor("Ethernet4", "10.0.0.2")
@@ -421,7 +392,8 @@ class TestAcl(BaseTestAcl):
         dvs.set_interface_status("Ethernet4", "down")
 
 
-class TestAclRuleValidation(BaseTestAcl):
+@pytest.mark.usefixtures('dvs_acl_manager')
+class TestAclRuleValidation():
     """
         Test class for cases that check if orchagent corectly validates
         ACL rules input
@@ -450,7 +422,6 @@ class TestAclRuleValidation(BaseTestAcl):
             to check the case when orchagent refuses to process rules with action that is not
             supported by the ASIC.
         """
-        self.setup_dvs_acl(dvs)
 
         stage_name_map = {
             "ingress": "SAI_SWITCH_ATTR_ACL_STAGE_INGRESS",

--- a/tests/test_port_dpb_acl.py
+++ b/tests/test_port_dpb_acl.py
@@ -1,4 +1,3 @@
-from swsscommon import swsscommon
 import redis
 import time
 import os
@@ -14,89 +13,84 @@ maxRootPorts = maxPorts/maxBreakout
 maxAclTables = 16
 
 @pytest.mark.usefixtures('dpb_setup_fixture')
+@pytest.mark.usefixtures('dvs_acl_manager')
 class TestPortDPBAcl(object):
 
     '''
     @pytest.mark.skip()
     '''
     def test_acl_table_empty_port_list(self, dvs):
-        dvs.setup_db()
-        dvs_acl = dvs.get_dvs_acl()
 
         # Create ACL table "test" and bind it to Ethernet0
         bind_ports = []
-        dvs_acl.create_acl_table("test", "L3", bind_ports)
-        dvs_acl.verify_acl_tables(1)
-        dvs_acl.verify_acl_group_num(0)
+        self.dvs_acl.create_acl_table("test", "L3", bind_ports)
+        self.dvs_acl.verify_acl_table_count(1)
+        self.dvs_acl.verify_acl_group_num(0)
 
         bind_ports = ["Ethernet0"]
-        dvs_acl.update_acl_table("test", bind_ports)
+        self.dvs_acl.update_acl_table("test", bind_ports)
 
         # Verify table, group, and member have been created
-        dvs_acl.verify_acl_tables(1)
-        dvs_acl.verify_acl_group_num(1)
-        acl_table_ids = dvs_acl.get_acl_table_ids()
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        self.dvs_acl.verify_acl_table_count(1)
+        self.dvs_acl.verify_acl_group_num(1)
+        acl_table_ids = self.dvs_acl.get_acl_table_ids()
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         bind_ports = []
-        dvs_acl.update_acl_table("test", bind_ports)
-        dvs_acl.verify_acl_tables(1)
-        dvs_acl.verify_acl_group_num(0)
+        self.dvs_acl.update_acl_table("test", bind_ports)
+        self.dvs_acl.verify_acl_table_count(1)
+        self.dvs_acl.verify_acl_group_num(0)
 
     '''
     @pytest.mark.skip()
     '''
     def test_one_port_two_acl_tables(self, dvs):
-        dvs.setup_db()
-        dvs_acl = dvs.get_dvs_acl()
 
         # Create ACL table "test" and bind it to Ethernet0
         bind_ports = ["Ethernet0"]
-        dvs_acl.create_acl_table("test", "L3", bind_ports)
-        dvs_acl.verify_acl_tables(1)
-        dvs_acl.verify_acl_group_num(1)
-        acl_table_ids = dvs_acl.get_acl_table_ids()
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        self.dvs_acl.create_acl_table("test", "L3", bind_ports)
+        self.dvs_acl.verify_acl_table_count(1)
+        self.dvs_acl.verify_acl_group_num(1)
+        acl_table_ids = self.dvs_acl.get_acl_table_ids()
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         # Create ACL table "test1" and bind it to Ethernet0
         bind_ports = ["Ethernet0"]
-        dvs_acl.create_acl_table("test1", "L3", bind_ports)
-        dvs_acl.verify_acl_tables(2)
-        dvs_acl.verify_acl_group_num(1)
-        acl_table_ids = dvs_acl.get_acl_table_ids(2)
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[1])
+        self.dvs_acl.create_acl_table("test1", "L3", bind_ports)
+        self.dvs_acl.verify_acl_table_count(2)
+        self.dvs_acl.verify_acl_group_num(1)
+        acl_table_ids = self.dvs_acl.get_acl_table_ids(2)
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[1])
 
         #Delete ACL tables
-        dvs_acl.remove_acl_table("test")
-        dvs_acl.verify_acl_tables(1)
-        dvs_acl.verify_acl_group_num(1)
+        self.dvs_acl.remove_acl_table("test")
+        self.dvs_acl.verify_acl_table_count(1)
+        self.dvs_acl.verify_acl_group_num(1)
 
-        dvs.remove_acl_table("test1")
-        dvs_acl.verify_acl_tables(0)
-        dvs_acl.verify_acl_group_num(0)
+        self.dvs_acl.remove_acl_table("test1")
+        self.dvs_acl.verify_acl_table_count(0)
+        self.dvs_acl.verify_acl_group_num(0)
 
     '''
     @pytest.mark.skip()
     '''
     def test_one_acl_table_many_ports(self, dvs):
-        dvs.setup_db()
-        dvs_acl = dvs.get_dvs_acl()
 
         # Create ACL table and bind it to Ethernet0 and Ethernet4
         bind_ports = ["Ethernet0", "Ethernet4"]
-        dvs_acl.create_acl_table("test", "L3", bind_ports)
-        dvs_acl.verify_acl_tables(1)
-        dvs_acl.verify_acl_group_num(2)
-        acl_table_ids = dvs_acl.get_acl_table_ids()
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        self.dvs_acl.create_acl_table("test", "L3", bind_ports)
+        self.dvs_acl.verify_acl_table_count(1)
+        self.dvs_acl.verify_acl_group_num(2)
+        acl_table_ids = self.dvs_acl.get_acl_table_ids()
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         # Update bind list and verify
         bind_ports = ["Ethernet4"]
-        dvs_acl.update_acl_table("test", bind_ports)
-        dvs_acl.verify_acl_group_num(1)
-        acl_table_ids = dvs_acl.get_acl_table_ids()
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        self.dvs_acl.update_acl_table("test", bind_ports)
+        self.dvs_acl.verify_acl_group_num(1)
+        acl_table_ids = self.dvs_acl.get_acl_table_ids()
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         # Breakout Ethernet0
         dpb = DPB()
@@ -105,15 +99,15 @@ class TestPortDPBAcl(object):
 
         #Update bind list and verify
         bind_ports = ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3","Ethernet4"]
-        dvs_acl.update_acl_table("test", bind_ports)
-        dvs_acl.verify_acl_group_num(5)
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        self.dvs_acl.update_acl_table("test", bind_ports)
+        self.dvs_acl.verify_acl_group_num(5)
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         # Update bind list and verify
         bind_ports = ["Ethernet4"]
-        dvs_acl.update_acl_table("test", bind_ports)
-        dvs_acl.verify_acl_group_num(1)
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        self.dvs_acl.update_acl_table("test", bind_ports)
+        self.dvs_acl.verify_acl_group_num(1)
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         #Breakin Ethernet0, 1, 2, 3
         dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
@@ -121,39 +115,37 @@ class TestPortDPBAcl(object):
 
         # Update bind list and verify
         bind_ports = ["Ethernet0", "Ethernet4"]
-        dvs_acl.update_acl_table("test", bind_ports)
-        dvs_acl.verify_acl_group_num(2)
-        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        self.dvs_acl.update_acl_table("test", bind_ports)
+        self.dvs_acl.verify_acl_group_num(2)
+        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         #Delete ACL table
-        dvs_acl.remove_acl_table("test")
-        dvs_acl.verify_acl_group_num(0)
+        self.dvs_acl.remove_acl_table("test")
+        self.dvs_acl.verify_acl_group_num(0)
 
     '''
     @pytest.mark.skip()
     '''
     def test_one_port_many_acl_tables(self, dvs):
-        dvs.setup_db()
-        dvs_acl = dvs.get_dvs_acl()
 
         # Create 4 ACL tables and bind them to Ethernet0
         bind_ports = ["Ethernet0"]
         acl_tables = ["test1", "test2", "test3", "test4"]
         for acl_tbl in acl_tables:
-            dvs_acl.create_acl_table(acl_tbl, "L3", bind_ports)
+            self.dvs_acl.create_acl_table(acl_tbl, "L3", bind_ports)
 
-        dvs_acl.verify_acl_tables(len(acl_tables))
-        dvs_acl.verify_acl_group_num(len(bind_ports))
-        acl_table_ids = dvs_acl.get_acl_table_ids(len(acl_tables))
+        self.dvs_acl.verify_acl_table_count(len(acl_tables))
+        self.dvs_acl.verify_acl_group_num(len(bind_ports))
+        acl_table_ids = self.dvs_acl.get_acl_table_ids(len(acl_tables))
         for acl_tbl_id in acl_table_ids:
-            dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_tbl_id)
+            self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_tbl_id)
 
         # Update bind list and verify
         bind_ports = []
         for acl_tbl in acl_tables:
-            dvs_acl.update_acl_table(acl_tbl, bind_ports)
+            self.dvs_acl.update_acl_table(acl_tbl, bind_ports)
 
-        dvs_acl.verify_acl_group_num(0)
+        self.dvs_acl.verify_acl_group_num(0)
 
         # Breakout Ethernet0
         dpb = DPB()
@@ -163,14 +155,12 @@ class TestPortDPBAcl(object):
         dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
 
         for acl_tbl in acl_tables:
-            dvs_acl.remove_acl_table(acl_tbl)
+            self.dvs_acl.remove_acl_table(acl_tbl)
 
     '''
     @pytest.mark.skip()
     '''
     def test_many_ports_many_acl_tables(self, dvs):
-        dvs.setup_db()
-        dvs_acl = dvs.get_dvs_acl()
 
         # Prepare ACL table names
         aclTableNames = []
@@ -189,15 +179,15 @@ class TestPortDPBAcl(object):
 
         # Create ACL tables and bind root ports
         for aclTable in aclTableNames:
-            dvs_acl.create_acl_table(aclTable, "L3", rootPortNames)
-        dvs_acl.verify_acl_group_num(maxRootPorts)
+            self.dvs_acl.create_acl_table(aclTable, "L3", rootPortNames)
+        self.dvs_acl.verify_acl_group_num(maxRootPorts)
 
         # Remove the dependency on all root ports by
         # unbinding them from all ACL tables.
         bind_ports = []
         for aclTable in aclTableNames:
-            dvs_acl.update_acl_table(aclTable, bind_ports)
-        dvs_acl.verify_acl_group_num(0)
+            self.dvs_acl.update_acl_table(aclTable, bind_ports)
+        self.dvs_acl.verify_acl_group_num(0)
 
         # Breakout all root ports
         dpb = DPB()
@@ -206,13 +196,13 @@ class TestPortDPBAcl(object):
             dpb.breakout(dvs, pName, maxBreakout)
 
         # Add all ports to aclTable1
-        dvs_acl.update_acl_table(aclTableNames[0], portNames)
-        dvs_acl.verify_acl_group_num(maxPorts)
+        self.dvs_acl.update_acl_table(aclTableNames[0], portNames)
+        self.dvs_acl.verify_acl_group_num(maxPorts)
 
         # Remove all ports from aclTable1
         bind_ports = []
-        dvs_acl.update_acl_table(aclTableNames[0], bind_ports)
-        dvs_acl.verify_acl_group_num(0)
+        self.dvs_acl.update_acl_table(aclTableNames[0], bind_ports)
+        self.dvs_acl.verify_acl_group_num(0)
 
         # Breakin all ports
         for i in range(0, maxPorts, maxBreakout):
@@ -220,5 +210,5 @@ class TestPortDPBAcl(object):
             dpb.breakin(dvs, portNames[i:i+maxBreakout])
 
         for aclTable in aclTableNames:
-            dvs_acl.remove_acl_table(aclTable)
-        dvs_acl.verify_acl_tables(0)
+            self.dvs_acl.remove_acl_table(aclTable)
+        self.dvs_acl.verify_acl_table_count(0)

--- a/tests/test_port_dpb_acl.py
+++ b/tests/test_port_dpb_acl.py
@@ -8,6 +8,11 @@ import json
 import re
 from port_dpb import DPB
 
+maxPorts = 32
+maxBreakout = 4
+maxRootPorts = maxPorts/maxBreakout
+maxAclTables = 16
+
 @pytest.mark.usefixtures('dpb_setup_fixture')
 class TestPortDPBAcl(object):
 
@@ -116,7 +121,7 @@ class TestPortDPBAcl(object):
 
         # Breakout Ethernet0
         dpb = DPB()
-        dpb.breakout(dvs, "Ethernet0", 4)
+        dpb.breakout(dvs, "Ethernet0", maxBreakout)
         time.sleep(2)
 
         #Update bind list and verify
@@ -163,7 +168,106 @@ class TestPortDPBAcl(object):
         time.sleep(2)
         dvs.verify_acl_group_num(0)
 
+    '''
     @pytest.mark.skip()
+    '''
     def test_one_port_many_acl_tables(self, dvs):
-        #TBD
-        return
+        dvs.setup_db()
+
+        # Create 4 ACL tables and bind them to Ethernet0
+        bind_ports = ["Ethernet0"]
+        dvs.create_acl_table("test1", "L3", bind_ports)
+        dvs.create_acl_table("test2", "L3", bind_ports)
+        dvs.create_acl_table("test3", "L3", bind_ports)
+        dvs.create_acl_table("test4", "L3", bind_ports)
+
+        acl_table_ids = dvs.get_acl_table_ids()
+        assert len(acl_table_ids) == 4
+        dvs.verify_acl_group_num(1)
+        acl_group_ids = dvs.get_acl_group_ids()
+        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
+        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[1])
+        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[2])
+        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[3])
+        dvs.verify_acl_port_binding(bind_ports)
+
+        # Update bind list and verify
+        bind_ports = []
+        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
+        dvs.update_acl_table("test1", fvs)
+        dvs.update_acl_table("test2", fvs)
+        dvs.update_acl_table("test3", fvs)
+        dvs.update_acl_table("test4", fvs)
+        dvs.verify_acl_group_num(0)
+
+        # Breakout Ethernet0
+        dpb = DPB()
+        dpb.breakout(dvs, "Ethernet0", maxBreakout)
+
+        #Breakin Ethernet0, 1, 2, 3
+        dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
+
+        dvs.remove_acl_table("test1")
+        dvs.remove_acl_table("test2")
+        dvs.remove_acl_table("test3")
+        dvs.remove_acl_table("test4")
+
+    '''
+    @pytest.mark.skip()
+    '''
+    def test_many_ports_many_acl_tables(self, dvs):
+        dvs.setup_db()
+
+        # Prepare ACL table names
+        aclTableNames = []
+        for i in range(maxAclTables):
+            aclTableNames.append("aclTable" + str(i+1))
+
+        # Prepare all port names
+        portNames = []
+        for i in range(maxPorts):
+            portNames.append("Ethernet" + str(i))
+
+        # Prepare root port names
+        rootPortNames = []
+        for i in range(0, maxPorts, maxBreakout):
+            rootPortNames.append("Ethernet" + str(i))
+
+        # Create ACL tables and bind root ports
+        for aclTable in aclTableNames:
+            dvs.create_acl_table(aclTable, "L3", rootPortNames)
+        dvs.verify_acl_group_num(maxRootPorts)
+
+        # Remove the dependency on all root ports by
+        # unbinding them from all ACL tables.
+        bind_ports = []
+        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
+        for aclTable in aclTableNames:
+            dvs.update_acl_table(aclTable, fvs)
+        dvs.verify_acl_group_num(0)
+
+        # Breakout all root ports
+        dpb = DPB()
+        for pName in rootPortNames:
+            #print "Breaking out %s"%pName
+            dpb.breakout(dvs, pName, maxBreakout)
+
+        # Add all ports to aclTable1
+        fvs = swsscommon.FieldValuePairs([("ports", ",".join(portNames))])
+        dvs.update_acl_table(aclTableNames[0], fvs)
+        dvs.verify_acl_group_num(maxPorts)
+
+        # Remove all ports from aclTable1
+        bind_ports = []
+        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
+        dvs.update_acl_table(aclTableNames[0], fvs)
+        dvs.verify_acl_group_num(0)
+
+        # Breakin all ports
+        for i in range(0, maxPorts, maxBreakout):
+            #print "Breaking in %s"%portNames[i:i+maxBreakout]
+            dpb.breakin(dvs, portNames[i:i+maxBreakout])
+
+        for aclTable in aclTableNames:
+            dvs.remove_acl_table(aclTable)
+        dvs.verify_acl_group_num(0)

--- a/tests/test_port_dpb_acl.py
+++ b/tests/test_port_dpb_acl.py
@@ -21,103 +21,82 @@ class TestPortDPBAcl(object):
     '''
     def test_acl_table_empty_port_list(self, dvs):
         dvs.setup_db()
+        dvs_acl = dvs.get_dvs_acl()
 
         # Create ACL table "test" and bind it to Ethernet0
         bind_ports = []
-        dvs.create_acl_table("test", "L3", bind_ports)
-        time.sleep(2)
-        acl_table_ids = dvs.get_acl_table_ids()
-        assert len(acl_table_ids) == 1
-        dvs.verify_acl_group_num(0)
-        acl_group_ids = dvs.get_acl_group_ids()
-        assert len(acl_group_ids) == 0
+        dvs_acl.create_acl_table("test", "L3", bind_ports)
+        dvs_acl.verify_acl_tables(1)
+        dvs_acl.verify_acl_group_num(0)
 
         bind_ports = ["Ethernet0"]
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
-        dvs.update_acl_table("test", fvs)
-        time.sleep(2)
-        acl_table_ids = dvs.get_acl_table_ids()
-        assert len(acl_table_ids) == 1
-        dvs.verify_acl_group_num(1)
-        acl_group_ids = dvs.get_acl_group_ids()
-        assert len(acl_group_ids) == 1
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_port_binding(bind_ports)
+        dvs_acl.update_acl_table("test", bind_ports)
+
+        # Verify table, group, and member have been created
+        dvs_acl.verify_acl_tables(1)
+        dvs_acl.verify_acl_group_num(1)
+        acl_table_ids = dvs_acl.get_acl_table_ids()
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         bind_ports = []
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
-        dvs.update_acl_table("test", fvs)
-        time.sleep(2)
-        acl_table_ids = dvs.get_acl_table_ids()
-        assert len(acl_table_ids) == 1
-        dvs.verify_acl_group_num(0)
-        acl_group_ids = dvs.get_acl_group_ids()
-        assert len(acl_group_ids) == 0
+        dvs_acl.update_acl_table("test", bind_ports)
+        dvs_acl.verify_acl_tables(1)
+        dvs_acl.verify_acl_group_num(0)
 
     '''
     @pytest.mark.skip()
     '''
     def test_one_port_two_acl_tables(self, dvs):
         dvs.setup_db()
+        dvs_acl = dvs.get_dvs_acl()
 
         # Create ACL table "test" and bind it to Ethernet0
         bind_ports = ["Ethernet0"]
-        dvs.create_acl_table("test", "L3", bind_ports)
-        time.sleep(2)
-        acl_table_ids = dvs.get_acl_table_ids()
-        assert len(acl_table_ids) == 1
-        dvs.verify_acl_group_num(1)
-        acl_group_ids = dvs.get_acl_group_ids()
-        assert len(acl_group_ids) == 1
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_port_binding(bind_ports)
+        dvs_acl.create_acl_table("test", "L3", bind_ports)
+        dvs_acl.verify_acl_tables(1)
+        dvs_acl.verify_acl_group_num(1)
+        acl_table_ids = dvs_acl.get_acl_table_ids()
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         # Create ACL table "test1" and bind it to Ethernet0
         bind_ports = ["Ethernet0"]
-        dvs.create_acl_table("test1", "L3", bind_ports)
-        time.sleep(2)
-        acl_table_ids = dvs.get_acl_table_ids()
-        assert len(acl_table_ids) == 2
-        dvs.verify_acl_group_num(1)
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[1])
-        dvs.verify_acl_port_binding(bind_ports)
+        dvs_acl.create_acl_table("test1", "L3", bind_ports)
+        dvs_acl.verify_acl_tables(2)
+        dvs_acl.verify_acl_group_num(1)
+        acl_table_ids = dvs_acl.get_acl_table_ids(2)
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[1])
 
         #Delete ACL tables
-        dvs.remove_acl_table("test")
-        time.sleep(2)
-        dvs.verify_acl_group_num(1)
+        dvs_acl.remove_acl_table("test")
+        dvs_acl.verify_acl_tables(1)
+        dvs_acl.verify_acl_group_num(1)
+
         dvs.remove_acl_table("test1")
-        time.sleep(2)
-        dvs.verify_acl_group_num(0)
+        dvs_acl.verify_acl_tables(0)
+        dvs_acl.verify_acl_group_num(0)
 
     '''
     @pytest.mark.skip()
     '''
     def test_one_acl_table_many_ports(self, dvs):
         dvs.setup_db()
+        dvs_acl = dvs.get_dvs_acl()
 
         # Create ACL table and bind it to Ethernet0 and Ethernet4
         bind_ports = ["Ethernet0", "Ethernet4"]
-        dvs.create_acl_table("test", "L3", bind_ports)
-        time.sleep(2)
-        acl_table_ids = dvs.get_acl_table_ids()
-        assert len(acl_table_ids) == 1
-        dvs.verify_acl_group_num(2)
-        acl_group_ids = dvs.get_acl_group_ids()
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_group_member(acl_group_ids[1], acl_table_ids[0])
-        dvs.verify_acl_port_binding(bind_ports)
+        dvs_acl.create_acl_table("test", "L3", bind_ports)
+        dvs_acl.verify_acl_tables(1)
+        dvs_acl.verify_acl_group_num(2)
+        acl_table_ids = dvs_acl.get_acl_table_ids()
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         # Update bind list and verify
         bind_ports = ["Ethernet4"]
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
-        dvs.update_acl_table("test", fvs)
-        time.sleep(2)
-        dvs.verify_acl_group_num(1)
-        acl_group_ids = dvs.get_acl_group_ids()
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_port_binding(bind_ports)
+        dvs_acl.update_acl_table("test", bind_ports)
+        dvs_acl.verify_acl_group_num(1)
+        acl_table_ids = dvs_acl.get_acl_table_ids()
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         # Breakout Ethernet0
         dpb = DPB()
@@ -126,27 +105,15 @@ class TestPortDPBAcl(object):
 
         #Update bind list and verify
         bind_ports = ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3","Ethernet4"]
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
-        dvs.update_acl_table("test", fvs)
-        time.sleep(2)
-        dvs.verify_acl_group_num(5)
-        acl_group_ids = dvs.get_acl_group_ids()
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_group_member(acl_group_ids[1], acl_table_ids[0])
-        dvs.verify_acl_group_member(acl_group_ids[2], acl_table_ids[0])
-        dvs.verify_acl_group_member(acl_group_ids[3], acl_table_ids[0])
-        dvs.verify_acl_group_member(acl_group_ids[4], acl_table_ids[0])
-        dvs.verify_acl_port_binding(bind_ports)
-        time.sleep(2)
+        dvs_acl.update_acl_table("test", bind_ports)
+        dvs_acl.verify_acl_group_num(5)
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         # Update bind list and verify
         bind_ports = ["Ethernet4"]
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
-        dvs.update_acl_table("test", fvs)
-        dvs.verify_acl_group_num(1)
-        acl_group_ids = dvs.get_acl_group_ids()
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_port_binding(bind_ports)
+        dvs_acl.update_acl_table("test", bind_ports)
+        dvs_acl.verify_acl_group_num(1)
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         #Breakin Ethernet0, 1, 2, 3
         dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
@@ -154,51 +121,39 @@ class TestPortDPBAcl(object):
 
         # Update bind list and verify
         bind_ports = ["Ethernet0", "Ethernet4"]
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
-        dvs.update_acl_table("test", fvs)
-        time.sleep(2)
-        dvs.verify_acl_group_num(2)
-        acl_group_ids = dvs.get_acl_group_ids()
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_group_member(acl_group_ids[1], acl_table_ids[0])
-        dvs.verify_acl_port_binding(bind_ports)
+        dvs_acl.update_acl_table("test", bind_ports)
+        dvs_acl.verify_acl_group_num(2)
+        dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
 
         #Delete ACL table
-        dvs.remove_acl_table("test")
-        time.sleep(2)
-        dvs.verify_acl_group_num(0)
+        dvs_acl.remove_acl_table("test")
+        dvs_acl.verify_acl_group_num(0)
 
     '''
     @pytest.mark.skip()
     '''
     def test_one_port_many_acl_tables(self, dvs):
         dvs.setup_db()
+        dvs_acl = dvs.get_dvs_acl()
 
         # Create 4 ACL tables and bind them to Ethernet0
         bind_ports = ["Ethernet0"]
-        dvs.create_acl_table("test1", "L3", bind_ports)
-        dvs.create_acl_table("test2", "L3", bind_ports)
-        dvs.create_acl_table("test3", "L3", bind_ports)
-        dvs.create_acl_table("test4", "L3", bind_ports)
+        acl_tables = ["test1", "test2", "test3", "test4"]
+        for acl_tbl in acl_tables:
+            dvs_acl.create_acl_table(acl_tbl, "L3", bind_ports)
 
-        acl_table_ids = dvs.get_acl_table_ids()
-        assert len(acl_table_ids) == 4
-        dvs.verify_acl_group_num(1)
-        acl_group_ids = dvs.get_acl_group_ids()
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[0])
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[1])
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[2])
-        dvs.verify_acl_group_member(acl_group_ids[0], acl_table_ids[3])
-        dvs.verify_acl_port_binding(bind_ports)
+        dvs_acl.verify_acl_tables(len(acl_tables))
+        dvs_acl.verify_acl_group_num(len(bind_ports))
+        acl_table_ids = dvs_acl.get_acl_table_ids(len(acl_tables))
+        for acl_tbl_id in acl_table_ids:
+            dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_tbl_id)
 
         # Update bind list and verify
         bind_ports = []
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
-        dvs.update_acl_table("test1", fvs)
-        dvs.update_acl_table("test2", fvs)
-        dvs.update_acl_table("test3", fvs)
-        dvs.update_acl_table("test4", fvs)
-        dvs.verify_acl_group_num(0)
+        for acl_tbl in acl_tables:
+            dvs_acl.update_acl_table(acl_tbl, bind_ports)
+
+        dvs_acl.verify_acl_group_num(0)
 
         # Breakout Ethernet0
         dpb = DPB()
@@ -207,16 +162,15 @@ class TestPortDPBAcl(object):
         #Breakin Ethernet0, 1, 2, 3
         dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
 
-        dvs.remove_acl_table("test1")
-        dvs.remove_acl_table("test2")
-        dvs.remove_acl_table("test3")
-        dvs.remove_acl_table("test4")
+        for acl_tbl in acl_tables:
+            dvs_acl.remove_acl_table(acl_tbl)
 
     '''
     @pytest.mark.skip()
     '''
     def test_many_ports_many_acl_tables(self, dvs):
         dvs.setup_db()
+        dvs_acl = dvs.get_dvs_acl()
 
         # Prepare ACL table names
         aclTableNames = []
@@ -235,16 +189,15 @@ class TestPortDPBAcl(object):
 
         # Create ACL tables and bind root ports
         for aclTable in aclTableNames:
-            dvs.create_acl_table(aclTable, "L3", rootPortNames)
-        dvs.verify_acl_group_num(maxRootPorts)
+            dvs_acl.create_acl_table(aclTable, "L3", rootPortNames)
+        dvs_acl.verify_acl_group_num(maxRootPorts)
 
         # Remove the dependency on all root ports by
         # unbinding them from all ACL tables.
         bind_ports = []
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
         for aclTable in aclTableNames:
-            dvs.update_acl_table(aclTable, fvs)
-        dvs.verify_acl_group_num(0)
+            dvs_acl.update_acl_table(aclTable, bind_ports)
+        dvs_acl.verify_acl_group_num(0)
 
         # Breakout all root ports
         dpb = DPB()
@@ -253,15 +206,13 @@ class TestPortDPBAcl(object):
             dpb.breakout(dvs, pName, maxBreakout)
 
         # Add all ports to aclTable1
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(portNames))])
-        dvs.update_acl_table(aclTableNames[0], fvs)
-        dvs.verify_acl_group_num(maxPorts)
+        dvs_acl.update_acl_table(aclTableNames[0], portNames)
+        dvs_acl.verify_acl_group_num(maxPorts)
 
         # Remove all ports from aclTable1
         bind_ports = []
-        fvs = swsscommon.FieldValuePairs([("ports", ",".join(bind_ports))])
-        dvs.update_acl_table(aclTableNames[0], fvs)
-        dvs.verify_acl_group_num(0)
+        dvs_acl.update_acl_table(aclTableNames[0], bind_ports)
+        dvs_acl.verify_acl_group_num(0)
 
         # Breakin all ports
         for i in range(0, maxPorts, maxBreakout):
@@ -269,5 +220,5 @@ class TestPortDPBAcl(object):
             dpb.breakin(dvs, portNames[i:i+maxBreakout])
 
         for aclTable in aclTableNames:
-            dvs.remove_acl_table(aclTable)
-        dvs.verify_acl_group_num(0)
+            dvs_acl.remove_acl_table(aclTable)
+        dvs_acl.verify_acl_tables(0)


### PR DESCRIPTION
* DPB-ACL scale tests and code-review comments addressed

* Remove sleeps that were put earlier

Co-authored-by: Vasant <vapatil@linkedin.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Wrote DPB scale test cases
**Why I did it**
To catch any race conditions or corner cases

**How I verified it**
Ran VS test cases

**Details if related**
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest --pdb -s -v --dvsname=vs-vp test_port_dpb_acl.py
======================================================================= test session starts ========================================================================
platform linux2 -- Python 2.7.15+, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 5 items

test_port_dpb_acl.py::TestPortDPBAcl::test_acl_table_empty_port_list remove extra link dummy
Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f3062bcde40>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f3062bcde40> = <_sre.SRE_Match object at 0x7f3062bcde40>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f3062bcbf10>> ignored
PASSED                                                                                  [ 20%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_two_acl_tables PASSED                                                                                    [ 40%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_acl_table_many_ports PASSED                                                                                   [ 60%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_many_acl_tables PASSED                                                                                   [ 80%]
test_port_dpb_acl.py::TestPortDPBAcl::test_all_ports_two_acl_tables PASSED                                                                                   [100%]Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f3062caa648>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f3062caa648> = <_sre.SRE_Match object at 0x7f3062caa648>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f3062c15f10>> ignored


=================================================================== 5 passed in 1080.87 seconds ====================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$
```

Test cases after second commit
```
$ sudo pytest -s -v --dvsname=vs-vp test_acl.py test_port_dpb_acl.py
================================================================================== test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 29 items

test_acl.py::TestAcl::test_AclTableCreation remove extra link dummy
PASSED                                                                                                                                [  3%]
test_acl.py::TestAcl::test_AclRuleL4SrcPort PASSED                                                                                                                                [  6%]
test_acl.py::TestAcl::test_AclRuleInOutPorts PASSED                                                                                                                               [ 10%]
test_acl.py::TestAcl::test_AclRuleInPortsNonExistingInterface PASSED                                                                                                              [ 13%]
test_acl.py::TestAcl::test_AclRuleOutPortsNonExistingInterface PASSED                                                                                                             [ 17%]
test_acl.py::TestAcl::test_AclTableDeletion PASSED                                                                                                                                [ 20%]
test_acl.py::TestAcl::test_V6AclTableCreation PASSED                                                                                                                              [ 24%]
test_acl.py::TestAcl::test_V6AclRuleIPv6Any PASSED                                                                                                                                [ 27%]
test_acl.py::TestAcl::test_V6AclRuleIPv6AnyDrop PASSED                                                                                                                            [ 31%]
test_acl.py::TestAcl::test_V6AclRuleIpProtocol PASSED                                                                                                                             [ 34%]
test_acl.py::TestAcl::test_V6AclRuleSrcIPv6 PASSED                                                                                                                                [ 37%]
test_acl.py::TestAcl::test_V6AclRuleDstIPv6 PASSED                                                                                                                                [ 41%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPort PASSED                                                                                                                              [ 44%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPort PASSED                                                                                                                              [ 48%]
test_acl.py::TestAcl::test_V6AclRuleTCPFlags PASSED                                                                                                                               [ 51%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPortRange PASSED                                                                                                                         [ 55%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPortRange PASSED                                                                                                                         [ 58%]
test_acl.py::TestAcl::test_V6AclTableDeletion PASSED                                                                                                                              [ 62%]
test_acl.py::TestAcl::test_InsertAclRuleBetweenPriorities PASSED                                                                                                                  [ 65%]
test_acl.py::TestAcl::test_RulesWithDiffMaskLengths PASSED                                                                                                                        [ 68%]
test_acl.py::TestAcl::test_AclRuleIcmp PASSED                                                                                                                                     [ 72%]
test_acl.py::TestAcl::test_AclRuleIcmpV6 PASSED                                                                                                                                   [ 75%]
test_acl.py::TestAcl::test_AclRuleRedirectToNextHop PASSED                                                                                                                        [ 79%]
test_acl.py::TestAclRuleValidation::test_AclActionValidation PASSED                                                                                                               [ 82%]
test_port_dpb_acl.py::TestPortDPBAcl::test_acl_table_empty_port_list remove extra link dummy
PASSED                                                                                                       [ 86%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_two_acl_tables PASSED                                                                                                         [ 89%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_acl_table_many_ports PASSED                                                                                                        [ 93%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_many_acl_tables PASSED                                                                                                        [ 96%]
test_port_dpb_acl.py::TestPortDPBAcl::test_many_ports_many_acl_tables PASSED                                                                                                      [100%]

============================================================================== 29 passed in 454.67 seconds ==============================================================================

```

Test result after third commit
```
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-vp test_port_dpb_acl.py
================================================================================== test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 5 items                                                                                                                                                                       

test_port_dpb_acl.py::TestPortDPBAcl::test_acl_table_empty_port_list remove extra link dummy
Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f520407f130>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f520407f130> = <_sre.SRE_Match object at 0x7f520407f130>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f5203fd5090>> ignored
PASSED                                                                                                       [ 20%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_two_acl_tables PASSED                                                                                                         [ 40%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_acl_table_many_ports PASSED                                                                                                        [ 60%]
test_port_dpb_acl.py::TestPortDPBAcl::test_one_port_many_acl_tables PASSED                                                                                                        [ 80%]
test_port_dpb_acl.py::TestPortDPBAcl::test_many_ports_many_acl_tables PASSED                                                                                                      [100%]Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7f52040457b0>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7f52040457b0> = <_sre.SRE_Match object at 0x7f52040457b0>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7f5203f7fa90>> ignored


============================================================================== 5 passed in 332.76 seconds ===============================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$

vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -v --pdb --dvsname=vs-vp test_acl.py
================================================================================== test session starts ==================================================================================
platform linux2 -- Python 2.7.17, pytest-3.3.0, py-1.8.0, pluggy-0.6.0 -- /usr/bin/python
cachedir: .cache
rootdir: /home/vapatil/workspace/DPB/sonic-buildimage/src/sonic-swss/tests, inifile:
collected 24 items

test_acl.py::TestAcl::test_AclTableCreation remove extra link dummy
PASSED                                                                                                                                [  4%]
test_acl.py::TestAcl::test_AclRuleL4SrcPort PASSED                                                                                                                                [  8%]
test_acl.py::TestAcl::test_AclRuleInOutPorts PASSED                                                                                                                               [ 12%]
test_acl.py::TestAcl::test_AclRuleInPortsNonExistingInterface PASSED                                                                                                              [ 16%]
test_acl.py::TestAcl::test_AclRuleOutPortsNonExistingInterface PASSED                                                                                                             [ 20%]
test_acl.py::TestAcl::test_AclTableDeletion PASSED                                                                                                                                [ 25%]
test_acl.py::TestAcl::test_V6AclTableCreation PASSED                                                                                                                              [ 29%]
test_acl.py::TestAcl::test_V6AclRuleIPv6Any PASSED                                                                                                                                [ 33%]
test_acl.py::TestAcl::test_V6AclRuleIPv6AnyDrop PASSED                                                                                                                            [ 37%]
test_acl.py::TestAcl::test_V6AclRuleIpProtocol PASSED                                                                                                                             [ 41%]
test_acl.py::TestAcl::test_V6AclRuleSrcIPv6 PASSED                                                                                                                                [ 45%]
test_acl.py::TestAcl::test_V6AclRuleDstIPv6 PASSED                                                                                                                                [ 50%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPort PASSED                                                                                                                              [ 54%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPort PASSED                                                                                                                              [ 58%]
test_acl.py::TestAcl::test_V6AclRuleTCPFlags PASSED                                                                                                                               [ 62%]
test_acl.py::TestAcl::test_V6AclRuleL4SrcPortRange PASSED                                                                                                                         [ 66%]
test_acl.py::TestAcl::test_V6AclRuleL4DstPortRange PASSED                                                                                                                         [ 70%]
test_acl.py::TestAcl::test_V6AclTableDeletion PASSED                                                                                                                              [ 75%]
test_acl.py::TestAcl::test_InsertAclRuleBetweenPriorities PASSED                                                                                                                  [ 79%]
test_acl.py::TestAcl::test_RulesWithDiffMaskLengths PASSED                                                                                                                        [ 83%]
test_acl.py::TestAcl::test_AclRuleIcmp PASSED                                                                                                                                     [ 87%]
test_acl.py::TestAcl::test_AclRuleIcmpV6 PASSED                                                                                                                                   [ 91%]
test_acl.py::TestAcl::test_AclRuleRedirectToNextHop PASSED                                                                                                                        [ 95%]
test_acl.py::TestAclRuleValidation::test_AclActionValidation PASSED                                                                                                               [100%]Exception AssertionError: AssertionError(u"assert 0 > 0\n +  where 0 = int('0')\n +    where '0' = <built-in method group of _sre.SRE_Match object at 0x7efdf26ac730>(1)\n +      where <built-in method group of _sre.SRE_Match object at 0x7efdf26ac730> = <_sre.SRE_Match object at 0x7efdf26ac730>.group",) in <bound method ApplDbValidator.__del__ of <conftest.ApplDbValidator object at 0x7efdf234b250>> ignored


============================================================================== 24 passed in 140.27 seconds ==============================================================================
vapatil@server09:~/workspace/DPB/sonic-buildimage/src/sonic-swss/tests$
```