### PR TITLE
[vstest]: fix vstest for python3

### DIFF
--- a/tests/dvslib/dvs_database.py
+++ b/tests/dvslib/dvs_database.py
@@ -40,7 +40,7 @@ class DVSDatabase(object):
         """
 
         table = swsscommon.Table(self.db_connection, table_name)
-        formatted_entry = swsscommon.FieldValuePairs(entry.items())
+        formatted_entry = swsscommon.FieldValuePairs(list(entry.items()))
         table.set(key, formatted_entry)
 
     def update_entry(self, table_name, key, entry):
@@ -54,7 +54,7 @@ class DVSDatabase(object):
         """
 
         table = swsscommon.Table(self.db_connection, table_name)
-        formatted_entry = swsscommon.FieldValuePairs(entry.items())
+        formatted_entry = swsscommon.FieldValuePairs(list(entry.items()))
         table.set(key, formatted_entry)
 
     def get_entry(self, table_name, key):

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -31,7 +31,7 @@ class TestDot1p(object):
 
     def create_dot1p_profile(self):
         tbl = swsscommon.Table(self.config_db, CFG_DOT1P_TO_TC_MAP_TABLE_NAME)
-        fvs = swsscommon.FieldValuePairs(DOT1P_TO_TC_MAP.items())
+        fvs = swsscommon.FieldValuePairs(list(DOT1P_TO_TC_MAP.items()))
         tbl.set(CFG_DOT1P_TO_TC_MAP_KEY, fvs)
         time.sleep(1)
 

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -5,7 +5,7 @@ from swsscommon import swsscommon
 
 
 def create_fvs(**kwargs):
-    return swsscommon.FieldValuePairs(kwargs.items())
+    return swsscommon.FieldValuePairs(list(kwargs.items()))
 
 
 class TestTunnelBase(object):


### PR DESCRIPTION
explicitly conver the items to list instead of dict_items

Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
explicitly conver the items to list instead of dict_items

**Why I did it**
dict_items cannot be converted to vector<std:pair<>> in c++

**How I verified it**
pytest

**Details if related**
