### PR TITLE
[tlm_teamd]: Try to add LAG again, when teamd is not ready first time

### DIFF
--- a/tlm_teamd/main.cpp
+++ b/tlm_teamd/main.cpp
@@ -107,6 +107,7 @@ int main()
             }
             else if (res == swss::Select::TIMEOUT)
             {
+                teamdctl_mgr.process_add_queue();
                 values_store.update(teamdctl_mgr.get_dumps());
             }
             else

--- a/tlm_teamd/teamdctl_mgr.cpp
+++ b/tlm_teamd/teamdctl_mgr.cpp
@@ -6,6 +6,24 @@
 #include "teamdctl_mgr.h"
 
 ///
+/// Custom function for libteamdctl logger. IT is empty to prevent libteamdctl to spam us with the error messages
+/// @param tdc teamdctl descriptor
+/// @param priority priority of the message
+/// @param file file where error was raised
+/// @param line line in the file where error was raised
+/// @param fn function where the error was raised
+/// @param format format of the error message
+/// @param args arguments of the error message
+void teamdctl_log_function(struct teamdctl *tdc, int priority,
+                           const char *file, int line,
+                           const char *fn, const char *format,
+                           va_list args)
+{
+
+}
+
+
+///
 /// The destructor clean up handlers to teamds
 ///
 TeamdCtlMgr::~TeamdCtlMgr()
@@ -71,6 +89,8 @@ bool TeamdCtlMgr::try_add_lag(const std::string & lag_name)
         m_lags_to_add[lag_name]++;
         return false;
     }
+
+    teamdctl_set_log_fn(tdc, &teamdctl_log_function);
 
     int err = teamdctl_connect(tdc, lag_name.c_str(), nullptr, nullptr);
     if (err)

--- a/tlm_teamd/teamdctl_mgr.cpp
+++ b/tlm_teamd/teamdctl_mgr.cpp
@@ -1,4 +1,5 @@
 #include <cstring>
+#include <algorithm>
 
 #include <logger.h>
 
@@ -31,10 +32,11 @@ bool TeamdCtlMgr::has_key(const std::string & lag_name) const
 }
 
 ///
-/// Adds a LAG interface with lag_name to the manager
-/// This method allocates structures to connect to teamd
+/// Public method to add a LAG interface with lag_name to the manager
+/// This method tries to add. If the method can't add the LAG interface,
+/// this action will be postponed.
 /// @param lag_name a name for LAG interface
-/// @return true if the lag was added successfully, false otherwise
+/// @return true if the lag was added or postponed successfully, false otherwise
 ///
 bool TeamdCtlMgr::add_lag(const std::string & lag_name)
 {
@@ -43,25 +45,48 @@ bool TeamdCtlMgr::add_lag(const std::string & lag_name)
         SWSS_LOG_DEBUG("The LAG '%s' was already added. Skip adding it.", lag_name.c_str());
         return true;
     }
-    else
-    {
-        auto tdc = teamdctl_alloc();
-        if (!tdc)
-        {
-            SWSS_LOG_ERROR("Can't allocate memory for teamdctl handler. LAG='%s'", lag_name.c_str());
-            return false;
-        }
+    return try_add_lag(lag_name);
+}
 
-        int err = teamdctl_connect(tdc, lag_name.c_str(), nullptr, nullptr);
-        if (err)
-        {
-            SWSS_LOG_ERROR("Can't connect to teamd LAG='%s', error='%s'", lag_name.c_str(), strerror(-err));
-            teamdctl_free(tdc);
-            return false;
-        }
-        m_handlers.emplace(lag_name, tdc);
-        SWSS_LOG_NOTICE("The LAG '%s' has been added.", lag_name.c_str());
+///
+/// Try to adds a LAG interface with lag_name to the manager
+/// This method allocates structures to connect to teamd
+/// if the method can't add, it will retry to add next time
+/// @param lag_name a name for LAG interface
+/// @return true if the lag was added successfully, false otherwise
+///
+bool TeamdCtlMgr::try_add_lag(const std::string & lag_name)
+{
+    if (m_lags_to_add.find(lag_name) == m_lags_to_add.end())
+    {
+        m_lags_to_add[lag_name] = 0;
     }
+
+    int attempt = m_lags_to_add[lag_name];
+
+    auto tdc = teamdctl_alloc();
+    if (!tdc)
+    {
+        SWSS_LOG_ERROR("Can't allocate memory for teamdctl handler. LAG='%s'. attempt=%d", lag_name.c_str(), attempt);
+        m_lags_to_add[lag_name]++;
+        return false;
+    }
+
+    int err = teamdctl_connect(tdc, lag_name.c_str(), nullptr, nullptr);
+    if (err)
+    {
+        if (attempt != 0)
+        {
+            SWSS_LOG_WARN("Can't connect to teamd LAG='%s', error='%s'. attempt=%d", lag_name.c_str(), strerror(-err), attempt);
+        }
+        teamdctl_free(tdc);
+        m_lags_to_add[lag_name]++;
+        return false;
+    }
+
+    m_handlers.emplace(lag_name, tdc);
+    m_lags_to_add.erase(lag_name);
+    SWSS_LOG_NOTICE("The LAG '%s' has been added.", lag_name.c_str());
 
     return true;
 }
@@ -82,11 +107,37 @@ bool TeamdCtlMgr::remove_lag(const std::string & lag_name)
         m_handlers.erase(lag_name);
         SWSS_LOG_NOTICE("The LAG '%s' has been removed.", lag_name.c_str());
     }
+    else if (m_lags_to_add.find(lag_name) != m_lags_to_add.end())
+    {
+        m_lags_to_add.erase(lag_name);
+        SWSS_LOG_DEBUG("The LAG '%s' has been removed from adding queue.", lag_name.c_str());
+    }
     else
     {
         SWSS_LOG_WARN("The LAG '%s' hasn't been added. Can't remove it", lag_name.c_str());
     }
     return true;
+}
+
+///
+/// Process the queue with postponed add operations for LAG.
+///
+void TeamdCtlMgr::process_add_queue()
+{
+    std::vector<std::string> lag_names_to_add;
+    std::transform(m_lags_to_add.begin(), m_lags_to_add.end(), lag_names_to_add.begin(), [](auto pair) { return pair.first; });
+    for (const auto lag_name: lag_names_to_add)
+    {
+        bool result = try_add_lag(lag_name);
+        if (!result)
+        {
+            if (m_lags_to_add[lag_name] == TeamdCtlMgr::max_attempts_to_add)
+            {
+                SWSS_LOG_ERROR("Can't connect to teamd after %d attempts. LAG '%s'", TeamdCtlMgr::max_attempts_to_add, lag_name.c_str());
+                m_lags_to_add.erase(lag_name);
+            }
+        }
+    }
 }
 
 ///

--- a/tlm_teamd/teamdctl_mgr.h
+++ b/tlm_teamd/teamdctl_mgr.h
@@ -15,13 +15,18 @@ class TeamdCtlMgr
 public:
     TeamdCtlMgr() = default;
     ~TeamdCtlMgr();
-    bool add_lag(const std::string & kag_name);
-    bool remove_lag(const std::string & kag_name);
+    bool add_lag(const std::string & lag_name);
+    bool remove_lag(const std::string & lag_name);
+    void process_add_queue();
     TeamdCtlDump get_dump(const std::string & lag_name);
     TeamdCtlDumps get_dumps();
 
 private:
     bool has_key(const std::string & lag_name) const;
+    bool try_add_lag(const std::string & lag_name);
 
     std::unordered_map<std::string, struct teamdctl*> m_handlers;
+    std::unordered_map<std::string, int> m_lags_to_add;
+
+    const int max_attempts_to_add = 10;
 };

--- a/tlm_teamd/values_store.cpp
+++ b/tlm_teamd/values_store.cpp
@@ -16,7 +16,7 @@ std::vector<std::string> ValuesStore::get_ports(json_t * root)
     int err = json_unpack(root, "{s:o}", "ports", &ports);
     if (err != 0)
     {
-        throw std::runtime_error("Can't find 'ports' in the json dump object");
+        return result;
     }
 
     const char * key;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. I add a queue, to try add a LAG for up to 10 times. tlm_teamd will make 1 seconds between attempts while working on other tasks.
2. I found another bug: "tlm_teamd doesn't work properly when teamd doesn't have member ports registered for a LAG"
3. I made an enhancement to prevent spam syslog with libteamdctl internal log messages.

**Why I did it**
1. To fix first half of the reported bug: https://github.com/Azure/sonic-swss/issues/1346
2. To fix the bug which prevented tlm_teamd to update telemetry data for teamds.
3. To clean up syslog from libteamd internal messages.

**How I verified it**
Run command `sudo config portchannel add PortChannelTest`
Before the fix you can see following output in syslog:
```
Jul  8 19:29:14.466829 str-s6100-acs-1 WARNING teamd#tlm_teamd: message repeated 35 times: [ :- update: Exception 'Can't find 'ports' in the json dump object' had been thrown in ValuesStore]
Jul  8 19:29:14.466829 str-s6100-acs-1 ERR teamd#tlm_teamd: :- add_lag: Can't connect to teamd LAG='PortChannelTest', error='Invalid argument'
Jul  8 19:29:14.466829 str-s6100-acs-1 INFO teamd#supervisord: tlm_teamd libteamdctl: teamdctl_connect: Failed to connect using all CLIs.
```
After the fix you can see following syslog output:
```
Jul  8 21:09:40.150962 str-s6100-acs-1 NOTICE teamd#tlm_teamd: :- try_add_lag: The LAG 'PortChannelTest' has been added.
```

**Details if related**
