### PR TITLE
Fix LAG member test case

### DIFF
--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -447,13 +447,10 @@ class TestVlan(object):
         assert len(lag_member_entries) == 1
 
         (status, fvs) = tbl.get(lag_member_entries[0])
-        for fv in fvs:
-            if fv[0] == "SAI_LAG_MEMBER_ATTR_LAG_ID":
-                assert fv[1] == lag_entries[0]
-            elif fv[0] == "SAI_LAG_MEMBER_ATTR_PORT_ID":
-                assert dvs.asicdb.portoidmap[fv[1]] == "Ethernet0"
-            else:
-                assert False
+        fvs = dict(fvs)
+        assert len(fvs) == 4
+        assert fvs.get("SAI_LAG_MEMBER_ATTR_LAG_ID") == lag_entries[0]
+        assert dvs.asicdb.portoidmap[fvs.get("SAI_LAG_MEMBER_ATTR_PORT_ID")] == "Ethernet0"
 
         # create vlan
         self.create_vlan(vlan)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed LAG memeber test case and ran the VS test case to ensure it passes.
Test was expecting only two fields for LAG member where actual is 4
```
(('SAI_LAG_MEMBER_ATTR_LAG_ID', 'oid:0x20000000005c4'), ('SAI_LAG_MEMBER_ATTR_PORT_ID', 'oid:0x1000000000002'), ('SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE', 'false'), ('SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE', 'false'))
```
**Why I did it**
Test case was broken.
**How I verified it**
By running VS test case
**Details if related**
```

test_vlan.py::TestVlan::test_AddPortChannelToVlan PASSED                                                                                                                                                                 [100%]
 
```
