### PR TITLE
[dvs] Mark unstable tests as xfail

### DIFF
--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 class TestNat(object):
     def setup_db(self, dvs):

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -279,7 +279,7 @@ class TestNat(object):
         # clear interfaces
         self.clear_interfaces(dvs)
 
-    @pytest.mark.xfail("Test unstable, blocking PR builds")
+    @pytest.mark.xfail(reason="Test unstable, blocking PR builds")
     def test_VerifyConntrackTimeoutForNatEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -278,6 +278,7 @@ class TestNat(object):
         # clear interfaces
         self.clear_interfaces(dvs)
 
+    @pytest.mark.xfail("Test unstable, blocking PR builds")
     def test_VerifyConntrackTimeoutForNatEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -248,7 +248,7 @@ class TestVrf(object):
 
         self.vrf_remove(dvs, "Vrf_a", state)
 
-    @pytest.mark.xfail("Test unstable, blocking PR builds")
+    @pytest.mark.xfail(reason="Test unstable, blocking PR builds")
     def test_VRFMgr_Capacity(self, dvs, testlog):
         self.setup_db(dvs)
 

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -248,6 +248,7 @@ class TestVrf(object):
 
         self.vrf_remove(dvs, "Vrf_a", state)
 
+    @pytest.mark.xfail("Test unstable, blocking PR builds")
     def test_VRFMgr_Capacity(self, dvs, testlog):
         self.setup_db(dvs)
 

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1797,7 +1797,7 @@ class TestWarmReboot(object):
         intf_tbl._del("{}".format(intfs[2]))
         time.sleep(2)
 
-    @pytest.mark.xfail("Test unstable, blocking PR builds")
+    @pytest.mark.xfail(reason="Test unstable, blocking PR builds")
     def test_system_warmreboot_neighbor_syncup(self, dvs, testlog):
 
         appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import json
+import pytest
 
 from swsscommon import swsscommon
 

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -1796,6 +1796,7 @@ class TestWarmReboot(object):
         intf_tbl._del("{}".format(intfs[2]))
         time.sleep(2)
 
+    @pytest.mark.xfail("Test unstable, blocking PR builds")
     def test_system_warmreboot_neighbor_syncup(self, dvs, testlog):
 
         appl_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Motivation**
I marked three tests that are consistently flaky as `xfail` so that they do not block PRs. Following up with the test authors to get them stabilized in the meantime.
