### PR TITLE
[Orchagent] Vxlanorch and Portsorch changes for EVPN VXLAN

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -142,6 +142,13 @@ bool OrchDaemon::init()
     VxlanVrfMapOrch *vxlan_vrf_orch = new VxlanVrfMapOrch(m_applDb, APP_VXLAN_VRF_TABLE_NAME);
     gDirectory.set(vxlan_vrf_orch);
 
+    EvpnRemoteVniOrch* evpn_remote_vni_orch = new EvpnRemoteVniOrch(m_applDb, APP_EVPN_REMOTE_VNI_TABLE_NAME);
+    gDirectory.set(evpn_remote_vni_orch);
+
+    EvpnNvoOrch* evpn_nvo_orch = new EvpnNvoOrch(m_applDb, APP_EVPN_NVO_TABLE_NAME);
+    gDirectory.set(evpn_nvo_orch);
+
+
     vector<string> qos_tables = {
         CFG_TC_TO_QUEUE_MAP_TABLE_NAME,
         CFG_SCHEDULER_TABLE_NAME,
@@ -274,7 +281,9 @@ bool OrchDaemon::init()
     m_orchList.push_back(chassis_frontend_orch);
     m_orchList.push_back(vrf_orch);
     m_orchList.push_back(vxlan_tunnel_orch);
+    m_orchList.push_back(evpn_nvo_orch);
     m_orchList.push_back(vxlan_tunnel_map_orch);
+    m_orchList.push_back(evpn_remote_vni_orch);
     m_orchList.push_back(vxlan_vrf_orch);
     m_orchList.push_back(cfg_vnet_rt_orch);
     m_orchList.push_back(vnet_orch);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -135,17 +135,17 @@ bool OrchDaemon::init()
     CoppOrch  *copp_orch  = new CoppOrch(m_applDb, APP_COPP_TABLE_NAME);
     TunnelDecapOrch *tunnel_decap_orch = new TunnelDecapOrch(m_applDb, APP_TUNNEL_DECAP_TABLE_NAME);
 
-    VxlanTunnelOrch *vxlan_tunnel_orch = new VxlanTunnelOrch(m_applDb, APP_VXLAN_TUNNEL_TABLE_NAME);
+    VxlanTunnelOrch *vxlan_tunnel_orch = new VxlanTunnelOrch(m_stateDb, m_applDb, APP_VXLAN_TUNNEL_TABLE_NAME);
     gDirectory.set(vxlan_tunnel_orch);
     VxlanTunnelMapOrch *vxlan_tunnel_map_orch = new VxlanTunnelMapOrch(m_applDb, APP_VXLAN_TUNNEL_MAP_TABLE_NAME);
     gDirectory.set(vxlan_tunnel_map_orch);
     VxlanVrfMapOrch *vxlan_vrf_orch = new VxlanVrfMapOrch(m_applDb, APP_VXLAN_VRF_TABLE_NAME);
     gDirectory.set(vxlan_vrf_orch);
 
-    EvpnRemoteVniOrch* evpn_remote_vni_orch = new EvpnRemoteVniOrch(m_applDb, APP_EVPN_REMOTE_VNI_TABLE_NAME);
+    EvpnRemoteVniOrch* evpn_remote_vni_orch = new EvpnRemoteVniOrch(m_applDb, APP_VXLAN_REMOTE_VNI_TABLE_NAME);
     gDirectory.set(evpn_remote_vni_orch);
 
-    EvpnNvoOrch* evpn_nvo_orch = new EvpnNvoOrch(m_applDb, APP_EVPN_NVO_TABLE_NAME);
+    EvpnNvoOrch* evpn_nvo_orch = new EvpnNvoOrch(m_applDb, APP_VXLAN_EVPN_NVO_TABLE_NAME);
     gDirectory.set(evpn_nvo_orch);
 
 

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -20,6 +20,8 @@ extern "C" {
  */
 #define DEFAULT_MTU             1492
 
+#define VNID_NONE               0xFFFFFFFF
+
 namespace swss {
 
 struct VlanMemberEntry
@@ -104,7 +106,7 @@ public:
     sai_port_priority_flow_control_mode_t m_pfc_asym = SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED;
     uint8_t   m_pfc_bitmask = 0;
     uint32_t  m_nat_zone_id = 0;
-    uint32_t  m_vnid = 0xFFFFFFFF;
+    uint32_t  m_vnid = VNID_NONE;
     uint32_t  m_fdb_count = 0;
 
     /*

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -46,6 +46,7 @@ public:
         LOOPBACK,
         VLAN,
         LAG,
+        TUNNEL,
         SUBPORT,
         UNKNOWN
     } ;
@@ -89,6 +90,7 @@ public:
     sai_object_id_t     m_hif_id = 0;
     sai_object_id_t     m_lag_id = 0;
     sai_object_id_t     m_lag_member_id = 0;
+    sai_object_id_t     m_tunnel_id = 0;
     sai_object_id_t     m_ingress_acl_table_group_id = 0;
     sai_object_id_t     m_egress_acl_table_group_id = 0;
     vlan_members_t      m_vlan_members;
@@ -102,6 +104,7 @@ public:
     sai_port_priority_flow_control_mode_t m_pfc_asym = SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED;
     uint8_t m_pfc_bitmask = 0;
     uint32_t m_nat_zone_id = 0;
+    uint32_t m_vnid = 0xFFFFFFFF;
 
     /*
      * Following two bit vectors are used to lock

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -102,9 +102,10 @@ public:
     std::vector<sai_object_id_t> m_queue_ids;
     std::vector<sai_object_id_t> m_priority_group_ids;
     sai_port_priority_flow_control_mode_t m_pfc_asym = SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED;
-    uint8_t m_pfc_bitmask = 0;
-    uint32_t m_nat_zone_id = 0;
-    uint32_t m_vnid = 0xFFFFFFFF;
+    uint8_t   m_pfc_bitmask = 0;
+    uint32_t  m_nat_zone_id = 0;
+    uint32_t  m_vnid = 0xFFFFFFFF;
+    uint32_t  m_fdb_count = 0;
 
     /*
      * Following two bit vectors are used to lock

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3581,7 +3581,7 @@ bool PortsOrch::removeVlan(Port vlan)
     }
 
     // Fail VLAN removal if there is a vnid associated
-    if (vlan.m_vnid != 0xFFFFFFFF)
+    if (vlan.m_vnid != VNID_NONE)
     {
        SWSS_LOG_ERROR("VLAN-VNI mapping not yet removed. VLAN %s VNI %d",
                       vlan.m_alias.c_str(), vlan.m_vnid);
@@ -3997,7 +3997,6 @@ bool PortsOrch::addTunnel(string tunnel_alias, sai_object_id_t tunnel_id, bool h
         tunnel.m_learn_mode = "disable";
     }
     m_portList[tunnel_alias] = tunnel;
-    //portOidToName[tunnel_id] = tunnel_alias;
 
     SWSS_LOG_INFO("addTunnel:: %" PRIx64, tunnel_id);
 
@@ -4008,7 +4007,6 @@ bool PortsOrch::removeTunnel(Port tunnel)
 {
     SWSS_LOG_ENTER();
 
-    //portOidToName.erase(tunnel.m_tunnel_id);
     m_portList.erase(tunnel.m_alias);
 
     return true;
@@ -4220,7 +4218,9 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
     port.m_oper_status = status;
 
     if(port.m_type == Port::TUNNEL)
-      return;
+    {
+        return;
+    }
 
     bool isUp = status == SAI_PORT_OPER_STATUS_UP;
     if (!setHostIntfsOperStatus(port, isUp))

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3,6 +3,8 @@
 #include "bufferorch.h"
 #include "neighorch.h"
 #include "gearboxutils.h"
+#include "vxlanorch.h"
+#include "directory.h"
 
 #include <inttypes.h>
 #include <cassert>
@@ -42,6 +44,7 @@ extern NeighOrch *gNeighOrch;
 extern CrmOrch *gCrmOrch;
 extern BufferOrch *gBufferOrch;
 extern FdbOrch *gFdbOrch;
+extern Directory<Orch*> gDirectory;
 
 #define VLAN_PREFIX         "Vlan"
 #define DEFAULT_VLAN_ID     1
@@ -1284,6 +1287,9 @@ bool PortsOrch::setPortPvid(Port &port, sai_uint32_t pvid)
 {
     SWSS_LOG_ENTER();
 
+    if(port.m_type == Port::TUNNEL)
+      return true;
+
     if (port.m_rif_id)
     {
         SWSS_LOG_ERROR("pvid setting for router interface %s is not allowed", port.m_alias.c_str());
@@ -1347,6 +1353,9 @@ bool PortsOrch::setHostIntfsStripTag(Port &port, sai_hostif_vlan_tag_t strip)
 {
     SWSS_LOG_ENTER();
     vector<Port> portv;
+
+    if(port.m_type == Port::TUNNEL)
+       return true;
 
     /*
      * Before SAI_HOSTIF_VLAN_TAG_ORIGINAL is supported by libsai from all asic vendors,
@@ -1716,6 +1725,13 @@ bool PortsOrch::setHostIntfsOperStatus(const Port& port, bool isUp) const
 void PortsOrch::updateDbPortOperStatus(const Port& port, sai_port_oper_status_t status) const
 {
     SWSS_LOG_ENTER();
+
+    if(port.m_type == Port::TUNNEL)
+    {
+      VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+      tunnel_orch->updateDbTunnelOperStatus(port.m_alias, status);
+      return;
+    }
 
     vector<FieldValueTuple> tuples;
     FieldValueTuple tuple("oper_status", oper_status_strings.at(status));
@@ -3350,6 +3366,48 @@ bool PortsOrch::addBridgePort(Port &port)
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
 
+    if (port.m_type == Port::PHY)
+    {
+      attr.id = SAI_BRIDGE_PORT_ATTR_TYPE;
+      attr.value.s32 = SAI_BRIDGE_PORT_TYPE_PORT;
+      attrs.push_back(attr);
+
+      attr.id = SAI_BRIDGE_PORT_ATTR_PORT_ID;
+      attr.value.oid = port.m_port_id;
+      attrs.push_back(attr);
+    }
+    else if  (port.m_type == Port::LAG)
+    {
+      attr.id = SAI_BRIDGE_PORT_ATTR_TYPE;
+      attr.value.s32 = SAI_BRIDGE_PORT_TYPE_PORT;
+      attrs.push_back(attr);
+
+      attr.id = SAI_BRIDGE_PORT_ATTR_PORT_ID;
+      attr.value.oid = port.m_lag_id;
+      attrs.push_back(attr);
+    }
+    else if  (port.m_type == Port::TUNNEL)
+    {
+      attr.id = SAI_BRIDGE_PORT_ATTR_TYPE;
+      attr.value.s32 = SAI_BRIDGE_PORT_TYPE_TUNNEL;
+      attrs.push_back(attr);
+
+      attr.id = SAI_BRIDGE_PORT_ATTR_TUNNEL_ID;
+      attr.value.oid = port.m_tunnel_id;
+      attrs.push_back(attr);
+
+      attr.id = SAI_BRIDGE_PORT_ATTR_BRIDGE_ID;
+      attr.value.oid = m_default1QBridge;
+      attrs.push_back(attr);
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Failed to add bridge port %s to default 1Q bridge, invalid port type %d",
+            port.m_alias.c_str(), port.m_type);
+        return false;
+    }
+
+#if 0
     attr.id = SAI_BRIDGE_PORT_ATTR_TYPE;
     attr.value.s32 = SAI_BRIDGE_PORT_TYPE_PORT;
     attrs.push_back(attr);
@@ -3370,6 +3428,7 @@ bool PortsOrch::addBridgePort(Port &port)
         return false;
     }
     attrs.push_back(attr);
+#endif
 
     /* Create a bridge port with admin status set to UP */
     attr.id = SAI_BRIDGE_PORT_ATTR_ADMIN_STATE;
@@ -3539,6 +3598,14 @@ bool PortsOrch::removeVlan(Port vlan)
         return false;
     }
 
+    // Fail VLAN removal if there is a vnid associated
+    if (vlan.m_vnid != 0xFFFFFFFF)
+    {
+       SWSS_LOG_ERROR("VLAN-VNI mapping not yet removed. VLAN %s VNI %d",
+                      vlan.m_alias.c_str(), vlan.m_vnid);
+       return false;
+    }
+
     sai_status_t status = sai_vlan_api->remove_vlan(vlan.m_vlan_info.vlan_oid);
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -3675,6 +3742,26 @@ bool PortsOrch::removeVlanMember(Port &vlan, Port &port)
     notify(SUBJECT_TYPE_VLAN_MEMBER_CHANGE, static_cast<void *>(&update));
 
     return true;
+}
+
+bool PortsOrch::isVlanMember(Port &vlan, Port &port)
+{
+    if (vlan.m_members.find(port.m_alias) == vlan.m_members.end())
+       return false;
+
+    return true;
+}
+
+uint32_t  PortsOrch::getNumVlanMember(Port &port)
+{
+    uint32_t num;
+
+    if(m_portVlanMember.find(port.m_alias) == m_portVlanMember.end())
+      return 0;
+
+    num =(uint32_t) (m_portVlanMember[port.m_alias].size());
+
+    return num;
 }
 
 bool PortsOrch::addLag(string lag_alias)
@@ -3925,6 +4012,34 @@ bool PortsOrch::setDistributionOnLagMember(Port &lagMember, bool enableDistribut
     return true;
 }
 
+bool PortsOrch::addTunnel(string tunnel_alias, sai_object_id_t tunnel_id, bool hwlearning)
+{
+    SWSS_LOG_ENTER();
+
+    Port tunnel(tunnel_alias, Port::TUNNEL);
+    tunnel.m_tunnel_id = tunnel_id;
+    if(hwlearning)
+      tunnel.m_learn_mode = "hardware";
+    else
+      tunnel.m_learn_mode = "disable";
+    m_portList[tunnel_alias] = tunnel;
+    portOidToName[tunnel_id] = tunnel_alias;
+
+    SWSS_LOG_WARN("addTunnel:: 0x%lx",tunnel_id);
+
+    return true;
+}
+
+bool PortsOrch::removeTunnel(Port tunnel)
+{
+    SWSS_LOG_ENTER();
+
+    portOidToName.erase(tunnel.m_tunnel_id);
+    m_portList.erase(tunnel.m_alias);
+
+    return true;
+}
+
 void PortsOrch::generateQueueMap()
 {
     if (m_isQueueMapGenerated)
@@ -4129,6 +4244,9 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
 
     updateDbPortOperStatus(port, status);
     port.m_oper_status = status;
+
+    if(port.m_type == Port::TUNNEL)
+      return;
 
     bool isUp = status == SAI_PORT_OPER_STATUS_UP;
     if (!setHostIntfsOperStatus(port, isUp))

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3752,18 +3752,6 @@ bool PortsOrch::isVlanMember(Port &vlan, Port &port)
     return true;
 }
 
-uint32_t  PortsOrch::getNumVlanMember(Port &port)
-{
-    uint32_t num;
-
-    if(m_portVlanMember.find(port.m_alias) == m_portVlanMember.end())
-      return 0;
-
-    num =(uint32_t) (m_portVlanMember[port.m_alias].size());
-
-    return num;
-}
-
 bool PortsOrch::addLag(string lag_alias)
 {
     SWSS_LOG_ENTER();
@@ -4023,7 +4011,7 @@ bool PortsOrch::addTunnel(string tunnel_alias, sai_object_id_t tunnel_id, bool h
     else
       tunnel.m_learn_mode = "disable";
     m_portList[tunnel_alias] = tunnel;
-    portOidToName[tunnel_id] = tunnel_alias;
+    //portOidToName[tunnel_id] = tunnel_alias;
 
     SWSS_LOG_WARN("addTunnel:: 0x%lx",tunnel_id);
 
@@ -4034,7 +4022,7 @@ bool PortsOrch::removeTunnel(Port tunnel)
 {
     SWSS_LOG_ENTER();
 
-    portOidToName.erase(tunnel.m_tunnel_id);
+    //portOidToName.erase(tunnel.m_tunnel_id);
     m_portList.erase(tunnel.m_alias);
 
     return true;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -113,7 +113,7 @@ public:
                         acl_stage_type_t acl_stage);
     bool bindUnbindAclTableGroup(Port &port,
                                  bool ingress,
-     bool bind);
+                                 bool bind);
     bool getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask);
     bool setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask);
 
@@ -126,6 +126,7 @@ public:
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
     void getLagMember(Port &lag, vector<Port> &portv);
+    void updateChildPortsMtu(const Port &p, const uint32_t mtu);
 
     bool addTunnel(string tunnel,sai_object_id_t, bool learning=true);
     bool removeTunnel(Port tunnel);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -224,6 +224,8 @@ private:
     bool removeVlan(Port vlan);
     bool addVlanMember(Port &vlan, Port &port, string& tagging_mode);
     bool removeVlanMember(Port &vlan, Port &port);
+    bool isVlanMember(Port &vlan, Port &port);
+    uint32_t  getNumVlanMember(Port &port);
 
     bool addLag(string lag);
     bool removeLag(Port lag);
@@ -231,6 +233,9 @@ private:
     bool removeLagMember(Port &lag, Port &port);
     bool setCollectionOnLagMember(Port &lagMember, bool enableCollection);
     bool setDistributionOnLagMember(Port &lagMember, bool enableDistribution);
+
+    bool addTunnel(string tunnel,sai_object_id_t, bool learning=true);
+    bool removeTunnel(Port tunnel);
 
     bool addPort(const set<int> &lane_set, uint32_t speed, int an=0, string fec="");
     sai_status_t removePort(sai_object_id_t port_id);
@@ -278,6 +283,9 @@ private:
                                 sai_acl_bind_point_type_t &sai_acl_bind_type);
     void initGearbox();
     bool initGearboxPort(Port &port);
+    friend class VxlanTunnelOrch;
+    friend class EvpnRemoteVniOrch;
+    
 };
 #endif /* SWSS_PORTSORCH_H */
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -113,7 +113,7 @@ public:
                         acl_stage_type_t acl_stage);
     bool bindUnbindAclTableGroup(Port &port,
                                  bool ingress,
-                                 bool bind);
+     bool bind);
     bool getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask);
     bool setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask);
 
@@ -126,8 +126,16 @@ public:
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
     void getLagMember(Port &lag, vector<Port> &portv);
-    void updateChildPortsMtu(const Port &p, const uint32_t mtu);
 
+    bool addTunnel(string tunnel,sai_object_id_t, bool learning=true);
+    bool removeTunnel(Port tunnel);
+    bool addBridgePort(Port &port);
+    bool removeBridgePort(Port &port);
+    bool addVlanMember(Port &vlan, Port &port, string& tagging_mode);
+    bool removeVlanMember(Port &vlan, Port &port);
+    bool isVlanMember(Port &vlan, Port &port);
+
+    
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;
@@ -216,15 +224,10 @@ private:
     bool addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id);
     bool setHostIntfsStripTag(Port &port, sai_hostif_vlan_tag_t strip);
 
-    bool addBridgePort(Port &port);
-    bool removeBridgePort(Port &port);
     bool setBridgePortLearnMode(Port &port, string learn_mode);
 
     bool addVlan(string vlan);
     bool removeVlan(Port vlan);
-    bool addVlanMember(Port &vlan, Port &port, string& tagging_mode);
-    bool removeVlanMember(Port &vlan, Port &port);
-    bool isVlanMember(Port &vlan, Port &port);
 
     bool addLag(string lag);
     bool removeLag(Port lag);
@@ -232,9 +235,6 @@ private:
     bool removeLagMember(Port &lag, Port &port);
     bool setCollectionOnLagMember(Port &lagMember, bool enableCollection);
     bool setDistributionOnLagMember(Port &lagMember, bool enableDistribution);
-
-    bool addTunnel(string tunnel,sai_object_id_t, bool learning=true);
-    bool removeTunnel(Port tunnel);
 
     bool addPort(const set<int> &lane_set, uint32_t speed, int an=0, string fec="");
     sai_status_t removePort(sai_object_id_t port_id);
@@ -282,8 +282,6 @@ private:
                                 sai_acl_bind_point_type_t &sai_acl_bind_type);
     void initGearbox();
     bool initGearboxPort(Port &port);
-    friend class VxlanTunnelOrch;
-    friend class EvpnRemoteVniOrch;
     
 };
 #endif /* SWSS_PORTSORCH_H */

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -225,7 +225,6 @@ private:
     bool addVlanMember(Port &vlan, Port &port, string& tagging_mode);
     bool removeVlanMember(Port &vlan, Port &port);
     bool isVlanMember(Port &vlan, Port &port);
-    uint32_t  getNumVlanMember(Port &port);
 
     bool addLag(string lag);
     bool removeLag(Port lag);

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -75,6 +75,8 @@ static inline uint32_t tunnel_map_val (MAP_T map_t)
     return vxlanTunnelMapKeyVal.at(map_t).second;
 }
 
+//------------------- SAI Interface functions --------------------------//
+
 static sai_object_id_t
 create_tunnel_map(MAP_T map_t)
 {
@@ -226,9 +228,9 @@ static sai_status_t create_nexthop_tunnel(
 // Create Tunnel
 static sai_object_id_t
 create_tunnel(
-    sai_object_id_t tunnel_encap_id,
-    sai_object_id_t tunnel_decap_id,
+    struct tunnel_ids_t* ids,
     sai_ip_address_t *src_ip,
+    sai_ip_address_t *dst_ip,
     sai_object_id_t underlay_rif,
     sai_uint8_t encap_ttl=0)
 {
@@ -243,26 +245,65 @@ create_tunnel(
     attr.value.oid = underlay_rif;
     tunnel_attrs.push_back(attr);
 
-    sai_object_id_t decap_list[] = { tunnel_decap_id };
+    sai_object_id_t map_list[TUNNEL_MAP_T_MAX_MAPPER+1];
+    uint8_t num_map=0;
+
+    for(int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
+    {
+      if(ids->tunnel_decap_id[i] != SAI_NULL_OBJECT_ID)
+      {
+        map_list[num_map] = ids->tunnel_decap_id[i];
+        SWSS_LOG_NOTICE("create_tunnel:maplist[%d]=0x%lx",num_map,map_list[num_map]);
+        num_map++;
+      }
+    }
+      
     attr.id = SAI_TUNNEL_ATTR_DECAP_MAPPERS;
-    attr.value.objlist.count = 1;
-    attr.value.objlist.list = decap_list;
+    attr.value.objlist.count = num_map;
+    attr.value.objlist.list = map_list;
     tunnel_attrs.push_back(attr);
 
-    if (tunnel_encap_id != SAI_NULL_OBJECT_ID)
+    sai_object_id_t emap_list[TUNNEL_MAP_T_MAX_MAPPER+1];
+    uint8_t num_emap=0;
+
+    for(int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
     {
-        sai_object_id_t encap_list[] = { tunnel_encap_id };
-        attr.id = SAI_TUNNEL_ATTR_ENCAP_MAPPERS;
-        attr.value.objlist.count = 1;
-        attr.value.objlist.list = encap_list;
-        tunnel_attrs.push_back(attr);
+      if(ids->tunnel_encap_id[i] != SAI_NULL_OBJECT_ID)
+      {
+        emap_list[num_emap] = ids->tunnel_encap_id[i];
+        SWSS_LOG_NOTICE("create_tunnel:encapmaplist[%d]=0x%lx",num_emap,emap_list[num_emap]);
+        num_emap++;
+      }
     }
+
+    attr.id = SAI_TUNNEL_ATTR_ENCAP_MAPPERS;
+    attr.value.objlist.count = num_emap;
+    attr.value.objlist.list = emap_list;
+    tunnel_attrs.push_back(attr);
 
     // source ip
     if (src_ip != nullptr)
     {
         attr.id = SAI_TUNNEL_ATTR_ENCAP_SRC_IP;
         attr.value.ipaddr = *src_ip;
+        tunnel_attrs.push_back(attr);
+    }
+
+    // dest ip
+    if (dst_ip != nullptr)
+    {
+        attr.id = SAI_TUNNEL_ATTR_PEER_MODE;
+        attr.value.s32 = SAI_TUNNEL_PEER_MODE_P2P;
+        tunnel_attrs.push_back(attr);
+
+        attr.id = SAI_TUNNEL_ATTR_ENCAP_DST_IP;
+        attr.value.ipaddr = *dst_ip;
+        tunnel_attrs.push_back(attr);
+    }
+    else
+    {
+        attr.id = SAI_TUNNEL_ATTR_PEER_MODE;
+        attr.value.s32 = SAI_TUNNEL_PEER_MODE_P2MP;
         tunnel_attrs.push_back(attr);
     }
 
@@ -385,27 +426,31 @@ remove_tunnel_termination(sai_object_id_t term_table_id)
     }
 }
 
+//------------------- VxlanTunnel Implementation --------------------------//
+
 bool VxlanTunnel::createTunnel(MAP_T encap, MAP_T decap, uint8_t encap_ttl)
 {
     try
     {
         sai_ip_address_t ips, ipd, *ip=nullptr;
+        uint8_t mapper_list = 0;
         swss::copy(ips, src_ip_);
 
-        ids_.tunnel_decap_id = SAI_NULL_OBJECT_ID;
-        ids_.tunnel_encap_id = SAI_NULL_OBJECT_ID;
+        // Only a single mapper type is created
 
-        if (decap != MAP_T::MAP_TO_INVALID)
-        {
-            ids_.tunnel_decap_id = create_tunnel_map(decap);
-        }
+        if(decap == MAP_T::VNI_TO_BRIDGE)
+          TUNNELMAP_SET_BRIDGE(mapper_list);
+        else if(decap == MAP_T::VNI_TO_VLAN_ID)
+          TUNNELMAP_SET_VLAN(mapper_list);
+        else
+          TUNNELMAP_SET_VRF(mapper_list);
+        
+        createMapperHW(mapper_list, (encap == MAP_T::MAP_TO_INVALID) ? USE_DECAP_ONLY: USE_DEDICATED_ENCAP_DECAP);
+
         if (encap != MAP_T::MAP_TO_INVALID)
-        {
-            ids_.tunnel_encap_id = create_tunnel_map(encap);
             ip = &ips;
-        }
 
-        ids_.tunnel_id = create_tunnel(ids_.tunnel_encap_id, ids_.tunnel_decap_id, ip, gUnderlayIfId, encap_ttl);
+        ids_.tunnel_id = create_tunnel(&ids_, ip, NULL, gUnderlayIfId, encap_ttl);
 
         ip = nullptr;
         if (!dst_ip_.isZero())
@@ -429,17 +474,17 @@ bool VxlanTunnel::createTunnel(MAP_T encap, MAP_T decap, uint8_t encap_ttl)
     return true;
 }
 
-sai_object_id_t VxlanTunnel::addEncapMapperEntry(sai_object_id_t obj, uint32_t vni)
+sai_object_id_t VxlanTunnel::addEncapMapperEntry(sai_object_id_t obj, uint32_t vni, tunnel_map_type_t type)
 {
-    const auto encap_id = getEncapMapId();
-    const auto map_t = tunnel_map_.first;
+    const auto encap_id = getEncapMapId(type);
+    const auto map_t = tunnel_map_type(type,true);
     return create_tunnel_map_entry(map_t, encap_id, vni, 0, obj, true);
 }
 
-sai_object_id_t VxlanTunnel::addDecapMapperEntry(sai_object_id_t obj, uint32_t vni)
+sai_object_id_t VxlanTunnel::addDecapMapperEntry(sai_object_id_t obj, uint32_t vni, tunnel_map_type_t type)
 {
-    const auto decap_id = getDecapMapId();
-    const auto map_t = tunnel_map_.second;
+    const auto decap_id = getDecapMapId(type);
+    const auto map_t = tunnel_map_type(type,false);
     return create_tunnel_map_entry(map_t, decap_id, vni, 0, obj);
 }
 
@@ -462,12 +507,19 @@ void VxlanTunnel::updateNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
 {
     auto key = nh_key_t(ipAddr, macAddress, vni);
 
+    SWSS_LOG_NOTICE("Update NH tunnel for ip %s, mac %s, vni %d",
+            ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
+
     auto it = nh_tunnels_.find(key);
     if (it == nh_tunnels_.end())
     {
         nh_tunnels_[key] = {nh_id, 1};
         return;
+    } else {
+        SWSS_LOG_NOTICE("Dup Update NH tunnel for ip %s, mac %s, vni %d",
+            ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
     }
+
 }
 
 sai_object_id_t VxlanTunnel::getNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni) const
@@ -487,12 +539,20 @@ void VxlanTunnel::incNextHopRefCount(IpAddress& ipAddr, MacAddress macAddress, u
 {
     auto key = nh_key_t(ipAddr, macAddress, vni);
     nh_tunnels_[key].ref_count ++;
+    SWSS_LOG_NOTICE("refcnt increment NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
+            ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni,
+            nh_tunnels_[key].ref_count);
+
 }
 
 void VxlanTunnel::decNextHopRefCount(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni)
 {
     auto key = nh_key_t(ipAddr, macAddress, vni);
     nh_tunnels_[key].ref_count --;
+    SWSS_LOG_NOTICE("refcnt decrement NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
+                    ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni,
+                    nh_tunnels_[key].ref_count);
+
 }
 
 bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni)
@@ -502,11 +562,14 @@ bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
     auto it = nh_tunnels_.find(key);
     if (it == nh_tunnels_.end())
     {
-        SWSS_LOG_INFO("NH tunnel for '%s' doesn't exist", ipAddr.to_string().c_str());
+        SWSS_LOG_NOTICE("remove NH tunnel for ip %s, mac %s, vni %d doesn't exist",
+                        ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
         return false;
     }
 
-    SWSS_LOG_INFO("NH tunnel for ip '%s' ref_count '%d'", ipAddr.to_string().c_str(), nh_tunnels_[key].ref_count);
+    SWSS_LOG_NOTICE("remove NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
+                    ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni,
+                    nh_tunnels_[key].ref_count);
 
     //Decrement ref count if already exists
     nh_tunnels_[key].ref_count --;
@@ -515,6 +578,8 @@ bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
     {
         if (sai_next_hop_api->remove_next_hop(nh_tunnels_[key].nh_id) != SAI_STATUS_SUCCESS)
         {
+            SWSS_LOG_NOTICE("delete NH tunnel for ip '%s', mac '%s' vni %d failed",
+                            ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
             string err_msg = "NH tunnel delete failed for " + ipAddr.to_string();
             throw std::runtime_error(err_msg);
         }
@@ -522,11 +587,530 @@ bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
         nh_tunnels_.erase(key);
     }
 
-    SWSS_LOG_INFO("NH tunnel for ip '%s', mac '%s' updated/deleted",
-                   ipAddr.to_string().c_str(), macAddress.to_string().c_str());
+    SWSS_LOG_NOTICE("NH tunnel for ip '%s', mac '%s' vni %d updated/deleted",
+                    ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
 
     return true;
 }
+
+bool VxlanTunnel::deleteMapperHW(uint8_t mapper_list,
+                                 tunnel_map_src_t map_src)
+{
+    sai_status_t status = SAI_STATUS_SUCCESS;
+
+    SWSS_LOG_INFO("Enter deleteMapper HW maplst=%d src=%d",mapper_list, map_src);
+
+    try
+    {
+      if(map_src == USE_DEDICATED_ENCAP_DECAP)
+      {
+        if(IS_TUNNELMAP_SET_VLAN(mapper_list))
+        {
+          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN]);
+          SWSS_LOG_INFO("deletevlandecap = %d", status);
+          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN]);
+          SWSS_LOG_INFO("deletevlanencap = %d", status);
+        }
+
+        if(IS_TUNNELMAP_SET_VRF(mapper_list))
+        {
+          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
+          SWSS_LOG_INFO("deleteVRFdecap = %d", status);
+          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
+          SWSS_LOG_INFO("deleteVRFencap = %d", status);
+        }
+
+        if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+        {
+          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE]);
+          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE]);
+        }
+      }
+      else if(map_src == USE_COMMON_DECAP_DEDICATED_ENCAP)
+      {
+        if(IS_TUNNELMAP_SET_VLAN(mapper_list))
+        {
+          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN]);
+        }
+
+        if(IS_TUNNELMAP_SET_VRF(mapper_list))
+        {
+          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
+        }
+
+        if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+        {
+          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE]);
+        }
+      }
+      else if(map_src == USE_DECAP_ONLY)
+      {
+        if(IS_TUNNELMAP_SET_VLAN(mapper_list))
+        {
+          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN]);
+          SWSS_LOG_INFO("deletevlandecap = %d", status);
+        }
+
+        if(IS_TUNNELMAP_SET_VRF(mapper_list))
+        {
+          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
+          SWSS_LOG_INFO("deleteVRFdecap = %d", status);
+        }
+
+        if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+        {
+          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE]);
+          SWSS_LOG_INFO("deletebridgedecap = %d", status);
+        }
+      }
+    }
+
+    catch (const std::runtime_error& error)
+    {
+      SWSS_LOG_ERROR("Error deleting mapper %s: %s", tunnel_name_.c_str(), error.what());
+      // FIXME: add code to remove already created objects
+      return false;
+    }
+
+    return true;
+}
+
+bool VxlanTunnel::createMapperHW(uint8_t mapper_list, 
+                                 tunnel_map_src_t map_src)
+{
+    try
+    {
+        for(int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
+        {
+          ids_.tunnel_decap_id[i] = SAI_NULL_OBJECT_ID;
+          ids_.tunnel_encap_id[i] = SAI_NULL_OBJECT_ID;
+        }
+
+        if(USE_DEDICATED_ENCAP_DECAP == map_src)
+        {
+           if(IS_TUNNELMAP_SET_VLAN(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VNI_TO_VLAN_ID);
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VLAN_ID_TO_VNI);
+
+             TUNNELMAP_SET_VLAN(encap_dedicated_mappers_);
+             TUNNELMAP_SET_VLAN(decap_dedicated_mappers_);
+           }
+
+           if(IS_TUNNELMAP_SET_VRF(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VNI_TO_VRID);
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VRID_TO_VNI);
+             TUNNELMAP_SET_VRF(encap_dedicated_mappers_);
+             TUNNELMAP_SET_VRF(decap_dedicated_mappers_);
+           }
+
+           if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::VNI_TO_BRIDGE);
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::BRIDGE_TO_VNI);
+
+             TUNNELMAP_SET_BRIDGE(encap_dedicated_mappers_);
+             TUNNELMAP_SET_BRIDGE(decap_dedicated_mappers_);
+           }
+        }
+        else if (map_src == USE_COMMON_DECAP_DEDICATED_ENCAP)
+        {
+           if(IS_TUNNELMAP_SET_VLAN(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VLAN);
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VLAN_ID_TO_VNI);
+             TUNNELMAP_SET_VLAN(encap_dedicated_mappers_);
+           }
+
+           if(IS_TUNNELMAP_SET_VRF(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VRID_TO_VNI);
+             TUNNELMAP_SET_VRF(encap_dedicated_mappers_);
+           }
+
+           if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_BRIDGE);
+
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::VRID_TO_VNI);
+
+             TUNNELMAP_SET_BRIDGE(encap_dedicated_mappers_);
+           }
+
+        }
+        else if (USE_COMMON_ENCAP_DECAP == map_src)
+        {
+           if(IS_TUNNELMAP_SET_VLAN(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VLAN);
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_VLAN);
+           }
+
+           if(IS_TUNNELMAP_SET_VRF(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
+           }
+
+           if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_BRIDGE);
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_BRIDGE);
+           }
+
+        }
+        else if(USE_DECAP_ONLY == map_src)
+        {
+           if(IS_TUNNELMAP_SET_VLAN(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VNI_TO_VLAN_ID);
+             TUNNELMAP_SET_VLAN(decap_dedicated_mappers_);
+           }
+
+           if(IS_TUNNELMAP_SET_VRF(mapper_list))
+           {
+             ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VNI_TO_VRID);
+             TUNNELMAP_SET_VRF(decap_dedicated_mappers_);
+           }
+
+           if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+           {
+             ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::BRIDGE_TO_VNI);
+
+             TUNNELMAP_SET_BRIDGE(decap_dedicated_mappers_);
+           }
+        }
+    }
+
+    catch (const std::runtime_error& error)
+    {
+        SWSS_LOG_ERROR("Error creating tunnel %s: %s", tunnel_name_.c_str(), error.what());
+        // FIXME: add code to remove already created objects
+        return false;
+    }
+
+    return true;
+}
+
+bool VxlanTunnel::deleteTunnelHW(uint8_t mapper_list, 
+                                 tunnel_map_src_t map_src, bool with_term)
+{
+    SWSS_LOG_INFO("Enter Delete Tunnel HW");
+    try
+    {
+      sai_status_t ret;
+
+      if(with_term)
+      {
+         ret = sai_tunnel_api->remove_tunnel_term_table_entry(ids_.tunnel_term_id);
+         SWSS_LOG_INFO("term table delete reststatus = %d",ret);
+      }
+
+      ret = sai_tunnel_api->remove_tunnel(ids_.tunnel_id);
+      SWSS_LOG_INFO("tunnel table delete reststatus = %d",ret);
+      deleteMapperHW(mapper_list, map_src);
+      total_diptunnel_del++;
+    }
+
+    catch (const std::runtime_error& error)
+    {
+      SWSS_LOG_ERROR("Error deleting tunnel %s: %s", tunnel_name_.c_str(), error.what());
+      // FIXME: add code to remove already created objects
+      return false;
+    }
+
+    active_ = false;
+
+    return true;
+}
+
+//Creation of SAI Tunnel Object with multiple mapper types
+
+bool VxlanTunnel::createTunnelHW(uint8_t mapper_list, 
+                                 tunnel_map_src_t map_src, bool with_term)
+{
+    try
+    {
+        sai_ip_address_t ips, ipd, *ip=nullptr;
+        swss::copy(ips, src_ip_);
+
+        createMapperHW(mapper_list, map_src);
+
+        ip = nullptr;
+        if (!dst_ip_.isZero())
+        {
+            swss::copy(ipd, dst_ip_);
+            ip = &ipd;
+            total_diptunnel_add++;
+        }
+
+        ids_.tunnel_id = create_tunnel(&ids_, &ips, ip, gUnderlayIfId);
+
+        if(with_term)
+          ids_.tunnel_term_id = create_tunnel_termination(ids_.tunnel_id, ips, ip, gVirtualRouterId);
+
+        active_ = true;
+    }
+
+    catch (const std::runtime_error& error)
+    {
+        SWSS_LOG_ERROR("Error creating tunnel %s: %s", tunnel_name_.c_str(), error.what());
+        // FIXME: add code to remove already created objects
+        return false;
+    }
+
+    SWSS_LOG_INFO("Vxlan tunnel '%s' was created", tunnel_name_.c_str());
+    return true;
+}
+
+void VxlanTunnel::deletePendingSIPTunnel()
+{
+   if((getDipTunnelCnt() == 0) && del_tnl_hw_pending)
+   {
+    uint8_t mapper_list=0;
+    TUNNELMAP_SET_VLAN(mapper_list);
+    TUNNELMAP_SET_VRF(mapper_list);
+    deleteTunnelHW(mapper_list, USE_DEDICATED_ENCAP_DECAP);
+    del_tnl_hw_pending = false;
+    SWSS_LOG_INFO("Removing SIP Tunnel HW which is pending");
+   }
+
+   return;
+}
+int VxlanTunnel::getDipTunnelCnt()
+{
+  int ret;
+
+  ret = (int)tnl_users_.size();
+  return ret;
+}
+
+void VxlanTunnel::increment_spurious_imr_add(const std::string remote_vtep)
+{
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    tunnel_refcnt_t tnl_refcnts;
+
+    it = tnl_users_.find(remote_vtep); 
+    if(it == tnl_users_.end())
+      return ; 
+    else
+    {
+      tnl_refcnts = it->second;
+      tnl_refcnts.spurious_add_imr_refcnt++;
+      tnl_users_[remote_vtep] = tnl_refcnts;
+    }
+}
+
+void VxlanTunnel::increment_spurious_imr_del(const std::string remote_vtep)
+{
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    tunnel_refcnt_t tnl_refcnts;
+
+    it = tnl_users_.find(remote_vtep); 
+    if(it == tnl_users_.end())
+      return ; 
+    else
+    {
+      tnl_refcnts = it->second;
+      tnl_refcnts.spurious_del_imr_refcnt++;
+      tnl_users_[remote_vtep] = tnl_refcnts;
+    }
+}
+
+int VxlanTunnel::getDipTunnelRefCnt(const std::string remote_vtep)
+{
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    tunnel_refcnt_t tnl_refcnts;
+
+    it = tnl_users_.find(remote_vtep); 
+    if(it == tnl_users_.end())
+      return -1; 
+    else
+    {
+      tnl_refcnts = it->second;
+      return (tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt);
+    }
+}
+
+int VxlanTunnel::getDipTunnelIMRRefCnt(const std::string remote_vtep)
+{
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    tunnel_refcnt_t tnl_refcnts;
+
+    it = tnl_users_.find(remote_vtep); 
+    if(it == tnl_users_.end())
+      return -1; 
+    else
+    {
+      tnl_refcnts = it->second;
+      return (tnl_refcnts.imr_refcnt);
+    }
+}
+
+int VxlanTunnel::getDipTunnelIPRefCnt(const std::string remote_vtep)
+{
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    tunnel_refcnt_t tnl_refcnts;
+
+    it = tnl_users_.find(remote_vtep);
+    if(it == tnl_users_.end())
+      return -1;
+    else
+    {
+      tnl_refcnts = it->second;
+      return (tnl_refcnts.ip_refcnt);
+    }
+}
+
+void VxlanTunnel::updateDipTunnelRefCnt(bool inc, tunnel_refcnt_t& tnl_refcnts, 
+                                        tunnel_user_type_e usr)
+{
+     switch(usr)
+     {
+       case TNL_SRC_IMR: 
+       {
+         if(inc)
+             tnl_refcnts.imr_refcnt++;
+         else
+             tnl_refcnts.imr_refcnt--;
+
+         break;
+       }
+       case TNL_SRC_MAC: 
+       {
+         if(inc)
+             tnl_refcnts.mac_refcnt++;
+         else
+             tnl_refcnts.mac_refcnt--;
+
+         break;
+       }
+       case TNL_SRC_IP: 
+       {
+         if(inc)
+             tnl_refcnts.ip_refcnt++;
+         else
+             tnl_refcnts.ip_refcnt--;
+
+         break;
+       }
+       default : break;
+     }
+}
+
+VxlanTunnel* VxlanTunnel::getDipTunnel(const std::string dip)
+{
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    tunnel_refcnt_t tnl_refcnts;
+
+    it = tnl_users_.find(dip); 
+    if(it == tnl_users_.end())
+      return NULL; 
+    else
+    {
+      tnl_refcnts = it->second;
+      return(tnl_refcnts.dip_tunnel);
+    }
+}
+
+bool VxlanTunnel::createDynamicDIPTunnel(const std::string dip, tunnel_user_type_e usr)
+{
+    uint8_t mapper_list = 0;
+    tunnel_refcnt_t tnl_refcnts;
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    VxlanTunnel* dip_tunnel=NULL;
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+
+    it = tnl_users_.find(dip); 
+    if(it == tnl_users_.end())
+    {
+       const string tunnel_name = "EVPN_"+dip;
+       auto dipaddr = IpAddress(dip);
+       dip_tunnel = (new VxlanTunnel(tunnel_name, src_ip_, dipaddr, TNL_CREATION_SRC_EVPN));
+       tunnel_orch->addTunnel(tunnel_name,dip_tunnel);
+
+       memset(&tnl_refcnts,0,sizeof(tunnel_refcnt_t));
+       updateDipTunnelRefCnt(true,tnl_refcnts,usr);
+       tnl_refcnts.dip_tunnel = dip_tunnel;
+       tnl_users_[dip] = tnl_refcnts;
+
+       TUNNELMAP_SET_VLAN(mapper_list);
+       TUNNELMAP_SET_VRF(mapper_list);
+       dip_tunnel->createTunnelHW(mapper_list,USE_COMMON_ENCAP_DECAP, FALSE);
+       SWSS_LOG_NOTICE("Created P2P Tunnel remote IP %s ", dip.c_str());
+    }
+    else 
+    {
+       tnl_refcnts = it->second;
+       updateDipTunnelRefCnt(true,tnl_refcnts,usr);
+       tnl_users_[dip] = tnl_refcnts;
+    }
+
+    return true;
+}
+
+bool VxlanTunnel::deleteDynamicDIPTunnel(const std::string dip, tunnel_user_type_e usr, bool update_refcnt)
+{
+    uint8_t mapper_list = 0;
+    tunnel_refcnt_t tnl_refcnts;
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    VxlanTunnel* dip_tunnel = NULL;
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    Port tunnelPort;
+
+    SWSS_LOG_INFO("Delete Dynamic DIP Tunnel Enter");
+
+    it = tnl_users_.find(dip); 
+    if(it != tnl_users_.end())
+    {
+       tnl_refcnts = it->second;
+
+       if(update_refcnt)
+       {
+         updateDipTunnelRefCnt(false,tnl_refcnts,usr);
+         tnl_users_[dip] = tnl_refcnts;
+       }
+
+       SWSS_LOG_INFO("diprefcnt = %d",tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt);
+       
+       if(tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt)
+         return true;
+
+       if(tunnel_orch->getTunnelPort(dip, tunnelPort))
+       {
+         SWSS_LOG_NOTICE("DIP = %s Not deleting tunnel from HW as tunnelPort is not yet deleted. fdbcount = %d",
+                          dip.c_str(),tunnelPort.m_fdb_count);
+         return true;
+       }
+
+       dip_tunnel = tnl_refcnts.dip_tunnel;
+       if(!dip_tunnel)
+       {
+         SWSS_LOG_INFO("DIP Tunnel is NULL unexpected");
+         return false;
+       }
+
+       TUNNELMAP_SET_VLAN(mapper_list);
+       TUNNELMAP_SET_VRF(mapper_list);
+       dip_tunnel->deleteTunnelHW(mapper_list,USE_COMMON_ENCAP_DECAP, FALSE);
+
+       tnl_users_.erase(dip);
+
+       const string tunnel_name = "EVPN_"+dip;
+       tunnel_orch->delTunnel(tunnel_name);
+       SWSS_LOG_NOTICE("P2P Tunnel deleted : %s", tunnel_name.c_str());
+    }
+    else 
+    {
+       SWSS_LOG_WARN("Unable to find dynamic tunnel for deletion");
+    }
+
+    return true;
+}
+
+//------------------- VxlanTunnelOrch Implementation --------------------------//
 
 sai_object_id_t
 VxlanTunnelOrch::createNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAddress macAddress, uint32_t vni)
@@ -538,6 +1122,10 @@ VxlanTunnelOrch::createNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAd
         SWSS_LOG_ERROR("Vxlan tunnel '%s' does not exists", tunnelName.c_str());
         return SAI_NULL_OBJECT_ID;
     }
+
+    SWSS_LOG_NOTICE("NH tunnel create for %s, ip %s, mac %s, vni %d",
+                     tunnelName.c_str(), ipAddr.to_string().c_str(), 
+                     macAddress.to_string().c_str(), vni);
 
     auto tunnel_obj = getVxlanTunnel(tunnelName);
     sai_object_id_t nh_id, tunnel_id = tunnel_obj->getTunnelId();
@@ -576,6 +1164,10 @@ VxlanTunnelOrch::removeNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAd
 {
     SWSS_LOG_ENTER();
 
+    SWSS_LOG_NOTICE("NH tunnel remove for %s, ip %s, mac %s, vni %d",
+                    tunnelName.c_str(), ipAddr.to_string().c_str(), 
+                    macAddress.to_string().c_str(), vni);
+
     if(!isTunnelExists(tunnelName))
     {
         SWSS_LOG_ERROR("Vxlan tunnel '%s' does not exists", tunnelName.c_str());
@@ -612,6 +1204,8 @@ bool VxlanTunnelOrch::createVxlanTunnelMap(string tunnelName, tunnel_map_type_t 
             tunnel_obj->createTunnel(MAP_T::BRIDGE_TO_VNI, MAP_T::VNI_TO_BRIDGE, encap_ttl);
         }
     }
+
+    tunnel_obj->vlan_vrf_vni_count++;
 
     try
     {
@@ -675,6 +1269,35 @@ bool VxlanTunnelOrch::removeVxlanTunnelMap(string tunnelName, uint32_t vni)
         return false;
     }
 
+    // Update the map count and if this is the last mapping entry 
+    // make SAI calls to delete the tunnel and tunnel termination objects.
+
+    tunnel_obj->vlan_vrf_vni_count--;
+    if(tunnel_obj->vlan_vrf_vni_count == 0)
+    {
+       auto tunnel_term_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelTermId();
+       try
+       {
+           remove_tunnel_termination(tunnel_term_id);
+       }
+       catch(const std::runtime_error& error)
+       {
+           SWSS_LOG_ERROR("Error removing tunnel term entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
+           return false;
+       }
+
+       auto tunnel_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelId();
+       try
+       {
+           remove_tunnel(tunnel_id);
+       }
+       catch(const std::runtime_error& error)
+       {
+           SWSS_LOG_ERROR("Error removing tunnel entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
+           return false;
+       }
+    }
+
     SWSS_LOG_NOTICE("Vxlan map entry deleted for tunnel '%s' with vni '%d'", tunnelName.c_str(), vni);
     return true;
 }
@@ -684,6 +1307,11 @@ bool VxlanTunnelOrch::addOperation(const Request& request)
     SWSS_LOG_ENTER();
 
     auto src_ip = request.getAttrIP("src_ip");
+    if (!src_ip.isV4())
+    {
+        SWSS_LOG_ERROR("Wrong format of the attribute: 'src_ip'. Currently only IPv4 address is supported");
+        return true;
+    }
 
     IpAddress dst_ip;
     auto attr_names = request.getAttrFieldNames();
@@ -713,7 +1341,7 @@ bool VxlanTunnelOrch::addOperation(const Request& request)
         return true;
     }
 
-    vxlan_tunnel_table_[tunnel_name] = std::unique_ptr<VxlanTunnel>(new VxlanTunnel(tunnel_name, src_ip, dst_ip));
+    vxlan_tunnel_table_[tunnel_name] = std::unique_ptr<VxlanTunnel>(new VxlanTunnel(tunnel_name, src_ip, dst_ip), TNL_CREATION_SRC_CLI);
 
     SWSS_LOG_NOTICE("Vxlan tunnel '%s' was added", tunnel_name.c_str());
     return true;
@@ -731,26 +1359,11 @@ bool VxlanTunnelOrch::delOperation(const Request& request)
         return true;
     }
 
-    auto tunnel_term_id = vxlan_tunnel_table_[tunnel_name].get()->getTunnelTermId();
-    try
+    auto vtep_ptr = getVxlanTunnel(tunnel_name);
+    if(vtep_ptr && vtep_ptr->del_tnl_hw_pending)
     {
-        remove_tunnel_termination(tunnel_term_id);
-    }
-    catch(const std::runtime_error& error)
-    {
-        SWSS_LOG_ERROR("Error removing tunnel term entry. Tunnel: %s. Error: %s", tunnel_name.c_str(), error.what());
-        return false;
-    }
-
-    auto tunnel_id = vxlan_tunnel_table_[tunnel_name].get()->getTunnelId();
-    try
-    {
-        remove_tunnel(tunnel_id);
-    }
-    catch(const std::runtime_error& error)
-    {
-        SWSS_LOG_ERROR("Error removing tunnel entry. Tunnel: %s. Error: %s", tunnel_name.c_str(), error.what());
-        return false;
+      SWSS_LOG_WARN("VTEP %s not deleted as hw delete is pending", tunnel_name.c_str());
+      return false;
     }
 
     vxlan_tunnel_table_.erase(tunnel_name);
@@ -760,12 +1373,265 @@ bool VxlanTunnelOrch::delOperation(const Request& request)
     return true;
 }
 
+bool  VxlanTunnelOrch::addTunnelUser(const std::string remote_vtep, uint32_t vni_id, 
+                                    uint32_t vlan, tunnel_user_type_e usr,
+                                    sai_object_id_t vrf_id)
+{
+    EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
+    VxlanTunnel* dip_tunnel=NULL;
+
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    Port tunport;
+
+    if(TNL_SRC_MAC == usr) return true;
+
+    auto vtep_ptr = evpn_orch->getEVPNVtep();
+
+    if(!vtep_ptr)
+    {
+      SWSS_LOG_WARN("Unable to find EVPN VTEP. user=%d remote_vtep=%s",
+                     usr,remote_vtep.c_str());
+      return false;
+    }
+
+    if (!vtep_ptr->isActive())
+    {
+      SWSS_LOG_WARN("VTEP not yet active.user=%d remote_vtep=%s",
+                      usr,remote_vtep.c_str()); 
+      return false;
+    }
+
+    vtep_ptr->createDynamicDIPTunnel(remote_vtep, usr);
+    dip_tunnel = vtep_ptr->getDipTunnel(remote_vtep);
+
+    SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
+                     remote_vtep.c_str(), vtep_ptr->getDipTunnelRefCnt(remote_vtep));
+
+    if(!tunnel_orch->getTunnelPort(remote_vtep, tunport))
+    {
+      Port tunnelPort;
+      auto port_tunnel_name = "Port_EVPN_" + remote_vtep;
+      SWSS_LOG_NOTICE("Creating Tunnel Port name = %s", port_tunnel_name.c_str());
+      gPortsOrch->addTunnel(port_tunnel_name,dip_tunnel->getTunnelId(), false);
+      SWSS_LOG_NOTICE("Created Tunnel Port name = %s", port_tunnel_name.c_str());
+      gPortsOrch->getPort(port_tunnel_name,tunnelPort);
+      gPortsOrch->addBridgePort(tunnelPort);
+      SWSS_LOG_NOTICE("Created Tunnel BridgePort name = %s", port_tunnel_name.c_str());
+    }
+
+    // TODO : Add Encap Mapper entry for DCI usecase
+
+    return true;
+}
+
+bool  VxlanTunnelOrch::delTunnelUser(const std::string remote_vtep, uint32_t vni_id, 
+                                    uint32_t vlan, tunnel_user_type_e usr,
+                                    sai_object_id_t vrf_id)
+{
+    // TODO : Del Encap Mapper entry for DCI usecase
+
+    if(TNL_SRC_MAC == usr) return true;
+
+    // If this is the last request to delete the tunnel.
+    auto tunnel_name = "EVPN_" + remote_vtep;
+
+    //if (isTunnelExists(tunnel_name))
+    {
+        auto port_tunnel_name = "Port_EVPN_" + remote_vtep;
+        EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
+
+        auto vtep_ptr = evpn_orch->getEVPNVtep();
+
+        if(!vtep_ptr) 
+        {
+          SWSS_LOG_WARN("Unable to find VTEP. remote=%s vlan=%d usr=%d",remote_vtep.c_str(), vlan, usr);
+          return true;
+        }
+
+        Port tunnelPort;
+        gPortsOrch->getPort(port_tunnel_name,tunnelPort);
+
+        if((vtep_ptr->getDipTunnelRefCnt(remote_vtep) == 1) &&
+           tunnelPort.m_fdb_count == 0)
+        {
+          bool ret;
+
+          ret = gPortsOrch->removeBridgePort(tunnelPort);
+          if(!ret) 
+          {
+            SWSS_LOG_ERROR("Remove Bridge port failed for remote = %s fdbcount = %d", 
+                            remote_vtep.c_str(), tunnelPort.m_fdb_count);
+            return true;
+          }
+        
+          gPortsOrch->removeTunnel(tunnelPort);
+        }
+
+        vtep_ptr->deleteDynamicDIPTunnel(remote_vtep, usr);
+        SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
+                         remote_vtep.c_str(), vtep_ptr->getDipTunnelRefCnt(remote_vtep));
+
+        vtep_ptr->deletePendingSIPTunnel();
+
+    }
+
+    return true;
+}
+
+void VxlanTunnelOrch::deleteTunnelPort(Port &tunnelPort)
+{
+    bool ret;
+    std::map<const std::string, tunnel_refcnt_t>::iterator it;
+    EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
+    std::string remote_vtep;
+
+    auto vtep_ptr = evpn_orch->getEVPNVtep();
+
+    SWSS_LOG_INFO("Delete Tunnelport Enter");
+    if(!vtep_ptr) 
+    {
+      SWSS_LOG_WARN("Unable to find VTEP. tunnelPort=%s",tunnelPort.m_alias.c_str());
+      return;
+    }
+
+    getTunnelDIPFromPort(tunnelPort, remote_vtep);
+
+    //If there are IMR/IP routes to the remote VTEP then ignore this call
+    if(vtep_ptr->getDipTunnelRefCnt(remote_vtep))
+      return;
+
+    // Remove Bridge port and Port objects for this DIP tunnel
+    ret = gPortsOrch->removeBridgePort(tunnelPort);
+    if(!ret) 
+    {
+      SWSS_LOG_ERROR("Remove Bridge port failed for remote = %s fdbcount = %d", 
+                      remote_vtep.c_str(), tunnelPort.m_fdb_count);
+      return;
+    }
+    gPortsOrch->removeTunnel(tunnelPort);
+
+    // Remove DIP Tunnel HW 
+    vtep_ptr->deleteDynamicDIPTunnel(remote_vtep, TNL_SRC_IMR, false);
+    SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
+                     remote_vtep.c_str(), vtep_ptr->getDipTunnelRefCnt(remote_vtep));
+
+    // Remove SIP Tunnel HW which might be pending on delete
+    vtep_ptr->deletePendingSIPTunnel();
+
+    return ;
+}
+
+void VxlanTunnelOrch::getTunnelName(string& tunnel_portname, string& tunnel_name)
+{
+   tunnel_name = tunnel_portname;
+   tunnel_name.erase(0, sizeof("Port_")-1);
+
+   SWSS_LOG_DEBUG("tunnel name = %s",tunnel_name.c_str());
+
+   return;
+}
+
+#if 0
+void VxlanTunnelOrch::getTunnelPortname(string& dip, string& tunnel_portname)
+{
+   tunnel_port_name = "Port_EVPN_" + dip;
+
+   return;
+}
+#endif
+
+void VxlanTunnelOrch:: getTunnelDIPFromPort(Port& tunnelPort, string& remote_vtep)
+{
+    remote_vtep = tunnelPort.m_alias;
+    remote_vtep.erase(0,sizeof("Port_EVPN_")-1);
+}
+
+
+void VxlanTunnelOrch::updateDbTunnelOperStatus(string tunnel_portname, 
+                                               sai_port_oper_status_t status)
+{
+   std::vector<FieldValueTuple> fvVector;
+   std::string tunnel_name;
+
+   if(status == SAI_PORT_OPER_STATUS_UP)
+     fvVector.emplace_back("operstatus", "up");
+   else
+     fvVector.emplace_back("operstatus", "down");
+
+   getTunnelName(tunnel_portname, tunnel_name);
+
+   m_stateVxlanTable.set(tunnel_name, fvVector);
+}
+
+void VxlanTunnelOrch::addRemoveStateTableEntry(string tunnel_name, 
+                                           IpAddress& sip, IpAddress& dip, 
+                                           tunnel_creation_src_t src, bool add)
+
+{
+    std::vector<FieldValueTuple> fvVector, tmpFvVector;
+    WarmStart::WarmStartState state;
+
+    WarmStart::getWarmStartState("orchagent",state);
+
+    if(add)
+    {
+      // Add tunnel entry only for non-warmboot case or WB with new tunnel coming up
+      // during WB
+      if ( (state != WarmStart::INITIALIZED) || 
+           !m_stateVxlanTable.get(tunnel_name, tmpFvVector))
+      {
+        fvVector.emplace_back("src_ip", (sip.to_string()).c_str());
+        fvVector.emplace_back("dst_ip", (dip.to_string()).c_str());
+
+        if(src == TNL_CREATION_SRC_CLI)
+          fvVector.emplace_back("tnl_src", "CLI");
+        else 
+          fvVector.emplace_back("tnl_src", "EVPN");
+
+        fvVector.emplace_back("operstatus", "down");
+        m_stateVxlanTable.set(tunnel_name, fvVector);
+        SWSS_LOG_INFO("adding tunnel %s during warmboot", tunnel_name.c_str());
+      }
+      else
+        SWSS_LOG_NOTICE("Skip adding tunnel %s during warmboot", tunnel_name.c_str());
+    }
+    else
+    {
+      m_stateVxlanTable.del(tunnel_name);
+    }
+}
+
+bool VxlanTunnelOrch::getTunnelPort(const std::string& remote_vtep,Port& tunnelPort)
+{
+    auto port_tunnel_name = "Port_EVPN_" + remote_vtep;
+
+    bool ret = gPortsOrch->getPort(port_tunnel_name,tunnelPort);
+
+    SWSS_LOG_INFO("getTunnelPort and getPort return ret=%d name=%s",
+                  ret,port_tunnel_name.c_str());
+
+    return ret;
+}
+
+//------------------- VXLAN_TUNNEL_MAP Table --------------------------//
+
 bool VxlanTunnelMapOrch::addOperation(const Request& request)
 {
     SWSS_LOG_ENTER();
 
-    auto vlan_id = request.getAttrVlan("vlan");
+    sai_vlan_id_t vlan_id = (sai_vlan_id_t)request.getAttrVlan("vlan");
     Port tempPort;
+
+    const auto full_tunnel_map_entry_name = request.getFullKey();
+    SWSS_LOG_NOTICE("Full name = %s",full_tunnel_map_entry_name.c_str());
+
+    if (isTunnelMapExists(full_tunnel_map_entry_name))
+    {
+        SWSS_LOG_ERROR("Vxlan tunnel map '%s' already exist", 
+                      full_tunnel_map_entry_name.c_str());
+        return true;
+    }
+
     if(!gPortsOrch->getVlanByVlanId(vlan_id, tempPort))
     {
         SWSS_LOG_WARN("Vxlan tunnel map vlan id doesn't exist: %d", vlan_id);
@@ -779,6 +1645,8 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
         return true;
     }
 
+    tempPort.m_vnid = (uint32_t) vni_id;
+
     auto tunnel_name = request.getKeyString(0);
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     if (!tunnel_orch->isTunnelExists(tunnel_name))
@@ -788,33 +1656,56 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
     }
 
     auto tunnel_obj = tunnel_orch->getVxlanTunnel(tunnel_name);
+ 
+    // The hw delete is pending due to an earlier incomplete operation. 
+    // process this add event when the deletion is complete. 
+    if(tunnel_obj->del_tnl_hw_pending)
+    {
+      SWSS_LOG_WARN("Tunnel Mapper deletion is pending");
+      return false;
+    }
+
     if (!tunnel_obj->isActive())
     {
+
         //@Todo, currently only decap mapper is allowed
-        tunnel_obj->createTunnel(MAP_T::MAP_TO_INVALID, MAP_T::VNI_TO_VLAN_ID);
+        //tunnel_obj->createTunnel(MAP_T::MAP_TO_INVALID, MAP_T::VNI_TO_VLAN_ID);
+        uint8_t mapper_list = 0;
+        TUNNELMAP_SET_VLAN(mapper_list);
+        TUNNELMAP_SET_VRF(mapper_list);
+        tunnel_obj->createTunnelHW(mapper_list,USE_DEDICATED_ENCAP_DECAP);
     }
 
-    const auto full_tunnel_map_entry_name = request.getFullKey();
-    if (isTunnelMapExists(full_tunnel_map_entry_name))
-    {
-        SWSS_LOG_NOTICE("Vxlan tunnel map '%s' already exist", full_tunnel_map_entry_name.c_str());
-        return true;
-    }
-
-    const auto tunnel_map_id = tunnel_obj->getDecapMapId();
+    const auto tunnel_map_id = tunnel_obj->getDecapMapId(TUNNEL_MAP_T_VLAN);
     const auto tunnel_map_entry_name = request.getKeyString(1);
+
+    tunnel_obj->vlan_vrf_vni_count++;
+    SWSS_LOG_INFO("vni count increased to %d",tunnel_obj->vlan_vrf_vni_count);
 
     try
     {
         auto tunnel_map_entry_id = create_tunnel_map_entry(MAP_T::VNI_TO_VLAN_ID,
                                                            tunnel_map_id, vni_id, vlan_id);
-        vxlan_tunnel_map_table_[full_tunnel_map_entry_name] = tunnel_map_entry_id;
+        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].map_entry_id = 
+                                                             tunnel_map_entry_id;
+        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].vlan_id = 
+                                                             vlan_id;
+        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].vni_id = 
+                                                             vni_id;
     }
     catch(const std::runtime_error& error)
     {
-        SWSS_LOG_ERROR("Error adding tunnel map entry. Tunnel: %s. Entry: %s. Error: %s",
+        SWSS_LOG_WARN("Error adding tunnel map entry. Tunnel: %s. Entry: %s. Error: %s",
             tunnel_name.c_str(), tunnel_map_entry_name.c_str(), error.what());
         return false;
+    }
+
+    tunnel_orch->addVlanMappedToVni(vni_id, vlan_id);
+    VRFOrch* vrf_orch = gDirectory.get<VRFOrch*>();
+    if (0 == vrf_orch->getL3VniVlan(vni_id))
+    {
+        SWSS_LOG_NOTICE("update l3vni %d, vlan %d", vni_id, vlan_id);
+        vrf_orch->updateL3VniVlan(vni_id, vlan_id);
     }
 
     SWSS_LOG_NOTICE("Vxlan tunnel map entry '%s' for tunnel '%s' was created",
@@ -827,6 +1718,7 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
 {
     SWSS_LOG_ENTER();
 
+    Port vlanPort;
     const auto& tunnel_name = request.getKeyString(0);
     const auto& tunnel_map_entry_name = request.getKeyString(1);
     const auto& full_tunnel_map_entry_name = request.getFullKey();
@@ -837,6 +1729,15 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
         SWSS_LOG_WARN("Vxlan tunnel map '%s' doesn't exist", full_tunnel_map_entry_name.c_str());
         return true;
     }
+
+    auto vlan_id = (sai_vlan_id_t) vxlan_tunnel_map_table_[full_tunnel_map_entry_name].vlan_id;
+    if(!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
+    {
+        SWSS_LOG_ERROR("Delete VLAN-VNI map.vlan id doesn't exist: %d", vlan_id);
+        return true;
+    }
+
+    vlanPort.m_vnid = (uint32_t) 0xFFFFFFFF;
 
     auto tunnel_map_entry_id = vxlan_tunnel_map_table_[full_tunnel_map_entry_name];
     try
@@ -851,11 +1752,60 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
 
     vxlan_tunnel_map_table_.erase(full_tunnel_map_entry_name);
 
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    if (!tunnel_orch->isTunnelExists(tunnel_name))
+    {
+        SWSS_LOG_WARN("Vxlan tunnel '%s' doesn't exist", tunnel_name.c_str());
+        return false;
+    }
+
+    auto tunnel_obj = tunnel_orch->getVxlanTunnel(tunnel_name);
+    tunnel_obj->vlan_vrf_vni_count--;
+
+    SWSS_LOG_NOTICE("vni count = %d",tunnel_obj->vlan_vrf_vni_count);
+
+    // Update the map count and if this is the last mapping entry 
+    // make SAI calls to delete the tunnel and tunnel termination objects.
+
+    if(tunnel_obj->vlan_vrf_vni_count == 0)
+    {
+      // If there are Dynamic DIP Tunnels referring to this SIP Tunnel 
+      // then mark it as pending for delete. 
+      if(tunnel_obj->getDipTunnelCnt() == 0)
+      {
+         uint8_t mapper_list=0;
+         TUNNELMAP_SET_VLAN(mapper_list);
+         TUNNELMAP_SET_VRF(mapper_list);
+         tunnel_obj->deleteTunnelHW(mapper_list, USE_DEDICATED_ENCAP_DECAP);
+      }
+      else
+      {
+        tunnel_obj->del_tnl_hw_pending = true;
+        SWSS_LOG_WARN("Postponing the SIP Tunnel HW deletion DIP Tunnel count = %d",
+                      tunnel_obj->getDipTunnelCnt());
+      }
+    }
+
+    vector<string> map_entries = tokenize(tunnel_map_entry_name, '_');
+    SWSS_LOG_INFO("Vxlan tunnel map '%s' size %ld", tunnel_map_entry_name.c_str(), 
+                                                    map_entries.size());
+    if (map_entries.size() == 3)
+    {
+        SWSS_LOG_INFO("Vxlan tunnel map %s, %s, %s ", map_entries[0].c_str(), 
+                                                      map_entries[1].c_str(), 
+                                                      map_entries[2].c_str());
+        uint32_t vni_id = static_cast<uint32_t>(stoul(map_entries[1]));
+        if (vni_id) {
+            tunnel_orch->delVlanMappedToVni(vni_id);
+        }
+    }
     SWSS_LOG_NOTICE("Vxlan tunnel map entry '%s' for tunnel '%s' was removed",
                    tunnel_map_entry_name.c_str(), tunnel_name.c_str());
 
     return true;
 }
+
+//------------------- VXLAN_VRF_MAP Table --------------------------//
 
 bool VxlanVrfMapOrch::addOperation(const Request& request)
 {
@@ -936,3 +1886,201 @@ bool VxlanVrfMapOrch::delOperation(const Request& request)
 
     return true;
 }
+
+//------------------- EVPN_REMOTE_VNI Table --------------------------//
+
+bool EvpnRemoteVniOrch::addOperation(const Request& request)
+{
+    SWSS_LOG_ENTER();
+
+    // Extract DIP and tunnel
+    auto remote_vtep = request.getKeyString(1);
+
+    // Extract VLAN and VNI
+    auto vlan_name = request.getKeyString(0);
+    sai_vlan_id_t vlan_id = (sai_vlan_id_t) stoi(vlan_name.substr(4));
+    //sai_vlan_id_t vlan_id = (sai_vlan_id_t)request.getAttrVlan("vlan");
+
+    auto vni_id  = static_cast<sai_uint32_t>(request.getAttrUint("vni"));
+    if (vni_id >= 1<<24)
+    {
+        SWSS_LOG_ERROR("Vxlan tunnel map vni id is too big: %d", vni_id);
+        return true;
+    }
+
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    Port tunnelPort, vlanPort;
+
+    if(!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
+    {
+        SWSS_LOG_WARN("Vxlan tunnel map vlan id doesn't exist: %d", vlan_id);
+        return false;
+    }
+
+    if(tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
+    {
+        SWSS_LOG_INFO("Vxlan tunnelPort exists: %s", remote_vtep.c_str());
+
+        if(gPortsOrch->isVlanMember(vlanPort, tunnelPort))
+        {
+           EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
+           auto vtep_ptr = evpn_orch->getEVPNVtep();
+           if(!vtep_ptr)
+           {
+             SWSS_LOG_WARN("Remote VNI add: VTEP not found. remote=%s vid=%d",
+                           remote_vtep.c_str(),vlan_id);
+             return true;
+           }
+           SWSS_LOG_WARN("tunnelPort %s already member of vid %d", 
+                           remote_vtep.c_str(),vlan_id);
+           vtep_ptr->increment_spurious_imr_add(remote_vtep);
+           return true;
+        }
+    }
+
+    tunnel_orch->addTunnelUser(remote_vtep, vni_id, vlan_id, TNL_SRC_IMR);
+
+    if(!tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
+    {
+      SWSS_LOG_WARN("Vxlan tunnelPort doesn't exist: %s", remote_vtep.c_str());
+      return false;
+    }
+
+    // SAI Call to add tunnel to the VLAN flood domain
+
+    string tagging_mode = "untagged"; 
+    gPortsOrch->addVlanMember(vlanPort, tunnelPort, tagging_mode);
+
+    SWSS_LOG_INFO("remote_vtep=%s vni=%d vlanid=%d ",
+                   remote_vtep.c_str(), vni_id, vlan_id);
+
+    return true;
+}
+
+bool EvpnRemoteVniOrch::delOperation(const Request& request)
+{
+    bool ret;
+    SWSS_LOG_ENTER();
+
+    // Extract DIP and tunnel
+    auto remote_vtep = request.getKeyString(1);
+
+    // Extract VLAN and VNI
+    auto vlan_name = request.getKeyString(0);
+    sai_vlan_id_t vlan_id = (sai_vlan_id_t)stoi(vlan_name.substr(4));
+
+    auto vni_id  = static_cast<sai_uint32_t>(request.getAttrUint("vni"));
+    if (vni_id >= 1<<24)
+    {
+        SWSS_LOG_ERROR("Vxlan tunnel map vni id is too big: %d", vni_id);
+        return true;
+    }
+
+    // SAI Call to add tunnel to the VLAN flood domain
+
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    Port vlanPort, tunnelPort;
+    if(!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
+    {
+        SWSS_LOG_WARN("Vxlan tunnel map vlan id doesn't exist: %d", vlan_id);
+        return true;
+    }
+
+    if(!tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
+    {
+        SWSS_LOG_WARN("RemoteVniDel getTunnelPort Fails: %s", remote_vtep.c_str());
+        return true;
+    }
+
+    EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
+    auto vtep_ptr = evpn_orch->getEVPNVtep();
+
+    if(!vtep_ptr)
+      {
+        SWSS_LOG_WARN("Remote VNI del: VTEP not found. remote=%s vid=%d",
+                       remote_vtep.c_str(),vlan_id);
+        return true;
+      }
+
+    // If VLAN is not member of the tunnel and 
+    // this is not a vlan which is pending delete
+    // consider it as spurious.
+#if 0
+    SWSS_LOG_NOTICE("ismember=%d vlan_pend_del=%d vlanid=%d",gPortsOrch->isVlanMember(vlanPort, tunnelPort), tunnelPort.m_tunnel_vlan_pending_delete, vlan_id);
+        (vlan_id != tunnelPort.m_tunnel_vlan_pending_delete))
+#endif
+
+    if(!gPortsOrch->isVlanMember(vlanPort, tunnelPort))
+    {
+       SWSS_LOG_WARN("marking it as spurious tunnelPort %s not a member of vid %d", 
+                      remote_vtep.c_str(), vlan_id);
+       vtep_ptr->increment_spurious_imr_del(remote_vtep);
+       return true;
+    }
+
+    if(gPortsOrch->isVlanMember(vlanPort, tunnelPort)) 
+    {
+       if(!gPortsOrch->removeVlanMember(vlanPort, tunnelPort))
+       {
+          SWSS_LOG_WARN("RemoteVniDel remove vlan member fails: %s",remote_vtep.c_str());
+          return true;
+       }
+    }
+
+    SWSS_LOG_WARN("imrcount=%d fdbcount=%d ",
+                   vtep_ptr->getDipTunnelIMRRefCnt(remote_vtep), 
+                   tunnelPort.m_fdb_count );
+
+    ret = tunnel_orch->delTunnelUser(remote_vtep, vni_id, vlan_id, TNL_SRC_IMR);
+
+    SWSS_LOG_INFO("remote_vtep=%s vni=%d vlanid=%d ",
+                   remote_vtep.c_str(), vni_id, vlan_id);
+
+
+    return ret;
+}
+
+//------------------- EVPN_NVO Table --------------------------//
+
+bool EvpnNvoOrch::addOperation(const Request& request)
+{
+    SWSS_LOG_ENTER();
+
+    auto nvo_name = request.getKeyString(0);
+    auto vtep_name = request.getAttrString("source_vtep");
+
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+
+    // FIXME: Currently assumes only 1 VTEP
+    source_vtep_ptr = tunnel_orch->getVxlanTunnel(vtep_name);
+
+    SWSS_LOG_INFO("evpnnvo: %s vtep : %s \n",nvo_name.c_str(), vtep_name.c_str());
+
+    return true;
+}
+
+bool EvpnNvoOrch::delOperation(const Request& request)
+{
+    SWSS_LOG_ENTER();
+
+    auto nvo_name = request.getKeyString(0);
+
+    if(!source_vtep_ptr) 
+    {
+       SWSS_LOG_WARN("NVO Delete failed as VTEP Ptr is NULL");
+       return true;
+    }
+
+    if(source_vtep_ptr->del_tnl_hw_pending)
+    {
+      SWSS_LOG_WARN("NVO not deleted as hw delete is pending");
+      return false;
+    }
+
+    source_vtep_ptr = NULL;
+
+    SWSS_LOG_INFO("NVO: %s \n",nvo_name.c_str());
+
+    return true;
+}
+

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1758,15 +1758,6 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
 
     tunnel_orch->addVlanMappedToVni(vni_id, vlan_id);
 
-#ifdef L3PR 
-    VRFOrch* vrf_orch = gDirectory.get<VRFOrch*>();
-    if (0 == vrf_orch->getL3VniVlan(vni_id))
-    {
-        SWSS_LOG_NOTICE("update l3vni %d, vlan %d", vni_id, vlan_id);
-        vrf_orch->updateL3VniVlan(vni_id, vlan_id);
-    }
-#endif
-
     SWSS_LOG_NOTICE("Vxlan tunnel map entry '%s' for tunnel '%s' was created",
                    tunnel_map_entry_name.c_str(), tunnel_name.c_str());
 
@@ -1991,11 +1982,6 @@ bool VxlanVrfMapOrch::delOperation(const Request& request)
             full_map_entry_name.c_str(), error.what());
         return false;
     }
-
-#ifdef L3PR
-    SWSS_LOG_NOTICE("VxlanVrfMapOrch Vxlan vrf map entry '%s' is removed. VRF Refcnt %d", full_map_entry_name.c_str(),
-            vrf_orch->getVrfRefCount(vrf_name));
-#endif
 
     return true;
 }

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -5,8 +5,6 @@
 #include <unordered_set>
 #include <stdexcept>
 #include <inttypes.h>
-
-
 #include "sai.h"
 #include "macaddress.h"
 #include "ipaddress.h"
@@ -79,24 +77,24 @@ static inline uint32_t tunnel_map_val (MAP_T map_t)
 
 static inline MAP_T tunnel_map_type (tunnel_map_type_t type, bool isencap)
 {
-    if(isencap)
+    if (isencap)
     {
       switch(type)
       {
-       case TUNNEL_MAP_T_VLAN : return MAP_T::VLAN_ID_TO_VNI;
-       case TUNNEL_MAP_T_VIRTUAL_ROUTER: return MAP_T::VRID_TO_VNI;
-       case TUNNEL_MAP_T_BRIDGE: return MAP_T::BRIDGE_TO_VNI;
-       default: return MAP_T::MAP_TO_INVALID;
+          case TUNNEL_MAP_T_VLAN : return MAP_T::VLAN_ID_TO_VNI;
+          case TUNNEL_MAP_T_VIRTUAL_ROUTER: return MAP_T::VRID_TO_VNI;
+          case TUNNEL_MAP_T_BRIDGE: return MAP_T::BRIDGE_TO_VNI;
+          default: return MAP_T::MAP_TO_INVALID;
       }
     }
     else
     {
       switch(type)
       {
-       case TUNNEL_MAP_T_VLAN : return MAP_T::VNI_TO_VLAN_ID;
-       case TUNNEL_MAP_T_VIRTUAL_ROUTER: return MAP_T::VNI_TO_VRID;
-       case TUNNEL_MAP_T_BRIDGE: return MAP_T::VNI_TO_BRIDGE;
-       default: return MAP_T::MAP_TO_INVALID;
+          case TUNNEL_MAP_T_VLAN : return MAP_T::VNI_TO_VLAN_ID;
+          case TUNNEL_MAP_T_VIRTUAL_ROUTER: return MAP_T::VNI_TO_VRID;
+          case TUNNEL_MAP_T_BRIDGE: return MAP_T::VNI_TO_BRIDGE;
+          default: return MAP_T::MAP_TO_INVALID;
       }
     }
 }
@@ -276,12 +274,12 @@ create_tunnel(
     sai_object_id_t map_list[TUNNEL_MAP_T_MAX_MAPPER+1];
     uint8_t num_map=0;
 
-    for(int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
+    for (int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
     {
-      if(ids->tunnel_decap_id[i] != SAI_NULL_OBJECT_ID)
+      if (ids->tunnel_decap_id[i] != SAI_NULL_OBJECT_ID)
       {
         map_list[num_map] = ids->tunnel_decap_id[i];
-        SWSS_LOG_NOTICE("create_tunnel:maplist[%d]=0x%lx",num_map,map_list[num_map]);
+        SWSS_LOG_INFO("create_tunnel:maplist[%d]=0x%lx",num_map,map_list[num_map]);
         num_map++;
       }
     }
@@ -294,9 +292,9 @@ create_tunnel(
     sai_object_id_t emap_list[TUNNEL_MAP_T_MAX_MAPPER+1];
     uint8_t num_emap=0;
 
-    for(int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
+    for (int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
     {
-      if(ids->tunnel_encap_id[i] != SAI_NULL_OBJECT_ID)
+      if (ids->tunnel_encap_id[i] != SAI_NULL_OBJECT_ID)
       {
         emap_list[num_emap] = ids->tunnel_encap_id[i];
         SWSS_LOG_NOTICE("create_tunnel:encapmaplist[%d]=0x%lx",num_emap,emap_list[num_emap]);
@@ -388,7 +386,7 @@ create_tunnel_termination(
     sai_attribute_t attr;
     std::vector<sai_attribute_t> tunnel_attrs;
 
-    if(dstip == nullptr) // It's P2MP tunnel
+    if (dstip == nullptr) // It's P2MP tunnel
     {
         attr.id = SAI_TUNNEL_TERM_TABLE_ENTRY_ATTR_TYPE;
         attr.value.s32 = SAI_TUNNEL_TERM_TABLE_ENTRY_TYPE_P2MP;
@@ -460,24 +458,23 @@ VxlanTunnel::VxlanTunnel(string name, IpAddress srcIp, IpAddress dstIp, tunnel_c
 {
    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
 
-   if(dstIp.isZero())
+   if (dstIp.isZero())
    {
-     //tunnel_orch->addVTEP(std::unique_ptr<VxlanTunnel>this,srcIp);
-     tunnel_orch->addVTEP(this,srcIp);
-     vtep_ptr = NULL;
+       tunnel_orch->addVTEP(this, srcIp);
+       vtep_ptr = NULL;
    }
-   else if(src_creation_ == TNL_CREATION_SRC_EVPN) 
+   else if (src_creation_ == TNL_CREATION_SRC_EVPN) 
    {
-     vtep_ptr = tunnel_orch->getVTEP(srcIp);
-     tunnel_orch->addRemoveStateTableEntry(name,srcIp, dstIp,
+       vtep_ptr = tunnel_orch->getVTEP(srcIp);
+       tunnel_orch->addRemoveStateTableEntry(name,srcIp, dstIp,
                                            src, true);
    }
 }
 
 VxlanTunnel::~VxlanTunnel()
 {
-   VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
-   tunnel_orch->addRemoveStateTableEntry(tunnel_name_,src_ip_, dst_ip_,
+    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    tunnel_orch->addRemoveStateTableEntry(tunnel_name_,src_ip_, dst_ip_,
                                           src_creation_, false);
 }
 
@@ -491,17 +488,26 @@ bool VxlanTunnel::createTunnel(MAP_T encap, MAP_T decap, uint8_t encap_ttl)
 
         // Only a single mapper type is created
 
-        if(decap == MAP_T::VNI_TO_BRIDGE)
-          TUNNELMAP_SET_BRIDGE(mapper_list);
-        else if(decap == MAP_T::VNI_TO_VLAN_ID)
-          TUNNELMAP_SET_VLAN(mapper_list);
+        if (decap == MAP_T::VNI_TO_BRIDGE)
+        {
+            TUNNELMAP_SET_BRIDGE(mapper_list);
+        }
+        else if (decap == MAP_T::VNI_TO_VLAN_ID)
+        {
+            TUNNELMAP_SET_VLAN(mapper_list);
+        }
         else
-          TUNNELMAP_SET_VRF(mapper_list);
+        {
+            TUNNELMAP_SET_VRF(mapper_list);
+        }
         
-        createMapperHW(mapper_list, (encap == MAP_T::MAP_TO_INVALID) ? USE_DECAP_ONLY: USE_DEDICATED_ENCAP_DECAP);
+        createMapperHw(mapper_list, (encap == MAP_T::MAP_TO_INVALID) ? 
+                       TUNNEL_MAP_USE_DECAP_ONLY: TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
 
         if (encap != MAP_T::MAP_TO_INVALID)
+        {
             ip = &ips;
+        }
 
         ids_.tunnel_id = create_tunnel(&ids_, ip, NULL, gUnderlayIfId, false, encap_ttl);
 
@@ -556,11 +562,12 @@ std::pair<sai_object_id_t, sai_object_id_t> VxlanTunnel::getMapperEntry(uint32_t
     return std::make_pair(SAI_NULL_OBJECT_ID, SAI_NULL_OBJECT_ID);
 }
 
-void VxlanTunnel::updateNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni, sai_object_id_t nh_id)
+void VxlanTunnel::updateNextHop(IpAddress& ipAddr, MacAddress macAddress, 
+                                uint32_t vni, sai_object_id_t nh_id)
 {
     auto key = nh_key_t(ipAddr, macAddress, vni);
 
-    SWSS_LOG_NOTICE("Update NH tunnel for ip %s, mac %s, vni %d",
+    SWSS_LOG_INFO("Update NH tunnel for ip %s, mac %s, vni %d",
             ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
 
     auto it = nh_tunnels_.find(key);
@@ -568,14 +575,17 @@ void VxlanTunnel::updateNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
     {
         nh_tunnels_[key] = {nh_id, 1};
         return;
-    } else {
-        SWSS_LOG_NOTICE("Dup Update NH tunnel for ip %s, mac %s, vni %d",
+    } 
+    else 
+    {
+        SWSS_LOG_INFO("Dup Update NH tunnel for ip %s, mac %s, vni %d",
             ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
     }
 
 }
 
-sai_object_id_t VxlanTunnel::getNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni) const
+sai_object_id_t VxlanTunnel::getNextHop(IpAddress& ipAddr, 
+                                        MacAddress macAddress, uint32_t vni) const
 {
     auto key = nh_key_t(ipAddr, macAddress, vni);
 
@@ -592,7 +602,7 @@ void VxlanTunnel::incNextHopRefCount(IpAddress& ipAddr, MacAddress macAddress, u
 {
     auto key = nh_key_t(ipAddr, macAddress, vni);
     nh_tunnels_[key].ref_count ++;
-    SWSS_LOG_NOTICE("refcnt increment NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
+    SWSS_LOG_INFO("refcnt increment NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
             ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni,
             nh_tunnels_[key].ref_count);
 
@@ -602,7 +612,7 @@ void VxlanTunnel::decNextHopRefCount(IpAddress& ipAddr, MacAddress macAddress, u
 {
     auto key = nh_key_t(ipAddr, macAddress, vni);
     nh_tunnels_[key].ref_count --;
-    SWSS_LOG_NOTICE("refcnt decrement NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
+    SWSS_LOG_INFO("refcnt decrement NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
                     ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni,
                     nh_tunnels_[key].ref_count);
 
@@ -615,12 +625,12 @@ bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
     auto it = nh_tunnels_.find(key);
     if (it == nh_tunnels_.end())
     {
-        SWSS_LOG_NOTICE("remove NH tunnel for ip %s, mac %s, vni %d doesn't exist",
+        SWSS_LOG_INFO("remove NH tunnel for ip %s, mac %s, vni %d doesn't exist",
                         ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
         return false;
     }
 
-    SWSS_LOG_NOTICE("remove NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
+    SWSS_LOG_INFO("remove NH tunnel for ip %s, mac %s, vni %d, ref_count %d",
                     ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni,
                     nh_tunnels_[key].ref_count);
 
@@ -631,7 +641,7 @@ bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
     {
         if (sai_next_hop_api->remove_next_hop(nh_tunnels_[key].nh_id) != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_NOTICE("delete NH tunnel for ip '%s', mac '%s' vni %d failed",
+            SWSS_LOG_INFO("delete NH tunnel for ip '%s', mac '%s' vni %d failed",
                             ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
             string err_msg = "NH tunnel delete failed for " + ipAddr.to_string();
             throw std::runtime_error(err_msg);
@@ -640,238 +650,209 @@ bool VxlanTunnel::removeNextHop(IpAddress& ipAddr, MacAddress macAddress, uint32
         nh_tunnels_.erase(key);
     }
 
-    SWSS_LOG_NOTICE("NH tunnel for ip '%s', mac '%s' vni %d updated/deleted",
+    SWSS_LOG_INFO("NH tunnel for ip '%s', mac '%s' vni %d updated/deleted",
                     ipAddr.to_string().c_str(), macAddress.to_string().c_str(), vni);
 
     return true;
 }
 
-bool VxlanTunnel::deleteMapperHW(uint8_t mapper_list,
-                                 tunnel_map_src_t map_src)
-{
-    sai_status_t status = SAI_STATUS_SUCCESS;
-
-    SWSS_LOG_INFO("Enter deleteMapper HW maplst=%d src=%d",mapper_list, map_src);
-
-    try
-    {
-      if(map_src == USE_DEDICATED_ENCAP_DECAP)
-      {
-        if(IS_TUNNELMAP_SET_VLAN(mapper_list))
-        {
-          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN]);
-          SWSS_LOG_INFO("deletevlandecap = %d", status);
-          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN]);
-          SWSS_LOG_INFO("deletevlanencap = %d", status);
-        }
-
-        if(IS_TUNNELMAP_SET_VRF(mapper_list))
-        {
-          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
-          SWSS_LOG_INFO("deleteVRFdecap = %d", status);
-          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
-          SWSS_LOG_INFO("deleteVRFencap = %d", status);
-        }
-
-        if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
-        {
-          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE]);
-          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE]);
-        }
-      }
-      else if(map_src == USE_COMMON_DECAP_DEDICATED_ENCAP)
-      {
-        if(IS_TUNNELMAP_SET_VLAN(mapper_list))
-        {
-          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN]);
-        }
-
-        if(IS_TUNNELMAP_SET_VRF(mapper_list))
-        {
-          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
-        }
-
-        if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
-        {
-          sai_tunnel_api->remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE]);
-        }
-      }
-      else if(map_src == USE_DECAP_ONLY)
-      {
-        if(IS_TUNNELMAP_SET_VLAN(mapper_list))
-        {
-          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN]);
-          SWSS_LOG_INFO("deletevlandecap = %d", status);
-        }
-
-        if(IS_TUNNELMAP_SET_VRF(mapper_list))
-        {
-          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
-          SWSS_LOG_INFO("deleteVRFdecap = %d", status);
-        }
-
-        if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
-        {
-          status = sai_tunnel_api->remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE]);
-          SWSS_LOG_INFO("deletebridgedecap = %d", status);
-        }
-      }
-    }
-
-    catch (const std::runtime_error& error)
-    {
-      SWSS_LOG_ERROR("Error deleting mapper %s: %s", tunnel_name_.c_str(), error.what());
-      // FIXME: add code to remove already created objects
-      return false;
-    }
-
-    return true;
-}
-
-bool VxlanTunnel::createMapperHW(uint8_t mapper_list, 
-                                 tunnel_map_src_t map_src)
+bool VxlanTunnel::deleteMapperHw(uint8_t mapper_list, tunnel_map_use_t map_src)
 {
     try
     {
-        for(int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
+        if (map_src == TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP)
         {
-          ids_.tunnel_decap_id[i] = SAI_NULL_OBJECT_ID;
-          ids_.tunnel_encap_id[i] = SAI_NULL_OBJECT_ID;
+            if (IS_TUNNELMAP_SET_VLAN(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN]);
+                remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN]);
+            }
+    
+            if (IS_TUNNELMAP_SET_VRF(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
+                remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
+            }
+    
+            if (IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE]);
+                remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE]);
+            }
         }
-
-        if(USE_DEDICATED_ENCAP_DECAP == map_src)
+        else if (map_src == TUNNEL_MAP_USE_COMMON_DECAP_DEDICATED_ENCAP)
         {
-           if(IS_TUNNELMAP_SET_VLAN(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VNI_TO_VLAN_ID);
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VLAN_ID_TO_VNI);
-
-             TUNNELMAP_SET_VLAN(encap_dedicated_mappers_);
-             TUNNELMAP_SET_VLAN(decap_dedicated_mappers_);
-           }
-
-           if(IS_TUNNELMAP_SET_VRF(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VNI_TO_VRID);
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VRID_TO_VNI);
-             TUNNELMAP_SET_VRF(encap_dedicated_mappers_);
-             TUNNELMAP_SET_VRF(decap_dedicated_mappers_);
-           }
-
-           if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::VNI_TO_BRIDGE);
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::BRIDGE_TO_VNI);
-
-             TUNNELMAP_SET_BRIDGE(encap_dedicated_mappers_);
-             TUNNELMAP_SET_BRIDGE(decap_dedicated_mappers_);
-           }
+            if (IS_TUNNELMAP_SET_VLAN(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN]);
+            }
+    
+            if (IS_TUNNELMAP_SET_VRF(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
+            }
+    
+            if (IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE]);
+            }
         }
-        else if (map_src == USE_COMMON_DECAP_DEDICATED_ENCAP)
+        else if (map_src == TUNNEL_MAP_USE_DECAP_ONLY)
         {
-           if(IS_TUNNELMAP_SET_VLAN(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VLAN);
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VLAN_ID_TO_VNI);
-             TUNNELMAP_SET_VLAN(encap_dedicated_mappers_);
-           }
-
-           if(IS_TUNNELMAP_SET_VRF(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VRID_TO_VNI);
-             TUNNELMAP_SET_VRF(encap_dedicated_mappers_);
-           }
-
-           if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_BRIDGE);
-
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::VRID_TO_VNI);
-
-             TUNNELMAP_SET_BRIDGE(encap_dedicated_mappers_);
-           }
-
-        }
-        else if (USE_COMMON_ENCAP_DECAP == map_src)
-        {
-           if(IS_TUNNELMAP_SET_VLAN(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VLAN);
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_VLAN);
-           }
-
-           if(IS_TUNNELMAP_SET_VRF(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
-           }
-
-           if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_BRIDGE);
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_BRIDGE);
-           }
-
-        }
-        else if(USE_DECAP_ONLY == map_src)
-        {
-           if(IS_TUNNELMAP_SET_VLAN(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VNI_TO_VLAN_ID);
-             TUNNELMAP_SET_VLAN(decap_dedicated_mappers_);
-           }
-
-           if(IS_TUNNELMAP_SET_VRF(mapper_list))
-           {
-             ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VNI_TO_VRID);
-             TUNNELMAP_SET_VRF(decap_dedicated_mappers_);
-           }
-
-           if(IS_TUNNELMAP_SET_BRIDGE(mapper_list))
-           {
-             ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::BRIDGE_TO_VNI);
-
-             TUNNELMAP_SET_BRIDGE(decap_dedicated_mappers_);
-           }
+            if (IS_TUNNELMAP_SET_VLAN(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN]);
+            }
+    
+            if (IS_TUNNELMAP_SET_VRF(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER]);
+            }
+    
+            if (IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+            {
+                remove_tunnel_map(ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE]);
+            }
         }
     }
 
     catch (const std::runtime_error& error)
     {
-        SWSS_LOG_ERROR("Error creating tunnel %s: %s", tunnel_name_.c_str(), error.what());
-        // FIXME: add code to remove already created objects
+        SWSS_LOG_ERROR("Error deleting mapper %s: %s", tunnel_name_.c_str(), error.what());
         return false;
     }
 
     return true;
 }
 
-bool VxlanTunnel::deleteTunnelHW(uint8_t mapper_list, 
-                                 tunnel_map_src_t map_src, bool with_term)
+bool VxlanTunnel::createMapperHw(uint8_t mapper_list, tunnel_map_use_t map_src)
 {
-    SWSS_LOG_INFO("Enter Delete Tunnel HW");
     try
     {
-      sai_status_t ret;
+        for (int i=TUNNEL_MAP_T_VLAN; i<TUNNEL_MAP_T_MAX_MAPPER; i++)
+        {
+            ids_.tunnel_decap_id[i] = SAI_NULL_OBJECT_ID;
+            ids_.tunnel_encap_id[i] = SAI_NULL_OBJECT_ID;
+        }
 
-      if(with_term)
-      {
-         ret = sai_tunnel_api->remove_tunnel_term_table_entry(ids_.tunnel_term_id);
-         SWSS_LOG_INFO("term table delete reststatus = %d",ret);
-      }
+        if (TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP == map_src)
+        {
+            if (IS_TUNNELMAP_SET_VLAN(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VNI_TO_VLAN_ID);
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VLAN_ID_TO_VNI);
+                TUNNELMAP_SET_VLAN(encap_dedicated_mappers_);
+                TUNNELMAP_SET_VLAN(decap_dedicated_mappers_);
+            }
 
-      ret = sai_tunnel_api->remove_tunnel(ids_.tunnel_id);
-      SWSS_LOG_INFO("tunnel table delete reststatus = %d",ret);
-      deleteMapperHW(mapper_list, map_src);
-      //total_diptunnel_del++;
+            if (IS_TUNNELMAP_SET_VRF(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VNI_TO_VRID);
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VRID_TO_VNI);
+                TUNNELMAP_SET_VRF(encap_dedicated_mappers_);
+                TUNNELMAP_SET_VRF(decap_dedicated_mappers_);
+            }
+
+            if (IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+            {
+               ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::VNI_TO_BRIDGE);
+               ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::BRIDGE_TO_VNI);
+               TUNNELMAP_SET_BRIDGE(encap_dedicated_mappers_);
+               TUNNELMAP_SET_BRIDGE(decap_dedicated_mappers_);
+            }
+        }
+        else if (map_src == TUNNEL_MAP_USE_COMMON_DECAP_DEDICATED_ENCAP)
+        {
+            if (IS_TUNNELMAP_SET_VLAN(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VLAN);
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VLAN_ID_TO_VNI);
+                TUNNELMAP_SET_VLAN(encap_dedicated_mappers_);
+            }
+
+            if (IS_TUNNELMAP_SET_VRF(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VRID_TO_VNI);
+                TUNNELMAP_SET_VRF(encap_dedicated_mappers_);
+            }
+
+            if (IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_BRIDGE);
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::BRIDGE_TO_VNI);
+                TUNNELMAP_SET_BRIDGE(encap_dedicated_mappers_);
+            }
+        }
+        else if (TUNNEL_MAP_USE_COMMON_ENCAP_DECAP == map_src)
+        {
+            if (IS_TUNNELMAP_SET_VLAN(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VLAN);
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_VLAN] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_VLAN);
+            }
+
+            if (IS_TUNNELMAP_SET_VRF(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_VIRTUAL_ROUTER);
+            }
+ 
+            if (IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getDecapMapId(TUNNEL_MAP_T_BRIDGE);
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = vtep_ptr->getEncapMapId(TUNNEL_MAP_T_BRIDGE);
+            }
+        }
+        else if (TUNNEL_MAP_USE_DECAP_ONLY == map_src)
+        {
+            if (IS_TUNNELMAP_SET_VLAN(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_VLAN] = create_tunnel_map(MAP_T::VNI_TO_VLAN_ID);
+                TUNNELMAP_SET_VLAN(decap_dedicated_mappers_);
+            }
+ 
+            if (IS_TUNNELMAP_SET_VRF(mapper_list))
+            {
+                ids_.tunnel_decap_id[TUNNEL_MAP_T_VIRTUAL_ROUTER] = create_tunnel_map(MAP_T::VNI_TO_VRID);
+                TUNNELMAP_SET_VRF(decap_dedicated_mappers_);
+            }
+ 
+            if (IS_TUNNELMAP_SET_BRIDGE(mapper_list))
+            {
+                ids_.tunnel_encap_id[TUNNEL_MAP_T_BRIDGE] = create_tunnel_map(MAP_T::BRIDGE_TO_VNI);
+                TUNNELMAP_SET_BRIDGE(decap_dedicated_mappers_);
+            }
+        }
     }
 
     catch (const std::runtime_error& error)
     {
-      SWSS_LOG_ERROR("Error deleting tunnel %s: %s", tunnel_name_.c_str(), error.what());
-      // FIXME: add code to remove already created objects
-      return false;
+        SWSS_LOG_ERROR("Error creating tunnel %s: %s", tunnel_name_.c_str(), error.what());
+        return false;
+    }
+
+    return true;
+}
+
+bool VxlanTunnel::deleteTunnelHw(uint8_t mapper_list, tunnel_map_use_t map_src, 
+                                                                  bool with_term)
+{
+    try
+    {
+      if (with_term)
+      {
+          remove_tunnel_termination(ids_.tunnel_term_id);
+      }
+
+      remove_tunnel_termination(ids_.tunnel_id);
+      deleteMapperHw(mapper_list, map_src);
+    }
+
+    catch (const std::runtime_error& error)
+    {
+        SWSS_LOG_ERROR("Error deleting tunnel %s: %s", tunnel_name_.c_str(), error.what());
+        return false;
     }
 
     active_ = false;
@@ -881,8 +862,8 @@ bool VxlanTunnel::deleteTunnelHW(uint8_t mapper_list,
 
 //Creation of SAI Tunnel Object with multiple mapper types
 
-bool VxlanTunnel::createTunnelHW(uint8_t mapper_list, 
-                                 tunnel_map_src_t map_src, bool with_term)
+bool VxlanTunnel::createTunnelHw(uint8_t mapper_list, tunnel_map_use_t map_src, 
+                                                                  bool with_term)
 {
     bool p2p = false;
 
@@ -891,7 +872,7 @@ bool VxlanTunnel::createTunnelHW(uint8_t mapper_list,
         sai_ip_address_t ips, ipd, *ip=nullptr;
         swss::copy(ips, src_ip_);
 
-        createMapperHW(mapper_list, map_src);
+        createMapperHw(mapper_list, map_src);
 
         ip = nullptr;
         if (!dst_ip_.isZero())
@@ -900,13 +881,15 @@ bool VxlanTunnel::createTunnelHW(uint8_t mapper_list,
             ip = &ipd;
             p2p = (src_creation_ == TNL_CREATION_SRC_EVPN)? true:false;
             SWSS_LOG_WARN("creation src = %d",src_creation_);
-            //total_diptunnel_add++;
         }
 
         ids_.tunnel_id = create_tunnel(&ids_, &ips, ip, gUnderlayIfId, p2p);
 
-        if(with_term)
-          ids_.tunnel_term_id = create_tunnel_termination(ids_.tunnel_id, ips, ip, gVirtualRouterId);
+        if (with_term)
+        {
+            ids_.tunnel_term_id = create_tunnel_termination(ids_.tunnel_id, ips, 
+                                                            ip, gVirtualRouterId);
+        }
 
         active_ = true;
     }
@@ -914,7 +897,6 @@ bool VxlanTunnel::createTunnelHW(uint8_t mapper_list,
     catch (const std::runtime_error& error)
     {
         SWSS_LOG_ERROR("Error creating tunnel %s: %s", tunnel_name_.c_str(), error.what());
-        // FIXME: add code to remove already created objects
         return false;
     }
 
@@ -924,33 +906,34 @@ bool VxlanTunnel::createTunnelHW(uint8_t mapper_list,
 
 void VxlanTunnel::deletePendingSIPTunnel()
 {
-   if((getDipTunnelCnt() == 0) && del_tnl_hw_pending)
+   if ((getDipTunnelCnt() == 0) && del_tnl_hw_pending)
    {
-    uint8_t mapper_list=0;
-    TUNNELMAP_SET_VLAN(mapper_list);
-    TUNNELMAP_SET_VRF(mapper_list);
-    deleteTunnelHW(mapper_list, USE_DEDICATED_ENCAP_DECAP);
-    del_tnl_hw_pending = false;
-    SWSS_LOG_INFO("Removing SIP Tunnel HW which is pending");
+       uint8_t mapper_list=0;
+
+       TUNNELMAP_SET_VLAN(mapper_list);
+       TUNNELMAP_SET_VRF(mapper_list);
+       deleteTunnelHw(mapper_list, TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
+       del_tnl_hw_pending = false;
+       SWSS_LOG_INFO("Removing SIP Tunnel HW which is pending");
    }
 
    return;
 }
+
 int VxlanTunnel::getDipTunnelCnt()
 {
-  int ret;
-
-  ret = (int)tnl_users_.size();
-  return ret;
+    int ret;
+  
+    ret = (int)tnl_users_.size();
+    return ret;
 }
 
 void VxlanTunnel::increment_spurious_imr_add(const std::string remote_vtep)
 {
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     tunnel_refcnt_t tnl_refcnts;
 
-    it = tnl_users_.find(remote_vtep); 
-    if(it == tnl_users_.end())
+    auto it = tnl_users_.find(remote_vtep); 
+    if (it == tnl_users_.end())
       return ; 
     else
     {
@@ -962,11 +945,10 @@ void VxlanTunnel::increment_spurious_imr_add(const std::string remote_vtep)
 
 void VxlanTunnel::increment_spurious_imr_del(const std::string remote_vtep)
 {
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     tunnel_refcnt_t tnl_refcnts;
 
-    it = tnl_users_.find(remote_vtep); 
-    if(it == tnl_users_.end())
+    auto it = tnl_users_.find(remote_vtep); 
+    if (it == tnl_users_.end())
       return ; 
     else
     {
@@ -978,11 +960,10 @@ void VxlanTunnel::increment_spurious_imr_del(const std::string remote_vtep)
 
 int VxlanTunnel::getDipTunnelRefCnt(const std::string remote_vtep)
 {
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     tunnel_refcnt_t tnl_refcnts;
 
-    it = tnl_users_.find(remote_vtep); 
-    if(it == tnl_users_.end())
+    auto it = tnl_users_.find(remote_vtep); 
+    if (it == tnl_users_.end())
       return -1; 
     else
     {
@@ -993,11 +974,10 @@ int VxlanTunnel::getDipTunnelRefCnt(const std::string remote_vtep)
 
 int VxlanTunnel::getDipTunnelIMRRefCnt(const std::string remote_vtep)
 {
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     tunnel_refcnt_t tnl_refcnts;
 
-    it = tnl_users_.find(remote_vtep); 
-    if(it == tnl_users_.end())
+    auto it = tnl_users_.find(remote_vtep); 
+    if (it == tnl_users_.end())
       return -1; 
     else
     {
@@ -1008,11 +988,10 @@ int VxlanTunnel::getDipTunnelIMRRefCnt(const std::string remote_vtep)
 
 int VxlanTunnel::getDipTunnelIPRefCnt(const std::string remote_vtep)
 {
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     tunnel_refcnt_t tnl_refcnts;
 
-    it = tnl_users_.find(remote_vtep);
-    if(it == tnl_users_.end())
+    auto it = tnl_users_.find(remote_vtep);
+    if (it == tnl_users_.end())
       return -1;
     else
     {
@@ -1022,31 +1001,31 @@ int VxlanTunnel::getDipTunnelIPRefCnt(const std::string remote_vtep)
 }
 
 void VxlanTunnel::updateDipTunnelRefCnt(bool inc, tunnel_refcnt_t& tnl_refcnts, 
-                                        tunnel_user_type_e usr)
+                                        tunnel_user_t usr)
 {
      switch(usr)
      {
-       case TNL_SRC_IMR: 
+       case TUNNEL_USER_IMR: 
        {
-         if(inc)
+         if (inc)
              tnl_refcnts.imr_refcnt++;
          else
              tnl_refcnts.imr_refcnt--;
 
          break;
        }
-       case TNL_SRC_MAC: 
+       case TUNNEL_USER_MAC: 
        {
-         if(inc)
+         if (inc)
              tnl_refcnts.mac_refcnt++;
          else
              tnl_refcnts.mac_refcnt--;
 
          break;
        }
-       case TNL_SRC_IP: 
+       case TUNNEL_USER_IP: 
        {
-         if(inc)
+         if (inc)
              tnl_refcnts.ip_refcnt++;
          else
              tnl_refcnts.ip_refcnt--;
@@ -1059,83 +1038,82 @@ void VxlanTunnel::updateDipTunnelRefCnt(bool inc, tunnel_refcnt_t& tnl_refcnts,
 
 VxlanTunnel* VxlanTunnel::getDipTunnel(const std::string dip)
 {
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     tunnel_refcnt_t tnl_refcnts;
 
-    it = tnl_users_.find(dip); 
-    if(it == tnl_users_.end())
-      return NULL; 
+    auto it = tnl_users_.find(dip); 
+    if (it == tnl_users_.end())
+    {
+        return NULL; 
+    }
     else
     {
-      tnl_refcnts = it->second;
-      return(tnl_refcnts.dip_tunnel);
+        tnl_refcnts = it->second;
+        return(tnl_refcnts.dip_tunnel);
     }
 }
 
-bool VxlanTunnel::createDynamicDIPTunnel(const std::string dip, tunnel_user_type_e usr)
+bool VxlanTunnel::createDynamicDIPTunnel(const std::string dip, tunnel_user_t usr)
 {
     uint8_t mapper_list = 0;
     tunnel_refcnt_t tnl_refcnts;
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     VxlanTunnel* dip_tunnel=NULL;
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
 
-    it = tnl_users_.find(dip); 
-    if(it == tnl_users_.end())
+    auto it = tnl_users_.find(dip); 
+    if (it == tnl_users_.end())
     {
-       const string tunnel_name = "EVPN_"+dip;
-       auto dipaddr = IpAddress(dip);
-       dip_tunnel = (new VxlanTunnel(tunnel_name, src_ip_, dipaddr, TNL_CREATION_SRC_EVPN));
-       tunnel_orch->addTunnel(tunnel_name,dip_tunnel);
+        const string tunnel_name = "EVPN_"+dip;
+        auto dipaddr = IpAddress(dip);
+        dip_tunnel = (new VxlanTunnel(tunnel_name, src_ip_, dipaddr, TNL_CREATION_SRC_EVPN));
+        tunnel_orch->addTunnel(tunnel_name,dip_tunnel);
 
-       memset(&tnl_refcnts,0,sizeof(tunnel_refcnt_t));
-       updateDipTunnelRefCnt(true,tnl_refcnts,usr);
-       tnl_refcnts.dip_tunnel = dip_tunnel;
-       tnl_users_[dip] = tnl_refcnts;
+        memset(&tnl_refcnts,0,sizeof(tunnel_refcnt_t));
+        updateDipTunnelRefCnt(true,tnl_refcnts,usr);
+        tnl_refcnts.dip_tunnel = dip_tunnel;
+        tnl_users_[dip] = tnl_refcnts;
 
-       TUNNELMAP_SET_VLAN(mapper_list);
-       TUNNELMAP_SET_VRF(mapper_list);
-       dip_tunnel->createTunnelHW(mapper_list,USE_COMMON_ENCAP_DECAP, false);
-       SWSS_LOG_NOTICE("Created P2P Tunnel remote IP %s ", dip.c_str());
+        TUNNELMAP_SET_VLAN(mapper_list);
+        TUNNELMAP_SET_VRF(mapper_list);
+        dip_tunnel->createTunnelHw(mapper_list,TUNNEL_MAP_USE_COMMON_ENCAP_DECAP, false);
+        SWSS_LOG_NOTICE("Created P2P Tunnel remote IP %s ", dip.c_str());
     }
     else 
     {
-       tnl_refcnts = it->second;
-       updateDipTunnelRefCnt(true,tnl_refcnts,usr);
-       tnl_users_[dip] = tnl_refcnts;
+        tnl_refcnts = it->second;
+        updateDipTunnelRefCnt(true,tnl_refcnts,usr);
+        tnl_users_[dip] = tnl_refcnts;
     }
 
     return true;
 }
 
-bool VxlanTunnel::deleteDynamicDIPTunnel(const std::string dip, tunnel_user_type_e usr, bool update_refcnt)
+bool VxlanTunnel::deleteDynamicDIPTunnel(const std::string dip, tunnel_user_t usr, 
+                                                                bool update_refcnt)
 {
     uint8_t mapper_list = 0;
     tunnel_refcnt_t tnl_refcnts;
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     VxlanTunnel* dip_tunnel = NULL;
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     Port tunnelPort;
 
-    SWSS_LOG_INFO("Delete Dynamic DIP Tunnel Enter");
-
-    it = tnl_users_.find(dip); 
-    if(it != tnl_users_.end())
+    auto it = tnl_users_.find(dip); 
+    if (it != tnl_users_.end())
     {
        tnl_refcnts = it->second;
 
-       if(update_refcnt)
+       if (update_refcnt)
        {
          updateDipTunnelRefCnt(false,tnl_refcnts,usr);
          tnl_users_[dip] = tnl_refcnts;
        }
 
-       SWSS_LOG_INFO("diprefcnt = %d",tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt);
+       SWSS_LOG_INFO("diprefcnt = %d",
+                     tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt);
        
-       if(tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt)
+       if (tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt)
          return true;
 
-       if(tunnel_orch->getTunnelPort(dip, tunnelPort))
+       if (tunnel_orch->getTunnelPort(dip, tunnelPort))
        {
          SWSS_LOG_NOTICE("DIP = %s Not deleting tunnel from HW as tunnelPort is not yet deleted. fdbcount = %d",
                           dip.c_str(),tunnelPort.m_fdb_count);
@@ -1143,7 +1121,7 @@ bool VxlanTunnel::deleteDynamicDIPTunnel(const std::string dip, tunnel_user_type
        }
 
        dip_tunnel = tnl_refcnts.dip_tunnel;
-       if(!dip_tunnel)
+       if (!dip_tunnel)
        {
          SWSS_LOG_INFO("DIP Tunnel is NULL unexpected");
          return false;
@@ -1151,7 +1129,7 @@ bool VxlanTunnel::deleteDynamicDIPTunnel(const std::string dip, tunnel_user_type
 
        TUNNELMAP_SET_VLAN(mapper_list);
        TUNNELMAP_SET_VRF(mapper_list);
-       dip_tunnel->deleteTunnelHW(mapper_list,USE_COMMON_ENCAP_DECAP, false);
+       dip_tunnel->deleteTunnelHw(mapper_list,TUNNEL_MAP_USE_COMMON_ENCAP_DECAP, false);
 
        tnl_users_.erase(dip);
 
@@ -1161,7 +1139,7 @@ bool VxlanTunnel::deleteDynamicDIPTunnel(const std::string dip, tunnel_user_type
     }
     else 
     {
-       SWSS_LOG_WARN("Unable to find dynamic tunnel for deletion");
+        SWSS_LOG_WARN("Unable to find dynamic tunnel for deletion");
     }
 
     return true;
@@ -1170,11 +1148,12 @@ bool VxlanTunnel::deleteDynamicDIPTunnel(const std::string dip, tunnel_user_type
 //------------------- VxlanTunnelOrch Implementation --------------------------//
 
 sai_object_id_t
-VxlanTunnelOrch::createNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAddress macAddress, uint32_t vni)
+VxlanTunnelOrch::createNextHopTunnel(string tunnelName, IpAddress& ipAddr, 
+                                     MacAddress macAddress, uint32_t vni)
 {
     SWSS_LOG_ENTER();
 
-    if(!isTunnelExists(tunnelName))
+    if (!isTunnelExists(tunnelName))
     {
         SWSS_LOG_ERROR("Vxlan tunnel '%s' does not exists", tunnelName.c_str());
         return SAI_NULL_OBJECT_ID;
@@ -1225,7 +1204,7 @@ VxlanTunnelOrch::removeNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAd
                     tunnelName.c_str(), ipAddr.to_string().c_str(), 
                     macAddress.to_string().c_str(), vni);
 
-    if(!isTunnelExists(tunnelName))
+    if (!isTunnelExists(tunnelName))
     {
         SWSS_LOG_ERROR("Vxlan tunnel '%s' does not exists", tunnelName.c_str());
         return false;
@@ -1242,7 +1221,7 @@ bool VxlanTunnelOrch::createVxlanTunnelMap(string tunnelName, tunnel_map_type_t 
 {
     SWSS_LOG_ENTER();
 
-    if(!isTunnelExists(tunnelName))
+    if (!isTunnelExists(tunnelName))
     {
         SWSS_LOG_ERROR("Vxlan tunnel '%s' does not exists", tunnelName.c_str());
         return false;
@@ -1292,7 +1271,7 @@ bool VxlanTunnelOrch::removeVxlanTunnelMap(string tunnelName, uint32_t vni)
 {
     SWSS_LOG_ENTER();
 
-    if(!isTunnelExists(tunnelName))
+    if (!isTunnelExists(tunnelName))
     {
         SWSS_LOG_ERROR("Vxlan tunnel '%s' does not exists", tunnelName.c_str());
         return false;
@@ -1330,7 +1309,7 @@ bool VxlanTunnelOrch::removeVxlanTunnelMap(string tunnelName, uint32_t vni)
     // make SAI calls to delete the tunnel and tunnel termination objects.
 
     tunnel_obj->vlan_vrf_vni_count--;
-    if(tunnel_obj->vlan_vrf_vni_count == 0)
+    if (tunnel_obj->vlan_vrf_vni_count == 0)
     {
        auto tunnel_term_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelTermId();
        try
@@ -1364,17 +1343,12 @@ bool VxlanTunnelOrch::addOperation(const Request& request)
     SWSS_LOG_ENTER();
 
     auto src_ip = request.getAttrIP("src_ip");
-    if (!src_ip.isV4())
-    {
-        SWSS_LOG_ERROR("Wrong format of the attribute: 'src_ip'. Currently only IPv4 address is supported");
-        return true;
-    }
 
     IpAddress dst_ip;
     auto attr_names = request.getAttrFieldNames();
     if (attr_names.count("dst_ip") == 0)
     {
-        if(src_ip.isV4()) {
+        if (src_ip.isV4()) {
             dst_ip = IpAddress("0.0.0.0");
         } else {
             dst_ip = IpAddress("::");
@@ -1383,7 +1357,7 @@ bool VxlanTunnelOrch::addOperation(const Request& request)
     else
     {
         dst_ip = request.getAttrIP("dst_ip");
-        if((src_ip.isV4() && !dst_ip.isV4()) ||
+        if ((src_ip.isV4() && !dst_ip.isV4()) ||
                (!src_ip.isV4() && dst_ip.isV4())) {
             SWSS_LOG_ERROR("Format mismatch: 'src_ip' and 'dst_ip' must be of the same family");
             return true;
@@ -1391,7 +1365,7 @@ bool VxlanTunnelOrch::addOperation(const Request& request)
     }
     const auto& tunnel_name = request.getKeyString(0);
 
-    if(isTunnelExists(tunnel_name))
+    if (isTunnelExists(tunnel_name))
     {
         SWSS_LOG_ERROR("Vxlan tunnel '%s' is already exists", tunnel_name.c_str());
         return true;
@@ -1409,14 +1383,14 @@ bool VxlanTunnelOrch::delOperation(const Request& request)
 
     const auto& tunnel_name = request.getKeyString(0);
 
-    if(!isTunnelExists(tunnel_name))
+    if (!isTunnelExists(tunnel_name))
     {
         SWSS_LOG_ERROR("Vxlan tunnel '%s' doesn't exist", tunnel_name.c_str());
         return true;
     }
 
     auto vtep_ptr = getVxlanTunnel(tunnel_name);
-    if(vtep_ptr && vtep_ptr->del_tnl_hw_pending)
+    if (vtep_ptr && vtep_ptr->del_tnl_hw_pending)
     {
       SWSS_LOG_WARN("VTEP %s not deleted as hw delete is pending", tunnel_name.c_str());
       return false;
@@ -1430,7 +1404,7 @@ bool VxlanTunnelOrch::delOperation(const Request& request)
 }
 
 bool  VxlanTunnelOrch::addTunnelUser(const std::string remote_vtep, uint32_t vni_id, 
-                                    uint32_t vlan, tunnel_user_type_e usr,
+                                    uint32_t vlan, tunnel_user_t usr,
                                     sai_object_id_t vrf_id)
 {
     EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
@@ -1439,11 +1413,11 @@ bool  VxlanTunnelOrch::addTunnelUser(const std::string remote_vtep, uint32_t vni
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     Port tunport;
 
-    if(TNL_SRC_MAC == usr) return true;
+    if (TUNNEL_USER_MAC == usr) return true;
 
     auto vtep_ptr = evpn_orch->getEVPNVtep();
 
-    if(!vtep_ptr)
+    if (!vtep_ptr)
     {
       SWSS_LOG_WARN("Unable to find EVPN VTEP. user=%d remote_vtep=%s",
                      usr,remote_vtep.c_str());
@@ -1463,73 +1437,63 @@ bool  VxlanTunnelOrch::addTunnelUser(const std::string remote_vtep, uint32_t vni
     SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
                      remote_vtep.c_str(), vtep_ptr->getDipTunnelRefCnt(remote_vtep));
 
-    if(!tunnel_orch->getTunnelPort(remote_vtep, tunport))
+    if (!tunnel_orch->getTunnelPort(remote_vtep, tunport))
     {
       Port tunnelPort;
-      auto port_tunnel_name = "Port_EVPN_" + remote_vtep;
-      SWSS_LOG_NOTICE("Creating Tunnel Port name = %s", port_tunnel_name.c_str());
+      auto port_tunnel_name = getTunnelPortName(remote_vtep);
       gPortsOrch->addTunnel(port_tunnel_name,dip_tunnel->getTunnelId(), false);
-      SWSS_LOG_NOTICE("Created Tunnel Port name = %s", port_tunnel_name.c_str());
       gPortsOrch->getPort(port_tunnel_name,tunnelPort);
       gPortsOrch->addBridgePort(tunnelPort);
-      SWSS_LOG_NOTICE("Created Tunnel BridgePort name = %s", port_tunnel_name.c_str());
     }
-
-    // TODO : Add Encap Mapper entry for DCI usecase
 
     return true;
 }
 
 bool  VxlanTunnelOrch::delTunnelUser(const std::string remote_vtep, uint32_t vni_id, 
-                                    uint32_t vlan, tunnel_user_type_e usr,
+                                    uint32_t vlan, tunnel_user_t usr,
                                     sai_object_id_t vrf_id)
 {
-    // TODO : Del Encap Mapper entry for DCI usecase
-
-    if(TNL_SRC_MAC == usr) return true;
+    if (TUNNEL_USER_MAC == usr) return true;
 
     // If this is the last request to delete the tunnel.
     auto tunnel_name = "EVPN_" + remote_vtep;
 
-    //if (isTunnelExists(tunnel_name))
+    auto port_tunnel_name = getTunnelPortName(remote_vtep);
+    EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
+
+    auto vtep_ptr = evpn_orch->getEVPNVtep();
+
+    if (!vtep_ptr) 
     {
-        auto port_tunnel_name = "Port_EVPN_" + remote_vtep;
-        EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
-
-        auto vtep_ptr = evpn_orch->getEVPNVtep();
-
-        if(!vtep_ptr) 
-        {
-          SWSS_LOG_WARN("Unable to find VTEP. remote=%s vlan=%d usr=%d",remote_vtep.c_str(), vlan, usr);
-          return true;
-        }
-
-        Port tunnelPort;
-        gPortsOrch->getPort(port_tunnel_name,tunnelPort);
-
-        if((vtep_ptr->getDipTunnelRefCnt(remote_vtep) == 1) &&
-           tunnelPort.m_fdb_count == 0)
-        {
-          bool ret;
-
-          ret = gPortsOrch->removeBridgePort(tunnelPort);
-          if(!ret) 
-          {
-            SWSS_LOG_ERROR("Remove Bridge port failed for remote = %s fdbcount = %d", 
-                            remote_vtep.c_str(), tunnelPort.m_fdb_count);
-            return true;
-          }
-        
-          gPortsOrch->removeTunnel(tunnelPort);
-        }
-
-        vtep_ptr->deleteDynamicDIPTunnel(remote_vtep, usr);
-        SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
-                         remote_vtep.c_str(), vtep_ptr->getDipTunnelRefCnt(remote_vtep));
-
-        vtep_ptr->deletePendingSIPTunnel();
-
+      SWSS_LOG_WARN("Unable to find VTEP. remote=%s vlan=%d usr=%d",
+                                         remote_vtep.c_str(), vlan, usr);
+      return true;
     }
+
+    Port tunnelPort;
+    gPortsOrch->getPort(port_tunnel_name,tunnelPort);
+
+    if ((vtep_ptr->getDipTunnelRefCnt(remote_vtep) == 1) &&
+       tunnelPort.m_fdb_count == 0)
+    {
+      bool ret;
+
+      ret = gPortsOrch->removeBridgePort(tunnelPort);
+      if (!ret) 
+      {
+        SWSS_LOG_ERROR("Remove Bridge port failed for remote = %s fdbcount = %d", 
+                        remote_vtep.c_str(), tunnelPort.m_fdb_count);
+        return true;
+      }
+    
+      gPortsOrch->removeTunnel(tunnelPort);
+    }
+
+    vtep_ptr->deleteDynamicDIPTunnel(remote_vtep, usr);
+    SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
+                     remote_vtep.c_str(), vtep_ptr->getDipTunnelRefCnt(remote_vtep));
+
+    vtep_ptr->deletePendingSIPTunnel();
 
     return true;
 }
@@ -1537,14 +1501,13 @@ bool  VxlanTunnelOrch::delTunnelUser(const std::string remote_vtep, uint32_t vni
 void VxlanTunnelOrch::deleteTunnelPort(Port &tunnelPort)
 {
     bool ret;
-    std::map<const std::string, tunnel_refcnt_t>::iterator it;
     EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
     std::string remote_vtep;
+    int refcnt;
 
     auto vtep_ptr = evpn_orch->getEVPNVtep();
 
-    SWSS_LOG_INFO("Delete Tunnelport Enter");
-    if(!vtep_ptr) 
+    if (!vtep_ptr) 
     {
       SWSS_LOG_WARN("Unable to find VTEP. tunnelPort=%s",tunnelPort.m_alias.c_str());
       return;
@@ -1553,21 +1516,26 @@ void VxlanTunnelOrch::deleteTunnelPort(Port &tunnelPort)
     getTunnelDIPFromPort(tunnelPort, remote_vtep);
 
     //If there are IMR/IP routes to the remote VTEP then ignore this call
-    if(vtep_ptr->getDipTunnelRefCnt(remote_vtep))
-      return;
+    refcnt = vtep_ptr->getDipTunnelRefCnt(remote_vtep);
+    if (refcnt > 0)
+    {
+        SWSS_LOG_INFO("Tunnel bridge port not removed. remote = %s refcnt = %d", 
+                                                        remote_vtep.c_str(), refcnt);
+        return;
+    }
 
     // Remove Bridge port and Port objects for this DIP tunnel
     ret = gPortsOrch->removeBridgePort(tunnelPort);
-    if(!ret) 
+    if (!ret) 
     {
-      SWSS_LOG_ERROR("Remove Bridge port failed for remote = %s fdbcount = %d", 
+        SWSS_LOG_ERROR("Remove Bridge port failed for remote = %s fdbcount = %d", 
                       remote_vtep.c_str(), tunnelPort.m_fdb_count);
-      return;
+        return;
     }
     gPortsOrch->removeTunnel(tunnelPort);
 
     // Remove DIP Tunnel HW 
-    vtep_ptr->deleteDynamicDIPTunnel(remote_vtep, TNL_SRC_IMR, false);
+    vtep_ptr->deleteDynamicDIPTunnel(remote_vtep, TUNNEL_USER_IMR, false);
     SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
                      remote_vtep.c_str(), vtep_ptr->getDipTunnelRefCnt(remote_vtep));
 
@@ -1587,15 +1555,6 @@ void VxlanTunnelOrch::getTunnelName(string& tunnel_portname, string& tunnel_name
    return;
 }
 
-#if 0
-void VxlanTunnelOrch::getTunnelPortname(string& dip, string& tunnel_portname)
-{
-   tunnel_port_name = "Port_EVPN_" + dip;
-
-   return;
-}
-#endif
-
 void VxlanTunnelOrch:: getTunnelDIPFromPort(Port& tunnelPort, string& remote_vtep)
 {
     remote_vtep = tunnelPort.m_alias;
@@ -1609,10 +1568,14 @@ void VxlanTunnelOrch::updateDbTunnelOperStatus(string tunnel_portname,
    std::vector<FieldValueTuple> fvVector;
    std::string tunnel_name;
 
-   if(status == SAI_PORT_OPER_STATUS_UP)
-     fvVector.emplace_back("operstatus", "up");
+   if (status == SAI_PORT_OPER_STATUS_UP)
+   {
+       fvVector.emplace_back("operstatus", "up");
+   }
    else
-     fvVector.emplace_back("operstatus", "down");
+   {
+       fvVector.emplace_back("operstatus", "down");
+   }
 
    getTunnelName(tunnel_portname, tunnel_name);
 
@@ -1625,42 +1588,47 @@ void VxlanTunnelOrch::addRemoveStateTableEntry(string tunnel_name,
 
 {
     std::vector<FieldValueTuple> fvVector, tmpFvVector;
-    //WarmStart::WarmStartState state;
+    WarmStart::WarmStartState state;
 
-    //WarmStart::getWarmStartState("orchagent",state);
+    WarmStart::getWarmStartState("orchagent",state);
 
-    if(add)
+    if (add)
     {
       // Add tunnel entry only for non-warmboot case or WB with new tunnel coming up
       // during WB
-      //if ( (state != WarmStart::INITIALIZED) || 
-      //     !m_stateVxlanTable.get(tunnel_name, tmpFvVector))
-      if(1)
+      if ( (state != WarmStart::INITIALIZED) || 
+           !m_stateVxlanTable.get(tunnel_name, tmpFvVector))
       {
-        fvVector.emplace_back("src_ip", (sip.to_string()).c_str());
-        fvVector.emplace_back("dst_ip", (dip.to_string()).c_str());
-
-        if(src == TNL_CREATION_SRC_CLI)
-          fvVector.emplace_back("tnl_src", "CLI");
-        else 
-          fvVector.emplace_back("tnl_src", "EVPN");
-
-        fvVector.emplace_back("operstatus", "down");
-        m_stateVxlanTable.set(tunnel_name, fvVector);
-        SWSS_LOG_INFO("adding tunnel %s during warmboot", tunnel_name.c_str());
+          fvVector.emplace_back("src_ip", (sip.to_string()).c_str());
+          fvVector.emplace_back("dst_ip", (dip.to_string()).c_str());
+  
+          if (src == TNL_CREATION_SRC_CLI)
+          {
+              fvVector.emplace_back("tnl_src", "CLI");
+          }
+          else 
+          {
+              fvVector.emplace_back("tnl_src", "EVPN");
+          }
+  
+          fvVector.emplace_back("operstatus", "down");
+          m_stateVxlanTable.set(tunnel_name, fvVector);
+          SWSS_LOG_INFO("adding tunnel %s during warmboot", tunnel_name.c_str());
       }
       else
-        SWSS_LOG_NOTICE("Skip adding tunnel %s during warmboot", tunnel_name.c_str());
+      {
+          SWSS_LOG_NOTICE("Skip adding tunnel %s during warmboot", tunnel_name.c_str());
+      }
     }
     else
     {
-      m_stateVxlanTable.del(tunnel_name);
+        m_stateVxlanTable.del(tunnel_name);
     }
 }
 
 bool VxlanTunnelOrch::getTunnelPort(const std::string& remote_vtep,Port& tunnelPort)
 {
-    auto port_tunnel_name = "Port_EVPN_" + remote_vtep;
+    auto port_tunnel_name = getTunnelPortName(remote_vtep);
 
     bool ret = gPortsOrch->getPort(port_tunnel_name,tunnelPort);
 
@@ -1680,7 +1648,7 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
     Port tempPort;
 
     const auto full_tunnel_map_entry_name = request.getFullKey();
-    SWSS_LOG_NOTICE("Full name = %s",full_tunnel_map_entry_name.c_str());
+    SWSS_LOG_INFO("Full name = %s",full_tunnel_map_entry_name.c_str());
 
     if (isTunnelMapExists(full_tunnel_map_entry_name))
     {
@@ -1689,7 +1657,7 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
         return true;
     }
 
-    if(!gPortsOrch->getVlanByVlanId(vlan_id, tempPort))
+    if (!gPortsOrch->getVlanByVlanId(vlan_id, tempPort))
     {
         SWSS_LOG_WARN("Vxlan tunnel map vlan id doesn't exist: %d", vlan_id);
         return false;
@@ -1716,7 +1684,7 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
  
     // The hw delete is pending due to an earlier incomplete operation. 
     // process this add event when the deletion is complete. 
-    if(tunnel_obj->del_tnl_hw_pending)
+    if (tunnel_obj->del_tnl_hw_pending)
     {
       SWSS_LOG_WARN("Tunnel Mapper deletion is pending");
       return false;
@@ -1729,7 +1697,7 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
         uint8_t mapper_list = 0;
         TUNNELMAP_SET_VLAN(mapper_list);
         TUNNELMAP_SET_VRF(mapper_list);
-        tunnel_obj->createTunnelHW(mapper_list,USE_DEDICATED_ENCAP_DECAP);
+        tunnel_obj->createTunnelHw(mapper_list,TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
     }
 
     const auto tunnel_map_id = tunnel_obj->getDecapMapId(TUNNEL_MAP_T_VLAN);
@@ -1781,7 +1749,7 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
     }
 
     auto vlan_id = (sai_vlan_id_t) vxlan_tunnel_map_table_[full_tunnel_map_entry_name].vlan_id;
-    if(!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
+    if (!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
     {
         SWSS_LOG_ERROR("Delete VLAN-VNI map.vlan id doesn't exist: %d", vlan_id);
         return true;
@@ -1817,16 +1785,16 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
     // Update the map count and if this is the last mapping entry 
     // make SAI calls to delete the tunnel and tunnel termination objects.
 
-    if(tunnel_obj->vlan_vrf_vni_count == 0)
+    if (tunnel_obj->vlan_vrf_vni_count == 0)
     {
       // If there are Dynamic DIP Tunnels referring to this SIP Tunnel 
       // then mark it as pending for delete. 
-      if(tunnel_obj->getDipTunnelCnt() == 0)
+      if (tunnel_obj->getDipTunnelCnt() == 0)
       {
          uint8_t mapper_list=0;
          TUNNELMAP_SET_VLAN(mapper_list);
          TUNNELMAP_SET_VRF(mapper_list);
-         tunnel_obj->deleteTunnelHW(mapper_list, USE_DEDICATED_ENCAP_DECAP);
+         tunnel_obj->deleteTunnelHw(mapper_list, TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
       }
       else
       {
@@ -1845,7 +1813,8 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
                                                       map_entries[1].c_str(), 
                                                       map_entries[2].c_str());
         uint32_t vni_id = static_cast<uint32_t>(stoul(map_entries[1]));
-        if (vni_id) {
+        if (vni_id) 
+        {
             tunnel_orch->delVlanMappedToVni(vni_id);
         }
     }
@@ -2010,21 +1979,21 @@ bool EvpnRemoteVniOrch::addOperation(const Request& request)
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     Port tunnelPort, vlanPort;
 
-    if(!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
+    if (!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
     {
         SWSS_LOG_WARN("Vxlan tunnel map vlan id doesn't exist: %d", vlan_id);
         return false;
     }
 
-    if(tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
+    if (tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
     {
         SWSS_LOG_INFO("Vxlan tunnelPort exists: %s", remote_vtep.c_str());
 
-        if(gPortsOrch->isVlanMember(vlanPort, tunnelPort))
+        if (gPortsOrch->isVlanMember(vlanPort, tunnelPort))
         {
            EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
            auto vtep_ptr = evpn_orch->getEVPNVtep();
-           if(!vtep_ptr)
+           if (!vtep_ptr)
            {
              SWSS_LOG_WARN("Remote VNI add: VTEP not found. remote=%s vid=%d",
                            remote_vtep.c_str(),vlan_id);
@@ -2037,9 +2006,9 @@ bool EvpnRemoteVniOrch::addOperation(const Request& request)
         }
     }
 
-    tunnel_orch->addTunnelUser(remote_vtep, vni_id, vlan_id, TNL_SRC_IMR);
+    tunnel_orch->addTunnelUser(remote_vtep, vni_id, vlan_id, TUNNEL_USER_IMR);
 
-    if(!tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
+    if (!tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
     {
       SWSS_LOG_WARN("Vxlan tunnelPort doesn't exist: %s", remote_vtep.c_str());
       return false;
@@ -2059,6 +2028,7 @@ bool EvpnRemoteVniOrch::addOperation(const Request& request)
 bool EvpnRemoteVniOrch::delOperation(const Request& request)
 {
     bool ret;
+
     SWSS_LOG_ENTER();
 
     // Extract DIP and tunnel
@@ -2079,13 +2049,13 @@ bool EvpnRemoteVniOrch::delOperation(const Request& request)
 
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     Port vlanPort, tunnelPort;
-    if(!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
+    if (!gPortsOrch->getVlanByVlanId(vlan_id, vlanPort))
     {
         SWSS_LOG_WARN("Vxlan tunnel map vlan id doesn't exist: %d", vlan_id);
         return true;
     }
 
-    if(!tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
+    if (!tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
     {
         SWSS_LOG_WARN("RemoteVniDel getTunnelPort Fails: %s", remote_vtep.c_str());
         return true;
@@ -2094,22 +2064,14 @@ bool EvpnRemoteVniOrch::delOperation(const Request& request)
     EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
     auto vtep_ptr = evpn_orch->getEVPNVtep();
 
-    if(!vtep_ptr)
-      {
+    if (!vtep_ptr)
+    {
         SWSS_LOG_WARN("Remote VNI del: VTEP not found. remote=%s vid=%d",
                        remote_vtep.c_str(),vlan_id);
         return true;
-      }
+    }
 
-    // If VLAN is not member of the tunnel and 
-    // this is not a vlan which is pending delete
-    // consider it as spurious.
-#if 0
-    SWSS_LOG_NOTICE("ismember=%d vlan_pend_del=%d vlanid=%d",gPortsOrch->isVlanMember(vlanPort, tunnelPort), tunnelPort.m_tunnel_vlan_pending_delete, vlan_id);
-        (vlan_id != tunnelPort.m_tunnel_vlan_pending_delete))
-#endif
-
-    if(!gPortsOrch->isVlanMember(vlanPort, tunnelPort))
+    if (!gPortsOrch->isVlanMember(vlanPort, tunnelPort))
     {
        SWSS_LOG_WARN("marking it as spurious tunnelPort %s not a member of vid %d", 
                       remote_vtep.c_str(), vlan_id);
@@ -2117,20 +2079,20 @@ bool EvpnRemoteVniOrch::delOperation(const Request& request)
        return true;
     }
 
-    if(gPortsOrch->isVlanMember(vlanPort, tunnelPort)) 
+    if (gPortsOrch->isVlanMember(vlanPort, tunnelPort)) 
     {
-       if(!gPortsOrch->removeVlanMember(vlanPort, tunnelPort))
+       if (!gPortsOrch->removeVlanMember(vlanPort, tunnelPort))
        {
           SWSS_LOG_WARN("RemoteVniDel remove vlan member fails: %s",remote_vtep.c_str());
           return true;
        }
     }
 
-    SWSS_LOG_WARN("imrcount=%d fdbcount=%d ",
+    SWSS_LOG_INFO("imrcount=%d fdbcount=%d ",
                    vtep_ptr->getDipTunnelIMRRefCnt(remote_vtep), 
                    tunnelPort.m_fdb_count );
 
-    ret = tunnel_orch->delTunnelUser(remote_vtep, vni_id, vlan_id, TNL_SRC_IMR);
+    ret = tunnel_orch->delTunnelUser(remote_vtep, vni_id, vlan_id, TUNNEL_USER_IMR);
 
     SWSS_LOG_INFO("remote_vtep=%s vni=%d vlanid=%d ",
                    remote_vtep.c_str(), vni_id, vlan_id);
@@ -2150,7 +2112,6 @@ bool EvpnNvoOrch::addOperation(const Request& request)
 
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
 
-    // FIXME: Currently assumes only 1 VTEP
     source_vtep_ptr = tunnel_orch->getVxlanTunnel(vtep_name);
 
     SWSS_LOG_INFO("evpnnvo: %s vtep : %s \n",nvo_name.c_str(), vtep_name.c_str());
@@ -2164,16 +2125,16 @@ bool EvpnNvoOrch::delOperation(const Request& request)
 
     auto nvo_name = request.getKeyString(0);
 
-    if(!source_vtep_ptr) 
+    if (!source_vtep_ptr) 
     {
-       SWSS_LOG_WARN("NVO Delete failed as VTEP Ptr is NULL");
-       return true;
+        SWSS_LOG_WARN("NVO Delete failed as VTEP Ptr is NULL");
+        return true;
     }
 
-    if(source_vtep_ptr->del_tnl_hw_pending)
+    if (source_vtep_ptr->del_tnl_hw_pending)
     {
-      SWSS_LOG_WARN("NVO not deleted as hw delete is pending");
-      return false;
+        SWSS_LOG_WARN("NVO not deleted as hw delete is pending");
+        return false;
     }
 
     source_vtep_ptr = NULL;

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -79,23 +79,23 @@ static inline MAP_T tunnel_map_type (tunnel_map_type_t type, bool isencap)
 {
     if (isencap)
     {
-      switch(type)
-      {
-          case TUNNEL_MAP_T_VLAN : return MAP_T::VLAN_ID_TO_VNI;
-          case TUNNEL_MAP_T_VIRTUAL_ROUTER: return MAP_T::VRID_TO_VNI;
-          case TUNNEL_MAP_T_BRIDGE: return MAP_T::BRIDGE_TO_VNI;
-          default: return MAP_T::MAP_TO_INVALID;
-      }
+        switch(type)
+        {
+            case TUNNEL_MAP_T_VLAN : return MAP_T::VLAN_ID_TO_VNI;
+            case TUNNEL_MAP_T_VIRTUAL_ROUTER: return MAP_T::VRID_TO_VNI;
+            case TUNNEL_MAP_T_BRIDGE: return MAP_T::BRIDGE_TO_VNI;
+            default: return MAP_T::MAP_TO_INVALID;
+        }
     }
     else
     {
-      switch(type)
-      {
-          case TUNNEL_MAP_T_VLAN : return MAP_T::VNI_TO_VLAN_ID;
-          case TUNNEL_MAP_T_VIRTUAL_ROUTER: return MAP_T::VNI_TO_VRID;
-          case TUNNEL_MAP_T_BRIDGE: return MAP_T::VNI_TO_BRIDGE;
-          default: return MAP_T::MAP_TO_INVALID;
-      }
+        switch(type)
+        {
+            case TUNNEL_MAP_T_VLAN : return MAP_T::VNI_TO_VLAN_ID;
+            case TUNNEL_MAP_T_VIRTUAL_ROUTER: return MAP_T::VNI_TO_VRID;
+            case TUNNEL_MAP_T_BRIDGE: return MAP_T::VNI_TO_BRIDGE;
+            default: return MAP_T::MAP_TO_INVALID;
+        }
     }
 }
 
@@ -278,9 +278,9 @@ create_tunnel(
     {
       if (ids->tunnel_decap_id[i] != SAI_NULL_OBJECT_ID)
       {
-        map_list[num_map] = ids->tunnel_decap_id[i];
-        SWSS_LOG_INFO("create_tunnel:maplist[%d]=0x%lx",num_map,map_list[num_map]);
-        num_map++;
+          map_list[num_map] = ids->tunnel_decap_id[i];
+          SWSS_LOG_INFO("create_tunnel:maplist[%d]=0x%lx",num_map,map_list[num_map]);
+          num_map++;
       }
     }
       
@@ -294,12 +294,12 @@ create_tunnel(
 
     for (int i=TUNNEL_MAP_T_VLAN;i<TUNNEL_MAP_T_MAX_MAPPER;i++)
     {
-      if (ids->tunnel_encap_id[i] != SAI_NULL_OBJECT_ID)
-      {
-        emap_list[num_emap] = ids->tunnel_encap_id[i];
-        SWSS_LOG_NOTICE("create_tunnel:encapmaplist[%d]=0x%lx",num_emap,emap_list[num_emap]);
-        num_emap++;
-      }
+        if (ids->tunnel_encap_id[i] != SAI_NULL_OBJECT_ID)
+        {
+            emap_list[num_emap] = ids->tunnel_encap_id[i];
+            SWSS_LOG_NOTICE("create_tunnel:encapmaplist[%d]=0x%lx",num_emap,emap_list[num_emap]);
+            num_emap++;
+        }
     }
 
     attr.id = SAI_TUNNEL_ATTR_ENCAP_MAPPERS;
@@ -840,13 +840,13 @@ bool VxlanTunnel::deleteTunnelHw(uint8_t mapper_list, tunnel_map_use_t map_src,
 {
     try
     {
-      if (with_term)
-      {
-          remove_tunnel_termination(ids_.tunnel_term_id);
-      }
-
-      remove_tunnel_termination(ids_.tunnel_id);
-      deleteMapperHw(mapper_list, map_src);
+        if (with_term)
+        {
+            remove_tunnel_termination(ids_.tunnel_term_id);
+        }
+  
+        remove_tunnel_termination(ids_.tunnel_id);
+        deleteMapperHw(mapper_list, map_src);
     }
 
     catch (const std::runtime_error& error)
@@ -934,12 +934,14 @@ void VxlanTunnel::increment_spurious_imr_add(const std::string remote_vtep)
 
     auto it = tnl_users_.find(remote_vtep); 
     if (it == tnl_users_.end())
-      return ; 
+    {
+        return ; 
+    }
     else
     {
-      tnl_refcnts = it->second;
-      tnl_refcnts.spurious_add_imr_refcnt++;
-      tnl_users_[remote_vtep] = tnl_refcnts;
+        tnl_refcnts = it->second;
+        tnl_refcnts.spurious_add_imr_refcnt++;
+        tnl_users_[remote_vtep] = tnl_refcnts;
     }
 }
 
@@ -949,12 +951,14 @@ void VxlanTunnel::increment_spurious_imr_del(const std::string remote_vtep)
 
     auto it = tnl_users_.find(remote_vtep); 
     if (it == tnl_users_.end())
-      return ; 
+    {
+        return ; 
+    }
     else
     {
-      tnl_refcnts = it->second;
-      tnl_refcnts.spurious_del_imr_refcnt++;
-      tnl_users_[remote_vtep] = tnl_refcnts;
+        tnl_refcnts = it->second;
+        tnl_refcnts.spurious_del_imr_refcnt++;
+        tnl_users_[remote_vtep] = tnl_refcnts;
     }
 }
 
@@ -964,11 +968,13 @@ int VxlanTunnel::getDipTunnelRefCnt(const std::string remote_vtep)
 
     auto it = tnl_users_.find(remote_vtep); 
     if (it == tnl_users_.end())
-      return -1; 
+    {
+        return -1; 
+    }
     else
     {
-      tnl_refcnts = it->second;
-      return (tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt);
+        tnl_refcnts = it->second;
+        return (tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt);
     }
 }
 
@@ -978,11 +984,13 @@ int VxlanTunnel::getDipTunnelIMRRefCnt(const std::string remote_vtep)
 
     auto it = tnl_users_.find(remote_vtep); 
     if (it == tnl_users_.end())
-      return -1; 
+    {
+        return -1; 
+    }
     else
     {
-      tnl_refcnts = it->second;
-      return (tnl_refcnts.imr_refcnt);
+        tnl_refcnts = it->second;
+        return (tnl_refcnts.imr_refcnt);
     }
 }
 
@@ -992,63 +1000,61 @@ int VxlanTunnel::getDipTunnelIPRefCnt(const std::string remote_vtep)
 
     auto it = tnl_users_.find(remote_vtep);
     if (it == tnl_users_.end())
-      return -1;
+    {
+        return -1;
+    }
     else
     {
-      tnl_refcnts = it->second;
-      return (tnl_refcnts.ip_refcnt);
+        tnl_refcnts = it->second;
+        return (tnl_refcnts.ip_refcnt);
     }
 }
 
 void VxlanTunnel::updateDipTunnelRefCnt(bool inc, tunnel_refcnt_t& tnl_refcnts, 
                                         tunnel_user_t usr)
 {
-     switch(usr)
-     {
-       case TUNNEL_USER_IMR: 
-       {
-         if (inc)
-             tnl_refcnts.imr_refcnt++;
-         else
-             tnl_refcnts.imr_refcnt--;
-
-         break;
-       }
-       case TUNNEL_USER_MAC: 
-       {
-         if (inc)
-             tnl_refcnts.mac_refcnt++;
-         else
-             tnl_refcnts.mac_refcnt--;
-
-         break;
-       }
-       case TUNNEL_USER_IP: 
-       {
-         if (inc)
-             tnl_refcnts.ip_refcnt++;
-         else
-             tnl_refcnts.ip_refcnt--;
-
-         break;
-       }
-       default : break;
-     }
-}
-
-VxlanTunnel* VxlanTunnel::getDipTunnel(const std::string dip)
-{
-    tunnel_refcnt_t tnl_refcnts;
-
-    auto it = tnl_users_.find(dip); 
-    if (it == tnl_users_.end())
+    switch(usr)
     {
-        return NULL; 
-    }
-    else
-    {
-        tnl_refcnts = it->second;
-        return(tnl_refcnts.dip_tunnel);
+        case TUNNEL_USER_IMR: 
+        {
+            if (inc)
+            {
+                tnl_refcnts.imr_refcnt++;
+            }
+            else
+            {
+                tnl_refcnts.imr_refcnt--;
+            }
+    
+            break;
+        }
+        case TUNNEL_USER_MAC: 
+        {
+            if (inc)
+            {
+                tnl_refcnts.mac_refcnt++;
+            }
+            else
+            {
+                tnl_refcnts.mac_refcnt--;
+            }
+    
+            break;
+        }
+        case TUNNEL_USER_IP: 
+        {
+            if (inc)
+            {
+                tnl_refcnts.ip_refcnt++;
+            }
+            else
+            {
+                tnl_refcnts.ip_refcnt--;
+            }
+    
+            break;
+        }
+        default : break;
     }
 }
 
@@ -1058,18 +1064,18 @@ bool VxlanTunnel::createDynamicDIPTunnel(const std::string dip, tunnel_user_t us
     tunnel_refcnt_t tnl_refcnts;
     VxlanTunnel* dip_tunnel=NULL;
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
+    string tunnel_name;
 
     auto it = tnl_users_.find(dip); 
     if (it == tnl_users_.end())
     {
-        const string tunnel_name = "EVPN_"+dip;
+        tunnel_orch->getTunnelNameFromDIP(dip, tunnel_name);
         auto dipaddr = IpAddress(dip);
         dip_tunnel = (new VxlanTunnel(tunnel_name, src_ip_, dipaddr, TNL_CREATION_SRC_EVPN));
         tunnel_orch->addTunnel(tunnel_name,dip_tunnel);
 
         memset(&tnl_refcnts,0,sizeof(tunnel_refcnt_t));
         updateDipTunnelRefCnt(true,tnl_refcnts,usr);
-        tnl_refcnts.dip_tunnel = dip_tunnel;
         tnl_users_[dip] = tnl_refcnts;
 
         TUNNELMAP_SET_VLAN(mapper_list);
@@ -1095,47 +1101,50 @@ bool VxlanTunnel::deleteDynamicDIPTunnel(const std::string dip, tunnel_user_t us
     VxlanTunnel* dip_tunnel = NULL;
     VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     Port tunnelPort;
+    std::string tunnel_name;
 
     auto it = tnl_users_.find(dip); 
     if (it != tnl_users_.end())
     {
-       tnl_refcnts = it->second;
-
-       if (update_refcnt)
-       {
-         updateDipTunnelRefCnt(false,tnl_refcnts,usr);
-         tnl_users_[dip] = tnl_refcnts;
-       }
-
-       SWSS_LOG_INFO("diprefcnt = %d",
-                     tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt);
-       
-       if (tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt)
-         return true;
-
-       if (tunnel_orch->getTunnelPort(dip, tunnelPort))
-       {
-         SWSS_LOG_NOTICE("DIP = %s Not deleting tunnel from HW as tunnelPort is not yet deleted. fdbcount = %d",
-                          dip.c_str(),tunnelPort.m_fdb_count);
-         return true;
-       }
-
-       dip_tunnel = tnl_refcnts.dip_tunnel;
-       if (!dip_tunnel)
-       {
-         SWSS_LOG_INFO("DIP Tunnel is NULL unexpected");
-         return false;
-       }
-
-       TUNNELMAP_SET_VLAN(mapper_list);
-       TUNNELMAP_SET_VRF(mapper_list);
-       dip_tunnel->deleteTunnelHw(mapper_list,TUNNEL_MAP_USE_COMMON_ENCAP_DECAP, false);
-
-       tnl_users_.erase(dip);
-
-       const string tunnel_name = "EVPN_"+dip;
-       tunnel_orch->delTunnel(tunnel_name);
-       SWSS_LOG_NOTICE("P2P Tunnel deleted : %s", tunnel_name.c_str());
+        tnl_refcnts = it->second;
+ 
+        if (update_refcnt)
+        {
+            updateDipTunnelRefCnt(false,tnl_refcnts,usr);
+            tnl_users_[dip] = tnl_refcnts;
+        }
+ 
+        SWSS_LOG_INFO("diprefcnt = %d",
+                      tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt);
+        
+        if (tnl_refcnts.imr_refcnt + tnl_refcnts.mac_refcnt + tnl_refcnts.ip_refcnt)
+        {
+            return true;
+        }
+ 
+        if (tunnel_orch->getTunnelPort(dip, tunnelPort))
+        {
+            SWSS_LOG_NOTICE("DIP = %s Not deleting tunnel from HW as tunnelPort is not yet deleted. fdbcount = %d",
+                           dip.c_str(),tunnelPort.m_fdb_count);
+            return true;
+        }
+ 
+        tunnel_orch->getTunnelNameFromDIP(dip, tunnel_name);
+        dip_tunnel = tunnel_orch->getVxlanTunnel(tunnel_name);
+        if (!dip_tunnel)
+        {
+            SWSS_LOG_INFO("DIP Tunnel is NULL unexpected");
+            return false;
+        }
+ 
+        TUNNELMAP_SET_VLAN(mapper_list);
+        TUNNELMAP_SET_VRF(mapper_list);
+        dip_tunnel->deleteTunnelHw(mapper_list,TUNNEL_MAP_USE_COMMON_ENCAP_DECAP, false);
+ 
+        tnl_users_.erase(dip);
+ 
+        tunnel_orch->delTunnel(tunnel_name);
+        SWSS_LOG_NOTICE("P2P Tunnel deleted : %s", tunnel_name.c_str());
     }
     else 
     {
@@ -1311,27 +1320,27 @@ bool VxlanTunnelOrch::removeVxlanTunnelMap(string tunnelName, uint32_t vni)
     tunnel_obj->vlan_vrf_vni_count--;
     if (tunnel_obj->vlan_vrf_vni_count == 0)
     {
-       auto tunnel_term_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelTermId();
-       try
-       {
-           remove_tunnel_termination(tunnel_term_id);
-       }
-       catch(const std::runtime_error& error)
-       {
-           SWSS_LOG_ERROR("Error removing tunnel term entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
-           return false;
-       }
-
-       auto tunnel_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelId();
-       try
-       {
-           remove_tunnel(tunnel_id);
-       }
-       catch(const std::runtime_error& error)
-       {
-           SWSS_LOG_ERROR("Error removing tunnel entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
-           return false;
-       }
+        auto tunnel_term_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelTermId();
+        try
+        {
+            remove_tunnel_termination(tunnel_term_id);
+        }
+        catch(const std::runtime_error& error)
+        {
+            SWSS_LOG_ERROR("Error removing tunnel term entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
+            return false;
+        }
+ 
+        auto tunnel_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelId();
+        try
+        {
+            remove_tunnel(tunnel_id);
+        }
+        catch(const std::runtime_error& error)
+        {
+            SWSS_LOG_ERROR("Error removing tunnel entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
+            return false;
+        }
     }
 
     SWSS_LOG_NOTICE("Vxlan map entry deleted for tunnel '%s' with vni '%d'", tunnelName.c_str(), vni);
@@ -1392,8 +1401,8 @@ bool VxlanTunnelOrch::delOperation(const Request& request)
     auto vtep_ptr = getVxlanTunnel(tunnel_name);
     if (vtep_ptr && vtep_ptr->del_tnl_hw_pending)
     {
-      SWSS_LOG_WARN("VTEP %s not deleted as hw delete is pending", tunnel_name.c_str());
-      return false;
+        SWSS_LOG_WARN("VTEP %s not deleted as hw delete is pending", tunnel_name.c_str());
+        return false;
     }
 
     vxlan_tunnel_table_.erase(tunnel_name);
@@ -1409,9 +1418,8 @@ bool  VxlanTunnelOrch::addTunnelUser(const std::string remote_vtep, uint32_t vni
 {
     EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
     VxlanTunnel* dip_tunnel=NULL;
-
-    VxlanTunnelOrch* tunnel_orch = gDirectory.get<VxlanTunnelOrch*>();
     Port tunport;
+    string tunnel_name;
 
     if (TUNNEL_USER_MAC == usr) return true;
 
@@ -1419,31 +1427,33 @@ bool  VxlanTunnelOrch::addTunnelUser(const std::string remote_vtep, uint32_t vni
 
     if (!vtep_ptr)
     {
-      SWSS_LOG_WARN("Unable to find EVPN VTEP. user=%d remote_vtep=%s",
+        SWSS_LOG_WARN("Unable to find EVPN VTEP. user=%d remote_vtep=%s",
                      usr,remote_vtep.c_str());
-      return false;
+        return false;
     }
 
     if (!vtep_ptr->isActive())
     {
-      SWSS_LOG_WARN("VTEP not yet active.user=%d remote_vtep=%s",
+        SWSS_LOG_WARN("VTEP not yet active.user=%d remote_vtep=%s",
                       usr,remote_vtep.c_str()); 
-      return false;
+        return false;
     }
 
     vtep_ptr->createDynamicDIPTunnel(remote_vtep, usr);
-    dip_tunnel = vtep_ptr->getDipTunnel(remote_vtep);
+
+    getTunnelNameFromDIP(remote_vtep, tunnel_name);
+    dip_tunnel = getVxlanTunnel(tunnel_name);
 
     SWSS_LOG_NOTICE("diprefcnt for remote %s = %d",
                      remote_vtep.c_str(), vtep_ptr->getDipTunnelRefCnt(remote_vtep));
 
-    if (!tunnel_orch->getTunnelPort(remote_vtep, tunport))
+    if (!getTunnelPort(remote_vtep, tunport))
     {
-      Port tunnelPort;
-      auto port_tunnel_name = getTunnelPortName(remote_vtep);
-      gPortsOrch->addTunnel(port_tunnel_name,dip_tunnel->getTunnelId(), false);
-      gPortsOrch->getPort(port_tunnel_name,tunnelPort);
-      gPortsOrch->addBridgePort(tunnelPort);
+        Port tunnelPort;
+        auto port_tunnel_name = getTunnelPortName(remote_vtep);
+        gPortsOrch->addTunnel(port_tunnel_name,dip_tunnel->getTunnelId(), false);
+        gPortsOrch->getPort(port_tunnel_name,tunnelPort);
+        gPortsOrch->addBridgePort(tunnelPort);
     }
 
     return true;
@@ -1455,9 +1465,6 @@ bool  VxlanTunnelOrch::delTunnelUser(const std::string remote_vtep, uint32_t vni
 {
     if (TUNNEL_USER_MAC == usr) return true;
 
-    // If this is the last request to delete the tunnel.
-    auto tunnel_name = "EVPN_" + remote_vtep;
-
     auto port_tunnel_name = getTunnelPortName(remote_vtep);
     EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
 
@@ -1465,9 +1472,9 @@ bool  VxlanTunnelOrch::delTunnelUser(const std::string remote_vtep, uint32_t vni
 
     if (!vtep_ptr) 
     {
-      SWSS_LOG_WARN("Unable to find VTEP. remote=%s vlan=%d usr=%d",
+        SWSS_LOG_WARN("Unable to find VTEP. remote=%s vlan=%d usr=%d",
                                          remote_vtep.c_str(), vlan, usr);
-      return true;
+        return true;
     }
 
     Port tunnelPort;
@@ -1476,17 +1483,17 @@ bool  VxlanTunnelOrch::delTunnelUser(const std::string remote_vtep, uint32_t vni
     if ((vtep_ptr->getDipTunnelRefCnt(remote_vtep) == 1) &&
        tunnelPort.m_fdb_count == 0)
     {
-      bool ret;
+        bool ret;
 
-      ret = gPortsOrch->removeBridgePort(tunnelPort);
-      if (!ret) 
-      {
-        SWSS_LOG_ERROR("Remove Bridge port failed for remote = %s fdbcount = %d", 
+        ret = gPortsOrch->removeBridgePort(tunnelPort);
+        if (!ret) 
+        {
+            SWSS_LOG_ERROR("Remove Bridge port failed for remote = %s fdbcount = %d", 
                         remote_vtep.c_str(), tunnelPort.m_fdb_count);
-        return true;
-      }
+            return true;
+        }
     
-      gPortsOrch->removeTunnel(tunnelPort);
+        gPortsOrch->removeTunnel(tunnelPort);
     }
 
     vtep_ptr->deleteDynamicDIPTunnel(remote_vtep, usr);
@@ -1509,8 +1516,8 @@ void VxlanTunnelOrch::deleteTunnelPort(Port &tunnelPort)
 
     if (!vtep_ptr) 
     {
-      SWSS_LOG_WARN("Unable to find VTEP. tunnelPort=%s",tunnelPort.m_alias.c_str());
-      return;
+        SWSS_LOG_WARN("Unable to find VTEP. tunnelPort=%s",tunnelPort.m_alias.c_str());
+        return;
     }
 
     getTunnelDIPFromPort(tunnelPort, remote_vtep);
@@ -1545,14 +1552,26 @@ void VxlanTunnelOrch::deleteTunnelPort(Port &tunnelPort)
     return ;
 }
 
-void VxlanTunnelOrch::getTunnelName(string& tunnel_portname, string& tunnel_name)
+std::string VxlanTunnelOrch::getTunnelPortName(const std::string& remote_vtep)
 {
-   tunnel_name = tunnel_portname;
-   tunnel_name.erase(0, sizeof("Port_")-1);
+    std::string tunnelPortName = "Port_EVPN_" + remote_vtep;
+    return tunnelPortName;
+}
 
-   SWSS_LOG_DEBUG("tunnel name = %s",tunnel_name.c_str());
+void VxlanTunnelOrch::getTunnelNameFromDIP(const string& dip, string& tunnel_name)
+{
+    tunnel_name = "EVPN_" + dip;
+    return;
+}
 
-   return;
+void VxlanTunnelOrch::getTunnelNameFromPort(string& tunnel_portname, string& tunnel_name)
+{
+    tunnel_name = tunnel_portname;
+    tunnel_name.erase(0, sizeof("Port_")-1);
+ 
+    SWSS_LOG_DEBUG("tunnel name = %s",tunnel_name.c_str());
+ 
+    return;
 }
 
 void VxlanTunnelOrch:: getTunnelDIPFromPort(Port& tunnelPort, string& remote_vtep)
@@ -1565,21 +1584,21 @@ void VxlanTunnelOrch:: getTunnelDIPFromPort(Port& tunnelPort, string& remote_vte
 void VxlanTunnelOrch::updateDbTunnelOperStatus(string tunnel_portname, 
                                                sai_port_oper_status_t status)
 {
-   std::vector<FieldValueTuple> fvVector;
-   std::string tunnel_name;
-
-   if (status == SAI_PORT_OPER_STATUS_UP)
-   {
-       fvVector.emplace_back("operstatus", "up");
-   }
-   else
-   {
-       fvVector.emplace_back("operstatus", "down");
-   }
-
-   getTunnelName(tunnel_portname, tunnel_name);
-
-   m_stateVxlanTable.set(tunnel_name, fvVector);
+    std::vector<FieldValueTuple> fvVector;
+    std::string tunnel_name;
+ 
+    if (status == SAI_PORT_OPER_STATUS_UP)
+    {
+        fvVector.emplace_back("operstatus", "up");
+    }
+    else
+    {
+        fvVector.emplace_back("operstatus", "down");
+    }
+ 
+    getTunnelNameFromPort(tunnel_portname, tunnel_name);
+ 
+    m_stateVxlanTable.set(tunnel_name, fvVector);
 }
 
 void VxlanTunnelOrch::addRemoveStateTableEntry(string tunnel_name, 
@@ -1686,8 +1705,8 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
     // process this add event when the deletion is complete. 
     if (tunnel_obj->del_tnl_hw_pending)
     {
-      SWSS_LOG_WARN("Tunnel Mapper deletion is pending");
-      return false;
+        SWSS_LOG_WARN("Tunnel Mapper deletion is pending");
+        return false;
     }
 
     if (!tunnel_obj->isActive())
@@ -1710,12 +1729,9 @@ bool VxlanTunnelMapOrch::addOperation(const Request& request)
     {
         auto tunnel_map_entry_id = create_tunnel_map_entry(MAP_T::VNI_TO_VLAN_ID,
                                                            tunnel_map_id, vni_id, vlan_id);
-        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].map_entry_id = 
-                                                             tunnel_map_entry_id;
-        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].vlan_id = 
-                                                             vlan_id;
-        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].vni_id = 
-                                                             vni_id;
+        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].map_entry_id = tunnel_map_entry_id;
+        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].vlan_id = vlan_id;
+        vxlan_tunnel_map_table_[full_tunnel_map_entry_name].vni_id = vni_id;
     }
     catch(const std::runtime_error& error)
     {
@@ -1755,7 +1771,7 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
         return true;
     }
 
-    vlanPort.m_vnid = (uint32_t) 0xFFFFFFFF;
+    vlanPort.m_vnid = (uint32_t) VNID_NONE;
 
     auto tunnel_map_entry_id = vxlan_tunnel_map_table_[full_tunnel_map_entry_name].map_entry_id;
     try
@@ -1791,15 +1807,15 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
       // then mark it as pending for delete. 
       if (tunnel_obj->getDipTunnelCnt() == 0)
       {
-         uint8_t mapper_list=0;
-         TUNNELMAP_SET_VLAN(mapper_list);
-         TUNNELMAP_SET_VRF(mapper_list);
-         tunnel_obj->deleteTunnelHw(mapper_list, TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
+          uint8_t mapper_list=0;
+          TUNNELMAP_SET_VLAN(mapper_list);
+          TUNNELMAP_SET_VRF(mapper_list);
+          tunnel_obj->deleteTunnelHw(mapper_list, TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
       }
       else
       {
-        tunnel_obj->del_tnl_hw_pending = true;
-        SWSS_LOG_WARN("Postponing the SIP Tunnel HW deletion DIP Tunnel count = %d",
+          tunnel_obj->del_tnl_hw_pending = true;
+          SWSS_LOG_WARN("Postponing the SIP Tunnel HW deletion DIP Tunnel count = %d",
                       tunnel_obj->getDipTunnelCnt());
       }
     }
@@ -1862,7 +1878,8 @@ bool VxlanVrfMapOrch::addOperation(const Request& request)
             full_map_entry_name.c_str(), vrf_name.c_str(), vni_id);
     if (vrf_orch->isVRFexists(vrf_name))
     {
-        if (!tunnel_obj->isActive()) {
+        if (!tunnel_obj->isActive()) 
+        {
             tunnel_obj->createTunnel(MAP_T::VRID_TO_VNI, MAP_T::VNI_TO_VRID);
         }
         vrf_id = vrf_orch->getVRFid(vrf_name);
@@ -1915,7 +1932,8 @@ bool VxlanVrfMapOrch::delOperation(const Request& request)
     }
 
     size_t pos = full_map_entry_name.find("Vrf");
-    if (pos == string::npos) {
+    if (pos == string::npos) 
+    {
         SWSS_LOG_ERROR("VxlanVrfMapOrch no VRF in Vxlan map '%s'", full_map_entry_name.c_str());
         return false;
     }
@@ -1967,7 +1985,6 @@ bool EvpnRemoteVniOrch::addOperation(const Request& request)
     // Extract VLAN and VNI
     auto vlan_name = request.getKeyString(0);
     sai_vlan_id_t vlan_id = (sai_vlan_id_t) stoi(vlan_name.substr(4));
-    //sai_vlan_id_t vlan_id = (sai_vlan_id_t)request.getAttrVlan("vlan");
 
     auto vni_id  = static_cast<sai_uint32_t>(request.getAttrUint("vni"));
     if (vni_id >= 1<<24)
@@ -1991,18 +2008,18 @@ bool EvpnRemoteVniOrch::addOperation(const Request& request)
 
         if (gPortsOrch->isVlanMember(vlanPort, tunnelPort))
         {
-           EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
-           auto vtep_ptr = evpn_orch->getEVPNVtep();
-           if (!vtep_ptr)
-           {
-             SWSS_LOG_WARN("Remote VNI add: VTEP not found. remote=%s vid=%d",
-                           remote_vtep.c_str(),vlan_id);
-             return true;
-           }
-           SWSS_LOG_WARN("tunnelPort %s already member of vid %d", 
-                           remote_vtep.c_str(),vlan_id);
-           vtep_ptr->increment_spurious_imr_add(remote_vtep);
-           return true;
+            EvpnNvoOrch* evpn_orch = gDirectory.get<EvpnNvoOrch*>();
+            auto vtep_ptr = evpn_orch->getEVPNVtep();
+            if (!vtep_ptr)
+            {
+                SWSS_LOG_WARN("Remote VNI add: VTEP not found. remote=%s vid=%d",
+                              remote_vtep.c_str(),vlan_id);
+                return true;
+            }
+            SWSS_LOG_WARN("tunnelPort %s already member of vid %d", 
+                            remote_vtep.c_str(),vlan_id);
+            vtep_ptr->increment_spurious_imr_add(remote_vtep);
+            return true;
         }
     }
 
@@ -2010,8 +2027,8 @@ bool EvpnRemoteVniOrch::addOperation(const Request& request)
 
     if (!tunnel_orch->getTunnelPort(remote_vtep,tunnelPort))
     {
-      SWSS_LOG_WARN("Vxlan tunnelPort doesn't exist: %s", remote_vtep.c_str());
-      return false;
+        SWSS_LOG_WARN("Vxlan tunnelPort doesn't exist: %s", remote_vtep.c_str());
+        return false;
     }
 
     // SAI Call to add tunnel to the VLAN flood domain
@@ -2073,19 +2090,19 @@ bool EvpnRemoteVniOrch::delOperation(const Request& request)
 
     if (!gPortsOrch->isVlanMember(vlanPort, tunnelPort))
     {
-       SWSS_LOG_WARN("marking it as spurious tunnelPort %s not a member of vid %d", 
-                      remote_vtep.c_str(), vlan_id);
-       vtep_ptr->increment_spurious_imr_del(remote_vtep);
-       return true;
+        SWSS_LOG_WARN("marking it as spurious tunnelPort %s not a member of vid %d", 
+                       remote_vtep.c_str(), vlan_id);
+        vtep_ptr->increment_spurious_imr_del(remote_vtep);
+        return true;
     }
 
     if (gPortsOrch->isVlanMember(vlanPort, tunnelPort)) 
     {
-       if (!gPortsOrch->removeVlanMember(vlanPort, tunnelPort))
-       {
-          SWSS_LOG_WARN("RemoteVniDel remove vlan member fails: %s",remote_vtep.c_str());
-          return true;
-       }
+        if (!gPortsOrch->removeVlanMember(vlanPort, tunnelPort))
+        {
+            SWSS_LOG_WARN("RemoteVniDel remove vlan member fails: %s",remote_vtep.c_str());
+            return true;
+        }
     }
 
     SWSS_LOG_INFO("imrcount=%d fdbcount=%d ",

--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1839,9 +1839,13 @@ bool VxlanVrfMapOrch::addOperation(const Request& request)
     string vrf_name = request.getAttrString("vrf");
     VRFOrch* vrf_orch = gDirectory.get<VRFOrch*>();
 
+    SWSS_LOG_NOTICE("VRF VNI mapping '%s' update vrf %s, vni %d",
+            full_map_entry_name.c_str(), vrf_name.c_str(), vni_id);
     if (vrf_orch->isVRFexists(vrf_name))
     {
-        tunnel_obj->createTunnel(MAP_T::VRID_TO_VNI, MAP_T::VNI_TO_VRID);
+        if (!tunnel_obj->isActive()) {
+            tunnel_obj->createTunnel(MAP_T::VRID_TO_VNI, MAP_T::VNI_TO_VRID);
+        }
         vrf_id = vrf_orch->getVRFid(vrf_name);
     }
     else
@@ -1882,8 +1886,55 @@ bool VxlanVrfMapOrch::delOperation(const Request& request)
 {
     SWSS_LOG_ENTER();
 
-    SWSS_LOG_ERROR("DEL operation is not implemented");
+    VRFOrch* vrf_orch = gDirectory.get<VRFOrch*>();
+    const auto full_map_entry_name = request.getFullKey();
 
+    if (!isVrfMapExists(full_map_entry_name))
+    {
+        SWSS_LOG_ERROR("VxlanVrfMapOrch Vxlan map '%s' do not exist", full_map_entry_name.c_str());
+        return false;
+    }
+
+    size_t pos = full_map_entry_name.find("Vrf");
+    if (pos == string::npos) {
+        SWSS_LOG_ERROR("VxlanVrfMapOrch no VRF in Vxlan map '%s'", full_map_entry_name.c_str());
+        return false;
+    }
+    string vrf_name = full_map_entry_name.substr(pos);
+
+    if (!vrf_orch->isVRFexists(vrf_name))
+    {
+        SWSS_LOG_ERROR("VxlanVrfMapOrch VRF '%s' not present", vrf_name.c_str());
+        return false;
+    }
+    SWSS_LOG_NOTICE("VxlanVrfMapOrch VRF VNI mapping '%s' remove vrf %s", full_map_entry_name.c_str(), vrf_name.c_str());
+    vrf_map_entry_t entry;
+    try
+    {
+        /*
+         * Remove encap and decap mapper
+         */
+        entry = vxlan_vrf_table_[full_map_entry_name];
+
+        SWSS_LOG_NOTICE("VxlanVrfMapOrch Vxlan tunnel VRF encap entry '%lx' decap entry '0x%lx'",
+                entry.encap_id, entry.decap_id);
+
+        remove_tunnel_map_entry(entry.encap_id);
+        vrf_orch->decreaseVrfRefCount(vrf_name);
+        remove_tunnel_map_entry(entry.decap_id);
+        vrf_orch->decreaseVrfRefCount(vrf_name);
+        vxlan_vrf_table_.erase(full_map_entry_name);
+        vxlan_vrf_tunnel_.erase(vrf_name);
+    }
+    catch(const std::runtime_error& error)
+    {
+        SWSS_LOG_ERROR("VxlanVrfMapOrch Error removing tunnel map entry. Entry: %s. Error: %s",
+            full_map_entry_name.c_str(), error.what());
+        return false;
+    }
+
+    SWSS_LOG_NOTICE("VxlanVrfMapOrch Vxlan vrf map entry '%s' is removed. VRF Refcnt %d", full_map_entry_name.c_str(),
+            vrf_orch->getVrfRefCount(vrf_name));
     return true;
 }
 

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -37,17 +37,17 @@ typedef enum
 
 typedef enum
 {
-  TNL_CREATION_SRC_CLI,
-  TNL_CREATION_SRC_EVPN
+    TNL_CREATION_SRC_CLI,
+    TNL_CREATION_SRC_EVPN
 } tunnel_creation_src_t;
 
 typedef enum
 {
-   USE_COMMON_ENCAP_DECAP,
-   USE_COMMON_DECAP_DEDICATED_ENCAP,
-   USE_DECAP_ONLY,
-   USE_DEDICATED_ENCAP_DECAP
-} tunnel_map_src_t;
+    TUNNEL_MAP_USE_COMMON_ENCAP_DECAP,
+    TUNNEL_MAP_USE_COMMON_DECAP_DEDICATED_ENCAP,
+    TUNNEL_MAP_USE_DECAP_ONLY,
+    TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP
+} tunnel_map_use_t;
 
 struct tunnel_ids_t
 {
@@ -99,10 +99,10 @@ struct nh_tunnel_t
 };
 
 typedef enum {
-  TNL_SRC_IMR,
-  TNL_SRC_MAC,
-  TNL_SRC_IP
-} tunnel_user_type_e;
+    TUNNEL_USER_IMR,
+    TUNNEL_USER_MAC,
+    TUNNEL_USER_IP
+} tunnel_user_t;
 
 class VxlanTunnel;
 
@@ -180,14 +180,14 @@ public:
     void incNextHopRefCount(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni);
     void decNextHopRefCount(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni);
 
-    bool deleteMapperHW(uint8_t mapper_list, tunnel_map_src_t map_src);
-    bool createMapperHW(uint8_t mapper_list, tunnel_map_src_t map_src);
-    bool createTunnelHW(uint8_t mapper_list, tunnel_map_src_t map_src, bool with_term = true);
-    bool deleteTunnelHW(uint8_t mapper_list, tunnel_map_src_t map_src, bool with_term = true);
+    bool deleteMapperHw(uint8_t mapper_list, tunnel_map_use_t map_src);
+    bool createMapperHw(uint8_t mapper_list, tunnel_map_use_t map_src);
+    bool createTunnelHw(uint8_t mapper_list, tunnel_map_use_t map_src, bool with_term = true);
+    bool deleteTunnelHw(uint8_t mapper_list, tunnel_map_use_t map_src, bool with_term = true);
     void deletePendingSIPTunnel();
     void increment_spurious_imr_add(const std::string remote_vtep);
     void increment_spurious_imr_del(const std::string remote_vtep);
-    void updateDipTunnelRefCnt(bool , tunnel_refcnt_t& , tunnel_user_type_e );
+    void updateDipTunnelRefCnt(bool , tunnel_refcnt_t& , tunnel_user_t );
     // Total Routes using the DIP tunnel. 
     int getDipTunnelRefCnt(const std::string);
     int getDipTunnelIMRRefCnt(const std::string);
@@ -195,8 +195,8 @@ public:
     // Total DIP tunnels associated with this SIP tunnel.
     int getDipTunnelCnt();
     VxlanTunnel* getDipTunnel(const std::string dip);
-    bool createDynamicDIPTunnel(const string dip, tunnel_user_type_e usr);
-    bool deleteDynamicDIPTunnel(const string dip, tunnel_user_type_e usr, bool update_refcnt = true);
+    bool createDynamicDIPTunnel(const string dip, tunnel_user_t usr);
+    bool deleteDynamicDIPTunnel(const string dip, tunnel_user_t usr, bool update_refcnt = true);
     uint32_t vlan_vrf_vni_count = 0;
     bool del_tnl_hw_pending = false;
 
@@ -297,7 +297,7 @@ public:
 
     bool
     removeNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAddress macAddress, uint32_t vni=0);
-   std::string getTunnelPortName(const std::string& remote_vtep)
+    std::string getTunnelPortName(const std::string& remote_vtep)
     {
         std::string tunnelPortName = "Port_EVPN_" + remote_vtep;
         return tunnelPortName;
@@ -306,11 +306,11 @@ public:
     bool getTunnelPort(const std::string& remote_vtep,Port& tunnelPort);
 
     bool addTunnelUser(string remote_vtep, uint32_t vni_id,
-                       uint32_t vlan, tunnel_user_type_e usr,
+                       uint32_t vlan, tunnel_user_t usr,
                        sai_object_id_t vrf_id=SAI_NULL_OBJECT_ID);
 
     bool delTunnelUser(string remote_vtep, uint32_t vni_id,
-                       uint32_t vlan, tunnel_user_type_e usr,
+                       uint32_t vlan, tunnel_user_t usr,
                        sai_object_id_t vrf_id=SAI_NULL_OBJECT_ID);
 
     void deleteTunnelPort(Port &tunnelPort);
@@ -324,9 +324,13 @@ public:
     uint16_t getVlanMappedToVni(const uint32_t vni)
     {
         if (vxlan_vni_vlan_map_table_.find(vni) != std::end(vxlan_vni_vlan_map_table_))
+        {
             return vxlan_vni_vlan_map_table_.at(vni);
+        }
         else
+        {
             return 0;
+        }
     }
 
     void addVlanMappedToVni(uint32_t vni, uint16_t vlan_id)
@@ -480,7 +484,10 @@ class EvpnNvoOrch : public Orch2
 public:
     EvpnNvoOrch(DBConnector *db, const std::string& tableName) : Orch2(db, tableName, request_) { }
 
-    VxlanTunnel* getEVPNVtep() { return source_vtep_ptr;}
+    VxlanTunnel* getEVPNVtep() 
+    { 
+        return source_vtep_ptr;
+    }
 
 private:
     virtual bool addOperation(const Request& request);

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -182,8 +182,8 @@ public:
 
     bool deleteMapperHW(uint8_t mapper_list, tunnel_map_src_t map_src);
     bool createMapperHW(uint8_t mapper_list, tunnel_map_src_t map_src);
-    bool createTunnelHW(uint8_t mapper_list, tunnel_map_src_t map_src, bool with_term = TRUE);
-    bool deleteTunnelHW(uint8_t mapper_list, tunnel_map_src_t map_src, bool with_term = TRUE);
+    bool createTunnelHW(uint8_t mapper_list, tunnel_map_src_t map_src, bool with_term = true);
+    bool deleteTunnelHW(uint8_t mapper_list, tunnel_map_src_t map_src, bool with_term = true);
     void deletePendingSIPTunnel();
     void increment_spurious_imr_add(const std::string remote_vtep);
     void increment_spurious_imr_del(const std::string remote_vtep);

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -113,7 +113,6 @@ typedef struct tunnel_refcnts_s
    uint32_t      ip_refcnt;
    uint32_t      spurious_add_imr_refcnt;
    uint32_t      spurious_del_imr_refcnt;
-   VxlanTunnel*  dip_tunnel;
 } tunnel_refcnt_t;
 
 typedef struct tunnel_map_entry_s
@@ -194,7 +193,6 @@ public:
     int getDipTunnelIPRefCnt(const std::string);
     // Total DIP tunnels associated with this SIP tunnel.
     int getDipTunnelCnt();
-    VxlanTunnel* getDipTunnel(const std::string dip);
     bool createDynamicDIPTunnel(const string dip, tunnel_user_t usr);
     bool deleteDynamicDIPTunnel(const string dip, tunnel_user_t usr, bool update_refcnt = true);
     uint32_t vlan_vrf_vni_count = 0;
@@ -297,11 +295,6 @@ public:
 
     bool
     removeNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAddress macAddress, uint32_t vni=0);
-    std::string getTunnelPortName(const std::string& remote_vtep)
-    {
-        std::string tunnelPortName = "Port_EVPN_" + remote_vtep;
-        return tunnelPortName;
-    }
 
     bool getTunnelPort(const std::string& remote_vtep,Port& tunnelPort);
 
@@ -317,7 +310,9 @@ public:
 
     void addRemoveStateTableEntry(const string, IpAddress&, IpAddress&, tunnel_creation_src_t, bool);
 
-    void getTunnelName(string& tunnel_portname, string& tunnel_name);
+    std::string getTunnelPortName(const std::string& remote_vtep);
+    void getTunnelNameFromDIP(const string& dip, string& tunnel_name);
+    void getTunnelNameFromPort(string& tunnel_portname, string& tunnel_name);
     void getTunnelDIPFromPort(Port& tunnelPort, string& remote_vtep);
     void updateDbTunnelOperStatus(string tunnel_portname,
                                                sai_port_oper_status_t status);

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -19,10 +19,40 @@ enum class MAP_T
     VNI_TO_BRIDGE
 };
 
+typedef enum
+{
+    TUNNEL_MAP_T_VLAN=0,
+    TUNNEL_MAP_T_BRIDGE,
+    TUNNEL_MAP_T_VIRTUAL_ROUTER,
+    TUNNEL_MAP_T_MAX_MAPPER,
+} tunnel_map_type_t;
+
+#define TUNNELMAP_SET_VLAN(x) ((x)|= (1<<TUNNEL_MAP_T_VLAN))
+#define TUNNELMAP_SET_VRF(x) ((x)|= (1<<TUNNEL_MAP_T_VIRTUAL_ROUTER))
+#define TUNNELMAP_SET_BRIDGE(x) ((x)|= (1<<TUNNEL_MAP_T_BRIDGE))
+
+#define IS_TUNNELMAP_SET_VLAN(x) ((x)& (1<<TUNNEL_MAP_T_VLAN))
+#define IS_TUNNELMAP_SET_VRF(x) ((x)& (1<<TUNNEL_MAP_T_VIRTUAL_ROUTER))
+#define IS_TUNNELMAP_SET_BRIDGE(x) ((x)& (1<<TUNNEL_MAP_T_BRIDGE))
+
+typedef enum
+{
+  TNL_CREATION_SRC_CLI,
+  TNL_CREATION_SRC_EVPN
+} tunnel_creation_src_t;
+
+typedef enum
+{
+   USE_COMMON_ENCAP_DECAP,
+   USE_COMMON_DECAP_DEDICATED_ENCAP,
+   USE_DECAP_ONLY,
+   USE_DEDICATED_ENCAP_DECAP
+} tunnel_map_src_t;
+
 struct tunnel_ids_t
 {
-    sai_object_id_t tunnel_encap_id;
-    sai_object_id_t tunnel_decap_id;
+    sai_object_id_t tunnel_encap_id[TUNNEL_MAP_T_MAX_MAPPER+1];
+    sai_object_id_t tunnel_decap_id[TUNNEL_MAP_T_MAX_MAPPER+1];
     sai_object_id_t tunnel_id;
     sai_object_id_t tunnel_term_id;
 };
@@ -68,14 +98,40 @@ struct nh_tunnel_t
     int             ref_count;
 };
 
+typedef enum {
+  TNL_SRC_IMR,
+  TNL_SRC_MAC,
+  TNL_SRC_IP
+} tunnel_user_type_e;
+
+class VxlanTunnel;
+
+typedef struct tunnel_refcnts_s
+{
+   uint32_t      imr_refcnt;
+   uint32_t      mac_refcnt;
+   uint32_t      ip_refcnt;
+   uint32_t      spurious_add_imr_refcnt;
+   uint32_t      spurious_del_imr_refcnt;
+   VxlanTunnel*  dip_tunnel;
+} tunnel_refcnt_t;
+
+typedef struct tunnel_map_entry_s
+{
+   sai_object_id_t map_entry_id;
+   uint32_t        vlan_id;
+   uint32_t        vni_id;
+} tunnel_map_entry_t;
+
 typedef std::map<uint32_t, std::pair<sai_object_id_t, sai_object_id_t>> TunnelMapEntries;
 typedef std::unordered_map<nh_key_t, nh_tunnel_t, nh_key_hash> TunnelNHs;
+typedef std::map<std::string, tunnel_refcnt_t> TunnelUsers;
 
 class VxlanTunnel
 {
 public:
-    VxlanTunnel(string name, IpAddress srcIp, IpAddress dstIp)
-                :tunnel_name_(name), src_ip_(srcIp), dst_ip_(dstIp) { }
+    VxlanTunnel(string name, IpAddress srcIp, IpAddress dstIp, tunnel_creation_src_t src);
+    ~VxlanTunnel();
 
     bool isActive() const
     {
@@ -83,8 +139,10 @@ public:
     }
 
     bool createTunnel(MAP_T encap, MAP_T decap, uint8_t encap_ttl=0);
-    sai_object_id_t addEncapMapperEntry(sai_object_id_t obj, uint32_t vni);
-    sai_object_id_t addDecapMapperEntry(sai_object_id_t obj, uint32_t vni);
+    sai_object_id_t addEncapMapperEntry(sai_object_id_t obj, uint32_t vni, 
+                                        tunnel_map_type_t type=TUNNEL_MAP_T_VIRTUAL_ROUTER);
+    sai_object_id_t addDecapMapperEntry(sai_object_id_t obj, uint32_t vni,
+                                        tunnel_map_type_t type=TUNNEL_MAP_T_VIRTUAL_ROUTER);
 
     void insertMapperEntry(sai_object_id_t encap, sai_object_id_t decap, uint32_t vni);
     std::pair<sai_object_id_t, sai_object_id_t> getMapperEntry(uint32_t vni);
@@ -94,14 +152,19 @@ public:
         return ids_.tunnel_id;
     }
 
-    sai_object_id_t getDecapMapId() const
+    sai_object_id_t getDecapMapId(tunnel_map_type_t type) const
     {
-        return ids_.tunnel_decap_id;
+        return ids_.tunnel_decap_id[type];
     }
 
-    sai_object_id_t getEncapMapId() const
+    sai_object_id_t getEncapMapId(tunnel_map_type_t type) const
     {
-        return ids_.tunnel_encap_id;
+        return ids_.tunnel_encap_id[type];
+    }
+
+    string getTunnelName() const
+    {
+        return tunnel_name_;
     }
 
     sai_object_id_t getTunnelTermId() const
@@ -117,11 +180,31 @@ public:
     void incNextHopRefCount(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni);
     void decNextHopRefCount(IpAddress& ipAddr, MacAddress macAddress, uint32_t vni);
 
+    bool deleteMapperHW(uint8_t mapper_list, tunnel_map_src_t map_src);
+    bool createMapperHW(uint8_t mapper_list, tunnel_map_src_t map_src);
+    bool createTunnelHW(uint8_t mapper_list, tunnel_map_src_t map_src, bool with_term = TRUE);
+    bool deleteTunnelHW(uint8_t mapper_list, tunnel_map_src_t map_src, bool with_term = TRUE);
+    void deletePendingSIPTunnel();
+    void increment_spurious_imr_add(const std::string remote_vtep);
+    void increment_spurious_imr_del(const std::string remote_vtep);
+    void updateDipTunnelRefCnt(bool , tunnel_refcnt_t& , tunnel_user_type_e );
+    // Total Routes using the DIP tunnel. 
+    int getDipTunnelRefCnt(const std::string);
+    int getDipTunnelIMRRefCnt(const std::string);
+    int getDipTunnelIPRefCnt(const std::string);
+    // Total DIP tunnels associated with this SIP tunnel.
+    int getDipTunnelCnt();
+    VxlanTunnel* getDipTunnel(const std::string dip);
+    bool createDynamicDIPTunnel(const string dip, tunnel_user_type_e usr);
+    bool deleteDynamicDIPTunnel(const string dip, tunnel_user_type_e usr, bool update_refcnt = true);
+    uint32_t vlan_vrf_vni_count = 0;
+    bool del_tnl_hw_pending = false;
+
 private:
     string tunnel_name_;
     bool active_ = false;
 
-    tunnel_ids_t ids_ = {0, 0, 0, 0};
+    tunnel_ids_t ids_ = {{0}, {0}, 0, 0};
     std::pair<MAP_T, MAP_T> tunnel_map_ = { MAP_T::MAP_TO_INVALID, MAP_T::MAP_TO_INVALID };
 
     TunnelMapEntries tunnel_map_entries_;
@@ -129,6 +212,12 @@ private:
 
     IpAddress src_ip_;
     IpAddress dst_ip_ = 0x0;
+
+    TunnelUsers tnl_users_;
+    VxlanTunnel* vtep_ptr=NULL;
+    tunnel_creation_src_t src_creation_;
+    uint8_t encap_dedicated_mappers_ = 0;
+    uint8_t decap_dedicated_mappers_ = 0;
 };
 
 const request_description_t vxlan_tunnel_request_description = {
@@ -148,18 +237,17 @@ public:
 
 typedef std::unique_ptr<VxlanTunnel> VxlanTunnel_T;
 typedef std::map<std::string, VxlanTunnel_T> VxlanTunnelTable;
-
-typedef enum
-{
-    TUNNEL_MAP_T_VLAN,
-    TUNNEL_MAP_T_BRIDGE,
-    TUNNEL_MAP_T_VIRTUAL_ROUTER,
-} tunnel_map_type_t;
+typedef std::map<uint32_t, uint16_t> VxlanVniVlanMapTable;
+typedef std::map<IpAddress, VxlanTunnel*> VTEPTable;
 
 class VxlanTunnelOrch : public Orch2
 {
 public:
-    VxlanTunnelOrch(DBConnector *db, const std::string& tableName) : Orch2(db, tableName, request_) { }
+    VxlanTunnelOrch(DBConnector *statedb, DBConnector *db, const std::string& tableName) :
+                    Orch2(db, tableName, request_),
+                    m_stateVxlanTable(statedb, STATE_VXLAN_TUNNEL_TABLE_NAME)
+    {}
+
 
     bool isTunnelExists(const std::string& tunnelName) const
     {
@@ -171,6 +259,34 @@ public:
         return vxlan_tunnel_table_.at(tunnelName).get();
     }
 
+    bool addTunnel(const std::string tunnel_name,VxlanTunnel* tnlptr)
+    {
+       vxlan_tunnel_table_[tunnel_name] = (VxlanTunnel_T)tnlptr;
+       return true;
+    }
+
+    bool delTunnel(const std::string tunnel_name)
+    {
+       vxlan_tunnel_table_.erase(tunnel_name);
+       return true;
+    }
+
+    bool isVTEPExists(const IpAddress& sip) const
+    {
+        return vtep_table_.find(sip) != std::end(vtep_table_);
+    }
+
+    VxlanTunnel* getVTEP(const IpAddress& sip)
+    {
+        return vtep_table_.at(sip);
+    }
+
+    void addVTEP(VxlanTunnel* pvtep,const IpAddress& sip)
+    {
+       vtep_table_[sip] = pvtep;
+    }
+
+
     bool createVxlanTunnelMap(string tunnelName, tunnel_map_type_t mapType, uint32_t vni,
                               sai_object_id_t encap, sai_object_id_t decap, uint8_t encap_ttl=0);
 
@@ -181,6 +297,49 @@ public:
 
     bool
     removeNextHopTunnel(string tunnelName, IpAddress& ipAddr, MacAddress macAddress, uint32_t vni=0);
+   std::string getTunnelPortName(const std::string& remote_vtep)
+    {
+        std::string tunnelPortName = "Port_EVPN_" + remote_vtep;
+        return tunnelPortName;
+    }
+
+    bool getTunnelPort(const std::string& remote_vtep,Port& tunnelPort);
+
+    bool addTunnelUser(string remote_vtep, uint32_t vni_id,
+                       uint32_t vlan, tunnel_user_type_e usr,
+                       sai_object_id_t vrf_id=SAI_NULL_OBJECT_ID);
+
+    bool delTunnelUser(string remote_vtep, uint32_t vni_id,
+                       uint32_t vlan, tunnel_user_type_e usr,
+                       sai_object_id_t vrf_id=SAI_NULL_OBJECT_ID);
+
+    void deleteTunnelPort(Port &tunnelPort);
+
+    void addRemoveStateTableEntry(const string, IpAddress&, IpAddress&, tunnel_creation_src_t, bool);
+
+    void getTunnelName(string& tunnel_portname, string& tunnel_name);
+    void getTunnelDIPFromPort(Port& tunnelPort, string& remote_vtep);
+    void updateDbTunnelOperStatus(string tunnel_portname,
+                                               sai_port_oper_status_t status);
+    uint16_t getVlanMappedToVni(const uint32_t vni)
+    {
+        if (vxlan_vni_vlan_map_table_.find(vni) != std::end(vxlan_vni_vlan_map_table_))
+            return vxlan_vni_vlan_map_table_.at(vni);
+        else
+            return 0;
+    }
+
+    void addVlanMappedToVni(uint32_t vni, uint16_t vlan_id)
+    {
+        vxlan_vni_vlan_map_table_[vni] = vlan_id;
+    }
+
+    void delVlanMappedToVni(uint32_t vni)
+    {
+        vxlan_vni_vlan_map_table_.erase(vni);
+    }
+
+
 
 private:
     virtual bool addOperation(const Request& request);
@@ -188,6 +347,9 @@ private:
 
     VxlanTunnelTable vxlan_tunnel_table_;
     VxlanTunnelRequest request_;
+    VxlanVniVlanMapTable vxlan_vni_vlan_map_table_;
+    VTEPTable vtep_table_;
+    Table m_stateVxlanTable;
 };
 
 const request_description_t vxlan_tunnel_map_request_description = {
@@ -199,7 +361,7 @@ const request_description_t vxlan_tunnel_map_request_description = {
             { "vni", "vlan" }
 };
 
-typedef std::map<std::string, sai_object_id_t> VxlanTunnelMapTable;
+typedef std::map<std::string, tunnel_map_entry_t> VxlanTunnelMapTable;
 
 class VxlanTunnelMapRequest : public Request
 {
@@ -266,4 +428,64 @@ private:
     VxlanVrfTable vxlan_vrf_table_;
     VxlanVrfTunnel vxlan_vrf_tunnel_;
     VxlanVrfRequest request_;
+};
+
+//---------------- EVPN_REMOTE_VNI table ---------------------
+
+const request_description_t evpn_remote_vni_request_description = {
+            { REQ_T_STRING, REQ_T_STRING },
+            {
+                { "vni",  REQ_T_UINT },
+            },
+            { "vni" }
+};
+
+class EvpnRemoteVniRequest : public Request
+{
+public:
+    EvpnRemoteVniRequest() : Request(evpn_remote_vni_request_description, ':') { }
+};
+
+class EvpnRemoteVniOrch : public Orch2
+{
+public:
+    EvpnRemoteVniOrch(DBConnector *db, const std::string& tableName) : Orch2(db, tableName, request_) { }
+
+
+private:
+    virtual bool addOperation(const Request& request);
+    virtual bool delOperation(const Request& request);
+
+    EvpnRemoteVniRequest request_;
+};
+
+//------------- EVPN_NVO Table -------------------------
+
+const request_description_t evpn_nvo_request_description = {
+            { REQ_T_STRING},
+            {
+                { "source_vtep",  REQ_T_STRING },
+            },
+            { "source_vtep" }
+};
+
+class EvpnNvoRequest : public Request
+{
+public:
+    EvpnNvoRequest() : Request(evpn_nvo_request_description, ':') { }
+};
+
+class EvpnNvoOrch : public Orch2
+{
+public:
+    EvpnNvoOrch(DBConnector *db, const std::string& tableName) : Orch2(db, tableName, request_) { }
+
+    VxlanTunnel* getEVPNVtep() { return source_vtep_ptr;}
+
+private:
+    virtual bool addOperation(const Request& request);
+    virtual bool delOperation(const Request& request);
+
+    EvpnNvoRequest request_;
+    VxlanTunnel* source_vtep_ptr=NULL;
 };


### PR DESCRIPTION
1. Existing code supports a single mapper type to be created. Either
   BRIDGE or VRF type mappers are supported.
   Change to support multiple mapper type creations is being added.
   Here mappers of type VLAN-VNI as well as VRF-VNI will be supported.
   support for single mapper type creation is not changed.
   Only one mode is accepted at a time.

2. Changes to support P2P tunnel creation and deletion.
   A refcnt is maintained per resource type (IMR or IP prefix)
   and based on this a P2P tunnel is created or deleted.
   The VxlanTunnel object is reused for P2P and P2MP tunnels.
   State DB updation for every P2P VXLAN tunnel discovered.

3. Changes to support handling of VXLAN_REMOTE_VNI table.
   Interfaces with portsorch to create a Port object of type
   TUNNEL on tunnel discovery. This is also used to extend

4. SAI interface function changes to support P2P tunnels.

5. EVPN NVO table handling.

HLD Location : https://github.com/Azure/SONiC/pull/437/commits

Signed-off-by: Rajesh Sankaran <rajesh.sankaran@broadcom.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Please refer to the details  above.

**Why I did it**
EVPN VXLAN Implementation

**How I verified it**
Tested along with PR 1266. Used test script in PR 1318.
Also ran test_vnet.py from master branch to verify there were no failures.

**Details if related**
