### PR TITLE
 Corrected the copp rule as per NAT HLD

### DIFF
--- a/swssconfig/sample/00-copp.config.json
+++ b/swssconfig/sample/00-copp.config.json
@@ -43,8 +43,8 @@
         "OP": "SET"
     },
     {
-        "COPP_TABLE:trap.group.nat.ip2me": {
-            "trap_ids": "ip2me,src_nat_miss,dest_nat_miss",
+        "COPP_TABLE:trap.group.ip2me": {
+            "trap_ids": "ip2me",
             "trap_action":"trap",
             "trap_priority":"1",
             "queue": "1",
@@ -52,6 +52,20 @@
             "mode":"sr_tcm",
             "cir":"6000",
             "cbs":"6000",
+            "red_action":"drop"
+        },
+        "OP": "SET"
+    },
+    {
+        "COPP_TABLE:trap.group.nat": {
+            "trap_ids": "src_nat_miss,dest_nat_miss",
+            "trap_action":"trap",
+            "trap_priority":"1",
+            "queue": "1",
+            "meter_type":"packets",
+            "mode":"sr_tcm",
+            "cir":"600",
+            "cbs":"600",
             "red_action":"drop"
         },
         "OP": "SET"


### PR DESCRIPTION
Updated the rate-limit value as per the "https://github.com/Azure/SONiC/blob/master/doc/nat/nat_design_spec.md"  in copp json file.

This PR is to address the issue - https://github.com/Azure/SONiC/issues/611

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>