### PR TITLE
[sonic-swsss] Fix the issue of field "next_hop_ip" not getting updated in state DB in ERSPAN Mirror

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1206,9 +1206,6 @@ void MirrorOrch::updateNextHop(const NextHopUpdate& update)
             session.nexthopInfo.nexthop = NextHopKey("0.0.0.0", "");
         }
 
-        SWSS_LOG_NOTICE("Update mirror session state db %s nexthop to %s",
-                        name.c_str(), session.nexthopInfo.nexthop.to_string().c_str());
-
         // Update State DB Nexthop
         setSessionState(name, session, MIRROR_SESSION_NEXT_HOP_IP);
 

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1205,8 +1205,17 @@ void MirrorOrch::updateNextHop(const NextHopUpdate& update)
         {
             session.nexthopInfo.nexthop = NextHopKey("0.0.0.0", "");
         }
+
+        SWSS_LOG_NOTICE("Update mirror session state db %s nexthop to %s",
+                        name.c_str(), session.nexthopInfo.nexthop.to_string().c_str());
+
         // Update State DB Nexthop
         setSessionState(name, session, MIRROR_SESSION_NEXT_HOP_IP);
+
+        SWSS_LOG_NOTICE("Updated mirror session state db %s nexthop to %s",
+                        name.c_str(), session.nexthopInfo.nexthop.to_string().c_str());
+
+
         // Resolve the neighbor of the new next hop
         updateSession(name, session);
     }

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1205,7 +1205,8 @@ void MirrorOrch::updateNextHop(const NextHopUpdate& update)
         {
             session.nexthopInfo.nexthop = NextHopKey("0.0.0.0", "");
         }
-
+        // Update State DB Nexthop
+        setSessionState(name, session, MIRROR_SESSION_NEXT_HOP_IP);
         // Resolve the neighbor of the new next hop
         updateSession(name, session);
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -946,6 +946,10 @@ class DockerVirtualSwitch(object):
         self.runcmd("ip route add " + prefix + " via " + nexthop)
         time.sleep(1)
     
+    def change_route(self, prefix, nexthop):
+        self.runcmd("ip route change " + prefix + " via " + nexthop)
+        time.sleep(1)
+
     def remove_route(self, prefix):
         self.runcmd("ip route del " + prefix)
         time.sleep(1)

--- a/tests/dvslib/dvs_mirror.py
+++ b/tests/dvslib/dvs_mirror.py
@@ -67,13 +67,9 @@ class DVSMirror(object):
 
     def verify_session_db(self, dvs, name, asic_table=None, asic=None, state=None, asic_size=None):
         if asic:
-            fv_pairs = dvs.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", asic_table)
-            assert all(fv_pairs.get(k) == v for k, v in asic.items())
-            if asic_size:
-                assert asic_size == len(fv_pairs)
+            dvs.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", asic_table, asic)
         if state:
-            fv_pairs = dvs.state_db.wait_for_entry("MIRROR_SESSION_TABLE", name)
-            assert all(fv_pairs.get(k) == v for k, v in state.items())
+            dvs.state_db.wait_for_field_match("MIRROR_SESSION_TABLE", name, state)
 
     def verify_session_policer(self, dvs, policer_oid, cir):
         if cir:

--- a/tests/dvslib/dvs_mirror.py
+++ b/tests/dvslib/dvs_mirror.py
@@ -1,3 +1,4 @@
+from dvslib.dvs_common import PollingConfig
 class DVSMirror(object):
     def __init__(self, adb, cdb, sdb, cntrdb, appdb):
         self.asic_db = adb
@@ -66,10 +67,13 @@ class DVSMirror(object):
                 assert "SAI_PORT_ATTR_EGRESS_MIRROR_SESSION" not in member.keys() or member["SAI_PORT_ATTR_EGRESS_MIRROR_SESSION"] == "0:null"
 
     def verify_session_db(self, dvs, name, asic_table=None, asic=None, state=None, asic_size=None):
+
+        mirror_session_db_poll = PollingConfig(polling_interval=0.01, timeout=10, strict=True)
+
         if asic:
-            dvs.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", asic_table, asic)
+            dvs.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", asic_table, asic, mirror_session_db_poll)
         if state:
-            dvs.state_db.wait_for_field_match("MIRROR_SESSION_TABLE", name, state)
+            dvs.state_db.wait_for_field_match("MIRROR_SESSION_TABLE", name, state, mirror_session_db_poll)
 
     def verify_session_policer(self, dvs, policer_oid, cir):
         if cir:

--- a/tests/dvslib/dvs_mirror.py
+++ b/tests/dvslib/dvs_mirror.py
@@ -1,4 +1,3 @@
-from dvslib.dvs_common import PollingConfig
 class DVSMirror(object):
     def __init__(self, adb, cdb, sdb, cntrdb, appdb):
         self.asic_db = adb
@@ -67,13 +66,10 @@ class DVSMirror(object):
                 assert "SAI_PORT_ATTR_EGRESS_MIRROR_SESSION" not in member.keys() or member["SAI_PORT_ATTR_EGRESS_MIRROR_SESSION"] == "0:null"
 
     def verify_session_db(self, dvs, name, asic_table=None, asic=None, state=None, asic_size=None):
-
-        mirror_session_db_poll = PollingConfig(polling_interval=0.01, timeout=120, strict=True)
-
         if asic:
-            dvs.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", asic_table, asic, mirror_session_db_poll)
+            dvs.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", asic_table, asic)
         if state:
-            dvs.state_db.wait_for_field_match("MIRROR_SESSION_TABLE", name, state, mirror_session_db_poll)
+            dvs.state_db.wait_for_field_match("MIRROR_SESSION_TABLE", name, state)
 
     def verify_session_policer(self, dvs, policer_oid, cir):
         if cir:

--- a/tests/dvslib/dvs_mirror.py
+++ b/tests/dvslib/dvs_mirror.py
@@ -68,7 +68,7 @@ class DVSMirror(object):
 
     def verify_session_db(self, dvs, name, asic_table=None, asic=None, state=None, asic_size=None):
 
-        mirror_session_db_poll = PollingConfig(polling_interval=0.01, timeout=10, strict=True)
+        mirror_session_db_poll = PollingConfig(polling_interval=0.01, timeout=120, strict=True)
 
         if asic:
             dvs.asic_db.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION", asic_table, asic, mirror_session_db_poll)

--- a/tests/test_mirror_port_erspan.py
+++ b/tests/test_mirror_port_erspan.py
@@ -61,11 +61,13 @@ class TestMirror(object):
                             "SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS": "02:04:06:08:10:12",
                             "SAI_MIRROR_SESSION_ATTR_SRC_MAC_ADDRESS": src_mac,
                             "SAI_MIRROR_SESSION_ATTR_GRE_PROTOCOL_TYPE": "25944"}
+
         expected_state_db = {"status": "active",
-                                "monitor_port": "Ethernet16",
-                                "dst_mac": "02:04:06:08:10:12",
-                                "route_prefix": "2.2.2.2/32",
-                                "next_hop_ip": "10.0.0.1@Ethernet16"}
+                             "monitor_port": "Ethernet16",
+                             "dst_mac": "02:04:06:08:10:12",
+                             "route_prefix": "2.2.2.2/32",
+                             "next_hop_ip": "10.0.0.1@Ethernet16"}
+        
         self.dvs_mirror.verify_session_status(session)
         self.dvs_mirror.verify_session(dvs, session, asic_db=expected_asic_db, state_db=expected_state_db, src_ports=src_asic_ports, asic_size=11)
         # change route to mirror destination via 10.0.0.2
@@ -81,11 +83,13 @@ class TestMirror(object):
                             "SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS": "02:04:06:08:10:13",
                             "SAI_MIRROR_SESSION_ATTR_SRC_MAC_ADDRESS": src_mac,
                             "SAI_MIRROR_SESSION_ATTR_GRE_PROTOCOL_TYPE": "25944"}
+
         expected_state_db = {"status": "active",
-                                "monitor_port": "Ethernet16",
-                                "dst_mac": "02:04:06:08:10:13",
-                                "route_prefix": "2.2.2.2/32",
-                                "next_hop_ip": "10.0.0.2@Ethernet16"}
+                             "monitor_port": "Ethernet16",
+                             "dst_mac": "02:04:06:08:10:13",
+                             "route_prefix": "2.2.2.2/32",
+                             "next_hop_ip": "10.0.0.2@Ethernet16"}
+
         self.dvs_mirror.verify_session_status(session)
         self.dvs_mirror.verify_session(dvs, session, asic_db=expected_asic_db, state_db=expected_state_db, src_ports=src_asic_ports, asic_size=11)
  
@@ -96,9 +100,11 @@ class TestMirror(object):
         # remove neighbor
         dvs.remove_neighbor("Ethernet16", "10.0.0.1")
         self.dvs_mirror.verify_session_status(session, status="inactive")
+        dvs.remove_neighbor("Ethernet16", "10.0.0.2")
+        self.dvs_mirror.verify_session_status(session, status="inactive")
 
         # remove IP address
-        dvs.remove_ip_address("Ethernet16", "10.0.0.0/31")
+        dvs.remove_ip_address("Ethernet16", "10.0.0.0/30")
         self.dvs_mirror.verify_session_status(session, status="inactive")
 
         # bring down Ethernet16

--- a/tests/test_mirror_port_erspan.py
+++ b/tests/test_mirror_port_erspan.py
@@ -36,11 +36,15 @@ class TestMirror(object):
         self.dvs_mirror.verify_session_status(session, status="inactive")
 
         # add IP address to Ethernet16
-        dvs.add_ip_address("Ethernet16", "10.0.0.0/31")
+        dvs.add_ip_address("Ethernet16", "10.0.0.0/30")
         self.dvs_mirror.verify_session_status(session, status="inactive")
 
         # add neighbor to Ethernet16
         dvs.add_neighbor("Ethernet16", "10.0.0.1", "02:04:06:08:10:12")
+        self.dvs_mirror.verify_session_status(session, status="inactive")
+
+        # add another neighbor to Ethernet16
+        dvs.add_neighbor("Ethernet16", "10.0.0.2", "02:04:06:08:10:13")
         self.dvs_mirror.verify_session_status(session, status="inactive")
 
         # add route to mirror destination via 10.0.0.1
@@ -60,10 +64,31 @@ class TestMirror(object):
         expected_state_db = {"status": "active",
                                 "monitor_port": "Ethernet16",
                                 "dst_mac": "02:04:06:08:10:12",
-                                "route_prefix": "2.2.2.2/32"}
+                                "route_prefix": "2.2.2.2/32",
+                                "next_hop_ip": "10.0.0.1@Ethernet16"}
         self.dvs_mirror.verify_session_status(session)
         self.dvs_mirror.verify_session(dvs, session, asic_db=expected_asic_db, state_db=expected_state_db, src_ports=src_asic_ports, asic_size=11)
-
+        # change route to mirror destination via 10.0.0.2
+        dvs.change_route("2.2.2.2", "10.0.0.2")
+        expected_asic_db = {"SAI_MIRROR_SESSION_ATTR_MONITOR_PORT": pmap.get("Ethernet16"),
+                            "SAI_MIRROR_SESSION_ATTR_TYPE": "SAI_MIRROR_SESSION_TYPE_ENHANCED_REMOTE",
+                            "SAI_MIRROR_SESSION_ATTR_ERSPAN_ENCAPSULATION_TYPE": "SAI_ERSPAN_ENCAPSULATION_TYPE_MIRROR_L3_GRE_TUNNEL",
+                            "SAI_MIRROR_SESSION_ATTR_IPHDR_VERSION": "4",
+                            "SAI_MIRROR_SESSION_ATTR_TOS": "32",
+                            "SAI_MIRROR_SESSION_ATTR_TTL": "100",
+                            "SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS": "1.1.1.1",
+                            "SAI_MIRROR_SESSION_ATTR_DST_IP_ADDRESS": "2.2.2.2",
+                            "SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS": "02:04:06:08:10:13",
+                            "SAI_MIRROR_SESSION_ATTR_SRC_MAC_ADDRESS": src_mac,
+                            "SAI_MIRROR_SESSION_ATTR_GRE_PROTOCOL_TYPE": "25944"}
+        expected_state_db = {"status": "active",
+                                "monitor_port": "Ethernet16",
+                                "dst_mac": "02:04:06:08:10:13",
+                                "route_prefix": "2.2.2.2/32",
+                                "next_hop_ip": "10.0.0.2@Ethernet16"}
+        self.dvs_mirror.verify_session_status(session)
+        self.dvs_mirror.verify_session(dvs, session, asic_db=expected_asic_db, state_db=expected_state_db, src_ports=src_asic_ports, asic_size=11)
+ 
         # remove route
         dvs.remove_route("2.2.2.2")
         self.dvs_mirror.verify_session_status(session, status="inactive")


### PR DESCRIPTION
What I did:
Fix the issue of field "next_hop_ip" not getting updated in state DB
Table: MIRROR_SESSION_TABLE when mirror destination ip next hop changes
for ERSPAN Mirror.

Also fixed divs_mirror library to use wait_for_field_match instead wait_for_entry
when comparing expected value for ASIC and State Db Table.

How I Verify:
Updated ERSPAN DVS test case to check next_hop_ip in state db.
Also test case is enhanced to see if route change in propagated correctly
to state and asic db.