### PR TITLE
[aclorch] Add support for creating ingress and egress MIRROR tables concurrently

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2717,22 +2717,21 @@ bool AclOrch::addAclTable(AclTable &newTable)
     // Check if a separate mirror table is needed or not based on the platform
     if (newTable.type == ACL_TABLE_MIRROR || newTable.type == ACL_TABLE_MIRRORV6)
     {
-        auto mirror_id = m_mirrorTableId.find(table_stage);
-        auto mirror_v6_id = m_mirrorV6TableId.find(table_stage);
         if (m_isCombinedMirrorV6Table &&
-            (!m_mirrorTableId[table_stage].empty() || !m_mirrorV6TableId[table_stage].empty())) {
+                (!m_mirrorTableId[table_stage].empty() ||
+                !m_mirrorV6TableId[table_stage].empty())) {
             string orig_table_name;
 
             // If v4 table is created, mark v6 table is created
             if (!m_mirrorTableId[table_stage].empty())
             {
-                orig_table_name = mirror_id->second;
+                orig_table_name = m_mirrorTableId[table_stage];
                 m_mirrorV6TableId[table_stage] = newTable.id;
             }
             // If v6 table is created, mark v4 table is created
             else
             {
-                orig_table_name = mirror_v6_id->second;
+                orig_table_name = m_mirrorV6TableId[table_stage];
                 m_mirrorTableId[table_stage] = newTable.id;
             }
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2713,23 +2713,24 @@ bool AclOrch::addAclTable(AclTable &newTable)
     // Check if a separate mirror table is needed or not based on the platform
     if (newTable.type == ACL_TABLE_MIRROR || newTable.type == ACL_TABLE_MIRRORV6)
     {
-
+        auto mirror_id = m_mirrorTableId.find(table_stage);
+        auto mirror_v6_id = m_mirrorV6TableId.find(table_stage);
         if (m_isCombinedMirrorV6Table &&
-                (m_mirrorTableId.find(table_stage) != m_mirrorTableId.end() ||
-                 m_mirrorV6TableId.find(table_stage) != m_mirrorV6TableId.end())) {
+                (mirror_id != m_mirrorTableId.end() ||
+                 mirror_v6_id != m_mirrorV6TableId.end())) {
 
             string orig_table_name;
 
             // If v4 table is created, mark v6 table is created
-            if (m_mirrorTableId.find(table_stage) != m_mirrorTableId.end())
+            if (mirror_id != m_mirrorTableId.end())
             {
-                orig_table_name = m_mirrorTableId[table_stage];
+                orig_table_name = mirror_id->second;
                 m_mirrorV6TableId.emplace(table_stage, newTable.id);
             }
             // If v6 table is created, mark v4 table is created
             else
             {
-                orig_table_name = m_mirrorV6TableId[table_stage];
+                orig_table_name = mirror_v6_id->second;
                 m_mirrorTableId.emplace(table_stage, newTable.id);
             }
 
@@ -3056,7 +3057,9 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             auto stage = m_AclTables[table_oid].stage;
             if (type == ACL_TABLE_MIRROR || type == ACL_TABLE_MIRRORV6)
             {
-                type = table_id == m_mirrorTableId[stage] ? ACL_TABLE_MIRROR : ACL_TABLE_MIRRORV6;
+                auto mirror_id = m_mirrorTableId.find(stage);
+                bool isMirror = mirror_id != m_mirrorTableId.end() && table_id == mirror_id->second;
+                type = isMirror ? ACL_TABLE_MIRROR : ACL_TABLE_MIRRORV6;
             }
 
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2792,20 +2792,22 @@ bool AclOrch::removeAclTable(string table_id)
         // Clear mirror table information
         // If the v4 and v6 ACL mirror tables are combined together,
         // remove both of them.
-        if (table_id == m_mirrorTableId[stage])
+        auto mirror_id = m_mirrorTableId.find(stage);
+        auto mirror_v6_id = m_mirrorV6TableId.find(stage);
+        if (mirror_id != m_mirrorTableId.end() && mirror_id->second == table_id)
         {
-            m_mirrorTableId.erase(stage);
+            m_mirrorTableId.erase(mirror_id);
             if (m_isCombinedMirrorV6Table)
             {
-                m_mirrorV6TableId.erase(stage);
+                m_mirrorV6TableId.erase(mirror_v6_id);
             }
         }
-        else if (table_id == m_mirrorV6TableId[stage])
+        else if (mirror_v6_id != m_mirrorV6TableId.end() && mirror_v6_id->second == table_id)
         {
-            m_mirrorV6TableId.erase(stage);
+            m_mirrorV6TableId.erase(mirror_v6_id);
             if (m_isCombinedMirrorV6Table)
             {
-                m_mirrorTableId.erase(stage);
+                m_mirrorTableId.erase(mirror_id);
             }
         }
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2666,6 +2666,7 @@ bool AclOrch::addAclTable(AclTable &newTable)
     }
 
     sai_object_id_t table_oid = getTableById(table_id);
+    auto table_stage = newTable.stage;
 
     if (table_oid != SAI_NULL_OBJECT_ID)
     {
@@ -2685,19 +2686,25 @@ bool AclOrch::addAclTable(AclTable &newTable)
         if (table_type == ACL_TABLE_MIRROR || table_type == ACL_TABLE_MIRRORV6)
         {
             string mirror_type;
-            if ((table_type == ACL_TABLE_MIRROR && !m_mirrorTableId.empty()))
+            if (table_type == ACL_TABLE_MIRROR &&
+                m_mirrorTableId.find(table_stage) != m_mirrorTableId.end())
             {
                 mirror_type = TABLE_TYPE_MIRROR;
             }
 
-            if (table_type == ACL_TABLE_MIRRORV6 && !m_mirrorV6TableId.empty())
+            if (table_type == ACL_TABLE_MIRRORV6 &&
+                m_mirrorV6TableId.find(table_stage) != m_mirrorV6TableId.end())
             {
                 mirror_type = TABLE_TYPE_MIRRORV6;
             }
 
             if (!mirror_type.empty())
             {
-                SWSS_LOG_ERROR("Mirror table %s has already been created", mirror_type.c_str());
+                string stage_str = table_stage == ACL_STAGE_INGRESS ? "INGRESS" : "EGRESS";
+                SWSS_LOG_ERROR(
+                    "Mirror table %s (%s) has already been created",
+                    mirror_type.c_str(),
+                    stage_str.c_str());
                 return false;
             }
         }
@@ -2708,21 +2715,22 @@ bool AclOrch::addAclTable(AclTable &newTable)
     {
 
         if (m_isCombinedMirrorV6Table &&
-                (!m_mirrorTableId.empty() || !m_mirrorV6TableId.empty())) {
+                (m_mirrorTableId.find(table_stage) != m_mirrorTableId.end() ||
+                 m_mirrorV6TableId.find(table_stage) != m_mirrorV6TableId.end())) {
 
             string orig_table_name;
 
             // If v4 table is created, mark v6 table is created
-            if (!m_mirrorTableId.empty())
+            if (m_mirrorTableId.find(table_stage) != m_mirrorTableId.end())
             {
-                orig_table_name = m_mirrorTableId;
-                m_mirrorV6TableId = newTable.id;
+                orig_table_name = m_mirrorTableId[table_stage];
+                m_mirrorV6TableId.emplace(table_stage, newTable.id);
             }
             // If v6 table is created, mark v4 table is created
             else
             {
-                orig_table_name = m_mirrorV6TableId;
-                m_mirrorTableId = newTable.id;
+                orig_table_name = m_mirrorV6TableId[table_stage];
+                m_mirrorTableId.emplace(table_stage, newTable.id);
             }
 
             SWSS_LOG_NOTICE("Created ACL table %s as a sibling of %s",
@@ -2741,11 +2749,11 @@ bool AclOrch::addAclTable(AclTable &newTable)
         // Mark the existence of the mirror table
         if (newTable.type == ACL_TABLE_MIRROR)
         {
-            m_mirrorTableId = table_id;
+            m_mirrorTableId.emplace(table_stage, table_id);
         }
         else if (newTable.type == ACL_TABLE_MIRRORV6)
         {
-            m_mirrorV6TableId = table_id;
+            m_mirrorV6TableId.emplace(table_stage, table_id);
         }
 
         return true;
@@ -2774,8 +2782,9 @@ bool AclOrch::removeAclTable(string table_id)
 
     if (deleteUnbindAclTable(table_oid) == SAI_STATUS_SUCCESS)
     {
-        sai_acl_stage_t stage = (m_AclTables[table_oid].stage == ACL_STAGE_INGRESS) ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS;
-        gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, stage, SAI_ACL_BIND_POINT_TYPE_PORT, table_oid);
+        auto stage = m_AclTables[table_oid].stage;
+        sai_acl_stage_t sai_stage = (stage == ACL_STAGE_INGRESS) ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS;
+        gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, sai_stage, SAI_ACL_BIND_POINT_TYPE_PORT, table_oid);
 
         SWSS_LOG_NOTICE("Successfully deleted ACL table %s", table_id.c_str());
         m_AclTables.erase(table_oid);
@@ -2783,20 +2792,20 @@ bool AclOrch::removeAclTable(string table_id)
         // Clear mirror table information
         // If the v4 and v6 ACL mirror tables are combined together,
         // remove both of them.
-        if (table_id == m_mirrorTableId)
+        if (table_id == m_mirrorTableId[stage])
         {
-            m_mirrorTableId.clear();
+            m_mirrorTableId.erase(stage);
             if (m_isCombinedMirrorV6Table)
             {
-                m_mirrorV6TableId.clear();
+                m_mirrorV6TableId.erase(stage);
             }
         }
-        else if (table_id == m_mirrorV6TableId)
+        else if (table_id == m_mirrorV6TableId[stage])
         {
-            m_mirrorV6TableId.clear();
+            m_mirrorV6TableId.erase(stage);
             if (m_isCombinedMirrorV6Table)
             {
-                m_mirrorTableId.clear();
+                m_mirrorTableId.erase(stage);
             }
         }
 
@@ -3042,9 +3051,10 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
             }
 
             auto type = m_AclTables[table_oid].type;
+            auto stage = m_AclTables[table_oid].stage;
             if (type == ACL_TABLE_MIRROR || type == ACL_TABLE_MIRRORV6)
             {
-                type = table_id == m_mirrorTableId ? ACL_TABLE_MIRROR : ACL_TABLE_MIRRORV6;
+                type = table_id == m_mirrorTableId[stage] ? ACL_TABLE_MIRROR : ACL_TABLE_MIRRORV6;
             }
 
 
@@ -3212,18 +3222,23 @@ sai_object_id_t AclOrch::getTableById(string table_id)
     }
 
     // Check if the table is a mirror table and a sibling mirror table is created
-    if (m_isCombinedMirrorV6Table &&
-            (table_id == m_mirrorTableId || table_id == m_mirrorV6TableId))
-    {
-        // If the table is v4, the corresponding v6 table is already created
-        if (table_id == m_mirrorTableId)
-        {
-            return getTableById(m_mirrorV6TableId);
-        }
-        // If the table is v6, the corresponding v4 table is already created
-        else
-        {
-            return getTableById(m_mirrorTableId);
+    if (m_isCombinedMirrorV6Table) {
+        for (auto stage: {ACL_STAGE_INGRESS, ACL_STAGE_EGRESS}) {
+            auto mirrorTableId = m_mirrorTableId.find(stage);
+            auto mirrorV6TableId = m_mirrorV6TableId.find(stage);
+
+            // If the table is v4, the corresponding v6 table is already created
+            if (mirrorTableId != m_mirrorTableId.end() &&
+                table_id == m_mirrorTableId[stage])
+            {
+                return getTableById(m_mirrorV6TableId[stage]);
+            }
+            // If the table is v6, the corresponding v4 table is already created
+            else if (mirrorV6TableId != m_mirrorV6TableId.end() &&
+                table_id == m_mirrorV6TableId[stage])
+            {
+                return getTableById(m_mirrorTableId[stage]);
+            }
         }
     }
 

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -477,8 +477,8 @@ private:
     static DBConnector m_db;
     static Table m_countersTable;
 
-    string m_mirrorTableId;
-    string m_mirrorV6TableId;
+    map<acl_stage_type_t, string> m_mirrorTableId;
+    map<acl_stage_type_t, string> m_mirrorV6TableId;
 
     acl_capabilities_t m_aclCapabilities;
     acl_action_enum_values_capabilities_t m_aclEnumActionCapabilities;

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -274,6 +274,7 @@ class TestMirror(object):
 
     def test_CreateMirrorIngressAndEgress(self, dvs, testlog):
         self.setup_db(dvs)
+        asic_db = dvs.get_asic_db()
 
         ingress_table = "INGRESS_TABLE"
         duplicate_ingress_table = "INGRESS_TABLE_2"
@@ -283,18 +284,18 @@ class TestMirror(object):
         self.create_acl_table(ingress_table, ports, "MIRROR")
 
         # Check that the table has been created
-        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
-        table_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_tables]
-        assert len(table_entries) == 1
+        table_ids = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", 
+                                            len(asic_db.default_acl_tables) + 1)
+        table_entries = [oid for oid in table_ids if oid not in asic_db.default_acl_tables]
         original_entry = table_entries[0]
 
         # Attempt to create another MIRROR table with ingress ACLs
         self.create_acl_table(duplicate_ingress_table, ports, "MIRROR")
 
         # Check that there is still only one table, and that it is the original table
-        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
-        table_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_tables]
-        assert len(table_entries) == 1
+        table_ids = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", 
+                                            len(asic_db.default_acl_tables) + 1)
+        table_entries = [oid for oid in table_ids if oid not in asic_db.default_acl_tables]
         assert table_entries[0] == original_entry
 
         egress_table = "EGRESS_TABLE"
@@ -304,22 +305,23 @@ class TestMirror(object):
         self.create_acl_table(egress_table, ports, "MIRROR", "egress")
 
         # Check that there are two tables
-        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
-        table_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_tables]
-        assert len(table_entries) == 2
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", 
+                                len(asic_db.default_acl_tables) + 2)
 
         # Attempt to create another MIRROR table with egress ACLs
         self.create_acl_table(duplicate_egress_table, ports, "MIRROR", "egress")
 
         # Check that there are still only two tables
-        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
-        table_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_tables]
-        assert len(table_entries) == 2
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", 
+                                len(asic_db.default_acl_tables) + 2)
 
         self.remove_acl_table(ingress_table)
         self.remove_acl_table(egress_table)
         self.remove_acl_table(duplicate_ingress_table)
         self.remove_acl_table(duplicate_egress_table)
+
+        table_ids = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", 
+                                            len(asic_db.default_acl_tables))
 
     # Test case - create a MIRROR table and a MIRRORV6 table in separated mode
     # 0. predefine the VS platform: mellanox platform

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -320,8 +320,7 @@ class TestMirror(object):
         self.remove_acl_table(duplicate_ingress_table)
         self.remove_acl_table(duplicate_egress_table)
 
-        table_ids = asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", 
-                                            len(asic_db.default_acl_tables))
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", len(asic_db.default_acl_tables))
 
     # Test case - create a MIRROR table and a MIRRORV6 table in separated mode
     # 0. predefine the VS platform: mellanox platform


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I made it so that users can create MIRROR tables with ingress ACLs and MIRROR tables with egress ACLs at the same time (and similarly for MIRRORv6 tables).

**Why I did it**
Currently only one mirror table of each type is allowed in order to support the logic for reconciling combined v4/v6 mirror tables. However, we can differentiate based on ACL stage, keeping the reconciliation logic intact while allowing users to mirror with ingress and egress ACLs simultaneously (on devices that support this).

**How I verified it**
WIP. I've provided a new VS test case to check the behavior, I'm in the process of testing the changes on a DUT just to be safe.

**Details if related**