### PR TITLE
[vnet] Verify if BITMAP route exists before creating new one to avoid…

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -791,6 +791,12 @@ bool VNetBitmapObject::addTunnelRoute(IpPrefix& ipPrefix, tunnelEndpoint& endp)
     sai_ip_address_t underlayAddr;
     copy(underlayAddr, endp.ip);
 
+    if (tunnelRouteMap_.find(ipPrefix) != tunnelRouteMap_.end())
+    {
+        SWSS_LOG_WARN("VNET tunnel route %s exists", ipPrefix.to_string().c_str());
+        return true;
+    }
+
     VNetOrch* vnet_orch = gDirectory.get<VNetOrch*>();
     for (auto peer : peer_list)
     {
@@ -1092,6 +1098,12 @@ bool VNetBitmapObject::addRoute(IpPrefix& ipPrefix, nextHop& nh)
     uint32_t peerBitmap = vnet_id_;
     Port port;
     RouteInfo routeInfo;
+
+    if (routeMap_.find(ipPrefix) != routeMap_.end())
+    {
+        SWSS_LOG_WARN("VNET route %s exists", ipPrefix.to_string().c_str());
+        return true;
+    }
 
     bool is_subnet = (!nh.ips.getSize() || nh.ips.contains("0.0.0.0")) ? true : false;
 


### PR DESCRIPTION
… dublication

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Before creating new route, verify if BITMAP route exists in order to avoid dublication.

**Why I did it**
It is possible that exactly the same VNET routes are installed few times by controller, so need to handle such case in order to avoid doublication in HW. Also dublication causes orchagent to crash after VNET interface removal since dublicated entries are not properly cleaned which means that interface is still in use and cannot be removed.

**How I verified it**
- Executed ```vxlan_vnet``` ansible test with the ```cleanup=False``` option to keep VNET config after test execution and verified there are no VNET route duplications in HW.
- Executed ```vxlan_vnet``` test with the ```cleanup=True``` option and verified there is no orchagent crash and all is removed from HW.

**Details if related**
N/A