### PR TITLE
Update DBConnector definition  in mock_dbconnector.cpp

### DIFF
--- a/tests/mock_tests/mock_dbconnector.cpp
+++ b/tests/mock_tests/mock_dbconnector.cpp
@@ -38,8 +38,9 @@ namespace swss
         m_conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
     }
 
-    DBConnector::DBConnector(const std::string& dbName, unsigned int timeout, bool isTcpConn)
+    DBConnector::DBConnector(const std::string& dbName, unsigned int timeout, bool isTcpConn, const string& nameSpace)
         : m_dbName(dbName)
+        , m_namespace(nameSpace)
     {
         if (swss::SonicDBConfig::isInit() == false)
             swss::SonicDBConfig::initialize("./database_config.json");
@@ -59,6 +60,12 @@ namespace swss
             m_conn->unix_sock.path = strdup(swss::SonicDBConfig::getDbSock(dbName).c_str());
             m_conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
         }
+    }
+
+    DBConnector::DBConnector(const string& dbName, unsigned int timeout, bool isTcpConn)
+        : DBConnector(dbName, timeout, isTcpConn, EMPTY_NAMESPACE)
+    {
+        // Empty contructor
     }
 
     int DBConnector::getDbId() const

--- a/tests/mock_tests/mock_dbconnector.cpp
+++ b/tests/mock_tests/mock_dbconnector.cpp
@@ -38,7 +38,7 @@ namespace swss
         m_conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
     }
 
-    DBConnector::DBConnector(const std::string& dbName, unsigned int timeout, bool isTcpConn, const string& nameSpace)
+    DBConnector::DBConnector(const std::string& dbName, unsigned int timeout, bool isTcpConn, const std::string& nameSpace)
         : m_dbName(dbName)
         , m_namespace(nameSpace)
     {
@@ -62,7 +62,7 @@ namespace swss
         }
     }
 
-    DBConnector::DBConnector(const string& dbName, unsigned int timeout, bool isTcpConn)
+    DBConnector::DBConnector(const std::string& dbName, unsigned int timeout, bool isTcpConn)
         : DBConnector(dbName, timeout, isTcpConn, EMPTY_NAMESPACE)
     {
         // Empty contructor


### PR DESCRIPTION
**What I did**
Added the additional "namespace" argument for the DBConnector constructor in mock_dbconnector.cpp

**Why I did it**
The DBConnector class in the sonic-swss-common was enhanced to take the namespace argument to talk to the DB in a particular namespace. Updating the definition of DBConnector constructor here in mock_dbconnector.cpp as well.

**How I verified it**

**Details if related**
