### PR TITLE
[qosorch] Update QoS scheduler params for shaping features

### DIFF
--- a/doc/swss-schema.md
+++ b/doc/swss-schema.md
@@ -256,23 +256,48 @@ and reflects the LAG ports into the redis under: `LAG_TABLE:<team0>:port`
 ### SCHEDULER_TABLE
     ; Scheduler table
     ; SAI mapping - saicheduler.h
-    key      = "SCHEDULER_TABLE":name
-    ; field     value
-    type     = "DWRR"/"WRR"/"PRIORITY"
-    weight   = 1*DIGIT
-    priority = 1*DIGIT
+    key        = "SCHEDULER_TABLE":name
+    ; field      value
+    type       = "DWRR"/"WRR"/"STRICT"
+    weight     = 2*DIGIT
+    priority   = 1*DIGIT
+    meter_type = "packets"/"bytes"
+    cir        = 1*11 DIGIT  ; guaranteed rate in pps or bytes/sec
+    cbs        = 1*11 DIGIT  ; guaranteed burst size in packets or bytes
+    pir        = 1*11 DIGIT  ; max rate in pps or bytes/sec
+    pbs        = 1*11 DIGIT  ; max burst size in packets or bytes
 
     Example:
     127.0.0.1:6379> hgetall SCHEDULER_TABLE:BEST_EFFORT
-    1) "type"
-    2) "PRIORITY"
-    3) "priority"
-    4) "7"
+     1) "type"
+     2) "PRIORITY"
+     3) "priority"
+     4) "7"
+     5) "meter_type"
+     6) "bytes"
+     7) "cir"
+     8) "1000000000"
+     9) "cbs"
+    10) "8192"
+    11) "pir"
+    12) "1250000000"
+    13) "pbs"
+    14) "8192"
     127.0.0.1:6379> hgetall SCHEDULER_TABLE:SCAVENGER
-    1) "type"
-    2) "DWRR"
-    3) "weight"
-    4) "35"
+     1) "type"
+     2) "DWRR"
+     3) "weight"
+     4) "35"
+     5) "meter_type"
+     6) "bytes"
+     7) "cir"
+     8) "1000000000"
+     9) "cbs"
+    10) "8192"
+    11) "pir"
+    12) "1250000000"
+    13) "pbs"
+    14) "8192"
 
 ---------------------------------------------
 ### WRED\_PROFILE\_TABLE

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -49,7 +49,13 @@ map<string, sai_port_attr_t> qos_to_attr_map = {
     {tc_to_queue_field_name, SAI_PORT_ATTR_QOS_TC_TO_QUEUE_MAP},
     {tc_to_pg_map_field_name, SAI_PORT_ATTR_QOS_TC_TO_PRIORITY_GROUP_MAP},
     {pfc_to_pg_map_name, SAI_PORT_ATTR_QOS_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP},
-    {pfc_to_queue_map_name, SAI_PORT_ATTR_QOS_PFC_PRIORITY_TO_QUEUE_MAP}
+    {pfc_to_queue_map_name, SAI_PORT_ATTR_QOS_PFC_PRIORITY_TO_QUEUE_MAP},
+    {scheduler_field_name, SAI_PORT_ATTR_QOS_SCHEDULER_PROFILE_ID}
+};
+
+map<string, sai_meter_type_t> scheduler_meter_map = {
+    {"packets", SAI_METER_TYPE_PACKETS},
+    {"bytes", SAI_METER_TYPE_BYTES}
 };
 
 type_map QosOrch::m_qos_maps = {
@@ -813,28 +819,35 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
                 // TODO: The meaning is to be able to adjus priority of the given scheduler group.
                 // However currently SAI model does not provide such ability.
             }
+            else if (fvField(*i) == scheduler_meter_type_field_name)
+            {
+                sai_meter_type_t meter_value = scheduler_meter_map.at(fvValue(*i));
+                attr.id = SAI_SCHEDULER_ATTR_METER_TYPE;
+                attr.value.s32 = meter_value;
+                sai_attr_list.push_back(attr);
+            }
             else if (fvField(*i) == scheduler_min_bandwidth_rate_field_name)
             {
                 attr.id = SAI_SCHEDULER_ATTR_MIN_BANDWIDTH_RATE;
-                attr.value.u64 = stoul(fvValue(*i));
+                attr.value.u64 = stoull(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
             else if (fvField(*i) == scheduler_min_bandwidth_burst_rate_field_name)
             {
                 attr.id = SAI_SCHEDULER_ATTR_MIN_BANDWIDTH_BURST_RATE;
-                attr.value.u64 = stoul(fvValue(*i));
+                attr.value.u64 = stoull(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
             else if (fvField(*i) == scheduler_max_bandwidth_rate_field_name)
             {
                 attr.id = SAI_SCHEDULER_ATTR_MAX_BANDWIDTH_RATE;
-                attr.value.u64 = stoul(fvValue(*i));
+                attr.value.u64 = stoull(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
             else if (fvField(*i) == scheduler_max_bandwidth_burst_rate_field_name)
             {
                 attr.id = SAI_SCHEDULER_ATTR_MAX_BANDWIDTH_BURST_RATE;
-                attr.value.u64 = stoul(fvValue(*i));
+                attr.value.u64 = stoull(fvValue(*i));
                 sai_attr_list.push_back(attr);
             }
             else {

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -36,7 +36,7 @@ const string scheduler_algo_WRR                 = "WRR";
 const string scheduler_algo_STRICT              = "STRICT";
 const string scheduler_weight_field_name        = "weight";
 const string scheduler_priority_field_name      = "priority";
-
+const string scheduler_meter_type_field_name    = "meter_type";
 const string scheduler_min_bandwidth_rate_field_name       = "cir";//Committed Information Rate
 const string scheduler_min_bandwidth_burst_rate_field_name = "cbs";//Committed Burst Size
 const string scheduler_max_bandwidth_rate_field_name       = "pir";//Peak Information Rate


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Added shaping meter_type field to SCHEDULER_TABLE
- Added scheduler reference field to PORT_QOS_MAP table for port level shaping

**Why I did it**
Update the shaping feature to reflect the corresponding QoS scheduling and shaping design doc: - https://github.com/Azure/SONiC/pull/535

**How I verified it**
See test cases executed in the QoS scheduling and shaping design doc

Signed-off-by: Michael Li <michael.li@broadcom.com>