### PR TITLE
[vnet] Set MTU for the VNET bridge RIF in BITMAP implementation

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -429,6 +429,10 @@ VnetBridgeInfo VNetBitmapObject::getBridgeInfoByVni(uint32_t vni, string tunnelN
     attr.value.oid = info.bridge_id;
     rif_attrs.push_back(attr);
 
+    attr.id = SAI_ROUTER_INTERFACE_ATTR_MTU;
+    attr.value.u32 = VNET_BITMAP_RIF_MTU;
+    rif_attrs.push_back(attr);
+
     status = sai_router_intfs_api->create_router_interface(
             &info.rif_id,
             gSwitchId,

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -17,6 +17,7 @@
 #define VNET_TUNNEL_SIZE 40960
 #define VNET_NEIGHBOR_MAX 0xffff
 #define VXLAN_ENCAP_TTL 128
+#define VNET_BITMAP_RIF_MTU 9100
 
 extern sai_object_id_t gVirtualRouterId;
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
In BITMAP implementation, set MTU for the internal VNET bridge RIF to max value.

**Why I did it**
To make jumbo frames routed on BITMAP VNET interfaces. Currently if sending traffic from VNET to another VNI using a tunnel route then frames larger than 1500 are not routed and trapped to the CPU.

**How I verified it**
Executed ```vxlan_vnet``` ansible test with the modified MTU.

**Details if related**
N/A