### PR TITLE
Enabling Sflow trap group in CoPP

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -451,14 +451,13 @@ bool CoppOrch::removeGenetlinkHostIf(string trap_group_name)
     return true;
 }
 
-task_process_status CoppOrch::processCoppRule(Consumer& consumer)
+task_process_status CoppOrch::processCoppRule(Consumer& consumer, SyncMap::iterator it)
 {
     SWSS_LOG_ENTER();
 
     sai_status_t sai_status;
     vector<string> trap_id_list;
     string queue_ind;
-    auto it = consumer.m_toSync.begin();
     KeyOpFieldsValuesTuple tuple = it->second;
     string trap_group_name = kfvKey(tuple);
     string op = kfvOp(tuple);
@@ -832,7 +831,7 @@ void CoppOrch::doTask(Consumer &consumer)
 
         try
         {
-            task_status = processCoppRule(consumer);
+            task_status = processCoppRule(consumer, it);
         }
         catch(const out_of_range& e)
         {
@@ -859,7 +858,6 @@ void CoppOrch::doTask(Consumer &consumer)
                 SWSS_LOG_ERROR("Processing copp task item failed, exiting. ");
                 return;
             case task_process_status::task_need_retry:
-                SWSS_LOG_ERROR("Processing copp task item failed, will retry.");
                 it++;
                 break;
             default:

--- a/orchagent/copporch.h
+++ b/orchagent/copporch.h
@@ -61,7 +61,7 @@ protected:
     void initDefaultTrapGroup();
     void initDefaultTrapIds();
 
-    task_process_status processCoppRule(Consumer& consumer);
+    task_process_status processCoppRule(Consumer& consumer, SyncMap::iterator it);
     bool isValidList(std::vector<std::string> &trap_id_list, std::vector<std::string> &all_items) const;
     void getTrapIdList(std::vector<std::string> &trap_id_name_list, std::vector<sai_hostif_trap_type_t> &trap_id_list) const;
     bool applyTrapIds(sai_object_id_t trap_group, std::vector<std::string> &trap_id_name_list, std::vector<sai_attribute_t> &trap_id_attribs);

--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -55,5 +55,21 @@
             "red_action":"drop"
         },
         "OP": "SET"
-    }
+    },
+    {
+        "COPP_TABLE:trap.group.sflow": {
+            "trap_ids": "sample_packet",
+            "trap_action":"trap",
+            "trap_priority":"1",
+            "queue": "2",
+            "meter_type":"packets",
+            "mode":"sr_tcm",
+            "cir":"5000",
+            "cbs":"5000",
+            "red_action":"drop",
+            "genetlink_name":"psample",
+            "genetlink_mcgrp_name":"packets"
+        },
+        "OP": "SET"
+   }
 ]


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Enabling SFLOW trap group in COPP json file.

**Why I did it**
Without the trap group being installed SFLOW will not work on hardware platforms. The bug https://github.com/Azure/sonic-buildimage/issues/4386 was raised for the issue.

**How I verified it**
Added sflow trap in file and verified it gets installed only when 'config sflow enable' command is given.

**Details if related**
Apart from including sflow trap in the file, the PR contains fix for an iterator issue in copporch. Without the fix the trap groups after sflow trap will not get installed.

Removed the log for task_needed_retry case. This log will flood the logging file and even when set to debug level it would hinder analyzing other debug logs.
