### PR TITLE
swss: gearsyncd should return 0 on exit

### DIFF
--- a/gearsyncd/gearsyncd.cpp
+++ b/gearsyncd/gearsyncd.cpp
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
         cerr << "Exception \"" << e.what() << "\" had been thrown in gearsyncd daemon" << endl;
         return EXIT_FAILURE;
     }
-    return 1;
+    return 0;
 }
 
 bool handleGearboxConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb, bool warm)

--- a/gearsyncd/gearsyncd.cpp
+++ b/gearsyncd/gearsyncd.cpp
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
             break;
         case 'h':
             usage();
-            return 1;
+            return EXIT_FAILURE;
         default: /* '?' */
             usage();
             return EXIT_FAILURE;
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
         cerr << "Exception \"" << e.what() << "\" had been thrown in gearsyncd daemon" << endl;
         return EXIT_FAILURE;
     }
-    return 0;
+    return EXIT_SUCCESS;
 }
 
 bool handleGearboxConfigFromConfigDB(ProducerStateTable &p, DBConnector &cfgDb, bool warm)


### PR DESCRIPTION
* changes made to supervisord conf require gearsyncd to return 0 otherwise
  restarts are performed, fail, and swss docker exits
* originally, gearsyncd did not exit, and if it did, 1 exit code was returned
  to indicate failure. We converted this to do its job and exit, but did not
  correct the exit code.
* prior state was not a problem until changes that are yet to merge for
  sonic-buildimage supervisord conf made returning a 1 problematic.

**What I did**

change exit code for gearsyncd to 0 from 1

**Why I did it**

for compatibility with supervisord.conf. Not to mention, processes should return 0 on success.

**How I verified it**

Local build.

HLD is located at https://github.com/Azure/SONiC/blob/b817a12fd89520d3fd26bbc5897487928e7f6de7/doc/gearbox/gearbox_mgr_design.md

  Signed-off-by: syd.logan@broadcom.com


