### PR TITLE
Using PRI instead of %l to support 32-bit arch

### DIFF
--- a/cfgmgr/natmgr.cpp
+++ b/cfgmgr/natmgr.cpp
@@ -5049,7 +5049,7 @@ void NatMgr::doStaticNatTask(Consumer &consumer)
         /* Ensure the key size is 1 otherwise ignore */
         if (keys.size() != STATIC_NAT_KEY_SIZE)
         {
-            SWSS_LOG_ERROR("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+            SWSS_LOG_ERROR("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             it = consumer.m_toSync.erase(it);
             continue;
         }
@@ -5366,7 +5366,7 @@ void NatMgr::doStaticNaptTask(Consumer &consumer)
         /* Ensure the key size is 3 otherwise ignore */
         if (keys.size() != STATIC_NAPT_KEY_SIZE)
         {   
-            SWSS_LOG_ERROR("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+            SWSS_LOG_ERROR("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             it = consumer.m_toSync.erase(it);
             continue;
         }
@@ -5707,7 +5707,7 @@ void NatMgr::doNatPoolTask(Consumer &consumer)
         /* Ensure the key size is 1 otherwise ignore */
         if (keys.size() != POOL_TABLE_KEY_SIZE)
         {
-            SWSS_LOG_ERROR("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+            SWSS_LOG_ERROR("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             it = consumer.m_toSync.erase(it);
             continue;
         }
@@ -5766,7 +5766,7 @@ void NatMgr::doNatPoolTask(Consumer &consumer)
             /* Ensure the Pool name length is not more than 32 otherwise ignore */
             if (key.length() > 32)
             {
-                SWSS_LOG_ERROR("Invalid pool name length - %lu, skipping %s", key.length(), key.c_str());
+                SWSS_LOG_ERROR("Invalid pool name length - %u, skipping %s", key.length(), key.c_str());
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
@@ -5791,7 +5791,7 @@ void NatMgr::doNatPoolTask(Consumer &consumer)
             /* Ensure the ip range size is not more than 2, otherwise ignore */
             if (nat_ip_range.size() > 2)
             {
-                SWSS_LOG_ERROR("Invalid nat ip range size %lu, skipping %s", nat_ip_range.size(), key.c_str());
+                SWSS_LOG_ERROR("Invalid nat ip range size %u, skipping %s", nat_ip_range.size(), key.c_str());
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
@@ -5876,7 +5876,7 @@ void NatMgr::doNatPoolTask(Consumer &consumer)
                 /* Ensure the port range size is not more than 2, otherwise ignore */
                 if (nat_port_range.size() > 2)
                 {
-                    SWSS_LOG_ERROR("Invalid nat port range size %lu, skipping %s", nat_port_range.size(), key.c_str());
+                    SWSS_LOG_ERROR("Invalid nat port range size %u, skipping %s", nat_port_range.size(), key.c_str());
                     it = consumer.m_toSync.erase(it);
                     continue;
                 }
@@ -6094,7 +6094,7 @@ void NatMgr::doNatBindingTask(Consumer &consumer)
         /* Ensure the key size is 1 otherwise ignore */
         if (keys.size() != BINDING_TABLE_KEY_SIZE)
         {
-            SWSS_LOG_ERROR("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+            SWSS_LOG_ERROR("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             it = consumer.m_toSync.erase(it);
             continue;
         }
@@ -6102,7 +6102,7 @@ void NatMgr::doNatBindingTask(Consumer &consumer)
         /* Ensure the Binding name length is not more than 32 otherwise ignore */
         if (key.length() > 32)
         {
-            SWSS_LOG_ERROR("Invalid binding name length - %lu, skipping %s", key.length(), key.c_str());
+            SWSS_LOG_ERROR("Invalid binding name length - %u, skipping %s", key.length(), key.c_str());
             it = consumer.m_toSync.erase(it);
             continue;
         }
@@ -6226,7 +6226,7 @@ void NatMgr::doNatBindingTask(Consumer &consumer)
             /* Ensure the Pool name length is not more than 32 otherwise ignore */
             if (nat_pool.length() > 32)
             {
-                SWSS_LOG_ERROR("Invalid pool name length - %lu, skipping %s", nat_pool.length(), key.c_str());
+                SWSS_LOG_ERROR("Invalid pool name length - %u, skipping %s", nat_pool.length(), key.c_str());
                 it = consumer.m_toSync.erase(it);
                 continue;
             }
@@ -6604,13 +6604,13 @@ void NatMgr::doNatIpInterfaceTask(Consumer &consumer)
         /* Ensure the key size is 2 or 1, otherwise ignore */
         if ((keys.size() != L3_INTERFACE_KEY_SIZE) and (keys.size() != L3_INTERFACE_ZONE_SIZE))
         {
-            SWSS_LOG_INFO("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+            SWSS_LOG_INFO("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             it = consumer.m_toSync.erase(it);
             continue;
         }
         else
         {
-            SWSS_LOG_INFO("Key size %lu for %s", keys.size(), key.c_str());
+            SWSS_LOG_INFO("Key size %u for %s", keys.size(), key.c_str());
         }
 
         /* Ensure the key starts with "Vlan" or "Ethernet" or "PortChannel" or "Loopback", otherwise ignore */
@@ -6849,7 +6849,7 @@ void NatMgr::doNatIpInterfaceTask(Consumer &consumer)
             }
             else
             {
-                SWSS_LOG_INFO("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+                SWSS_LOG_INFO("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             }
             it = consumer.m_toSync.erase(it);
         }
@@ -6935,7 +6935,7 @@ void NatMgr::doNatIpInterfaceTask(Consumer &consumer)
             }
             else
             {
-                SWSS_LOG_INFO("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+                SWSS_LOG_INFO("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             }
             it = consumer.m_toSync.erase(it);
         }
@@ -6971,7 +6971,7 @@ void NatMgr::doNatAclTableTask(Consumer &consumer)
         /* Ensure the key size is 1 otherwise ignore */
         if (keys.size() != ACL_TABLE_KEY_SIZE)
         {
-            SWSS_LOG_INFO("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+            SWSS_LOG_INFO("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             it = consumer.m_toSync.erase(it);
             continue;
         }
@@ -7112,7 +7112,7 @@ void NatMgr::doNatAclRuleTask(Consumer &consumer)
         /* Ensure the key size is 2 otherwise ignore */
         if (keys.size() != ACL_RULE_TABLE_KEY_SIZE)
         {
-            SWSS_LOG_INFO("Invalid key size %lu, skipping %s", keys.size(), key.c_str());
+            SWSS_LOG_INFO("Invalid key size %u, skipping %s", keys.size(), key.c_str());
             it = consumer.m_toSync.erase(it);
             continue;
         }
@@ -7239,7 +7239,7 @@ void NatMgr::doNatAclRuleTask(Consumer &consumer)
                     /* Ensure the port range size is valid, otherwise ignore */
                     if (port_range.size() != L4_PORT_RANGE_SIZE)
                     {
-                        SWSS_LOG_INFO("Invalid port range size %lu for Matching Port Range Field, skipping %s", port_range.size(), key.c_str());
+                        SWSS_LOG_INFO("Invalid port range size %u for Matching Port Range Field, skipping %s", port_range.size(), key.c_str());
                         isNatAclRuleNotValid = true;
                         break;
                     }

--- a/orchagent/natorch.cpp
+++ b/orchagent/natorch.cpp
@@ -3312,7 +3312,7 @@ bool NatOrch::getNatCounters(const NatEntry::iterator &iter)
     {
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_ERROR("Failed to get Counters for SNAT entry [src-ip %s], bytes = %lu, pkts = %lu", ipAddr.to_string().c_str(),
+            SWSS_LOG_ERROR("Failed to get Counters for SNAT entry [src-ip %s], bytes = %" PRIu64 ", pkts = %" PRIu64 "", ipAddr.to_string().c_str(),
                            nat_entry_attr[0].value.u64, nat_entry_attr[1].value.u64);
         }
         else
@@ -3325,7 +3325,7 @@ bool NatOrch::getNatCounters(const NatEntry::iterator &iter)
     {
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_ERROR("Failed to get Counters for DNAT entry [dst-ip %s], bytes = %lu, pkts = %lu", ipAddr.to_string().c_str(),
+            SWSS_LOG_ERROR("Failed to get Counters for DNAT entry [dst-ip %s], bytes = %" PRIu64 ", pkts = %" PRIu64 "", ipAddr.to_string().c_str(),
                            nat_entry_attr[0].value.u64, nat_entry_attr[1].value.u64);
         }
         else
@@ -3376,7 +3376,7 @@ bool NatOrch::getTwiceNatCounters(const TwiceNatEntry::iterator &iter)
     status = sai_nat_api->get_nat_entry_attribute(&dbl_nat_entry, attr_count, nat_entry_attr);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to get Counters for Twice NAT entry [src-ip %s, dst-ip %s], bytes = %lu, pkts = %lu",
+        SWSS_LOG_ERROR("Failed to get Counters for Twice NAT entry [src-ip %s, dst-ip %s], bytes = %" PRIu64 ", pkts = %" PRIu64 "",
                         key.src_ip.to_string().c_str(), key.dst_ip.to_string().c_str(),
                         nat_entry_attr[0].value.u64, nat_entry_attr[1].value.u64);
     }
@@ -3521,7 +3521,7 @@ bool NatOrch::getNaptCounters(const NaptEntry::iterator &iter)
     { 
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_ERROR("Failed to get Counters for SNAPT entry for [proto %s, src-ip %s, src-port %d], bytes = %lu, pkts = %lu",
+            SWSS_LOG_ERROR("Failed to get Counters for SNAPT entry for [proto %s, src-ip %s, src-port %d], bytes = %" PRIu64 ", pkts = %" PRIu64 "",
                            naptKey.prototype.c_str(), naptKey.ip_address.to_string().c_str(), naptKey.l4_port,
                            nat_entry_attr[0].value.u64, nat_entry_attr[1].value.u64);
         }
@@ -3535,7 +3535,7 @@ bool NatOrch::getNaptCounters(const NaptEntry::iterator &iter)
     {
         if (status != SAI_STATUS_SUCCESS)
         {
-            SWSS_LOG_ERROR("Failed to get Counters for DNAPT entry for [proto %s, dst-ip %s, dst-port %d], bytes = %lu, pkts = %lu",
+            SWSS_LOG_ERROR("Failed to get Counters for DNAPT entry for [proto %s, dst-ip %s, dst-port %d], bytes = %" PRIu64 ", pkts = %" PRIu64 "",
                            naptKey.prototype.c_str(), naptKey.ip_address.to_string().c_str(), naptKey.l4_port,
                            nat_entry_attr[0].value.u64, nat_entry_attr[1].value.u64);
         }
@@ -4732,7 +4732,7 @@ void NatOrch::debugdumpALL()
         SWSS_DEBUG_PRINT(m_dbgCompName, "%8d.  IP: %s", count, ipAddr.to_string().c_str());
         SWSS_DEBUG_PRINT(m_dbgCompName, "             Translated IP: %s, NAT Type: %s, Entry Type: %s",
                          value.translated_ip.to_string().c_str(), value.nat_type.c_str(), value.entry_type.c_str());
-        SWSS_DEBUG_PRINT(m_dbgCompName, "             Age-out time: %ld secs, Added-to-Hw: %s",
+        SWSS_DEBUG_PRINT(m_dbgCompName, "             Age-out time: %" PRId64 " secs, Added-to-Hw: %s",
                          (value.ageOutTime - time_now.tv_sec), ((value.addedToHw) ? "Yes" : "No"));
         natIter++;
     }
@@ -4751,7 +4751,7 @@ void NatOrch::debugdumpALL()
         SWSS_DEBUG_PRINT(m_dbgCompName, "             Translated IP: %s, L4 Port: %d, NAT Type: %s, Entry Type: %s",
                          naptValue.translated_ip.to_string().c_str(), naptValue.translated_l4_port,
                          naptValue.nat_type.c_str(), naptValue.entry_type.c_str());
-        SWSS_DEBUG_PRINT(m_dbgCompName, "             Age-out time: %ld secs, Added-to-Hw: %s",
+        SWSS_DEBUG_PRINT(m_dbgCompName, "             Age-out time: %" PRId64 " secs, Added-to-Hw: %s",
                          (naptValue.ageOutTime - time_now.tv_sec), ((naptValue.addedToHw) ? "Yes" : "No"));
         naptIter++;
     }
@@ -4771,7 +4771,7 @@ void NatOrch::debugdumpALL()
         SWSS_DEBUG_PRINT(m_dbgCompName, "             Translated Src IP: %s, Dst IP: %s, Entry Type: %s",
                          twiceNatValue.translated_src_ip.to_string().c_str(), twiceNatValue.translated_dst_ip.to_string().c_str(),
                          twiceNatValue.entry_type.c_str());
-        SWSS_DEBUG_PRINT(m_dbgCompName, "             Age-out time: %ld secs, Added-to-Hw: %s",
+        SWSS_DEBUG_PRINT(m_dbgCompName, "             Age-out time: %" PRId64 " secs, Added-to-Hw: %s",
                          (twiceNatValue.ageOutTime - time_now.tv_sec), ((twiceNatValue.addedToHw) ? "Yes" : "No"));
         twiceNatIter++;
     }
@@ -4793,7 +4793,7 @@ void NatOrch::debugdumpALL()
                          twiceNaptValue.translated_src_ip.to_string().c_str(), twiceNaptValue.translated_src_l4_port,
                          twiceNaptValue.translated_dst_ip.to_string().c_str(), twiceNaptValue.translated_dst_l4_port,
                          twiceNaptValue.entry_type.c_str());
-        SWSS_DEBUG_PRINT(m_dbgCompName, "             Age-out time: %ld secs, Added-to-Hw: %s",
+        SWSS_DEBUG_PRINT(m_dbgCompName, "             Age-out time: %" PRId64 " secs, Added-to-Hw: %s",
                          (twiceNaptValue.ageOutTime - time_now.tv_sec), ((twiceNaptValue.addedToHw) ? "Yes" : "No"));
         twiceNaptIter++;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1638,7 +1638,7 @@ void PortsOrch::removePortFromPortListMap(sai_object_id_t port_id)
     {
         if (it->second == port_id)
         {
-            SWSS_LOG_NOTICE("Removing port-id %lx from port list map", port_id);
+            SWSS_LOG_NOTICE("Removing port-id %" PRIx64 " from port list map", port_id);
             it = m_portListLaneMap.erase(it);
             break;
         }
@@ -2146,7 +2146,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
             deInitPort(alias, port_id);
 
-            SWSS_LOG_NOTICE("Removing hostif %lx for Port %s", hif_id, alias.c_str());
+            SWSS_LOG_NOTICE("Removing hostif %" PRIx64 " for Port %s", hif_id, alias.c_str());
             sai_status_t status = sai_hostif_api->remove_hostif(hif_id);
             if (status != SAI_STATUS_SUCCESS)
             {


### PR DESCRIPTION
Fixing compilation issue in 32-bit arch(marvell-armhf)

Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>
