### PR TITLE
[201911] Create AclTableGroup only for platforms using AclHandler logic in pfcwd

### DIFF
--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -560,10 +560,15 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
                 sai_serialize_object_id(queueId));
     }
 
-    // Create egress ACL table group for each port of pfcwd's interest
-    sai_object_id_t groupId;
-    gPortsOrch->createBindAclTableGroup(port.m_port_id, groupId, ACL_STAGE_INGRESS);
-    gPortsOrch->createBindAclTableGroup(port.m_port_id, groupId, ACL_STAGE_EGRESS);
+    string platform = getenv("platform") ? getenv("platform") : "";
+    if ((platform == BFN_PLATFORM_SUBSTRING)
+        || (platform == BRCM_PLATFORM_SUBSTRING))
+    {
+        // Create egress ACL table group for each port of pfcwd's interest
+        sai_object_id_t groupId;
+        gPortsOrch->createBindAclTableGroup(port.m_port_id, groupId, ACL_STAGE_INGRESS);
+        gPortsOrch->createBindAclTableGroup(port.m_port_id, groupId, ACL_STAGE_EGRESS);
+    }
 
     return true;
 }

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -560,7 +560,8 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
                 sai_serialize_object_id(queueId));
     }
 
-    string platform = getenv("platform") ? getenv("platform") : "";
+    auto platform_env_var = getenv("platform");
+    string platform = platform_env_var ? platform_env_var: "";
     if ((platform == BFN_PLATFORM_SUBSTRING)
         || (platform == BRCM_PLATFORM_SUBSTRING))
     {


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Avoid creating/binding AclTableGroup for platforms that do not use AclHandler logic in pfcwd

**How I verified it**
Install swss with the changes
Verified that createBindAclTableGroup() is called only on platforms that uses AclHandler logic when pfcwd is started on a port

--- on a platform using AclHandler logic ---
Jul 19 02:38:04.586515 str-7260cx3-acs-7 DEBUG swss#orchagent: :> initWdCounters: enter
Jul 19 02:38:04.586515 str-7260cx3-acs-7 DEBUG swss#orchagent: :> getQueueStats: enter
Jul 19 02:38:04.586515 str-7260cx3-acs-7 DEBUG swss#orchagent: :< getQueueStats: exit
Jul 19 02:38:04.586515 str-7260cx3-acs-7 DEBUG swss#orchagent: :< initWdCounters: exit
Jul 19 02:38:04.586515 str-7260cx3-acs-7 DEBUG swss#orchagent: :> createBindAclTableGroup: enter
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :> getPort: enter
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :< getPort: exit
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :< createBindAclTableGroup: exit
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :> createBindAclTableGroup: enter
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :> getPort: enter
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :< getPort: exit
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :< createBindAclTableGroup: exit
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :< registerInWdDb: exit
Jul 19 02:38:04.586619 str-7260cx3-acs-7 DEBUG swss#orchagent: :< startWdOnPort: exit
Jul 19 02:38:04.586619 str-7260cx3-acs-7 NOTICE swss#orchagent: :- createEntry: Started PFC Watchdog on port Ethernet4

--- on a platform using ZeroBuffer logic ---
Jul 19 02:56:05.623851 str-msn2700-22 DEBUG swss#orchagent: :> initWdCounters: enter
Jul 19 02:56:05.623851 str-msn2700-22 DEBUG swss#orchagent: :> getQueueStats: enter
Jul 19 02:56:05.623851 str-msn2700-22 DEBUG swss#orchagent: :< getQueueStats: exit
Jul 19 02:56:05.624822 str-msn2700-22 DEBUG swss#orchagent: :< initWdCounters: exit
Jul 19 02:56:05.624822 str-msn2700-22 DEBUG swss#orchagent: :< registerInWdDb: exit
Jul 19 02:56:05.624822 str-msn2700-22 DEBUG swss#orchagent: :< startWdOnPort: exit
Jul 19 02:56:05.624822 str-msn2700-22 NOTICE swss#orchagent: :- createEntry: Started PFC Watchdog on port Ethernet4
