### PR TITLE
[sonic-swss] ARMHF warning fixes

### DIFF
--- a/mclagsyncd/mclaglink.cpp
+++ b/mclagsyncd/mclaglink.cpp
@@ -197,14 +197,14 @@ void MclagLink::setPortIsolate(char *msg)
     cur = msg;
 
     /*get isolate src port infor*/
-    op_hdr = (mclag_sub_option_hdr_t *)cur;
+    op_hdr = reinterpret_cast<mclag_sub_option_hdr_t *>(static_cast<void *>(cur));
     cur = cur + MCLAG_SUB_OPTION_HDR_LEN;
     isolate_src_port.insert(0, (const char*)cur, op_hdr->op_len);
 
     cur = cur + op_hdr->op_len;
 
     /*get isolate dst ports infor*/
-    op_hdr = (mclag_sub_option_hdr_t *)cur;
+    op_hdr = reinterpret_cast<mclag_sub_option_hdr_t *>(static_cast<void *>(cur));
     cur = cur + MCLAG_SUB_OPTION_HDR_LEN;
     isolate_dst_port.insert(0, (const char*)cur, op_hdr->op_len);
 
@@ -265,7 +265,7 @@ void MclagLink::setPortMacLearnMode(char *msg)
     cur = msg;
 
     /*get port learning mode info*/
-    op_hdr = (mclag_sub_option_hdr_t *)cur;
+    op_hdr = reinterpret_cast<mclag_sub_option_hdr_t *>(static_cast<void *>(cur));
     if (op_hdr->op_type == MCLAG_SUB_OPTION_TYPE_MAC_LEARN_ENABLE)
     {
         learn_mode = "hardware";
@@ -319,7 +319,7 @@ void MclagLink::setFdbFlushByPort(char *msg)
 
     cur = msg;
     /*get port infor*/
-    op_hdr = (mclag_sub_option_hdr_t *)cur;
+    op_hdr = reinterpret_cast<mclag_sub_option_hdr_t *>(static_cast<void *>(cur));
     cur = cur + MCLAG_SUB_OPTION_HDR_LEN;
     port.insert(0, (const char*)cur, op_hdr->op_len);
 
@@ -340,14 +340,14 @@ void MclagLink::setIntfMac(char *msg)
     cur = msg;
 
     /*get intf key name*/
-    op_hdr = (mclag_sub_option_hdr_t *)cur;
+    op_hdr = reinterpret_cast<mclag_sub_option_hdr_t *>(static_cast<void *>(cur));
     cur = cur + MCLAG_SUB_OPTION_HDR_LEN;
     intf_key.insert(0, (const char*)cur, op_hdr->op_len);
 
     cur = cur + op_hdr->op_len;
 
     /*get mac*/
-    op_hdr = (mclag_sub_option_hdr_t *)cur;
+    op_hdr = reinterpret_cast<mclag_sub_option_hdr_t *>(static_cast<void *>(cur));
     cur = cur + MCLAG_SUB_OPTION_HDR_LEN;
     mac_value.insert(0, (const char*)cur, op_hdr->op_len);
 
@@ -379,7 +379,7 @@ void MclagLink::setFdbEntry(char *msg, int msg_len)
     {
         memset(key, 0, 64);
 
-        fdb_info = (struct mclag_fdb_info *)(cur + index * sizeof(struct mclag_fdb_info));
+        fdb_info = reinterpret_cast<struct mclag_fdb_info *>(static_cast<void *>(cur + index * sizeof(struct mclag_fdb_info)));
 
         fdb.mac = fdb_info->mac;
         fdb.port_name = fdb_info->port_name;
@@ -502,7 +502,7 @@ ssize_t  MclagLink::getFdbChange(char *msg_buf)
     {
         if (MCLAG_MAX_SEND_MSG_LEN - infor_len < sizeof(struct mclag_fdb_info))
         {
-            msg_head = (mclag_msg_hdr_t *)infor_start;
+            msg_head = reinterpret_cast<mclag_msg_hdr_t *>(static_cast<void *>(infor_start));
             msg_head->version = 1;
             msg_head->msg_len = (unsigned short)infor_len;
             msg_head->msg_type = MCLAG_SYNCD_MSG_TYPE_FDB_OPERATION;
@@ -535,7 +535,7 @@ ssize_t  MclagLink::getFdbChange(char *msg_buf)
     {
         if (MCLAG_MAX_SEND_MSG_LEN - infor_len < sizeof(struct mclag_fdb_info))
         {
-            msg_head = (mclag_msg_hdr_t *)infor_start;
+            msg_head = reinterpret_cast<mclag_msg_hdr_t *>(static_cast<void *>(infor_start));
             msg_head->version = 1;
             msg_head->msg_len = (unsigned short)infor_len;
             msg_head->msg_type = MCLAG_SYNCD_MSG_TYPE_FDB_OPERATION;
@@ -567,7 +567,7 @@ ssize_t  MclagLink::getFdbChange(char *msg_buf)
     if (infor_len <= sizeof(mclag_msg_hdr_t)) /*no fdb entry need notifying iccpd*/
         return 1;
 
-    msg_head = (mclag_msg_hdr_t *)infor_start;
+    msg_head = reinterpret_cast<mclag_msg_hdr_t *>(static_cast<void *>(infor_start));
     msg_head->version = 1;
     msg_head->msg_len = (unsigned short)infor_len;
     msg_head->msg_type = MCLAG_SYNCD_MSG_TYPE_FDB_OPERATION;
@@ -676,7 +676,7 @@ uint64_t MclagLink::readData()
 
     while (true)
     {
-        hdr = (mclag_msg_hdr_t *)(m_messageBuffer + start);
+        hdr = reinterpret_cast<mclag_msg_hdr_t *>(static_cast<void *>(m_messageBuffer + start));
         left = m_pos - start;
         if (left < MCLAG_MSG_HDR_LEN)
             break;


### PR DESCRIPTION
Compiler Warnings : cast increases required alignment of target type [-Wcast-align]
Fix: Use reintrepret cast to cast lower size pointer to bigger size
pointer types

Signed-off-by: Antony Rheneus <arheneus@marvell.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
