### PR TITLE
[routeorch] Handle the empty "nexthop" field for backward compatibility

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -475,11 +475,13 @@ void RouteOrch::doTask(Consumer& consumer)
              * as tokenize(",", ',') will miss the last empty segment. */
             if (alsv.size() == 0)
             {
+                SWSS_LOG_WARN("Skip the route %s, for it has an empty ifname field.", key.c_str());
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
             else if (alsv.size() != ipv.size())
             {
+                SWSS_LOG_NOTICE("Route %s: resize ipv to match alsv, %zd -> %zd.", key.c_str(), ipv.size(), alsv.size());
                 ipv.resize(alsv.size());
             }
 
@@ -489,6 +491,7 @@ void RouteOrch::doTask(Consumer& consumer)
             {
                 if (ip.empty())
                 {
+                    SWSS_LOG_NOTICE("Route %s: set the empty nexthop ip to zero.", key.c_str());
                     ip = ip_prefix.isV4() ? "0.0.0.0" : "::";
                 }
             }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -467,10 +467,12 @@ void RouteOrch::doTask(Consumer& consumer)
             vector<string> alsv = tokenize(aliases, ',');
 
             /*
-             * To check the validity of nexthop and make sure it works even in
-             * abnormal cases. One case is old format - empty "nexthop",
-             * then set ip to zero for backward compatibility.
+             * For backward compatibility, adjust ip string from old format to
+             * new format. Meanwhile it can deal with some abnormal cases.
              */
+
+            /* Resize the ip vector to match ifname vector
+             * as tokenize(",", ',') will miss the last empty segment. */
             if (alsv.size() == 0)
             {
                 it = consumer.m_toSync.erase(it);
@@ -480,6 +482,9 @@ void RouteOrch::doTask(Consumer& consumer)
             {
                 ipv.resize(alsv.size());
             }
+
+            /* Set the empty ip(s) to zero
+             * as IpAddress("") will construst a incorrect ip. */
             for (auto &ip : ipv)
             {
                 if (ip.empty())

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -466,6 +466,21 @@ void RouteOrch::doTask(Consumer& consumer)
             vector<string> ipv = tokenize(ips, ',');
             vector<string> alsv = tokenize(aliases, ',');
 
+            /*
+             * To check the validity of nexthop and make sure it works even in
+             * abnormal cases. One case is old format - empty "nexthop",
+             * then set ip to zero for backward compatibility.
+             */
+            if (alsv.size() == 0)
+            {
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+            else if (alsv.size() != ipv.size())
+            {
+                ipv.resize(alsv.size(), "0.0.0.0");
+            }
+
             for (auto alias : alsv)
             {
                 if (alias == "eth0" || alias == "lo" || alias == "docker0")

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -478,7 +478,14 @@ void RouteOrch::doTask(Consumer& consumer)
             }
             else if (alsv.size() != ipv.size())
             {
-                ipv.resize(alsv.size(), "0.0.0.0");
+                ipv.resize(alsv.size());
+            }
+            for (auto &ip : ipv)
+            {
+                if (ip.empty())
+                {
+                    ip = ip_prefix.isV4() ? "0.0.0.0" : "::";
+                }
             }
 
             for (auto alias : alsv)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add handling route entries with abnormal field in RouteOrch.
a. empty "ifname", skip it and do nothing
b. empty "nexthop", fill ips with zeros to match ifnames
c. ip number < interface number, like b, append zeros to ips to match ifnames
d. ip number > interface number,  truncate ips to match ifnames
Ussually none of above would happen, while warmboot from old version b will happen, others only when writing app_db manully.

**Why I did it**
To fix the issue [sonic-buildimage#4399](https://github.com/Azure/sonic-buildimage/issues/4399)

**How I verified it**
test varies of route entries & vs test


**Details if related**
