### PR TITLE
[fdborch] Fixed Orchagent crash in FDB flush on port disable.

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -232,13 +232,14 @@ void FdbOrch::update(sai_fdb_event_t        type,
                            update.entry.mac.to_string().c_str(),
                            vlanName.c_str(), update.port.m_alias.c_str());
 
-            for (const auto& itr : m_entries)
+            for (auto itr = m_entries.begin(); itr != m_entries.end();)
             {
-                if (itr.port_name == update.port.m_alias)
+                if (itr->port_name == update.port.m_alias)
                 {
-                    update.entry.mac = itr.mac;
-                    update.entry.bv_id = itr.bv_id;
+                    update.entry.mac = itr->mac;
+                    update.entry.bv_id = itr->bv_id;
                     update.add = false;
+                    itr++;
 
                     storeFdbEntryState(update);
 
@@ -247,6 +248,10 @@ void FdbOrch::update(sai_fdb_event_t        type,
                         observer->update(SUBJECT_TYPE_FDB_CHANGE, &update);
                     }
                 } 
+                else
+                {
+                    itr++;
+                }
             }
         }
         else if (bridge_port_id == SAI_NULL_OBJECT_ID)

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -234,12 +234,12 @@ void FdbOrch::update(sai_fdb_event_t        type,
 
             for (auto itr = m_entries.begin(); itr != m_entries.end();)
             {
+                auto next_item = std::next(itr);
                 if (itr->port_name == update.port.m_alias)
                 {
                     update.entry.mac = itr->mac;
                     update.entry.bv_id = itr->bv_id;
                     update.add = false;
-                    itr++;
 
                     storeFdbEntryState(update);
 
@@ -247,11 +247,8 @@ void FdbOrch::update(sai_fdb_event_t        type,
                     {
                         observer->update(SUBJECT_TYPE_FDB_CHANGE, &update);
                     }
-                } 
-                else
-                {
-                    itr++;
                 }
+                itr = next_item;
             }
         }
         else if (bridge_port_id == SAI_NULL_OBJECT_ID)


### PR DESCRIPTION
Signed-off-by: Rajkumar Pennadam Ramamoorthy <rpennadamram@marvell.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed Orchagent crash in FDB flush on port disable.
Steps to reproduce:
1) configure vlan and a port.
2) Learn MAC and populate FDB table.
3) Disable the port.

In fdborch.cpp:485, "m_entries" element is erased (from function "storeFdbEntryState") inside range based loop.
Iterators or references to erased element are invalidated. Hence update the iterator before removing the element.

**Why I did it**

**How I verified it**
Validate the above testcase with fix.

**Details if related**
Logs:

Using host libthread_db library "/lib/arm-linux-gnueabihf/libthread_db.so.1".
Core was generated by `/usr/bin/orchagent -d /var/log/swss -b 8192 -m 00:50:b6:50:51:51'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0xb6b5676c in std::local_Rb_tree_increment (__x=0x3633240a, __x@entry=0x69b2e0) at ../../../../../src/libstdc++-v3/src/c++98/tree.cc:65
65      ../../../../../src/libstdc++-v3/src/c++98/tree.cc: No such file or directory.
[Current thread is 1 (Thread 0xb6f69000 (LWP 44))]
(gdb) bt
#0  0xb6b5676c in std::local_Rb_tree_increment (__x=0x3633240a, __x@entry=0x69b2e0) at ../../../../../src/libstdc++-v3/src/c++98/tree.cc:65
#1  std::_Rb_tree_increment (__x=__x@entry=0x69b2e0) at ../../../../../src/libstdc++-v3/src/c++98/tree.cc:91
#2  0x004bfea0 in std::_Rb_tree_const_iterator<FdbEntry>::operator++ (this=<synthetic pointer>) at /usr/include/c++/6/bits/stl_tree.h:288
#3  FdbOrch::update (this=this@entry=0x5ace68, type=<optimized out>, entry=<optimized out>, bridge_port_id=16325548649219474) at fdborch.cpp:235
#4  0x004c0746 in FdbOrch::doTask (this=0x5ace68, consumer=...) at fdborch.cpp:485
#5  0x004684a6 in OrchDaemon::start (this=0x59b57c) at orchdaemon.cpp:467
#6  0x00458e10 in main (argc=<optimized out>, argv=<optimized out>) at main.cpp:346
(gdb) p * __x
Cannot access memory at address 0x3633240a
(gdb) p __x
$1 = (std::_Rb_tree_node_base *) 0x3633240a
(gdb) fr 1
#1  std::_Rb_tree_increment (__x=__x@entry=0x69b2e0) at ../../../../../src/libstdc++-v3/src/c++98/tree.cc:91
91      in ../../../../../src/libstdc++-v3/src/c++98/tree.cc
(gdb) p __x
$2 = (const std::_Rb_tree_node_base *) 0x69b2e0
(gdb) p* __x
$3 = {_M_color = (unknown: 11347552), _M_parent = 0xa0d3324, _M_left = 0xd4c4544, _M_right = 0x3633240a}
(gdb) p __x->_M_right
$4 = (std::_Rb_tree_node_base::_Base_ptr) 0x3633240a
(gdb) p* __x->_M_right
Cannot access memory at address 0x3633240a
(gdb) p/x m_entries
$1 = std::set with 4159 elements = {[0] = {mac = {m_mac = {0x0, 0x0, 0x0, 0xaa, 0x11, 0x12}}, bv_id = 0x26000000000591, port_name = "Ethernet0"}, [1] = {


