### PR TITLE
Revert "[portsorch] Enable port-level buffer drop counters"

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -114,8 +114,6 @@ const vector<sai_port_stat_t> port_stat_ids =
     SAI_PORT_STAT_ETHER_STATS_TX_NO_ERRORS,
     SAI_PORT_STAT_IP_IN_UCAST_PKTS,
     SAI_PORT_STAT_ETHER_IN_PKTS_128_TO_255_OCTETS,
-    SAI_PORT_STAT_IN_DROPPED_PKTS,
-    SAI_PORT_STAT_OUT_DROPPED_PKTS,
 };
 
 static const vector<sai_queue_stat_t> queue_stat_ids =


### PR DESCRIPTION
Reverts Azure/sonic-swss#1237

These counters are causing widespread issues in the master branch, so we're backing them out for now to be revisited in a later PR. They will likely need to be polled separately from the other counters, and on a longer interval, to avoid performance issues and conflicts.