### PR TITLE
 Do not set PG to Buffer porfile mapping again if already exist.

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -182,6 +182,21 @@ task_process_status BufferMgr::doSpeedUpdateTask(string port, string speed)
                          buffer_profile_key +
                          "]";
 
+    /* Check if PG Mapping is already then log message and return. */
+
+    m_cfgBufferPgTable.get(buffer_pg_key, fvVector);
+    
+    for (auto& prop : fvVector)
+    {
+        if ((fvField(prop) == "profile") && (profile_ref == fvValue(prop)))
+        {
+            SWSS_LOG_NOTICE("PG to Buffer Profile Mapping %s already present", buffer_pg_key.c_str());
+            return task_process_status::task_success;
+        }
+    }
+    
+    fvVector.clear();
+ 
     fvVector.push_back(make_pair("profile", profile_ref));
     m_cfgBufferPgTable.set(buffer_pg_key, fvVector);
     return task_process_status::task_success;


### PR DESCRIPTION
**What I did**
Do not set PG to Buffer profile mapping again if already exist.
This will avoid not to call SAI API
set_ingress_priority_group_attribute() if mapping already exist

**Why I did it**
Calling SAI API set_ingress_priority_group_attribute()  Multiples times result in Buffer getting reduced on Dell-6000

**How I verified it**

a) Load Minigraph
b) Config save
c) config reload

Made sure set of  PG to Buffer profile mapping is not done more than one time via syslog and checking buffer limit in SAI.

