### PR TITLE
COPP_DEL_fix: op="DEL" for one trap group from SONIC is resetting all the …

### DIFF
--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -731,12 +731,12 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
             if (it.second.trap_group_obj == m_trap_group_map[trap_group_name])
             {
                 trap_ids_to_reset.push_back(it.first);
-            }
-            sai_status = sai_hostif_api->remove_hostif_trap(it.second.trap_obj);
-            if (sai_status != SAI_STATUS_SUCCESS)
-            {
-                SWSS_LOG_ERROR("Failed to remove trap object %" PRId64 "", it.second.trap_obj);
-                return task_process_status::task_failed;
+                sai_status = sai_hostif_api->remove_hostif_trap(it.second.trap_obj);
+                if (sai_status != SAI_STATUS_SUCCESS)
+                {
+                    SWSS_LOG_ERROR("Failed to remove trap object %" PRId64 "", it.second.trap_obj);
+                    return task_process_status::task_failed;
+                }
             }
         }
 


### PR DESCRIPTION
…trap IDs

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Called hostif trap remove only for those trap IDs which belong to the trap group for which op="DEL" is set.

**Why I did it**
hostif trap remove was being called for all the trap IDs belonging to all trap groups. It was resetting all trap IDs to the default trap group configurations.

**How I verified it**
Followed below steps:
1)Loaded the COPP configuration "00-copp.config.json".
2)Verified that the rate limit and queue mapping for every trap ID is correct . 
3)Loaded the below mentioned configuration (with op = "DEL") for the trap group(arp) using
swssconfig command. 

 [(no_arp.json)]
[
{
"COPP_TABLE:trap.group.arp": {
"trap_ids": "arp_req,arp_resp,neigh_discovery",
"trap_action":"copy",
"trap_priority":"4",
"queue": "4",
"meter_type":"packets",
"mode":"sr_tcm",
"cir":"600",
"cbs":"600",
"red_action":"drop"
},
"OP": "DEL"
}
]
4) Only the trap IDs belonging to the arp trap group are getting reset to the default trap group configuration. Rest of the trap IDs belonging to other trap groups still have their corresponding configuration. 
5) All these verification are done through the ASIC CLI and sending corresponding packets.

**Details if related**
