### PR TITLE
[fdborch]: Flush fdb entries on port link down (Resolves #1063, #1294, resolves Azure/sonic-buildimage#4184)

### DIFF
--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -9,6 +9,7 @@ struct FdbEntry
 {
     MacAddress mac;
     sai_object_id_t bv_id;
+    std::string port_name;
 
     bool operator<(const FdbEntry& other) const
     {
@@ -46,6 +47,7 @@ public:
     void update(sai_fdb_event_t, const sai_fdb_entry_t *, sai_object_id_t);
     void update(SubjectType type, void *cntx);
     bool getPort(const MacAddress&, uint16_t, Port&);
+    bool ifChangeInformFdb(Port&, bool);
 
 private:
     PortsOrch *m_portsOrch;
@@ -60,7 +62,7 @@ private:
     void doTask(NotificationConsumer& consumer);
 
     void updateVlanMember(const VlanMemberUpdate&);
-    bool addFdbEntry(const FdbEntry&, const string&, const string&);
+    bool addFdbEntry(FdbEntry&, const string&, const string&);
     bool removeFdbEntry(const FdbEntry&);
 
     bool storeFdbEntryState(const FdbUpdate& update);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2,6 +2,7 @@
 #include "intfsorch.h"
 #include "bufferorch.h"
 #include "neighorch.h"
+#include "fdborch.h"
 
 #include <inttypes.h>
 #include <cassert>
@@ -39,6 +40,7 @@ extern IntfsOrch *gIntfsOrch;
 extern NeighOrch *gNeighOrch;
 extern CrmOrch *gCrmOrch;
 extern BufferOrch *gBufferOrch;
+extern FdbOrch *gFdbOrch;
 
 #define VLAN_PREFIX         "Vlan"
 #define DEFAULT_VLAN_ID     1
@@ -3829,6 +3831,11 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
     if (!gNeighOrch->ifChangeInformNextHop(port.m_alias, isUp))
     {
         SWSS_LOG_WARN("Inform nexthop operation failed for interface %s", port.m_alias.c_str());
+    }
+
+    if (!gFdbOrch->ifChangeInformFdb(port, isUp))
+    {
+        SWSS_LOG_WARN("Inform fdb operation failed for interface %s", port.m_alias.c_str());
     }
 }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

1. Add a method to inform fdborch to flush FDB while port operation status changed.
2. Implement codes for processing events of the flushed FDB on specified port or vlan notifications of SAI

**Why I did it**
Fix issue: [[FDB] Doesn't flush fdb entries on port link down #1294](https://github.com/Azure/sonic-swss/issues/1294)

**How I verified it**
Please refer test steps in [[FDB] Doesn't flush fdb entries on port link down #1294](https://github.com/Azure/sonic-swss/issues/1294)

Test on broadcom platform 'x86_64-delta_ag9032v1-r0 with SONiC Software Version: 201911 branch commit 2218ed4 on May 1, 2020.

**Details if related**
