### PR TITLE
Update nat entries to use nat_type to support DNAT Pool changes.

### DIFF
--- a/cfgmgr/natmgr.cpp
+++ b/cfgmgr/natmgr.cpp
@@ -45,7 +45,8 @@ NatMgr::NatMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
         m_appTwiceNatTableProducer(appDb, APP_NAT_TWICE_TABLE_NAME),
         m_appTwiceNaptTableProducer(appDb, APP_NAPT_TWICE_TABLE_NAME),
         m_appNatGlobalTableProducer(appDb, APP_NAT_GLOBAL_TABLE_NAME),
-        m_appNaptPoolIpTable(appDb, APP_NAPT_POOL_IP_TABLE_NAME)
+        m_appNaptPoolIpTable(appDb, APP_NAPT_POOL_IP_TABLE_NAME),
+        m_appNatDnatPoolProducer(appDb, APP_NAT_DNAT_POOL_TABLE_NAME)
 {
     SWSS_LOG_ENTER();
   
@@ -79,7 +80,7 @@ NatMgr::NatMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
     Orch::addExecutor(refresh_executor);
 }
 
-/* To check the port init id done or not */
+/* To check the port init is done or not */
 bool NatMgr::isPortInitDone(DBConnector *app_db)
 {
     bool portInit = 0;
@@ -909,6 +910,12 @@ bool NatMgr::setMangleIptablesRules(const string &opCmd, const string &interface
     std::string res;
     int ret;
 
+    if (nat_zone.empty())
+    {
+        SWSS_LOG_INFO("Nat zone is empty");
+        return false;
+    }
+
     const std::string cmds = std::string("")
           + IPTABLES_CMD + " -t mangle " + "-" + opCmd + " PREROUTING -i " + interface + " -j MARK --set-mark " + nat_zone + " && "
           + IPTABLES_CMD + " -t mangle " + "-" + opCmd + " POSTROUTING -o " + interface + " -j MARK --set-mark " + nat_zone ;
@@ -1343,7 +1350,7 @@ bool NatMgr::setDynamicNatIptablesRulesWithAcl(const string &opCmd, const string
                    + IPTABLES_CMD + " -t nat " + "-" + opCmd + " POSTROUTING -p udp" + srcIpAddressString + dstIpAddressString
                    + srcPortString + dstPortString + " -j RETURN" + " && "
                    + IPTABLES_CMD + " -t nat " + "-" + opCmd + " POSTROUTING -p icmp" + srcIpAddressString + dstIpAddressString
-                   + srcPortString + dstPortString + " -j RETURN";
+                   + " -j RETURN";
             }
             else
             {
@@ -1356,7 +1363,7 @@ bool NatMgr::setDynamicNatIptablesRulesWithAcl(const string &opCmd, const string
                        + IPTABLES_CMD + " -t nat " + "-" + opCmd + " POSTROUTING -p udp" + srcIpAddressString + " -d " + keys[0]
                        + srcPortString + " --dport " + keys[2] + " -j RETURN" + " && "
                        + IPTABLES_CMD + " -t nat " + "-" + opCmd + " POSTROUTING -p icmp" + srcIpAddressString + " -d " + keys[0]
-                       + srcPortString + " --dport " + keys[2] + " -j RETURN";
+                       + " -j RETURN";
                 }
                 else
                 {
@@ -1366,7 +1373,7 @@ bool NatMgr::setDynamicNatIptablesRulesWithAcl(const string &opCmd, const string
                        + IPTABLES_CMD + " -t nat " + "-" + opCmd + " POSTROUTING -p udp" + srcIpAddressString + " -d " + keys[0]
                        + srcPortString + " -j RETURN" + " && "
                        + IPTABLES_CMD + " -t nat " + "-" + opCmd + " POSTROUTING -p icmp" + srcIpAddressString + " -d " + keys[0]
-                       + srcPortString + " -j RETURN";
+                       + " -j RETURN";
                 }
 
             }
@@ -1457,6 +1464,92 @@ bool NatMgr::setDynamicNatIptablesRulesWithAcl(const string &opCmd, const string
     }
 
     return true;
+}
+
+/* To add/remove a DNAT Pool entry from Nat Pool */
+void NatMgr::setDnatPoolfromNatPool(const string &opCmd, const string &ip_range)
+{
+    uint32_t ipv4_addr_low, ipv4_addr_high, ip;
+    vector<string> nat_ip = tokenize(ip_range, range_specifier);
+
+    /* Check the pool is valid */
+    if (nat_ip.empty())
+    {
+        SWSS_LOG_INFO("NAT pool is not valid");
+        return;
+    }
+    else if (nat_ip.size() == 2)
+    {
+        IpAddress addr_high(nat_ip[1]);
+        ipv4_addr_high = ntohl(addr_high.getV4Addr());
+        IpAddress addr_low(nat_ip[0]);
+        ipv4_addr_low = ntohl(addr_low.getV4Addr());
+    }
+    else
+    {
+        IpAddress addr_high(nat_ip[0]);
+        ipv4_addr_high = ntohl(addr_high.getV4Addr());
+        ipv4_addr_low = ipv4_addr_high;
+    }
+
+    for (ip = ipv4_addr_low; ip <= ipv4_addr_high; ip++)
+    {
+        IpAddress ipAddr(htonl(ip));
+        if (opCmd == ADD)
+        {
+            addDnatPoolEntry(ipAddr.to_string());
+        }
+        else
+        {
+            removeDnatPoolEntry(ipAddr.to_string());
+        }
+    }
+}
+
+/* To add a DNAT Pool entry */
+void NatMgr::addDnatPoolEntry(string destIp)
+{
+
+    if (m_natDnatPoolInfo.find(destIp) != m_natDnatPoolInfo.end())
+    {
+        /* Increment the ref count */
+        m_natDnatPoolInfo[destIp] = (m_natDnatPoolInfo[destIp] + 1);
+        SWSS_LOG_INFO("Increased the ref count to %d for dnat pool entry %s", m_natDnatPoolInfo[destIp], destIp.c_str());
+    }
+    else
+    {
+        /* Create the ref count */
+        SWSS_LOG_INFO("Create the ref count for dnat pool entry %s", destIp.c_str());
+        m_natDnatPoolInfo[destIp] = 1;
+
+        std::vector<swss::FieldValueTuple> values;
+        swss::FieldValueTuple p("NULL", "NULL");
+        values.push_back(p);
+        m_appNatDnatPoolProducer.set(destIp, values);
+    }
+}
+
+/* To remove a DNAT Pool */
+void NatMgr::removeDnatPoolEntry(string destIp)
+{
+
+    if (m_natDnatPoolInfo.find(destIp) != m_natDnatPoolInfo.end())
+    {
+        /* Decrement the ref count */
+        m_natDnatPoolInfo[destIp] = (m_natDnatPoolInfo[destIp] - 1);
+        SWSS_LOG_INFO("Decreased the ref count to %d for dnat pool entry %s", m_natDnatPoolInfo[destIp], destIp.c_str());
+    }
+    else
+    {
+        SWSS_LOG_INFO("Invalid DestIp DNAT pool removal for %s", destIp.c_str());
+        return;
+    }
+
+    if (!m_natDnatPoolInfo[destIp])
+    {
+        m_natDnatPoolInfo.erase(destIp);
+        m_appNatDnatPoolProducer.del(destIp);
+    }
 }
 
 /* To add Static NAT entry based on Static Key if all valid conditions are met */
@@ -1943,6 +2036,10 @@ void NatMgr::addStaticSingleNatEntry(const string &key)
         fvVectorDnat.push_back(q);
     }
 
+    /* Add DnatPool entry to APPL_DB*/
+    SWSS_LOG_INFO("Adding dnat pool entry for %s", appKeyDnat.c_str());
+    addDnatPoolEntry(appKeyDnat);
+
     FieldValueTuple r(NAT_TYPE, DNAT_NAT_TYPE);
     fvVectorDnat.push_back(r);
     FieldValueTuple s(NAT_TYPE, SNAT_NAT_TYPE);
@@ -2050,6 +2147,13 @@ void NatMgr::addStaticTwiceNatEntry(const string &key)
             translated_dest = m_staticNatEntry[key].local_ip;
             interface = m_staticNatEntry[key].interface;
         }
+
+        /* Add DnatPool entry to APPL_DB*/
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", dest.c_str());
+        addDnatPoolEntry(dest);
+
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", translated_src.c_str());
+        addDnatPoolEntry(translated_src);
 
         /* Create APPL_DB key and it's values */
         string appKey = src + ":" + dest;
@@ -2172,6 +2276,14 @@ void NatMgr::addStaticTwiceNatEntry(const string &key)
                                             m_natPoolInfo[pool_name].port_range, (*it).second.acl_name,
                                             (*it).first);
 
+        /* Add DnatPool entry to APPL_DB*/
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", m_staticNatEntry[key].local_ip.c_str());
+        addDnatPoolEntry(m_staticNatEntry[key].local_ip);
+
+        /* Add DnatPool entry to APPL_DB*/
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+        setDnatPoolfromNatPool(ADD, m_natPoolInfo[pool_name].ip_range);
+
         break;
     }
 
@@ -2224,6 +2336,10 @@ void NatMgr::addStaticSingleNaptEntry(const string &key)
         FieldValueTuple s(TRANSLATED_L4_PORT, keys[2]);
         fvVectorSnat.push_back(r);
         fvVectorSnat.push_back(s);
+
+        /* Add DnatPool entry to APPL_DB*/
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", keys[0].c_str());
+        addDnatPoolEntry(keys[0]);
     }
     else if (m_staticNaptEntry[key].nat_type == SNAT_NAT_TYPE)
     {
@@ -2238,6 +2354,10 @@ void NatMgr::addStaticSingleNaptEntry(const string &key)
         FieldValueTuple s(TRANSLATED_L4_PORT, keys[2]);
         fvVectorDnat.push_back(r);
         fvVectorDnat.push_back(s);
+
+        /* Add DnatPool entry to APPL_DB*/
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", m_staticNaptEntry[key].local_ip.c_str());
+        addDnatPoolEntry(m_staticNaptEntry[key].local_ip);
     }
 
     FieldValueTuple t(NAT_TYPE, DNAT_NAT_TYPE);
@@ -2371,6 +2491,13 @@ void NatMgr::addStaticTwiceNaptEntry(const string &key)
             translated_dest_port = m_staticNaptEntry[key].local_port;
             interface = m_staticNaptEntry[key].interface;
         }
+
+        /* Add DnatPool entry to APPL_DB*/
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", dest.c_str());
+        addDnatPoolEntry(dest);
+
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", translated_src.c_str());
+        addDnatPoolEntry(translated_src);
 
         /* Create APPL_DB key and it's values */
         string appKey = keys[1] + ":" + src + ":" + src_port + ":" + dest + ":" + dest_port;
@@ -2510,6 +2637,14 @@ void NatMgr::addStaticTwiceNaptEntry(const string &key)
                                             m_natPoolInfo[pool_name].port_range, (*it).second.acl_name,
                                             (*it).first);
 
+        /* Add DnatPool entry to APPL_DB*/
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", m_staticNaptEntry[key].local_ip.c_str());
+        addDnatPoolEntry(m_staticNaptEntry[key].local_ip);
+
+        /* Add DnatPool entry to APPL_DB*/
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+        setDnatPoolfromNatPool(ADD, m_natPoolInfo[pool_name].ip_range);
+
         break;
     }
 
@@ -2564,6 +2699,10 @@ void NatMgr::removeStaticSingleNatEntry(const string &key)
         appKeySnat += key;
         appKeyDnat += m_staticNatEntry[key].local_ip;
     }
+
+    /* Delete DnatPool entry from APPL_DB*/
+    SWSS_LOG_INFO("Deleting dnat pool entry for %s", appKeyDnat.c_str());
+    removeDnatPoolEntry(appKeyDnat);
 
     /* Delete conntrack entry */
     deleteConntrackStaticSingleNatEntry(key);
@@ -2670,6 +2809,13 @@ void NatMgr::removeStaticTwiceNatEntry(const string &key)
             translated_dest = m_staticNatEntry[key].local_ip;
             interface = m_staticNatEntry[key].interface;
         }
+
+        /* Delete DnatPool entry from APPL_DB*/
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", dest.c_str());
+        removeDnatPoolEntry(dest);
+
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", translated_src.c_str());
+        removeDnatPoolEntry(translated_src);
 
         string appKey = src + ":" + dest;
         string reverseAppKey = translated_dest + ":" + translated_src;
@@ -2784,6 +2930,14 @@ void NatMgr::removeStaticTwiceNatEntry(const string &key)
         setDynamicAllForwardOrAclbasedRules(DELETE, (*it).second.pool_interface, m_natPoolInfo[pool_name].ip_range,
                                             m_natPoolInfo[pool_name].port_range, acls_name, (*it).first);
 
+        /* Delete DnatPool entry from APPL_DB*/
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_staticNatEntry[key].local_ip.c_str());
+        removeDnatPoolEntry(m_staticNatEntry[key].local_ip);
+
+        /* Delete DnatPool entry from APPL_DB*/
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+        setDnatPoolfromNatPool(DELETE, m_natPoolInfo[pool_name].ip_range);
+
         (*it).second.twice_nat_added = false;
         (*it).second.static_key = EMPTY_STRING;
         m_staticNatEntry[key].twice_nat_added = false;
@@ -2845,11 +2999,19 @@ void NatMgr::removeStaticSingleNaptEntry(const string &key)
     {
         appKeyDnat += (keys[1] + DEFAULT_KEY_SEPARATOR + keys[0] + DEFAULT_KEY_SEPARATOR + keys[2]);
         appKeySnat += (keys[1] + DEFAULT_KEY_SEPARATOR + m_staticNaptEntry[key].local_ip + DEFAULT_KEY_SEPARATOR + m_staticNaptEntry[key].local_port);
+
+        /* Delete DnatPool entry from APPL_DB*/
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", keys[0].c_str());
+        removeDnatPoolEntry(keys[0]);
     }
     else if (m_staticNaptEntry[key].nat_type == SNAT_NAT_TYPE)
     {
         appKeySnat += (keys[1] + DEFAULT_KEY_SEPARATOR + keys[0] + DEFAULT_KEY_SEPARATOR + keys[2]);
         appKeyDnat += (keys[1] + DEFAULT_KEY_SEPARATOR + m_staticNaptEntry[key].local_ip + DEFAULT_KEY_SEPARATOR + m_staticNaptEntry[key].local_port);
+
+        /* Delete DnatPool entry from APPL_DB*/
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_staticNaptEntry[key].local_ip.c_str());
+        removeDnatPoolEntry(m_staticNaptEntry[key].local_ip);
     }
 
     /* Delete conntrack entry */
@@ -2986,6 +3148,13 @@ void NatMgr::removeStaticTwiceNaptEntry(const string &key)
             interface = m_staticNaptEntry[key].interface;
         }
 
+        /* Delete DnatPool entry from APPL_DB*/
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", dest.c_str());
+        removeDnatPoolEntry(dest);
+
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", translated_src.c_str());
+        removeDnatPoolEntry(translated_src);
+
         string appKey = keys[1] + ":" + src + ":" + src_port + ":" + dest + ":" + dest_port;
         string reverseAppKey = keys[1] + ":" + translated_dest + ":" + translated_dest_port + ":" + translated_src + ":" + translated_src_port;
 
@@ -3100,10 +3269,18 @@ void NatMgr::removeStaticTwiceNaptEntry(const string &key)
         setDynamicAllForwardOrAclbasedRules(DELETE, (*it).second.pool_interface, m_natPoolInfo[pool_name].ip_range,
                                             m_natPoolInfo[pool_name].port_range, acls_name, (*it).first);
 
+        /* Delete DnatPool entry from APPL_DB*/
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_staticNaptEntry[key].local_ip.c_str());
+        removeDnatPoolEntry(m_staticNaptEntry[key].local_ip);
+
+        /* Delete DnatPool entry from APPL_DB*/
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+        setDnatPoolfromNatPool(DELETE, m_natPoolInfo[pool_name].ip_range);
+
         (*it).second.twice_nat_added = false;
         (*it).second.static_key = EMPTY_STRING;
-        m_staticNatEntry[key].twice_nat_added = false;
-        m_staticNatEntry[key].binding_key = EMPTY_STRING;
+        m_staticNaptEntry[key].twice_nat_added = false;
+        m_staticNaptEntry[key].binding_key = EMPTY_STRING;
         isEntryDeleted = true;
         break;
     }
@@ -4489,6 +4666,10 @@ void NatMgr::addDynamicNatRule(const string &key)
         SWSS_LOG_INFO("Adding dynamic single nat rules for %s", key.c_str());   
         setDynamicAllForwardOrAclbasedRules(ADD, pool_interface, m_natPoolInfo[pool_name].ip_range,
                                             m_natPoolInfo[pool_name].port_range, acls_name, key);
+
+        /* Add DnatPool entry to APPL_DB */
+        SWSS_LOG_INFO("Adding dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+        setDnatPoolfromNatPool(ADD, m_natPoolInfo[pool_name].ip_range);
     }
     else
     {
@@ -4545,6 +4726,10 @@ void NatMgr::removeDynamicNatRule(const string &key)
         SWSS_LOG_INFO("Deleting dynamic single nat rules for %s", key.c_str());
         setDynamicAllForwardOrAclbasedRules(DELETE, pool_interface, m_natPoolInfo[pool_name].ip_range,
                                             m_natPoolInfo[pool_name].port_range, acls_name, key);
+
+        /* Delete DNAT pool entry from APPL_DB */
+        SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str()); 
+        setDnatPoolfromNatPool(DELETE, m_natPoolInfo[pool_name].ip_range);
     }
     else
     {
@@ -4659,6 +4844,10 @@ void NatMgr::addDynamicNatRuleByAcl(const string &aclKey, bool isRuleId)
                     /* Set pool ip to APPL_DB */
                     setNaptPoolIpTable(DELETE, ip_range, port_range);
 
+                    /* Delete DnatPool entry from APPL_DB*/
+                    SWSS_LOG_INFO("Deleting dnat pool entry for %s", ip_range.c_str());
+                    setDnatPoolfromNatPool(DELETE, ip_range);
+
                     /* Set dynamic iptables rule without acl */
                     if (!setDynamicNatIptablesRulesWithoutAcl(DELETE, poolInterface, ip_range, port_range, (*it).second.static_key))
                     {
@@ -4678,6 +4867,10 @@ void NatMgr::addDynamicNatRuleByAcl(const string &aclKey, bool isRuleId)
 
                 /* Set pool ip to APPL_DB */
                 setNaptPoolIpTable(ADD, ip_range, port_range);
+
+                /* Add DnatPool entry to APPL_DB*/
+                SWSS_LOG_INFO("Adding dnat pool entry for %s", ip_range.c_str());
+                setDnatPoolfromNatPool(ADD, ip_range);
 
                 /* Set dynamic iptables rule with acls*/
                 if (!setDynamicNatIptablesRulesWithAcl(ADD, poolInterface, ip_range, port_range, m_natAclRuleInfo[aclKey], (*it).second.static_key))
@@ -4708,6 +4901,10 @@ void NatMgr::addDynamicNatRuleByAcl(const string &aclKey, bool isRuleId)
                     /* Set pool ip to APPL_DB */
                     setNaptPoolIpTable(ADD, ip_range, port_range);
 
+                    /* Add DnatPool entry to APPL_DB*/
+                    SWSS_LOG_INFO("Adding dnat pool entry for %s", ip_range.c_str());
+                    setDnatPoolfromNatPool(ADD, ip_range);
+
                     /* Add dynamic iptables rule with acls */
                     if (!setDynamicNatIptablesRulesWithAcl(ADD, poolInterface, ip_range, port_range, (*it2).second, (*it).second.static_key))
                     {
@@ -4725,6 +4922,10 @@ void NatMgr::addDynamicNatRuleByAcl(const string &aclKey, bool isRuleId)
                 {
                     /* Set pool ip to APPL_DB */
                     setNaptPoolIpTable(DELETE, ip_range, port_range);
+
+                    /* Delete DnatPool entry from APPL_DB*/
+                    SWSS_LOG_INFO("Deleting dnat pool entry for %s", ip_range.c_str());
+                    setDnatPoolfromNatPool(DELETE, ip_range);
 
                     /* Delete dynamic iptables rule without acl */
                     if (!setDynamicNatIptablesRulesWithoutAcl(DELETE, poolInterface, ip_range, port_range, (*it).second.static_key))
@@ -4843,6 +5044,10 @@ void NatMgr::removeDynamicNatRuleByAcl(const string &aclKey, bool isRuleId)
                 /* Set pool ip to APPL_DB */
                 setNaptPoolIpTable(DELETE, ip_range, port_range);
 
+                /* Delete DnatPool entry from APPL_DB*/
+                SWSS_LOG_INFO("Deleting dnat pool entry for %s", ip_range.c_str());
+                setDnatPoolfromNatPool(DELETE, ip_range);
+
                 /* Delete dynamic iptables rule with acls*/
                 if (!setDynamicNatIptablesRulesWithAcl(DELETE, poolInterface, ip_range, port_range, m_natAclRuleInfo[aclKey], (*it).second.static_key))
                 {
@@ -4877,6 +5082,10 @@ void NatMgr::removeDynamicNatRuleByAcl(const string &aclKey, bool isRuleId)
                     /* Set pool ip to APPL_DB */
                     setNaptPoolIpTable(ADD, ip_range, port_range);
 
+                    /* Set DnatPool entry to APPL_DB*/
+                    SWSS_LOG_INFO("Adding dnat pool entry for %s", ip_range.c_str());
+                    setDnatPoolfromNatPool(ADD, ip_range);
+
                     /* Set dynamic iptables rule without acl */
                     if (!setDynamicNatIptablesRulesWithoutAcl(ADD, poolInterface, ip_range, port_range, (*it).second.static_key))
                     {
@@ -4909,6 +5118,10 @@ void NatMgr::removeDynamicNatRuleByAcl(const string &aclKey, bool isRuleId)
                     /* Set pool ip to APPL_DB */
                     setNaptPoolIpTable(DELETE, ip_range, port_range);
 
+                    /* Set DnatPool entry to APPL_DB*/
+                    SWSS_LOG_INFO("Deleting dnat pool entry for %s", ip_range.c_str());
+                    setDnatPoolfromNatPool(DELETE, ip_range);
+
                     /* Delete dynamic iptables rule with acls */
                     if (!setDynamicNatIptablesRulesWithAcl(DELETE, poolInterface, ip_range, port_range, (*it2).second, (*it).second.static_key))
                     {
@@ -4926,6 +5139,10 @@ void NatMgr::removeDynamicNatRuleByAcl(const string &aclKey, bool isRuleId)
                 {
                     /* Set pool ip to APPL_DB */
                     setNaptPoolIpTable(ADD, ip_range, port_range);
+
+                    /* Add DnatPool entry to APPL_DB*/
+                    SWSS_LOG_INFO("Adding dnat pool entry for %s", ip_range.c_str());
+                    setDnatPoolfromNatPool(ADD, ip_range);
 
                     /* Add dynamic iptables rule without acl */
                     if (!setDynamicNatIptablesRulesWithoutAcl(ADD, poolInterface, ip_range, port_range, (*it).second.static_key))
@@ -5037,6 +5254,10 @@ void NatMgr::addDynamicNatRules(const string port, const string ipPrefix)
             setDynamicAllForwardOrAclbasedRules(ADD, pool_interface, m_natPoolInfo[pool_name].ip_range,
                                                 m_natPoolInfo[pool_name].port_range, (*it).second.acl_name,
                                                 (*it).first);
+
+            /* Add DnatPool entry to APPL_DB*/
+            SWSS_LOG_INFO("Adding dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+            setDnatPoolfromNatPool(ADD, m_natPoolInfo[pool_name].ip_range);
         }
         else
         {
@@ -5147,6 +5368,10 @@ void NatMgr::removeDynamicNatRules(const string port, const string ipPrefix)
             setDynamicAllForwardOrAclbasedRules(DELETE, pool_interface, m_natPoolInfo[pool_name].ip_range,
                                                 m_natPoolInfo[pool_name].port_range, (*it).second.acl_name,
                                                 (*it).first);
+
+            /* Delete DnatPool entry from APPL_DB*/
+            SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+            setDnatPoolfromNatPool(DELETE, m_natPoolInfo[pool_name].ip_range);
         }
         else
         {
@@ -5236,6 +5461,14 @@ void NatMgr::addDynamicTwiceNatRule(const string &key)
             setDynamicAllForwardOrAclbasedRules(ADD, m_natBindingInfo[key].pool_interface, m_natPoolInfo[pool_name].ip_range,
                                                 m_natPoolInfo[pool_name].port_range, acls_name, key);
 
+            /* Add DnatPool entry to APPL_DB*/                                                             
+            SWSS_LOG_INFO("Adding dnat pool entry for %s", (*it).second.local_ip.c_str());        
+            addDnatPoolEntry((*it).second.local_ip);
+
+            /* Add DnatPool entry to APPL_DB*/
+            SWSS_LOG_INFO("Adding dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+            setDnatPoolfromNatPool(ADD, m_natPoolInfo[pool_name].ip_range);
+
             isRuleAdded = true;
             break;
         }
@@ -5277,6 +5510,14 @@ void NatMgr::addDynamicTwiceNatRule(const string &key)
             /* Add Dynamic rules */
             setDynamicAllForwardOrAclbasedRules(ADD, m_natBindingInfo[key].pool_interface, m_natPoolInfo[pool_name].ip_range,
                                                 m_natPoolInfo[pool_name].port_range, acls_name, key);
+
+            /* Add DnatPool entry to APPL_DB*/
+            SWSS_LOG_INFO("Adding dnat pool entry for %s", (*it).second.local_ip.c_str());
+            addDnatPoolEntry((*it).second.local_ip);
+
+            /* Add DnatPool entry to APPL_DB*/
+            SWSS_LOG_INFO("Adding dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+            setDnatPoolfromNatPool(ADD, m_natPoolInfo[pool_name].ip_range);
 
             isRuleAdded = true;
             break;
@@ -5356,6 +5597,14 @@ void NatMgr::deleteDynamicTwiceNatRule(const string &key)
             setDynamicAllForwardOrAclbasedRules(DELETE, m_natBindingInfo[key].pool_interface, m_natPoolInfo[pool_name].ip_range,
                                                 m_natPoolInfo[pool_name].port_range, acls_name, key);
 
+            /* Delete DnatPool entry from APPL_DB*/
+            SWSS_LOG_INFO("Adding dnat pool entry for %s", (*it).second.local_ip.c_str());
+            removeDnatPoolEntry((*it).second.local_ip);
+
+            /* Delete DnatPool entry from APPL_DB*/
+            SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+            setDnatPoolfromNatPool(DELETE, m_natPoolInfo[pool_name].ip_range);
+
             (*it).second.twice_nat_added = false;
             (*it).second.binding_key = EMPTY_STRING;
             m_natBindingInfo[key].twice_nat_added = false;
@@ -5402,6 +5651,14 @@ void NatMgr::deleteDynamicTwiceNatRule(const string &key)
             /* Delete Dynamic rules */
             setDynamicAllForwardOrAclbasedRules(DELETE, m_natBindingInfo[key].pool_interface, m_natPoolInfo[pool_name].ip_range,
                                                 m_natPoolInfo[pool_name].port_range, acls_name, key);
+
+            /* Delete DnatPool entry to APPL_DB*/
+            SWSS_LOG_INFO("Deleting dnat pool entry for %s", (*it).second.local_ip.c_str());
+            removeDnatPoolEntry((*it).second.local_ip);
+
+            /* Delete DnatPool entry from APPL_DB*/
+            SWSS_LOG_INFO("Deleting dnat pool entry for %s", m_natPoolInfo[pool_name].ip_range.c_str());
+            setDnatPoolfromNatPool(DELETE, m_natPoolInfo[pool_name].ip_range);
 
             (*it).second.twice_nat_added = false;
             (*it).second.binding_key = EMPTY_STRING;

--- a/cfgmgr/natmgr.h
+++ b/cfgmgr/natmgr.h
@@ -228,6 +228,12 @@ typedef std::map<std::string, natAclRule_t> natAclRule_map_t;
  */
 typedef std::map<std::string, std::string> natZoneInterface_map_t;
 
+/* To store NAT Dnat Pool information,
+ * Key is "Dst-Ip" (Eg. 65.55.45.1)
+ * Value is "ref_count" (Eg. 1)
+ */
+typedef std::map<std::string, int> natDnatPool_map_t;
+
 /* Define NatMgr Class inherited from Orch Class */
 class NatMgr : public Orch
 {
@@ -246,7 +252,7 @@ public:
 private:
     /* Declare APPL_DB, CFG_DB and STATE_DB tables */
     ProducerStateTable m_appNatTableProducer, m_appNaptTableProducer, m_appNatGlobalTableProducer;
-    ProducerStateTable m_appTwiceNatTableProducer, m_appTwiceNaptTableProducer;
+    ProducerStateTable m_appTwiceNatTableProducer, m_appTwiceNaptTableProducer, m_appNatDnatPoolProducer;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateInterfaceTable, m_appNaptPoolIpTable;
     Table m_stateWarmRestartEnableTable, m_stateWarmRestartTable;
 
@@ -264,6 +270,7 @@ private:
     natZoneInterface_map_t   m_natZoneInterfaceInfo;
     natAclTable_map_t        m_natAclTableInfo;
     natAclRule_map_t         m_natAclRuleInfo;
+    natDnatPool_map_t        m_natDnatPoolInfo;
     SelectableTimer          *m_natRefreshTimer;
 
     /* Declare doTask related fucntions */
@@ -346,6 +353,9 @@ private:
     void deleteDynamicTwiceNatRule(const std::string &key);
     void setDynamicAllForwardOrAclbasedRules(const std::string &opCmd, const std::string &pool_interface, const std::string &ip_range,
                                              const std::string &port_range, const std::string &acls_name, const std::string &dynamicKey);
+    void setDnatPoolfromNatPool(const std::string &opCmd, const std::string &ip_range);
+    void addDnatPoolEntry(std::string destIp);
+    void removeDnatPoolEntry(std::string destIp);
 
     bool isNatEnabled(void);
     bool isPortStateOk(const std::string &alias);

--- a/orchagent/natorch.cpp
+++ b/orchagent/natorch.cpp
@@ -737,7 +737,7 @@ bool NatOrch::addHwDnatEntry(const IpAddress &ip_address)
 {
     uint32_t        attr_count;
     sai_nat_entry_t dnat_entry;
-    sai_attribute_t nat_entry_attr[5];
+    sai_attribute_t nat_entry_attr[4];
     sai_status_t    status;
 
     SWSS_LOG_ENTER();
@@ -753,23 +753,22 @@ bool NatOrch::addHwDnatEntry(const IpAddress &ip_address)
 
     memset(nat_entry_attr, 0, sizeof(nat_entry_attr));
 
-    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_NAT_TYPE;
-    nat_entry_attr[0].value.u32 = SAI_NAT_TYPE_DESTINATION_NAT;
-    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_DST_IP;
-    nat_entry_attr[1].value.u32 = entry.translated_ip.getV4Addr();
-    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_DST_IP_MASK;
-    nat_entry_attr[2].value.u32 = 0xffffffff;
-    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_DST_IP;
+    nat_entry_attr[0].value.u32 = entry.translated_ip.getV4Addr();
+    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_DST_IP_MASK;
+    nat_entry_attr[1].value.u32 = 0xffffffff;
+    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[2].value.booldata = true;
+    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
     nat_entry_attr[3].value.booldata = true;
-    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
-    nat_entry_attr[4].value.booldata = true;
 
-    attr_count = 5;
+    attr_count = 4;
 
     memset(&dnat_entry, 0, sizeof(dnat_entry));
 
     dnat_entry.vr_id = gVirtualRouterId;
     dnat_entry.switch_id = gSwitchId;
+    dnat_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT;
     dnat_entry.data.key.dst_ip = ip_address.getV4Addr();
     dnat_entry.data.mask.dst_ip = 0xffffffff;
 
@@ -810,7 +809,7 @@ bool NatOrch::addHwDnaptEntry(const NaptEntryKey &key)
 {
     uint32_t        attr_count;
     sai_nat_entry_t dnat_entry;
-    sai_attribute_t nat_entry_attr[6];
+    sai_attribute_t nat_entry_attr[5];
     uint8_t         ip_protocol = ((key.prototype == "TCP") ? IPPROTO_TCP : IPPROTO_UDP);
     sai_status_t    status;
 
@@ -829,25 +828,24 @@ bool NatOrch::addHwDnaptEntry(const NaptEntryKey &key)
 
     memset(nat_entry_attr, 0, sizeof(nat_entry_attr));
 
-    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_NAT_TYPE;
-    nat_entry_attr[0].value.u32 = SAI_NAT_TYPE_DESTINATION_NAT;
-    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_DST_IP;
-    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_DST_IP_MASK;
-    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_L4_DST_PORT;
-    nat_entry_attr[1].value.u32 = entry.translated_ip.getV4Addr();
-    nat_entry_attr[2].value.u32 = 0xffffffff;
-    nat_entry_attr[3].value.u16 = (uint16_t)(entry.translated_l4_port);
-    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_DST_IP;
+    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_DST_IP_MASK;
+    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_L4_DST_PORT;
+    nat_entry_attr[0].value.u32 = entry.translated_ip.getV4Addr();
+    nat_entry_attr[1].value.u32 = 0xffffffff;
+    nat_entry_attr[2].value.u16 = (uint16_t)(entry.translated_l4_port);
+    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[3].value.booldata = true;
+    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
     nat_entry_attr[4].value.booldata = true;
-    nat_entry_attr[5].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
-    nat_entry_attr[5].value.booldata = true;
 
-    attr_count = 6;
+    attr_count = 5;
 
     memset(&dnat_entry, 0, sizeof(dnat_entry));
 
     dnat_entry.vr_id = gVirtualRouterId;
     dnat_entry.switch_id = gSwitchId;
+    dnat_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT;
     dnat_entry.data.key.dst_ip = key.ip_address.getV4Addr();
     dnat_entry.data.key.l4_dst_port = (uint16_t)(key.l4_port);
     dnat_entry.data.mask.dst_ip = 0xffffffff;
@@ -920,6 +918,7 @@ bool NatOrch::removeHwDnatEntry(const IpAddress &dstIp)
 
     dnat_entry.vr_id = gVirtualRouterId;
     dnat_entry.switch_id = gSwitchId;
+    dnat_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT;
     dnat_entry.data.key.dst_ip = dstIp.getV4Addr();
     dnat_entry.data.mask.dst_ip = 0xffffffff;
 
@@ -1002,6 +1001,7 @@ bool NatOrch::removeHwTwiceNatEntry(const TwiceNatEntryKey &key)
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.dst_ip = key.dst_ip.getV4Addr();
@@ -1094,6 +1094,7 @@ bool NatOrch::removeHwDnaptEntry(const NaptEntryKey &key)
 
     dnat_entry.vr_id = gVirtualRouterId;
     dnat_entry.switch_id = gSwitchId;
+    dnat_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT;
     dnat_entry.data.key.dst_ip = key.ip_address.getV4Addr();
     dnat_entry.data.key.l4_dst_port = (uint16_t)(key.l4_port);
     dnat_entry.data.mask.dst_ip = 0xffffffff;
@@ -1186,6 +1187,7 @@ bool NatOrch::removeHwTwiceNaptEntry(const TwiceNaptEntryKey &key)
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.l4_src_port = (uint16_t)(key.src_l4_port);
@@ -1256,7 +1258,7 @@ bool NatOrch::addHwSnatEntry(const IpAddress &ip_address)
 {
     uint32_t        attr_count;
     sai_nat_entry_t snat_entry;
-    sai_attribute_t nat_entry_attr[5];
+    sai_attribute_t nat_entry_attr[4];
     sai_status_t    status;
     struct timespec  time_now;
 
@@ -1272,23 +1274,22 @@ bool NatOrch::addHwSnatEntry(const IpAddress &ip_address)
 
     memset(nat_entry_attr, 0, sizeof(nat_entry_attr));
 
-    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_NAT_TYPE;
-    nat_entry_attr[0].value.u32 = SAI_NAT_TYPE_SOURCE_NAT;
-    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_SRC_IP;
-    nat_entry_attr[1].value.u32 = entry.translated_ip.getV4Addr();
-    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_SRC_IP_MASK;
-    nat_entry_attr[2].value.u32 = 0xffffffff;
-    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_SRC_IP;
+    nat_entry_attr[0].value.u32 = entry.translated_ip.getV4Addr();
+    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_SRC_IP_MASK;
+    nat_entry_attr[1].value.u32 = 0xffffffff;
+    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[2].value.booldata = true;
+    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
     nat_entry_attr[3].value.booldata = true;
-    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
-    nat_entry_attr[4].value.booldata = true;
 
-    attr_count = 5;
+    attr_count = 4;
 
     memset(&snat_entry, 0, sizeof(snat_entry));
 
     snat_entry.vr_id = gVirtualRouterId;
     snat_entry.switch_id = gSwitchId;
+    snat_entry.nat_type = SAI_NAT_TYPE_SOURCE_NAT;
     snat_entry.data.key.src_ip = ip_address.getV4Addr();
     snat_entry.data.mask.src_ip = 0xffffffff;
 
@@ -1328,7 +1329,7 @@ bool NatOrch::addHwTwiceNatEntry(const TwiceNatEntryKey &key)
 {
     uint32_t        attr_count;
     sai_nat_entry_t dbl_nat_entry;
-    sai_attribute_t nat_entry_attr[8];
+    sai_attribute_t nat_entry_attr[6];
 
     sai_status_t    status;
     struct timespec  time_now;
@@ -1345,27 +1346,26 @@ bool NatOrch::addHwTwiceNatEntry(const TwiceNatEntryKey &key)
 
     memset(nat_entry_attr, 0, sizeof(nat_entry_attr));
 
-    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_NAT_TYPE;
-    nat_entry_attr[0].value.u32 = SAI_NAT_TYPE_DOUBLE_NAT;
-    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_SRC_IP;
-    nat_entry_attr[1].value.u32 = value.translated_src_ip.getV4Addr();
-    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_SRC_IP_MASK;
-    nat_entry_attr[2].value.u32 = 0xffffffff;
-    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_DST_IP;
-    nat_entry_attr[3].value.u32 = value.translated_dst_ip.getV4Addr();
-    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_DST_IP_MASK;
-    nat_entry_attr[4].value.u32 = 0xffffffff;
-    nat_entry_attr[5].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_SRC_IP;
+    nat_entry_attr[0].value.u32 = value.translated_src_ip.getV4Addr();
+    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_SRC_IP_MASK;
+    nat_entry_attr[1].value.u32 = 0xffffffff;
+    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_DST_IP;
+    nat_entry_attr[2].value.u32 = value.translated_dst_ip.getV4Addr();
+    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_DST_IP_MASK;
+    nat_entry_attr[3].value.u32 = 0xffffffff;
+    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[4].value.booldata = true;
+    nat_entry_attr[5].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
     nat_entry_attr[5].value.booldata = true;
-    nat_entry_attr[6].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
-    nat_entry_attr[6].value.booldata = true;
 
-    attr_count = 7;
+    attr_count = 6;
 
     memset(&dbl_nat_entry, 0, sizeof(dbl_nat_entry));
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.dst_ip = key.dst_ip.getV4Addr();
@@ -1417,7 +1417,7 @@ bool NatOrch::addHwSnaptEntry(const NaptEntryKey &keyEntry)
 {
     uint32_t        attr_count;
     sai_nat_entry_t snat_entry;
-    sai_attribute_t nat_entry_attr[6];
+    sai_attribute_t nat_entry_attr[5];
     uint8_t         ip_protocol = ((keyEntry.prototype == "TCP") ? IPPROTO_TCP : IPPROTO_UDP);
     sai_status_t    status;
     struct timespec  time_now;
@@ -1435,25 +1435,24 @@ bool NatOrch::addHwSnaptEntry(const NaptEntryKey &keyEntry)
 
     memset(nat_entry_attr, 0, sizeof(nat_entry_attr));
 
-    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_NAT_TYPE;
-    nat_entry_attr[0].value.u32 = SAI_NAT_TYPE_SOURCE_NAT;
-    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_SRC_IP;
-    nat_entry_attr[1].value.u32 = entry.translated_ip.getV4Addr();
-    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_SRC_IP_MASK;
-    nat_entry_attr[2].value.u32 = 0xffffffff;
-    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_L4_SRC_PORT;
-    nat_entry_attr[3].value.u16 = (uint16_t)(entry.translated_l4_port);
-    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_SRC_IP;
+    nat_entry_attr[0].value.u32 = entry.translated_ip.getV4Addr();
+    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_SRC_IP_MASK;
+    nat_entry_attr[1].value.u32 = 0xffffffff;
+    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_L4_SRC_PORT;
+    nat_entry_attr[2].value.u16 = (uint16_t)(entry.translated_l4_port);
+    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[3].value.booldata = true;
+    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
     nat_entry_attr[4].value.booldata = true;
-    nat_entry_attr[5].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
-    nat_entry_attr[5].value.booldata = true;
 
-    attr_count = 6;
+    attr_count = 5;
 
     memset(&snat_entry, 0, sizeof(snat_entry));
 
     snat_entry.vr_id = gVirtualRouterId;
     snat_entry.switch_id = gSwitchId;
+    snat_entry.nat_type = SAI_NAT_TYPE_SOURCE_NAT;
     snat_entry.data.key.src_ip = keyEntry.ip_address.getV4Addr();
     snat_entry.data.key.l4_src_port = (uint16_t)(keyEntry.l4_port);
     snat_entry.data.mask.src_ip = 0xffffffff;
@@ -1500,7 +1499,7 @@ bool NatOrch::addHwTwiceNaptEntry(const TwiceNaptEntryKey &key)
 {
     uint32_t        attr_count;
     sai_nat_entry_t dbl_nat_entry;
-    sai_attribute_t nat_entry_attr[10];
+    sai_attribute_t nat_entry_attr[8];
     uint8_t         protoType = ((key.prototype == "TCP") ? IPPROTO_TCP : IPPROTO_UDP);
     sai_status_t    status;
     struct timespec  time_now;
@@ -1519,31 +1518,30 @@ bool NatOrch::addHwTwiceNaptEntry(const TwiceNaptEntryKey &key)
 
     memset(nat_entry_attr, 0, sizeof(nat_entry_attr));
 
-    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_NAT_TYPE;
-    nat_entry_attr[0].value.u32 = SAI_NAT_TYPE_DOUBLE_NAT;
-    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_SRC_IP;
-    nat_entry_attr[1].value.u32 = value.translated_src_ip.getV4Addr();
-    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_SRC_IP_MASK;
-    nat_entry_attr[2].value.u32 = 0xffffffff;
-    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_L4_SRC_PORT;
-    nat_entry_attr[3].value.u16 = (uint16_t)(value.translated_src_l4_port);
-    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_DST_IP;
-    nat_entry_attr[4].value.u32 = value.translated_dst_ip.getV4Addr();
-    nat_entry_attr[5].id = SAI_NAT_ENTRY_ATTR_DST_IP_MASK;
-    nat_entry_attr[5].value.u32 = 0xffffffff;
-    nat_entry_attr[6].id = SAI_NAT_ENTRY_ATTR_L4_DST_PORT;
-    nat_entry_attr[6].value.u16 = (uint16_t)(value.translated_dst_l4_port);
-    nat_entry_attr[7].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[0].id = SAI_NAT_ENTRY_ATTR_SRC_IP;
+    nat_entry_attr[0].value.u32 = value.translated_src_ip.getV4Addr();
+    nat_entry_attr[1].id = SAI_NAT_ENTRY_ATTR_SRC_IP_MASK;
+    nat_entry_attr[1].value.u32 = 0xffffffff;
+    nat_entry_attr[2].id = SAI_NAT_ENTRY_ATTR_L4_SRC_PORT;
+    nat_entry_attr[2].value.u16 = (uint16_t)(value.translated_src_l4_port);
+    nat_entry_attr[3].id = SAI_NAT_ENTRY_ATTR_DST_IP;
+    nat_entry_attr[3].value.u32 = value.translated_dst_ip.getV4Addr();
+    nat_entry_attr[4].id = SAI_NAT_ENTRY_ATTR_DST_IP_MASK;
+    nat_entry_attr[4].value.u32 = 0xffffffff;
+    nat_entry_attr[5].id = SAI_NAT_ENTRY_ATTR_L4_DST_PORT;
+    nat_entry_attr[5].value.u16 = (uint16_t)(value.translated_dst_l4_port);
+    nat_entry_attr[6].id = SAI_NAT_ENTRY_ATTR_ENABLE_PACKET_COUNT;
+    nat_entry_attr[6].value.booldata = true;
+    nat_entry_attr[7].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
     nat_entry_attr[7].value.booldata = true;
-    nat_entry_attr[8].id = SAI_NAT_ENTRY_ATTR_ENABLE_BYTE_COUNT;
-    nat_entry_attr[8].value.booldata = true;
 
-    attr_count = 9;
+    attr_count = 8;
 
     memset(&dbl_nat_entry, 0, sizeof(dbl_nat_entry));
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.l4_src_port = (uint16_t)(key.src_l4_port);
@@ -1615,6 +1613,7 @@ bool NatOrch::removeHwSnatEntry(const IpAddress &ip_address)
 
     snat_entry.vr_id = gVirtualRouterId;
     snat_entry.switch_id = gSwitchId;
+    snat_entry.nat_type = SAI_NAT_TYPE_SOURCE_NAT;
     snat_entry.data.key.src_ip = ip_address.getV4Addr();
     snat_entry.data.mask.src_ip = 0xffffffff;
 
@@ -1698,6 +1697,7 @@ bool NatOrch::removeHwSnaptEntry(const NaptEntryKey &keyEntry)
 
     snat_entry.vr_id = gVirtualRouterId;
     snat_entry.switch_id = gSwitchId;
+    snat_entry.nat_type = SAI_NAT_TYPE_SOURCE_NAT;
     snat_entry.data.key.src_ip = keyEntry.ip_address.getV4Addr();
     snat_entry.data.key.l4_src_port = (uint16_t)(keyEntry.l4_port);
     snat_entry.data.mask.src_ip = 0xffffffff;
@@ -1760,6 +1760,90 @@ bool NatOrch::removeHwSnaptEntry(const NaptEntryKey &keyEntry)
         totalEntries--;
 
     return true;
+}
+
+// Add the DNAT Pool entry to the hardware
+bool NatOrch::addHwDnatPoolEntry(const IpAddress &ip_address)
+{
+    uint32_t        attr_count;
+    sai_nat_entry_t dnat_pool_entry;
+    sai_attribute_t nat_entry_attr[1];
+    sai_status_t    status;
+
+    SWSS_LOG_ENTER();
+
+    if (!isNatEnabled())
+    {
+        SWSS_LOG_WARN("NAT Feature is not yet enabled, skipped adding DNAT Pool entry with ip %s", ip_address.to_string().c_str());
+        return true;
+    }
+
+    SWSS_LOG_INFO("Create DNAT Pool entry for ip %s", ip_address.to_string().c_str());
+
+    memset(nat_entry_attr, 0, sizeof(nat_entry_attr));
+    attr_count = 0;
+
+    memset(&dnat_pool_entry, 0, sizeof(dnat_pool_entry));
+
+    dnat_pool_entry.vr_id = gVirtualRouterId;
+    dnat_pool_entry.switch_id = gSwitchId;
+    dnat_pool_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT_POOL;
+    dnat_pool_entry.data.key.dst_ip = ip_address.getV4Addr();
+    dnat_pool_entry.data.mask.dst_ip = 0xffffffff;
+
+    status = sai_nat_api->create_nat_entry(&dnat_pool_entry, attr_count, nat_entry_attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to create DNAT Pool entry with ip %s", ip_address.to_string().c_str());
+
+        return false;
+    }
+
+    SWSS_LOG_NOTICE("Created DNAT Pool entry with ip %s", ip_address.to_string().c_str());
+
+    return true;
+}
+
+// Remove the DNAT Pool entry from the hardware
+bool NatOrch::removeHwDnatPoolEntry(const IpAddress &dstIp)
+{
+    sai_nat_entry_t dnat_pool_entry;
+    sai_status_t    status;
+
+    SWSS_LOG_ENTER();
+    SWSS_LOG_INFO("Deleting DNAT Pool entry ip %s from hardware", dstIp.to_string().c_str());
+
+    memset(&dnat_pool_entry, 0, sizeof(dnat_pool_entry));
+
+    dnat_pool_entry.vr_id = gVirtualRouterId;
+    dnat_pool_entry.switch_id = gSwitchId;
+    dnat_pool_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT_POOL;
+    dnat_pool_entry.data.key.dst_ip = dstIp.getV4Addr();
+    dnat_pool_entry.data.mask.dst_ip = 0xffffffff;
+
+    status = sai_nat_api->remove_nat_entry(&dnat_pool_entry);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_INFO("Failed to remove DNAT Pool entry with ip %s", dstIp.to_string().c_str());
+
+        return false;
+    }
+
+    SWSS_LOG_NOTICE("Removed DNAT Pool entry with ip %s", dstIp.to_string().c_str());
+
+    return true;
+}
+
+void NatOrch::addAllDnatPoolEntries()
+{
+    SWSS_LOG_ENTER();
+
+    DnatPoolEntry::iterator dnatPoolIter = m_dnatPoolEntries.begin();
+    while (dnatPoolIter != m_dnatPoolEntries.end())
+    {
+        addHwDnatPoolEntry((*dnatPoolIter));
+        dnatPoolIter++;
+    }
 }
 
 bool NatOrch::addNatEntry(const IpAddress &ip_address, const NatEntryValue &entry)
@@ -2472,6 +2556,9 @@ void NatOrch::enableNatFeature(void)
         m_neighOrch->attach(this);
     }
 
+    SWSS_LOG_INFO("Adding DNAT Pool Entries ");
+    addAllDnatPoolEntries();
+
     SWSS_LOG_INFO("Adding NAT Entries ");
     addAllNatEntries();
 }
@@ -2864,6 +2951,72 @@ void NatOrch::doNatGlobalTableTask(Consumer& consumer)
     }
 }
 
+void NatOrch::doDnatPoolTableTask(Consumer& consumer)
+{
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+        string key = kfvKey(t);
+        string op = kfvOp(t);
+        vector<string> keys = tokenize(key, ':');
+        IpAddress global_address;
+        /* Example : APPL_DB
+         * NAT_DNAT_POOL_TABLE:65.55.45.1
+         *     NULL: NULL
+         */
+
+        /* Ensure the key size is 1 otherwise ignore */
+        if (keys.size() != 1)
+        {
+            SWSS_LOG_ERROR("Invalid key size, skipping %s", key.c_str());
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
+
+        IpAddress ip_address = IpAddress(key);
+
+        if (op == SET_COMMAND)
+        {
+
+            if (m_dnatPoolEntries.find(ip_address) != m_dnatPoolEntries.end())
+            {
+                SWSS_LOG_INFO("DNAT Pool entry found for ip %s", ip_address.to_string().c_str());
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+            
+            m_dnatPoolEntries.insert(ip_address);
+
+            if (addHwDnatPoolEntry(ip_address))
+                it = consumer.m_toSync.erase(it);
+            else
+                it++;
+        }
+        else if (op == DEL_COMMAND)
+        {
+            if (m_dnatPoolEntries.find(ip_address) == m_dnatPoolEntries.end())
+            {
+                SWSS_LOG_INFO("DNAT Pool entry isn't found for ip %s", ip_address.to_string().c_str());
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
+            m_dnatPoolEntries.erase(ip_address);
+
+            if (removeHwDnatPoolEntry(ip_address))
+                it = consumer.m_toSync.erase(it);
+            else
+                it++;
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unknown operation type %s\n", op.c_str());
+            it = consumer.m_toSync.erase(it);
+        }
+    }
+}
+
 void NatOrch::doTask(Consumer& consumer)
 {
     SWSS_LOG_ENTER();
@@ -2896,6 +3049,11 @@ void NatOrch::doTask(Consumer& consumer)
     {
         SWSS_LOG_INFO("Received APP_NAT_GLOBAL_TABLE_NAME update");
         doNatGlobalTableTask(consumer);
+    }
+    else if (table_name == APP_NAT_DNAT_POOL_TABLE_NAME)
+    {
+        SWSS_LOG_INFO("Received APP_NAT_DNAT_POOL_TABLE_NAME update");
+        doDnatPoolTableTask(consumer);
     }
     else
     {
@@ -3362,11 +3520,13 @@ bool NatOrch::getNatCounters(const NatEntry::iterator &iter)
 
     if (entry.nat_type == "dnat")
     {
+        nat_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT;
         nat_entry.data.key.dst_ip = ipAddr.getV4Addr();   
         nat_entry.data.mask.dst_ip = 0xffffffff;
     }
     else
     {
+        nat_entry.nat_type = SAI_NAT_TYPE_SOURCE_NAT;
         nat_entry.data.key.src_ip = ipAddr.getV4Addr();
         nat_entry.data.mask.src_ip = 0xffffffff;
     }
@@ -3432,6 +3592,7 @@ bool NatOrch::getTwiceNatCounters(const TwiceNatEntry::iterator &iter)
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.dst_ip = key.dst_ip.getV4Addr();
@@ -3484,11 +3645,13 @@ bool NatOrch::setNatCounters(const NatEntry::iterator &iter)
 
     if (entry.nat_type == "dnat")
     {
+        nat_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT;
         nat_entry.data.key.dst_ip = ipAddr.getV4Addr();
         nat_entry.data.mask.dst_ip = 0xffffffff;
     }
     else
     {
+        nat_entry.nat_type = SAI_NAT_TYPE_SOURCE_NAT;
         nat_entry.data.key.src_ip = ipAddr.getV4Addr();
         nat_entry.data.mask.src_ip = 0xffffffff;
     }
@@ -3563,6 +3726,7 @@ bool NatOrch::getNaptCounters(const NaptEntry::iterator &iter)
 
     if (entry.nat_type == "dnat")
     {
+        nat_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT;
         nat_entry.data.key.dst_ip      = naptKey.ip_address.getV4Addr();
         nat_entry.data.key.l4_dst_port = (uint16_t)(naptKey.l4_port);
         nat_entry.data.mask.dst_ip      = 0xffffffff;
@@ -3570,6 +3734,7 @@ bool NatOrch::getNaptCounters(const NaptEntry::iterator &iter)
     }
     else if (entry.nat_type == "snat")
     {
+        nat_entry.nat_type = SAI_NAT_TYPE_SOURCE_NAT;
         nat_entry.data.key.src_ip      = naptKey.ip_address.getV4Addr();
         nat_entry.data.key.l4_src_port = (uint16_t)(naptKey.l4_port);
         nat_entry.data.mask.src_ip      = 0xffffffff;
@@ -3645,6 +3810,7 @@ bool NatOrch::getTwiceNaptCounters(const TwiceNaptEntry::iterator &iter)
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.l4_src_port = (uint16_t)(key.src_l4_port);
@@ -3705,6 +3871,7 @@ bool NatOrch::setNaptCounters(const NaptEntry::iterator &iter)
 
     if (entry.nat_type == "dnat")
     {
+        nat_entry.nat_type = SAI_NAT_TYPE_DESTINATION_NAT;
         nat_entry.data.key.dst_ip      = naptKey.ip_address.getV4Addr();
         nat_entry.data.key.l4_dst_port = (uint16_t)(naptKey.l4_port);
         nat_entry.data.mask.dst_ip      = 0xffffffff;
@@ -3712,6 +3879,7 @@ bool NatOrch::setNaptCounters(const NaptEntry::iterator &iter)
     }
     else if (entry.nat_type == "snat")
     {
+        nat_entry.nat_type = SAI_NAT_TYPE_SOURCE_NAT;
         nat_entry.data.key.src_ip      = naptKey.ip_address.getV4Addr();
         nat_entry.data.key.l4_src_port = (uint16_t)(naptKey.l4_port);
         nat_entry.data.mask.src_ip      = 0xffffffff;
@@ -3791,6 +3959,7 @@ bool NatOrch::setTwiceNatCounters(const TwiceNatEntry::iterator &iter)
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.dst_ip = key.dst_ip.getV4Addr();
@@ -3845,6 +4014,7 @@ bool NatOrch::setTwiceNaptCounters(const TwiceNaptEntry::iterator &iter)
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.l4_src_port = (uint16_t)(key.src_l4_port);
@@ -4006,6 +4176,7 @@ bool NatOrch::checkIfNatEntryIsActive(const NatEntry::iterator &iter, time_t now
 
     snat_entry.vr_id                 = gVirtualRouterId;
     snat_entry.switch_id             = gSwitchId;
+    snat_entry.nat_type              = SAI_NAT_TYPE_SOURCE_NAT;
     srcIp     = ipAddr;
     snat_entry.data.key.src_ip   = srcIp.getV4Addr();
     snat_entry.data.mask.src_ip  = 0xffffffff;
@@ -4038,6 +4209,7 @@ bool NatOrch::checkIfNatEntryIsActive(const NatEntry::iterator &iter, time_t now
 
             dnat_entry.vr_id             = gVirtualRouterId;
             dnat_entry.switch_id         = gSwitchId;
+            dnat_entry.nat_type          = SAI_NAT_TYPE_DESTINATION_NAT;
             dnat_entry.data.key.dst_ip   = entry.translated_ip.getV4Addr();
             dnat_entry.data.mask.dst_ip  = 0xffffffff;
 
@@ -4100,6 +4272,7 @@ bool NatOrch::checkIfNaptEntryIsActive(const NaptEntry::iterator &iter, time_t n
 
     snat_entry.vr_id                 = gVirtualRouterId;
     snat_entry.switch_id             = gSwitchId;
+    snat_entry.nat_type              = SAI_NAT_TYPE_SOURCE_NAT;
 
     srcIp     = naptKey.ip_address;
     srcPort   = (uint16_t)(naptKey.l4_port);
@@ -4144,6 +4317,7 @@ bool NatOrch::checkIfNaptEntryIsActive(const NaptEntry::iterator &iter, time_t n
 
             dnat_entry.vr_id                 = gVirtualRouterId;
             dnat_entry.switch_id             = gSwitchId;
+            dnat_entry.nat_type              = SAI_NAT_TYPE_DESTINATION_NAT;
 
             dnat_entry.data.key.dst_ip       = entry.translated_ip.getV4Addr();
             dnat_entry.data.key.l4_dst_port  = (uint16_t)(entry.translated_l4_port);
@@ -4203,6 +4377,7 @@ bool NatOrch::checkIfTwiceNatEntryIsActive(const TwiceNatEntry::iterator &iter, 
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.dst_ip = key.dst_ip.getV4Addr();
@@ -4257,6 +4432,7 @@ bool NatOrch::checkIfTwiceNaptEntryIsActive(const TwiceNaptEntry::iterator &iter
 
     dbl_nat_entry.vr_id = gVirtualRouterId;
     dbl_nat_entry.switch_id = gSwitchId;
+    dbl_nat_entry.nat_type = SAI_NAT_TYPE_DOUBLE_NAT;
     dbl_nat_entry.data.key.src_ip = key.src_ip.getV4Addr();
     dbl_nat_entry.data.mask.src_ip = 0xffffffff;
     dbl_nat_entry.data.key.l4_src_port = (uint16_t)(key.src_l4_port);

--- a/orchagent/natorch.h
+++ b/orchagent/natorch.h
@@ -160,6 +160,9 @@ typedef std::set<NaptEntryKey> DnaptCache;
 typedef std::set<TwiceNatEntryKey> TwiceNatCache;
 typedef std::set<TwiceNaptEntryKey> TwiceNaptCache;
 
+// Cache of DNAT Pool destIp 
+typedef std::set<IpAddress> DnatPoolEntry;
+
 struct DnatEntries
 {
     IpAddress        dnatIp;       /* NAT entry cache */
@@ -214,6 +217,7 @@ private:
     mutex                   m_natMutex;
     string                  m_dbgCompName;
     IpAddress               nullIpv4Addr;
+    DnatPoolEntry           m_dnatPoolEntries;
 
     std::shared_ptr<NotificationProducer> setTimeoutNotifier;
 
@@ -246,6 +250,7 @@ private:
     void doTwiceNatTableTask(Consumer& consumer);
     void doTwiceNaptTableTask(Consumer& consumer);
     void doNatGlobalTableTask(Consumer& consumer);
+    void doDnatPoolTableTask(Consumer& consumer);
 
     bool addNatEntry(const IpAddress &ip_address, const NatEntryValue &entry);
     bool removeNatEntry(const IpAddress &ip_address);
@@ -281,6 +286,8 @@ private:
     bool addHwDnaptEntry(const NaptEntryKey &key);
     bool removeHwDnatEntry(const IpAddress &dstIp);
     bool removeHwDnaptEntry(const NaptEntryKey &key);
+    bool addHwDnatPoolEntry(const IpAddress &dstIp);
+    bool removeHwDnatPoolEntry(const IpAddress &dstIp);
 
     bool checkIfNatEntryIsActive(const NatEntry::iterator &iter, time_t now);
     bool checkIfNaptEntryIsActive(const NaptEntry::iterator &iter, time_t now);
@@ -290,6 +297,7 @@ private:
     void enableNatFeature(void);
     void disableNatFeature(void);
     void addAllNatEntries(void);
+    void addAllDnatPoolEntries(void);
     void clearAllDnatEntries(void);
     void cleanupAppDbEntries(void);
     void clearCounters(void);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -218,11 +218,12 @@ bool OrchDaemon::init()
     const int natorch_base_pri = 50;
 
     vector<table_name_with_pri_t> nat_tables = {
-        { APP_NAT_TABLE_NAME,        natorch_base_pri + 4 },
-        { APP_NAPT_TABLE_NAME,       natorch_base_pri + 3 },
-        { APP_NAT_TWICE_TABLE_NAME,  natorch_base_pri + 2 },
-        { APP_NAPT_TWICE_TABLE_NAME, natorch_base_pri + 1 },
-        { APP_NAT_GLOBAL_TABLE_NAME, natorch_base_pri     }
+        { APP_NAT_DNAT_POOL_TABLE_NAME,  natorch_base_pri + 5 },
+        { APP_NAT_TABLE_NAME,            natorch_base_pri + 4 },
+        { APP_NAPT_TABLE_NAME,           natorch_base_pri + 3 },
+        { APP_NAT_TWICE_TABLE_NAME,      natorch_base_pri + 2 },
+        { APP_NAPT_TWICE_TABLE_NAME,     natorch_base_pri + 1 },
+        { APP_NAT_GLOBAL_TABLE_NAME,     natorch_base_pri     }
     };
 
     gNatOrch = new NatOrch(m_applDb, m_stateDb, nat_tables, gRouteOrch, gNeighOrch);

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -94,8 +94,8 @@ class TestNat(object):
             "entry_type": "static"
         }
 
-        #check the entry in asic db
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 2)
+        #check the entry in asic db, 3 keys = SNAT, DNAT and DNAT_Pool
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 3)
 
         for key in keys:
             assert "\"dst_ip\":\"67.66.65.1\"" in key or "\"src_ip\":\"18.18.18.2\"" in key
@@ -140,8 +140,8 @@ class TestNat(object):
 
         assert fvs == {"translated_ip": "18.18.18.2", "translated_l4_port": "180", "nat_type": "dnat", "entry_type": "static"}
 
-        #check the entry in asic db
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 2)
+        #check the entry in asic db, 3 keys = SNAT, DNAT and DNAT_Pool
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 3)
         for key in keys:
             if "\"dst_ip\":\"67.66.65.1\"" in key and "\"l4_dst_port\":\"670\"" in key:
                 assert True
@@ -196,8 +196,8 @@ class TestNat(object):
         fvs = self.app_db.wait_for_entry("NAT_TWICE_TABLE", "18.18.18.2:18.18.18.1")
         assert fvs == {"translated_src_ip": "67.66.65.1", "translated_dst_ip": "67.66.65.2", "entry_type": "static"}
 
-        #check the entry in asic db
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 2)
+        #check the entry in asic db, 4 keys = SNAT, DNAT and 2 DNAT_Pools
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 4)
         for key in keys:
             assert "\"dst_ip\":\"67.66.65.1\"" in key or "\"src_ip\":\"18.18.18.2\"" in key
 
@@ -248,8 +248,8 @@ class TestNat(object):
         fvs = self.app_db.wait_for_entry("NAPT_TWICE_TABLE", "UDP:18.18.18.2:182:18.18.18.1:181")
         assert fvs == {"translated_src_ip": "67.66.65.1", "translated_src_l4_port": "660", "translated_dst_ip": "67.66.65.2", "translated_dst_l4_port": "670", "entry_type": "static"}
 
-        #check the entry in asic db
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 2)
+        #check the entry in asic db, 4 keys = SNAT, DNAT and 2 DNAT_Pools
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 4)
         for key in keys:
             if "\"src_ip\":\"18.18.18.2\"" in key or "\"l4_src_port\":\"182\"" in key:
                 assert True

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -96,9 +96,11 @@ class TestNat(object):
 
         #check the entry in asic db, 3 keys = SNAT, DNAT and DNAT_Pool
         keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 3)
-
         for key in keys:
-            assert "\"dst_ip\":\"67.66.65.1\"" in key or "\"src_ip\":\"18.18.18.2\"" in key
+            if (key.find("dst_ip:67.66.65.1")) or (key.find("src_ip:18.18.18.2")):
+                assert True
+            else:
+                assert False
 
     def test_DelNatStaticEntry(self, dvs, testlog):
         # initialize
@@ -143,9 +145,9 @@ class TestNat(object):
         #check the entry in asic db, 3 keys = SNAT, DNAT and DNAT_Pool
         keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 3)
         for key in keys:
-            if "\"dst_ip\":\"67.66.65.1\"" in key and "\"l4_dst_port\":\"670\"" in key:
+            if (key.find("dst_ip:67.66.65.1")) and (key.find("key.l4_dst_port:670")):
                 assert True
-            elif "\"src_ip\":\"18.18.18.2\"" in key or "\"l4_src_port\":\"180\"" in key:
+            if (key.find("src_ip:18.18.18.2")) or (key.find("key.l4_src_port:180")):
                 assert True
             else:
                 assert False
@@ -199,7 +201,10 @@ class TestNat(object):
         #check the entry in asic db, 4 keys = SNAT, DNAT and 2 DNAT_Pools
         keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 4)
         for key in keys:
-            assert "\"dst_ip\":\"67.66.65.1\"" in key or "\"src_ip\":\"18.18.18.2\"" in key
+            if (key.find("dst_ip:18.18.18.1")) or (key.find("src_ip:18.18.18.2")):
+                assert True
+            else:
+                assert False
 
     def test_DelTwiceNatStaticEntry(self, dvs, testlog):
         # initialize
@@ -251,9 +256,9 @@ class TestNat(object):
         #check the entry in asic db, 4 keys = SNAT, DNAT and 2 DNAT_Pools
         keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 4)
         for key in keys:
-            if "\"src_ip\":\"18.18.18.2\"" in key or "\"l4_src_port\":\"182\"" in key:
+            if (key.find("src_ip:18.18.18.2")) or (key.find("l4_src_port:182")):
                 assert True
-            elif "\"dst_ip\":\"67.66.65.1\"" in key or "\"l4_dst_port\":\"660\"" in key:
+            if (key.find("dst_ip:18.18.18.1")) or (key.find("l4_dst_port:181")):
                 assert True
             else:
                 assert False


### PR DESCRIPTION
Code changes:

NatMgr:

Setting the "APP_NAT_DNAT_POOL_TABLE_NAME" table with destination-ip when first Static NAT/NAPT entry is added at config_db.
Incrementing the ref count in "m_natDnatPoolInfo" for same destination-ip for next Static NAT/NAPT entry is added at config_db.
Decrementing the reference count in "m_natDnatPoolInfo" for same destination-ip when Static NAT/NAPT entry is deleted at config_db.
Deleting the "APP_NAT_DNAT_POOL_TABLE_NAME" table with destination-ip when last Static NAT/NAPT entry is deleted at config_db.
It does the same for all IP-Addresses from pool-addresses range in NAT Pool configuration in config_db.

NatOrch:

Creating DNAT_POOL entries using nat_type as "SAI_NAT_TYPE_DESTINATION_NAT_POOL" when "APP_NAT_DNAT_POOL_TABLE_NAME" table is created.
Deleting DNAT_POOL entries using nat_type as "SAI_NAT_TYPE_DESTINATION_NAT_POOL" when "APP_NAT_DNAT_POOL_TABLE_NAME" table is deleted.
Updated code to use nat_type while creating the nat entries.

Depends on :
https://github.com/Azure/sonic-utilities/pull/1001
https://github.com/Azure/sonic-swss-common/pull/367
https://github.com/Azure/sonic-sairedis/pull/644

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
