### PR TITLE
[bufferorch] Fixed SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE to uint64_t

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -433,7 +433,7 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
             else if (field == buffer_size_field_name)
             {
                 attr.id = SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE;
-                attr.value.u32 = (uint32_t)stoul(value);
+                attr.value.u64 = (uint64_t)stoul(value);
                 attribs.push_back(attr);
             }
             else if (field == buffer_dynamic_th_field_name)


### PR DESCRIPTION
 
**What I did**
As per  SAI 1.5 made value of SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE  as uint64_t
**Why I did it**
Buffer size was getting corrupted and not programming ASIC Correctly.
**How I verified it**
Verified Manually in ASIC DB the value of the attribute is correct. 


