### PR TITLE
[MultiDB] Use database name instead of database ID

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -557,7 +557,7 @@ bool Orch::parseIndexRange(const string &input, sai_uint32_t &range_low, sai_uin
 
 void Orch::addConsumer(DBConnector *db, string tableName, int pri)
 {
-    if (db->getDbId() == CONFIG_DB || db->getDbId() == STATE_DB)
+    if (db->getDbName() == "CONFIG_DB" || db->getDbName() == "STATE_DB")
     {
         addExecutor(new Consumer(new SubscriberStateTable(db, tableName, TableConsumable::DEFAULT_POP_BATCH_SIZE, pri), this, tableName));
     }

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -136,6 +136,11 @@ public:
         return getConsumerTable()->getDbConnector()->getDbId();
     }
 
+    std::string getDbName() const
+    {
+        return getConsumerTable()->getDbConnector()->getDbName();
+    }
+
     std::string dumpTuple(const swss::KeyOpFieldsValuesTuple &tuple);
     void dumpPendingTasks(std::vector<std::string> &ts);
 

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -59,7 +59,7 @@ void PfcWdOrch<DropHandler, ForwardHandler>::doTask(Consumer& consumer)
         return;
     }
 
-    if ((consumer.getDbId() == CONFIG_DB) && (consumer.getTableName() == CFG_PFC_WD_TABLE_NAME))
+    if ((consumer.getDbName() == "CONFIG_DB") && (consumer.getTableName() == CFG_PFC_WD_TABLE_NAME))
     {
         auto it = consumer.m_toSync.begin();
         while (it != consumer.m_toSync.end())
@@ -761,7 +761,7 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::doTask(Consumer& consumer)
         return;
     }
 
-    if ((consumer.getDbId() == APPL_DB) && (consumer.getTableName() == APP_PFC_WD_TABLE_NAME))
+    if ((consumer.getDbName() == "APPL_DB") && (consumer.getTableName() == APP_PFC_WD_TABLE_NAME))
     {
         auto it = consumer.m_toSync.begin();
         while (it != consumer.m_toSync.end())


### PR DESCRIPTION
Remove references to hardcoded DB ID in swss as in a MultiDB, the DB Name
should always be used to accurately identify the connector's database role.

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Use database name as the key to match a database instead of DB ID. In a MultiDB environment,
the db ID can be changed in database_config.json

**Why I did it**
Modify default DB ID's in database_config.json

**How I verified it**
Swap APPL_DB and CONFIG_DB IDs in database_config.json and reboot. Ensure that switch comes
back up and ports are created.

**Details if related**
 Use database name instead of database ID