### PR TITLE
Fix in script to avoid orchagent crash when port down followed by fdb…

### DIFF
--- a/tests/test_mirror_port_erspan.py
+++ b/tests/test_mirror_port_erspan.py
@@ -149,8 +149,6 @@ class TestMirror(object):
                             "SAI_MIRROR_SESSION_ATTR_VLAN_CFI": "0"}
         self.dvs_mirror.verify_session(dvs, session, asic_db=expected_asic_db, src_ports=src_asic_ports, asic_size=16, direction="TX")
 
-        dvs.set_interface_status("Ethernet4", "down")
-
         # remove fdb entry
         dvs.remove_fdb(vlan_id, "66-66-66-66-66-66")
         self.dvs_mirror.verify_session_status(session, status="inactive")


### PR DESCRIPTION
**What I did**
Observed that sometimes  orchagent is hitting seg fault with below stack when port down followed by FDB delete.

Crash: 
Thread 1 "orchagent" received signal SIGSEGV, Segmentation fault.
0x00007f8f742aebb3 in std::_Rb_tree_increment(std::_Rb_tree_node_base const*) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
(gdb) bt
#0  0x00007f8f742aebb3 in std::_Rb_tree_increment(std::_Rb_tree_node_base const*) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#1  0x000055c07f1f1078 in std::_Rb_tree_const_iterator<FdbEntry>::operator++ (this=<synthetic pointer>) at /usr/include/c++/6/bits/stl_tree.h:288
#2  FdbOrch::update (this=this@entry=0x55c07f89f6d0, type=<optimized out>, entry=<optimized out>, bridge_port_id=<optimized out>) at fdborch.cpp:235
#3  0x000055c07f1f2002 in FdbOrch::doTask (this=0x55c07f89f6d0, consumer=...) at fdborch.cpp:485
#4  0x000055c07f15d712 in OrchDaemon::start (this=0x55c07f882e80) at orchdaemon.cpp:467
#5  0x000055c07f148322 in main (argc=<optimized out>, argv=<optimized out>) at main.cpp:346

**Why I did it**
Fixed in script to avoid this as it may be hitting some timing issue.

**How I verified it**
Ran script 50 times without any issue.

**Details if related**