### PR TITLE
[orchagent] Set default MTU for the underlay loopback interface

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -36,6 +36,8 @@ extern sai_router_interface_api_t *sai_router_intfs_api;
 
 #define UNREFERENCED_PARAMETER(P)       (P)
 
+#define UNDERLAY_RIF_DEFAULT_MTU 9100
+
 /* Global variables */
 sai_object_id_t gVirtualRouterId;
 sai_object_id_t gUnderlayIfId;
@@ -304,6 +306,10 @@ int main(int argc, char **argv)
 
     underlay_intf_attr.id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
     underlay_intf_attr.value.s32 = SAI_ROUTER_INTERFACE_TYPE_LOOPBACK;
+    underlay_intf_attrs.push_back(underlay_intf_attr);
+
+    underlay_intf_attr.id = SAI_ROUTER_INTERFACE_ATTR_MTU;
+    underlay_intf_attr.value.u32 = UNDERLAY_RIF_DEFAULT_MTU;
     underlay_intf_attrs.push_back(underlay_intf_attr);
 
     status = sai_router_intfs_api->create_router_interface(&gUnderlayIfId, gSwitchId, (uint32_t)underlay_intf_attrs.size(), underlay_intf_attrs.data());


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Set default MTU for the underlay loopback interface to ```9100``` in order to make it working with jumbo frames.

**Why I did it**
Underlay loopback is used for VxLAN tunnel and without setting MTU jumbo frames are trapped to CPU on ```decap``` flow. But they should be successfully decapsulated and routed to the appropriate destination.

**How I verified it**
* Configure VxLAN tunnel 
* Send encapsulated jumbo frame to switch port 1
* Verify that decapsulated jumbo frame is sent by switch from port 2

**Details if related**
N/A