### PR TITLE
[aclorch] Use IPv6 Next Header internally for protocol number on MLNX platform

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -389,7 +389,8 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
 
     // NOTE: Temporary workaround to support matching protocol numbers on MLNX platform.
     // In a later SAI version we will transition to using NEXT_HEADER for IPv6 on all platforms.
-    string platform = getenv("platform") ? getenv("platform") : "";
+    auto platform_env_var = getenv("platform");
+    string platform = platform_env_var ? platform_env_var: "";
     if ((m_tableType == ACL_TABLE_MIRRORV6 || m_tableType == ACL_TABLE_L3V6)
             && platform == MLNX_PLATFORM_SUBSTRING
             && attr_name == MATCH_IP_PROTOCOL)
@@ -1367,7 +1368,8 @@ bool AclTable::create()
 
     // NOTE: Temporary workaround to support matching protocol numbers on MLNX platform.
     // In a later SAI version we will transition to using NEXT_HEADER for IPv6 on all platforms.
-    string platform = getenv("platform") ? getenv("platform") : "";
+    auto platform_env_var = getenv("platform");
+    string platform = platform_env_var ? platform_env_var: "";
     if ((type == ACL_TABLE_MIRRORV6 || type == ACL_TABLE_L3V6)
             && platform == MLNX_PLATFORM_SUBSTRING)
     {

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -44,6 +44,7 @@ acl_rule_attr_lookup_t aclMatchLookup =
     { MATCH_L4_DST_PORT,       SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT },
     { MATCH_ETHER_TYPE,        SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE },
     { MATCH_IP_PROTOCOL,       SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL },
+    { MATCH_NEXT_HEADER,       SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER },
     { MATCH_TCP_FLAGS,         SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS },
     { MATCH_IP_TYPE,           SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE },
     { MATCH_DSCP,              SAI_ACL_ENTRY_ATTR_FIELD_DSCP },
@@ -302,7 +303,7 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
                 value.aclfield.mask.u8 = 0x3F;
             }
         }
-        else if (attr_name == MATCH_IP_PROTOCOL)
+        else if (attr_name == MATCH_IP_PROTOCOL || attr_name == MATCH_NEXT_HEADER)
         {
             value.aclfield.data.u8 = to_uint<uint8_t>(attr_value);
             value.aclfield.mask.u8 = 0xFF;
@@ -384,6 +385,16 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
     {
         SWSS_LOG_ERROR("Failed to parse %s attribute %s value.", attr_name.c_str(), attr_value.c_str());
         return false;
+    }
+
+    // NOTE: Temporary workaround to support matching protocol numbers on MLNX platform.
+    // In a later SAI version we will transition to using NEXT_HEADER for IPv6 on all platforms.
+    string platform = getenv("platform") ? getenv("platform") : "";
+    if ((m_tableType == ACL_TABLE_MIRRORV6 || m_tableType == ACL_TABLE_L3V6)
+            && platform == MLNX_PLATFORM_SUBSTRING
+            && attr_name == MATCH_IP_PROTOCOL)
+    {
+        attr_name = MATCH_NEXT_HEADER;
     }
 
     m_matches[aclMatchLookup[attr_name]] = value;
@@ -1354,9 +1365,22 @@ bool AclTable::create()
     attr.value.booldata = true;
     table_attrs.push_back(attr);
 
-    attr.id = SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL;
-    attr.value.booldata = true;
-    table_attrs.push_back(attr);
+    // NOTE: Temporary workaround to support matching protocol numbers on MLNX platform.
+    // In a later SAI version we will transition to using NEXT_HEADER for IPv6 on all platforms.
+    string platform = getenv("platform") ? getenv("platform") : "";
+    if ((type == ACL_TABLE_MIRRORV6 || type == ACL_TABLE_L3V6)
+            && platform == MLNX_PLATFORM_SUBSTRING)
+    {
+        attr.id = SAI_ACL_TABLE_ATTR_FIELD_IPV6_NEXT_HEADER;
+        attr.value.booldata = true;
+        table_attrs.push_back(attr);
+    }
+    else
+    {
+        attr.id = SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL;
+        attr.value.booldata = true;
+        table_attrs.push_back(attr);
+    }
 
     /*
      * Type of Tables and Supported Match Types (ASIC database)

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -46,6 +46,7 @@
 #define MATCH_L4_DST_PORT       "L4_DST_PORT"
 #define MATCH_ETHER_TYPE        "ETHER_TYPE"
 #define MATCH_IP_PROTOCOL       "IP_PROTOCOL"
+#define MATCH_NEXT_HEADER       "NEXT_HEADER"
 #define MATCH_TCP_FLAGS         "TCP_FLAGS"
 #define MATCH_IP_TYPE           "IP_TYPE"
 #define MATCH_DSCP              "DSCP"

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -230,7 +230,7 @@ class TestMirror(object):
         # dscp mirror tables.
         expected_sai_attributes = [
             "SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE",
-            "SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL",
+            "SAI_ACL_TABLE_ATTR_FIELD_IPV6_NEXT_HEADER",  # NOTE: We use the MLNX2700 VS implementation for this test suite.
             "SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6",
             "SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6",
             "SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE",


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I updated the qualifiers we use internally for IP_PROTOCOL to IPV6_NEXT_HEADER for Mellanox SKUs.

**Why I did it**
IPV6_NEXT_HEADER *should* be used for MIRRORV6 and L3V6 across the board, but some SAI libraries do not implement this qualifier yet. We will push the other SAI vendors to implement this qualifier so we can transition to it moving forward.

The reason this is important to do now for Mellanox is that certain ACL rules will crash if they include the IP_PROTOCOL field.

**How I verified it**
1. Install new SWSS with this change
2. Confirm that ASIC DB shows IPV6_NEXT_HEADER as a MIRRORV6 table qualifier
3. Confirm that ASIC DB shows IPV6_NEXT_HEADER as a qualifier for rules with IP_PROTOCOL
4. Confirm that rules with IP Protocol and other fields (e.g. src ipv6, src port, dscp, etc.) do not crash the ASIC

**Details if related**
