### PR TITLE
const initializer_list is not a constant expression

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2782,7 +2782,7 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
 
 void PortsOrch::doTask()
 {
-    constexpr auto tableOrder = {
+    auto tableOrder = {
         APP_PORT_TABLE_NAME,
         APP_LAG_TABLE_NAME,
         APP_LAG_MEMBER_TABLE_NAME,


### PR DESCRIPTION
ref: https://lgtm.com/logs/17a00021acc56bf7a82ba4ade589d7c385cca8bb/lang:cpp
```
[2020-04-08 10:39:16] [build] g++ -DHAVE_CONFIG_H -I. -I.. -I .. -I ../warmrestart -I flex_counter -I debug_counter -g -DNDEBUG  -std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/libnl3 -I/usr/include/swss -Werror -Wno-reorder -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Wextra -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Winvalid-pch -Wlong-long -Wmissing-field-initializers -Wmissing-format-attribute -Wno-aggregate-return -Wno-padded -Wno-switch-enum -Wno-unused-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wstack-protector -Wstrict-aliasing=3 -Wswitch -Wswitch-default -Wunreachable-code -Wunused -Wvariadic-macros -Wno-switch-default -Wno-long-long -Wno-redundant-decls -I /usr/include/sai -I/opt/out/snapshot/workspace/usr/include -I/opt/out/snapshot/workspace/usr/include/swss -I/opt/out/snapshot/workspace/usr/include/sai  -g -O2 -MT orchagent-portsorch.o -MD -MP -MF .deps/orchagent-portsorch.Tpo -c -o orchagent-portsorch.o `test -f 'portsorch.cpp' || echo './'`portsorch.cpp
[2020-04-08 10:39:18] [build] portsorch.cpp: In member function ‘virtual void PortsOrch::doTask()’:
[2020-04-08 10:39:18] [build] portsorch.cpp:2791:5: error: ‘const std::initializer_list<const char*>{((const char* const*)(&<anonymous>)), 5}’ is not a constant expression
[2020-04-08 10:39:18] [build]  2791 |     };
[2020-04-08 10:39:18] [build]       |     ^
```