### PR TITLE
[Multi-AISC] Pass the asic instance as SAI attribute during switch_create 

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -59,7 +59,7 @@ string gRecordFile;
 
 void usage()
 {
-    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-b batch_size] [-m MAC] [-s]" << endl;
+    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-b batch_size] [-m MAC] [-i INST_ID] [-s]" << endl;
     cout << "    -h: display this message" << endl;
     cout << "    -r record_type: record orchagent logs with type (default 3)" << endl;
     cout << "                    0: do not record logs" << endl;
@@ -69,6 +69,7 @@ void usage()
     cout << "    -d record_location: set record logs folder location (default .)" << endl;
     cout << "    -b batch_size: set consumer table pop operation batch size (default 128)" << endl;
     cout << "    -m MAC: set switch MAC address" << endl;
+    cout << "    -i INST_ID: set the ASIC instance ID in multi-asic platform" << endl;
     cout << "    -s: enable synchronous mode" << endl;
 }
 

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -70,7 +70,7 @@ void usage()
     cout << "    -d record_location: set record logs folder location (default .)" << endl;
     cout << "    -b batch_size: set consumer table pop operation batch size (default 128)" << endl;
     cout << "    -m MAC: set switch MAC address" << endl;
-    cout << "    -i INST_ID: set the ASIC instance ID in multi-asic platform" << endl;
+    cout << "    -i INST_ID: set the ASIC instance_id in multi-asic platform" << endl;
     cout << "    -s: enable synchronous mode" << endl;
 }
 
@@ -233,7 +233,7 @@ int main(int argc, char **argv)
         sai_switch_api->set_switch_attribute(gSwitchId, &attr);
     }
 
-    if(gAsicInstance)
+    if (gAsicInstance)
     {
         attr.id = SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO;
         attr.value.s8list.count = (uint32_t)(strlen(gAsicInstance)+1);


### PR DESCRIPTION
**What I did**
Added the new option [-i INST_ID] in orchagent to get the asic instance id passed by user and populate it in SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO during create_switch().

**Why I did it**
In multi-ASIC platforms the create_switch API should inform the syncd/SAI/SDK the particular ASIC instance to be initialized and controller by this orchagent.

**How I verified it**
Verified on a multi-ASIC and single ASIC devices the orchagent/syncd is up interfaces in good state. 

**Need additional change in the file sonic-buildimage/dockers/docker-orchagent/orchagent.sh to pass the instance ID with -i option.**

**Details if related**
