### PR TITLE
[intfsorch] Retrieve Port object before setting NAT zone on router interfaces.

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -681,21 +681,24 @@ void IntfsOrch::doTask(Consumer &consumer)
                     continue;
                 }
 
-                /* Set nat zone id */
-                if ((!nat_zone.empty()) and (port.m_nat_zone_id != nat_zone_id))
+                if (gPortsOrch->getPort(alias, port))
                 {
-                    port.m_nat_zone_id = nat_zone_id;
+                    /* Set nat zone id */
+                    if ((!nat_zone.empty()) and (port.m_nat_zone_id != nat_zone_id))
+                    {
+                        port.m_nat_zone_id = nat_zone_id;
 
-                    if (gIsNatSupported)
-                    {
-                        setRouterIntfsNatZoneId(port);
+                        if (gIsNatSupported)
+                        {
+                            setRouterIntfsNatZoneId(port);
+                        }
+                        else
+                        {
+                            SWSS_LOG_NOTICE("Not set router interface %s NAT Zone Id to %u, as NAT is not supported",
+                                            port.m_alias.c_str(), port.m_nat_zone_id);
+                        }
+                        gPortsOrch->setPort(alias, port);
                     }
-                    else
-                    {
-                        SWSS_LOG_NOTICE("Not set router interface %s NAT Zone Id to %u, as NAT is not supported",
-                                        port.m_alias.c_str(), port.m_nat_zone_id);
-                    }
-                    gPortsOrch->setPort(alias, port);
                 }
             }
 


### PR DESCRIPTION
Method(setRouterIntfsNatZoneId) is called using local Port object that causes orchagent to crash on config reload with non-zero NAT zone configuration.

Orchagent:
Retrieve Port object using getPort method before setting NAT zone on Router interfaces.

Addressing the issue : https://github.com/Azure/sonic-swss/issues/1312
Signed-off-by: Kumaresh Perumal kumaresh.perumal@intel.com
