### PR TITLE
 Update NAT conntrack entries from natmgr instead of natorch

### DIFF
--- a/cfgmgr/natmgr.h
+++ b/cfgmgr/natmgr.h
@@ -17,10 +17,12 @@
 #ifndef __NATMGR__
 #define __NATMGR__
 
+#include "selectabletimer.h"
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "orch.h"
 #include "notificationproducer.h"
+#include "timer.h"
 #include <unistd.h>
 #include <set>
 #include <map>
@@ -60,6 +62,7 @@ namespace swss {
 #define NAT_TIMEOUT_MIN            300
 #define NAT_TIMEOUT_MAX            432000
 #define NAT_TIMEOUT_DEFAULT        600
+#define NAT_TIMEOUT_LOW            0
 #define NAT_TCP_TIMEOUT            "nat_tcp_timeout"
 #define NAT_TCP_TIMEOUT_MIN        300
 #define NAT_TCP_TIMEOUT_MAX        432000
@@ -119,6 +122,9 @@ namespace swss {
 #define IS_RESERVED_ADDR(ipaddr)   (ipaddr >= 0xF0000000)
 #define IS_ZERO_ADDR(ipaddr)       (ipaddr == 0)
 #define IS_BROADCAST_ADDR(ipaddr)  (ipaddr == 0xFFFFFFFF)
+#define NAT_ENTRY_REFRESH_PERIOD   86400    // 1 day
+#define REDIRECT_TO_DEV_NULL       " &> /dev/null"
+#define FLUSH                      " -F"
 
 const char ip_address_delimiter = '/';
 
@@ -234,13 +240,15 @@ public:
     void cleanupPoolIpTable();
     void cleanupMangleIpTables();
     bool isPortInitDone(DBConnector *app_db);
-   
+    void timeoutNotifications(std::string op, std::string data);
+    void flushNotifications(std::string op, std::string data);
+
 private:
     /* Declare APPL_DB, CFG_DB and STATE_DB tables */
     ProducerStateTable m_appNatTableProducer, m_appNaptTableProducer, m_appNatGlobalTableProducer;
     ProducerStateTable m_appTwiceNatTableProducer, m_appTwiceNaptTableProducer;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateInterfaceTable, m_appNaptPoolIpTable;
-    std::shared_ptr<swss::NotificationProducer> flushNotifier;
+    Table m_stateWarmRestartEnableTable, m_stateWarmRestartTable;
 
     /* Declare containers to store NAT Info */
     int          m_natTimeout;
@@ -256,9 +264,12 @@ private:
     natZoneInterface_map_t   m_natZoneInterfaceInfo;
     natAclTable_map_t        m_natAclTableInfo;
     natAclRule_map_t         m_natAclRuleInfo;
+    SelectableTimer          *m_natRefreshTimer;
 
     /* Declare doTask related fucntions */
     void doTask(Consumer &consumer);
+    void doTask(SelectableTimer &timer);
+    void doNatRefreshTimerTask();
     void doStaticNatTask(Consumer &consumer);
     void doStaticNaptTask(Consumer &consumer);
     void doNatPoolTask(Consumer &consumer);
@@ -271,15 +282,26 @@ private:
     /* Declare all NAT functionality member functions*/
     void enableNatFeature(void);
     void disableNatFeature(void);
-    void addConntrackSingleNatEntry(const std::string &key);
-    void addConntrackSingleNaptEntry(const std::string &key);
-    void deleteConntrackSingleNatEntry(const std::string &key);
-    void deleteConntrackSingleNaptEntry(const std::string &key);
-    void addConntrackTwiceNatEntry(const std::string &snatKey, const std::string &dnatKey);
-    void addConntrackTwiceNaptEntry(const std::string &snatKey, const std::string &dnatKey);
-    void deleteConntrackTwiceNatEntry(const std::string &snatKey, const std::string &dnatKey);
-    void deleteConntrackTwiceNaptEntry(const std::string &snatKey, const std::string &dnatKey);
+    bool warmBootingInProgress(void);
+    void flushAllNatEntries(void);
+    void addAllStaticConntrackEntries(void);
+    void addConntrackStaticSingleNatEntry(const std::string &key);
+    void addConntrackStaticSingleNaptEntry(const std::string &key);
+    void updateConntrackStaticSingleNatEntry(const std::string &key);
+    void updateConntrackStaticSingleNaptEntry(const std::string &key);
+    void deleteConntrackStaticSingleNatEntry(const std::string &key);
+    void deleteConntrackStaticSingleNaptEntry(const std::string &key);
+    void addConntrackStaticTwiceNatEntry(const std::string &snatKey, const std::string &dnatKey);
+    void addConntrackStaticTwiceNaptEntry(const std::string &snatKey, const std::string &dnatKey);
+    void updateConntrackStaticTwiceNatEntry(const std::string &snatKey, const std::string &dnatKey);
+    void updateConntrackStaticTwiceNaptEntry(const std::string &snatKey, const std::string &dnatKey);
+    void deleteConntrackStaticTwiceNatEntry(const std::string &snatKey, const std::string &dnatKey);
+    void deleteConntrackStaticTwiceNaptEntry(const std::string &snatKey, const std::string &dnatKey);
     void deleteConntrackDynamicEntries(const std::string &ip_range);
+    void updateDynamicSingleNatConnTrackTimeout(std::string key, int timeout);
+    void updateDynamicSingleNaptConnTrackTimeout(std::string key, int timeout);
+    void updateDynamicTwiceNatConnTrackTimeout(std::string key, int timeout);
+    void updateDynamicTwiceNaptConnTrackTimeout(std::string key, int timeout);
     void addStaticNatEntry(const std::string &key);
     void addStaticNaptEntry(const std::string &key);
     void addStaticSingleNatEntry(const std::string &key);
@@ -308,6 +330,12 @@ private:
     void addStaticNaptIptables(const std::string port);
     void removeStaticNatIptables(const std::string port);
     void removeStaticNaptIptables(const std::string port);
+    void setStaticNatConntrackEntries(std::string mode);
+    void setStaticSingleNatConntrackEntry(const std::string &key, std::string &mode);
+    void setStaticTwiceNatConntrackEntry(const std::string &key, std::string &mode);
+    void setStaticNaptConntrackEntries(std::string mode);
+    void setStaticSingleNaptConntrackEntry(const std::string &key, std::string &mode);
+    void setStaticTwiceNaptConntrackEntry(const std::string &key, std::string &mode);
     void addDynamicNatRule(const std::string &key);
     void removeDynamicNatRule(const std::string &key);
     void addDynamicNatRuleByAcl(const std::string &key, bool isRuleId = false);

--- a/natsyncd/natsync.cpp
+++ b/natsyncd/natsync.cpp
@@ -59,6 +59,8 @@ NatSync::NatSync(RedisPipeline *pipelineAppDB, DBConnector *appDb, DBConnector *
         m_AppRestartAssist->registerAppTable(APP_NAT_TWICE_TABLE_NAME, &m_natTwiceTable);
         m_AppRestartAssist->registerAppTable(APP_NAPT_TWICE_TABLE_NAME, &m_naptTwiceTable);
     }
+
+    setTimeoutNotifier = std::make_shared<swss::NotificationProducer>(appDb, "SETTIMEOUTNAT");
 }
 
 /* To check the port init is done or not */
@@ -482,6 +484,7 @@ int NatSync::addNatEntry(struct nfnl_ct *ct, struct naptEntry &entry, bool addFl
                 {
                     m_naptTwiceTable.set(key, fvVector);
                     SWSS_LOG_NOTICE("Twice NAPT entry with key %s added to APP_DB", key.c_str());
+                    setTimeoutNotifier->send("SET-TWICE-NAPT", key, fvVector);
                     m_naptTwiceTable.set(reverseEntryKey, reverseFvVector);
                     SWSS_LOG_NOTICE("Twice NAPT entry with reverse key %s added to APP_DB", reverseEntryKey.c_str());
                 }
@@ -522,6 +525,7 @@ int NatSync::addNatEntry(struct nfnl_ct *ct, struct naptEntry &entry, bool addFl
                 {
                     m_natTwiceTable.set(key, fvVector);
                     SWSS_LOG_NOTICE("Twice NAT entry with key %s added to APP_DB", key.c_str());
+                    setTimeoutNotifier->send("SET-TWICE-NAT", key, fvVector);
                     m_natTwiceTable.set(reverseEntryKey, reverseFvVector);
                     SWSS_LOG_NOTICE("Twice NAT entry with reverse key %s added to APP_DB", reverseEntryKey.c_str());
                 }
@@ -674,6 +678,7 @@ int NatSync::addNatEntry(struct nfnl_ct *ct, struct naptEntry &entry, bool addFl
                         {
                             m_naptTable.set(key, fvVector);
                             SWSS_LOG_NOTICE("SNAPT entry with key %s added to APP_DB", key.c_str());
+                            setTimeoutNotifier->send("SET-SINGLE-NAPT", key, fvVector);
                             m_naptTable.set(reverseEntryKey, reverseFvVector);
                             SWSS_LOG_NOTICE("Implicit DNAPT entry with key %s added to APP_DB", reverseEntryKey.c_str());
                         }
@@ -778,6 +783,7 @@ int NatSync::addNatEntry(struct nfnl_ct *ct, struct naptEntry &entry, bool addFl
                         {
                             m_natTable.set(key, fvVector);
                             SWSS_LOG_NOTICE("SNAT entry with key %s added to APP_DB", key.c_str());
+                            setTimeoutNotifier->send("SET-SINGLE-NAT", key, fvVector);
                             m_natTable.set(reverseEntryKey, reverseFvVector);
                             SWSS_LOG_NOTICE("Implicit DNAT entry with key %s added to APP_DB", reverseEntryKey.c_str());
                         }
@@ -882,6 +888,7 @@ int NatSync::addNatEntry(struct nfnl_ct *ct, struct naptEntry &entry, bool addFl
                     {
                         m_naptTable.set(key, fvVector);
                         SWSS_LOG_NOTICE("DNAPT entry with key %s added to APP_DB", key.c_str());
+                        setTimeoutNotifier->send("SET-SINGLE-NAPT", key, fvVector);
                         m_naptTable.set(reverseEntryKey, reverseFvVector);
                         SWSS_LOG_NOTICE("Implicit SNAPT entry with key %s added to APP_DB", reverseEntryKey.c_str());
                     }
@@ -955,6 +962,7 @@ int NatSync::addNatEntry(struct nfnl_ct *ct, struct naptEntry &entry, bool addFl
                     {
                         m_natTable.set(key, fvVector);
                         SWSS_LOG_NOTICE("DNAT entry with key %s added to APP_DB", key.c_str());
+                        setTimeoutNotifier->send("SET-SINGLE-NAT", key, fvVector);
                         m_natTable.set(reverseEntryKey, reverseFvVector);
                         SWSS_LOG_NOTICE("Implicit SNAT entry with key %s added to APP_DB", reverseEntryKey.c_str());
                     }

--- a/natsyncd/natsync.h
+++ b/natsyncd/natsync.h
@@ -19,6 +19,7 @@
 
 #include "dbconnector.h"
 #include "producerstatetable.h"
+#include "notificationproducer.h"
 #include "netmsg.h"
 #include "warmRestartAssist.h"
 #include "ipaddress.h"
@@ -63,6 +64,8 @@ private:
     bool        matchingSnaptEntryExists(const naptEntry &entry);
     bool        matchingDnaptEntryExists(const naptEntry &entry);
     int         addNatEntry(struct nfnl_ct *ct, struct naptEntry &entry, bool addFlag);
+
+    std::shared_ptr<swss::NotificationProducer> setTimeoutNotifier;
 
     ProducerStateTable m_natTable;
     ProducerStateTable m_naptTable;

--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -43,8 +43,8 @@
         "OP": "SET"
     },
     {
-        "COPP_TABLE:trap.group.ip2me": {
-            "trap_ids": "ip2me",
+        "COPP_TABLE:trap.group.nat.ip2me": {
+            "trap_ids": "ip2me,src_nat_miss,dest_nat_miss",
             "trap_action":"trap",
             "trap_priority":"1",
             "queue": "1",
@@ -52,20 +52,6 @@
             "mode":"sr_tcm",
             "cir":"6000",
             "cbs":"6000",
-            "red_action":"drop"
-        },
-        "OP": "SET"
-    },
-    {
-        "COPP_TABLE:trap.group.nat": {
-            "trap_ids": "src_nat_miss,dest_nat_miss",
-            "trap_action":"trap",
-            "trap_priority":"1",
-            "queue": "1",
-            "meter_type":"packets",
-            "mode":"sr_tcm",
-            "cir":"600",
-            "cbs":"600",
             "red_action":"drop"
         },
         "OP": "SET"

--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -43,8 +43,22 @@
         "OP": "SET"
     },
     {
-        "COPP_TABLE:trap.group.nat.ip2me": {
-            "trap_ids": "ip2me,src_nat_miss,dest_nat_miss",
+        "COPP_TABLE:trap.group.ip2me": {
+            "trap_ids": "ip2me",
+            "trap_action":"trap",
+            "trap_priority":"1",
+            "queue": "1",
+            "meter_type":"packets",
+            "mode":"sr_tcm",
+            "cir":"6000",
+            "cbs":"6000",
+            "red_action":"drop"
+        },
+        "OP": "SET"
+    },
+    {
+        "COPP_TABLE:trap.group.nat": {
+            "trap_ids": "src_nat_miss,dest_nat_miss",
             "trap_action":"trap",
             "trap_priority":"1",
             "queue": "1",

--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -64,8 +64,8 @@
             "queue": "1",
             "meter_type":"packets",
             "mode":"sr_tcm",
-            "cir":"6000",
-            "cbs":"6000",
+            "cir":"600",
+            "cbs":"600",
             "red_action":"drop"
         },
         "OP": "SET"


### PR DESCRIPTION
Approach:

1. All NAT conntrack entries would be updated with large timeout (432000) value initially (when entry is created) by sending notifcation from NatSync to NatMgr.
2. All NAT conntrack enrries would be updated with Zero timeout value (when entry is deleted) be sending notification from OA to NatMgr.
3. Added a 1 day timer in NatMgr to reset the timeout for all conntrack entries to large time (43200) value.
4. NatOrch caches the time in secs whenever the entry is active, and compares it with specific timeout for every 30 secs when entry is not active.

Code changes:

NatSync:

1. Added a new timeout notification producer to send notifications to NatMgr.
2. Send a notification (whenever a new entry to created) to NatMgr to set 43200 time for that conntrack entry.

NatMgr:
1. While creating conntrack for Static entries, sets the timeout to max value (432000).
2. Added a new Refresh Timer for 1 day to set the timeout for all Static conntrack entries to max value (432000).
3. Added a new flush notification consumer for command “sonic-clear nat translations” and handling “Flushing all conntrack entries and added all existing Static conntrack entries” (This is moved from OA code).
4. Added an another new timeout notification consumer to handle timeout notifications from NatSync and NatOrch.
5. Setting the timeout for conntrack entries as per received notifications based on entry’s Key.

NatOrch:
1. Added a new variable for every entry, it caches the current time whenever entry becomes Active.
2. If entry is not Active, compares the cached time with current time and if it greater than global timeout, sends a age-out (0 timeout) notification to delete the conntrack entry.
3. Added a new timeout notification producer to send notification whenever an entry needs to be deleted.
4. Added a new Refresh Timer for 1 day to send SET (432000) timeout notifications to NatMgr for all dynamic entries.
 
Depends on:
https://github.com/Azure/sonic-utilities/pull/892
https://github.com/Azure/sonic-buildimage/pull/4596

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>