### PR TITLE
[vstest]: unmark fixture for create/remove_dpb_config_file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1017,7 +1017,6 @@ def dvs_acl_manager(request, dvs):
                                          dvs.get_counters_db())
 
 ##################### DPB fixtures ###########################################
-@pytest.yield_fixture(scope="module")
 def create_dpb_config_file(dvs):
     cmd = "sonic-cfggen -j /etc/sonic/init_cfg.json -j /tmp/ports.json --print-data > /tmp/dpb_config_db.json"
     dvs.runcmd(['sh', '-c', cmd])
@@ -1026,7 +1025,6 @@ def create_dpb_config_file(dvs):
     cmd = "cp /tmp/dpb_config_db.json /etc/sonic/config_db.json"
     dvs.runcmd(cmd)
 
-@pytest.yield_fixture(scope="module")
 def remove_dpb_config_file(dvs):
     cmd = "mv /etc/sonic/config_db.json.bak /etc/sonic/config_db.json"
     dvs.runcmd(cmd)


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
unmark fixture for create/remove_dpb_config_file

**Why I did it**
see issue

Fixture "create_dpb_config_file" called directly. Fixtures are not meant to be called directly,
but are created automatically when test functions request them as parameters.
See https://docs.pytest.org/en/latest/fixture.html for more information about fixtures, and
https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly about how to update your code.

**How I verified it**
check vstest

**Details if related**
