### PR TITLE
[dvs_acl] Refactor and document dvs_acl library

### DIFF
--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -402,7 +402,7 @@ class DVSAcl:
             self.verify_acl_rule(expected[priority], in_actions[priority], priority, entry)
 
     # FIXME: This `get_x_comparator` abstraction is a bit clunky, we should try to improve this later.
-    def get_simple_qualifier_comparator(self, expected_qualifier: str) -> Callable[str, bool]:
+    def get_simple_qualifier_comparator(self, expected_qualifier: str) -> Callable[[str], bool]:
         """Generate a method that compares if a given SAI qualifer matches `expected_qualifier`.
 
         Args:
@@ -416,7 +416,7 @@ class DVSAcl:
 
         return _match_qualifier
 
-    def get_port_list_comparator(self, expected_ports: List[str]) -> Callable[str, bool]:
+    def get_port_list_comparator(self, expected_ports: List[str]) -> Callable[[str], bool]:
         """Generate a method that compares if a list of SAI ports matches the ports from `expected_ports`.
 
         Args:
@@ -436,7 +436,7 @@ class DVSAcl:
 
         return _match_port_list
 
-    def get_acl_range_comparator(self, expected_type: str, expected_ports: str) -> Callable[str, bool]:
+    def get_acl_range_comparator(self, expected_type: str, expected_ports: str) -> Callable[[str], bool]:
         """Generate a method that compares if a SAI range object matches the range from `expected ports`.
 
         Args:

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -1,13 +1,60 @@
-class DVSAcl(object):
-    def __init__(self, adb, cdb, sdb, cntrdb):
-        self.asic_db = adb
-        self.config_db = cdb
-        self.state_db = sdb
-        self.counters_db = cntrdb
+"""Utilities for interacting with ACLs when writing VS tests."""
+from typing import Callable, Dict, List
 
-    def create_acl_table(self, table_name, table_type, ports, stage=None):
+
+class DVSAcl:
+    """Manage ACL tables and rules on the virtual switch."""
+
+    CDB_ACL_TABLE_NAME = "ACL_TABLE"
+
+    CDB_MIRROR_ACTION_LOOKUP = {
+        "ingress": "MIRROR_INGRESS_ACTION",
+        "egress": "MIRROR_EGRESS_ACTION"
+    }
+
+    ADB_ACL_TABLE_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE"
+    ADB_ACL_GROUP_TABLE_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP"
+    ADB_ACL_GROUP_MEMBER_TABLE_NAME = "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER"
+
+    ADB_ACL_STAGE_LOOKUP = {
+        "ingress": "SAI_ACL_STAGE_INGRESS",
+        "egress": "SAI_ACL_STAGE_EGRESS"
+    }
+
+    ADB_PACKET_ACTION_LOOKUP = {
+        "FORWARD": "SAI_PACKET_ACTION_FORWARD",
+        "DROP": "SAI_PACKET_ACTION_DROP"
+    }
+
+    ADB_MIRROR_ACTION_LOOKUP = {
+        "ingress": "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS",
+        "egress": "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_EGRESS"
+    }
+
+    def __init__(self, asic_db, config_db, state_db, counters_db):
+        """Create a new DVS ACL Manager."""
+        self.asic_db = asic_db
+        self.config_db = config_db
+        self.state_db = state_db
+        self.counters_db = counters_db
+
+    def create_acl_table(
+            self,
+            table_name: str,
+            table_type: str,
+            ports: List[str],
+            stage: str = None
+    ) -> None:
+        """Create a new ACL table in Config DB.
+
+        Args:
+            table_name: The name for the new ACL table.
+            table_type: The type of table to create.
+            ports: A list of ports to bind to the ACL table.
+            stage: The stage for the ACL table. {ingress, egress}
+        """
         table_attrs = {
-            "policy_desc": "DVS acl table test",
+            "policy_desc": table_name,
             "type": table_type,
             "ports": ",".join(ports)
         }
@@ -15,24 +62,39 @@ class DVSAcl(object):
         if stage:
             table_attrs["stage"] = stage
 
-        self.config_db.create_entry("ACL_TABLE", table_name, table_attrs)
+        self.config_db.create_entry(self.CDB_ACL_TABLE_NAME, table_name, table_attrs)
 
-    def update_acl_table(self, acl_table_name, ports):
-        table_attrs = {
-            "ports": ",".join(ports)
-        }
-        self.config_db.update_entry("ACL_TABLE", acl_table_name, table_attrs)
+    def update_acl_table_port_list(self, table_name: str, ports: List[str]) -> None:
+        """Update the port binding list for a given ACL table.
 
-    def remove_acl_table(self, table_name):
-        self.config_db.delete_entry("ACL_TABLE", table_name)
+        Args:
+            table_name: The name of the ACL table to update.
+            ports: The new list of ports to bind to the ACL table.
+        """
+        table_attrs = {"ports": ",".join(ports)}
+        self.config_db.update_entry(self.CDB_ACL_TABLE_NAME, table_name, table_attrs)
 
-    def get_acl_table_group_ids(self, expt):
-        acl_table_groups = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", expt)
-        return acl_table_groups
+    def remove_acl_table(self, table_name: str) -> None:
+        """Remove an ACL table from Config DB.
 
-    def get_acl_table_ids(self, expt=1):
-        num_keys = len(self.asic_db.default_acl_tables) + expt
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
+        Args:
+            table_name: The name of the ACL table to delete.
+        """
+        self.config_db.delete_entry(self.CDB_ACL_TABLE_NAME, table_name)
+
+    def get_acl_table_ids(self, expected: int) -> List[str]:
+        """Get all of the ACL table IDs in ASIC DB.
+
+        This method will wait for the expected number of tables to exist, or fail.
+
+        Args:
+            expected: The number of tables that are expected to be present in ASIC DB.
+
+        Returns:
+            The list of ACL table IDs in ASIC DB.
+        """
+        num_keys = len(self.asic_db.default_acl_tables) + expected
+        keys = self.asic_db.wait_for_n_keys(self.ADB_ACL_TABLE_NAME, num_keys)
         for k in self.asic_db.default_acl_tables:
             assert k in keys
 
@@ -40,28 +102,47 @@ class DVSAcl(object):
 
         return acl_tables
 
-    def get_acl_table_id(self):
-        acl_tables = self.get_acl_table_ids()
-        return acl_tables[0]
+    def verify_acl_table_count(self, expected: int) -> None:
+        """Verify that some number of tables exists in ASIC DB.
 
-    def verify_acl_table_count(self, expt):
-        num_keys = len(self.asic_db.default_acl_tables) + expt
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", num_keys)
-        for k in self.asic_db.default_acl_tables:
-            assert k in keys
+        This method will wait for the expected number of tables to exist, or fail.
 
-        acl_tables = [k for k in keys if k not in self.asic_db.default_acl_tables]
+        Args:
+            expected: The number of tables that are expected to be present in ASIC DB.
+        """
+        self.get_acl_table_ids(expected)
 
-        assert len(acl_tables) == expt
+    def get_acl_table_group_ids(self, expected: int) -> List[str]:
+        """Get all of the ACL group IDs in ASIC DB.
 
-    def verify_acl_group_num(self, expt):
-        acl_table_groups = self.get_acl_table_group_ids(expt)
+        This method will wait for the expected number of groups to exist, or fail.
+
+        Args:
+            expected: The number of groups that are expected to be present in ASIC DB.
+
+        Returns:
+            The list of ACL group IDs in ASIC DB.
+        """
+        acl_table_groups = self.asic_db.wait_for_n_keys(self.ADB_ACL_GROUP_TABLE_NAME, expected)
+        return acl_table_groups
+
+    # FIXME: This method currently assumes only ingress xor egress tables exist.
+    def verify_acl_table_groups(self, expected: int, stage: str = "ingress") -> None:
+        """Verify that the expected ACL table groups exist in ASIC DB.
+
+        This method will wait for the expected number of groups to exist, or fail.
+
+        Args:
+            expected: The number of groups that are expected to be present in ASIC DB.
+            stage: The stage of the ACL table that was created.
+        """
+        acl_table_groups = self.get_acl_table_group_ids(expected)
 
         for group in acl_table_groups:
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", group)
+            fvs = self.asic_db.wait_for_entry(self.ADB_ACL_GROUP_TABLE_NAME, group)
             for k, v in fvs.items():
                 if k == "SAI_ACL_TABLE_GROUP_ATTR_ACL_STAGE":
-                    assert v == "SAI_ACL_STAGE_INGRESS"
+                    assert v == self.ADB_ACL_STAGE_LOOKUP[stage]
                 elif k == "SAI_ACL_TABLE_GROUP_ATTR_ACL_BIND_POINT_TYPE_LIST":
                     assert v == "1:SAI_ACL_BIND_POINT_TYPE_PORT"
                 elif k == "SAI_ACL_TABLE_GROUP_ATTR_TYPE":
@@ -69,63 +150,69 @@ class DVSAcl(object):
                 else:
                     assert False
 
-    def verify_acl_table_group_member(self, acl_table_group_id, acl_table_id):
-        self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", acl_table_group_id)
-        self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE", acl_table_id)
-        members = self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER")
-        for m in members:
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", m)
-            fvs = dict(fvs)
-            if (fvs.pop("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_GROUP_ID") == acl_table_group_id and
-                    fvs.pop("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID") == acl_table_id) :
-                return True
-        assert False
+    def verify_acl_table_group_members(self, acl_table_id: str, acl_table_group_ids: str, num_tables: int) -> None:
+        """Verify that the expected ACL table group members exist in ASIC DB.
 
-    def verify_acl_group_member(self, acl_group_ids, acl_table_id):
-        members = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", len(acl_group_ids))
+        Args:
+            acl_table_id: The ACL table that the group members belong to.
+            acl_table_group_ids: The ACL table groups to check.
+            num_tables: The total number of ACL tables in ASIC DB.
+        """
+        members = self.asic_db.wait_for_n_keys(self.ADB_ACL_GROUP_MEMBER_TABLE_NAME,
+                                               len(acl_table_group_ids) * num_tables)
 
         member_groups = []
         for member in members:
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER", member)
-            for k, v in fvs.items():
-                if k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_GROUP_ID":
-                    assert v in acl_group_ids
-                    member_groups.append(v)
-                elif k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID":
-                    assert v == acl_table_id
-                elif k == "SAI_ACL_TABLE_GROUP_MEMBER_ATTR_PRIORITY":
-                    assert True
-                else:
-                    assert False
+            fvs = self.asic_db.wait_for_entry(self.ADB_ACL_GROUP_MEMBER_TABLE_NAME, member)
+            group_id = fvs.get("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_GROUP_ID")
+            table_id = fvs.get("SAI_ACL_TABLE_GROUP_MEMBER_ATTR_ACL_TABLE_ID")
 
-        assert set(member_groups) == set(acl_group_ids)
+            if group_id in acl_table_group_ids and table_id == acl_table_id:
+                member_groups.append(group_id)
 
-    def verify_acl_table_ports_binding(self, ports, acl_table_id):
-        for p in ports:
-            # TBD: Introduce new API in dvs_databse.py to read by field
-            fvs = self.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "")
-            fvs = dict(fvs)
-            port_oid = fvs.pop(p)
-            #port_oid = self.counters_db.hget_entry("COUNTERS_PORT_NAME_MAP", "", p)
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
-            fvs = dict(fvs)
-            acl_table_group_id = fvs.pop("SAI_PORT_ATTR_INGRESS_ACL")
-            self.verify_acl_table_group_member(acl_table_group_id, acl_table_id)
+        assert set(member_groups) == set(acl_table_group_ids)
 
-    def verify_acl_port_binding(self, bind_ports):
-        acl_table_groups = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
+    def verify_acl_table_port_binding(self, acl_table_id: str, bind_ports: List[str], num_tables: int) -> None:
+        """Verify that the ACL table has been bound to the given list of ports.
+
+        Args:
+            acl_table_id: The ACL table that is being checked.
+            bind_ports: The ports that should be bound to the given ACL table.
+            num_tables: The total number of ACL tables in ASIC DB.
+        """
+        acl_table_group_ids = self.asic_db.wait_for_n_keys(self.ADB_ACL_GROUP_TABLE_NAME, len(bind_ports))
 
         port_groups = []
-        for port in [self.asic_db.port_name_map[p] for p in bind_ports]:
-            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port)
-            acl_table_group = fvs.pop("SAI_PORT_ATTR_INGRESS_ACL", None)
-            assert acl_table_group in acl_table_groups
-            port_groups.append(acl_table_group)
+        for port in bind_ports:
+            port_oid = self.counters_db.get_entry("COUNTERS_PORT_NAME_MAP", "").get(port)
+            fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid)
+
+            acl_table_group_id = fvs.pop("SAI_PORT_ATTR_INGRESS_ACL", None)
+            assert acl_table_group_id in acl_table_group_ids
+            port_groups.append(acl_table_group_id)
 
         assert len(port_groups) == len(bind_ports)
-        assert set(port_groups) == set(acl_table_groups)
+        assert set(port_groups) == set(acl_table_group_ids)
 
-    def create_acl_rule(self, table_name, rule_name, qualifiers, action="FORWARD", priority="2020"):
+        self.verify_acl_table_group_members(acl_table_id, acl_table_group_ids, num_tables)
+
+    def create_acl_rule(
+            self,
+            table_name: str,
+            rule_name: str,
+            qualifiers: Dict[str, str],
+            action: str = "FORWARD",
+            priority: str = "2020"
+    ) -> None:
+        """Create a new ACL rule in the given table.
+
+        Args:
+            table_name: The name of the ACL table to add the rule to.
+            rule_name: The name of the ACL rule.
+            qualifiers: The list of qualifiers to add to the rule.
+            action: The packet action of the rule.
+            priority: The priority of the rule.
+        """
         fvs = {
             "priority": priority,
             "PACKET_ACTION": action
@@ -136,9 +223,33 @@ class DVSAcl(object):
 
         self.config_db.create_entry("ACL_RULE", "{}|{}".format(table_name, rule_name), fvs)
 
-    def create_mirror_acl_rule(self, table_name, rule_name, qualifiers, priority="2020"):
+    def create_redirect_acl_rule(
+            self,
+            table_name: str,
+            rule_name: str,
+            qualifiers: Dict[str, str],
+            intf: str,
+            ip: str = None,
+            priority: str = "2020"
+    ) -> None:
+        """Create a new ACL redirect rule in the given table.
+
+        Args:
+            table_name: The name of the ACL table to add the rule to.
+            rule_name: The name of the ACL rule.
+            qualifiers: The list of qualifiers to add to the rule.
+            intf: The interface to redirect packets to.
+            ip: The IP to redirect packets to, if the redirect is a Next Hop.
+            priority: The priority of the rule.
+        """
+        if ip:
+            redirect_action = f"{ip}@{intf}"
+        else:
+            redirect_action = intf
+
         fvs = {
-            "priority": priority
+            "priority": priority,
+            "REDIRECT_ACTION": redirect_action
         }
 
         for k, v in qualifiers.items():
@@ -146,28 +257,140 @@ class DVSAcl(object):
 
         self.config_db.create_entry("ACL_RULE", "{}|{}".format(table_name, rule_name), fvs)
 
-    def remove_acl_rule(self, table_name, rule_name):
+    def create_mirror_acl_rule(
+            self,
+            table_name: str,
+            rule_name: str,
+            qualifiers: Dict[str, str],
+            session_name: str,
+            stage: str = None,
+            priority: str = "2020"
+    ) -> None:
+        """Create a new ACL mirror rule in the given table.
+
+        Args:
+            table_name: The name of the ACL table to add the rule to.
+            rule_name: The name of the ACL rule.
+            qualifiers: The list of qualifiers to add to the rule.
+            session_name: The name of the session to mirror to.
+            stage: The type of mirroring to use. {ingress, egress}
+            priority: The priority of the rule.
+        """
+        if not stage:
+            mirror_action = "MIRROR_ACTION"
+        else:
+            mirror_action = self.CDB_MIRROR_ACTION_LOOKUP[stage]
+
+        fvs = {
+            "priority": priority,
+            mirror_action: session_name
+        }
+
+        for k, v in qualifiers.items():
+            fvs[k] = v
+
+        self.config_db.create_entry("ACL_RULE", "{}|{}".format(table_name, rule_name), fvs)
+
+    def remove_acl_rule(self, table_name: str, rule_name: str) -> None:
+        """Remove the ACL rule from the table.
+
+        Args:
+            table_name: The name of the table to remove the rule from.
+            rule_name: The name of the rule to remove.
+        """
         self.config_db.delete_entry("ACL_RULE", "{}|{}".format(table_name, rule_name))
 
-    def get_acl_rule_id(self):
-        num_keys = len(self.asic_db.default_acl_entries) + 1
-        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
-
-        acl_entries = [k for k in keys if k not in self.asic_db.default_acl_entries]
-        return acl_entries[0]
-
-    def verify_no_acl_rules(self):
+    def verify_no_acl_rules(self) -> None:
+        """Verify that there are no ACL rules in the ASIC DB."""
         num_keys = len(self.asic_db.default_acl_entries)
         keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
         assert set(keys) == set(self.asic_db.default_acl_entries)
 
-    def verify_acl_rule(self, qualifiers, action="FORWARD", priority="2020"):
-        acl_rule_id = self.get_acl_rule_id()
+    def verify_acl_rule(
+            self,
+            sai_qualifiers: Dict[str, str],
+            action: str = "FORWARD",
+            priority: str = "2020",
+            acl_rule_id: str = None
+    ) -> None:
+        """Verify that an ACL rule has the correct ASIC DB representation.
+
+        Args:
+            sai_qualifiers: The expected set of SAI qualifiers to be found in ASIC DB.
+            action: The type of PACKET_ACTION the given rule has.
+            priority: The priority of the rule.
+            acl_rule_id: A specific OID to check in ASIC DB. If left empty, this method
+                         assumes that only one rule exists in ASIC DB.
+        """
+        if not acl_rule_id:
+            acl_rule_id = self._get_acl_rule_id()
 
         fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
-        self._check_acl_entry(fvs, qualifiers, action, priority)
+        self._check_acl_entry_base(fvs, sai_qualifiers, action, priority)
+        self._check_acl_entry_packet_action(fvs, action)
 
-    def verify_acl_rule_set(self, priorities, in_actions, expected):
+    def verify_redirect_acl_rule(
+            self,
+            sai_qualifiers: Dict[str, str],
+            expected_destination: str,
+            priority: str = "2020",
+            acl_rule_id=None
+    ) -> None:
+        """Verify that an ACL redirect rule has the correct ASIC DB representation.
+
+        Args:
+            sai_qualifiers: The expected set of SAI qualifiers to be found in ASIC DB.
+            expected_destination: Where we expect the rule to redirect to. This can be an interface or
+                                  a next hop.
+            priority: The priority of the rule.
+            acl_rule_id: A specific OID to check in ASIC DB. If left empty, this method
+                         assumes that only one rule exists in ASIC DB.
+        """
+        if not acl_rule_id:
+            acl_rule_id = self._get_acl_rule_id()
+
+        fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
+        self._check_acl_entry_base(fvs, sai_qualifiers, "REDIRECT", priority)
+        self._check_acl_entry_redirect_action(fvs, expected_destination)
+
+    def verify_mirror_acl_rule(
+            self,
+            sai_qualifiers: Dict[str, str],
+            session_oid: str,
+            stage: str = "ingress",
+            priority: str = "2020",
+            acl_rule_id: str = None
+    ) -> None:
+        """Verify that an ACL mirror rule has the correct ASIC DB representation.
+
+        Args:
+            sai_qualifiers: The expected set of SAI qualifiers to be found in ASIC DB.
+            session_oid: The OID of the mirror session this rule is using.
+            stage: What stage/type of mirroring this rule is using.
+            priority: The priority of the rule.
+            acl_rule_id: A specific OID to check in ASIC DB. If left empty, this method
+                         assumes that only one rule exists in ASIC DB.
+        """
+        if not acl_rule_id:
+            acl_rule_id = self._get_acl_rule_id()
+
+        fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
+        self._check_acl_entry_base(fvs, sai_qualifiers, "MIRROR", priority)
+        self._check_acl_entry_mirror_action(fvs, session_oid, stage)
+
+    def verify_acl_rule_set(
+            self,
+            priorities: List[str],
+            in_actions: Dict[str, str],
+            expected: Dict[str, Dict[str, str]]
+    ) -> None:
+        """Verify that a set of rules with PACKET_ACTIONs have the correct ASIC DB representation.
+
+        Args:
+            priorities: A list of the priorities of each rule to be checked.
+            in_actions: The type of action each rule has, keyed by priority.
+            expected: The expected SAI qualifiers for each rule, keyed by priority.
+        """
         num_keys = len(self.asic_db.default_acl_entries) + len(priorities)
         keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
 
@@ -176,42 +399,32 @@ class DVSAcl(object):
             rule = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", entry)
             priority = rule.get("SAI_ACL_ENTRY_ATTR_PRIORITY", None)
             assert priority in priorities
-            self._check_acl_entry(rule, expected[priority],
-                                  action=in_actions[priority], priority=priority)
+            self.verify_acl_rule(expected[priority], in_actions[priority], priority, entry)
 
-    def _check_acl_entry(self, entry, qualifiers, action, priority):
-        acl_table_id = self.get_acl_table_id()
+    # FIXME: This `get_x_comparator` abstraction is a bit clunky, we should try to improve this later.
+    def get_simple_qualifier_comparator(self, expected_qualifier: str) -> Callable[str, bool]:
+        """Generate a method that compares if a given SAI qualifer matches `expected_qualifier`.
 
-        for k, v in entry.items():
-            if k == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
-                assert v == acl_table_id
-            elif k == "SAI_ACL_ENTRY_ATTR_ADMIN_STATE":
-                assert v == "true"
-            elif k == "SAI_ACL_ENTRY_ATTR_PRIORITY":
-                assert v == priority
-            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_COUNTER":
-                assert True
-            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION":
-                if action == "FORWARD":
-                    assert v == "SAI_PACKET_ACTION_FORWARD"
-                elif action == "DROP":
-                    assert v == "SAI_PACKET_ACTION_DROP"
-                else:
-                    assert False
-            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT":
-                assert True
-            elif k in qualifiers:
-                assert qualifiers[k](v)
-            else:
-                assert False
+        Args:
+            expected_qualifier: The SAI qualifier that the generated method will check against.
 
-    def get_simple_qualifier_comparator(self, expected_qualifier):
+        Returns:
+            A method that will compare qualifiers to `expected_qualifier`.
+        """
         def _match_qualifier(sai_qualifier):
             return expected_qualifier == sai_qualifier
 
         return _match_qualifier
 
-    def get_port_list_comparator(self, expected_ports):
+    def get_port_list_comparator(self, expected_ports: List[str]) -> Callable[str, bool]:
+        """Generate a method that compares if a list of SAI ports matches the ports from `expected_ports`.
+
+        Args:
+            expected_ports: The port list that the generated method will check against.
+
+        Returns:
+            A method that will compare SAI port lists against `expected_ports`.
+        """
         def _match_port_list(sai_port_list):
             if not sai_port_list.startswith("{}:".format(len(expected_ports))):
                 return False
@@ -223,7 +436,16 @@ class DVSAcl(object):
 
         return _match_port_list
 
-    def get_acl_range_comparator(self, expected_type, expected_ports):
+    def get_acl_range_comparator(self, expected_type: str, expected_ports: str) -> Callable[str, bool]:
+        """Generate a method that compares if a SAI range object matches the range from `expected ports`.
+
+        Args:
+            expected_type: The expected type of range.
+            expected_ports: A range of numbers described as "lower_bound,upper_bound".
+
+        Returns:
+            A method that will compare SAI ranges against `expected_type` and `expected_ports`.
+        """
         def _match_acl_range(sai_acl_range):
             range_id = sai_acl_range.split(":", 1)[1]
             fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_RANGE", range_id)
@@ -239,13 +461,48 @@ class DVSAcl(object):
 
         return _match_acl_range
 
-    def create_redirect_action_acl_rule(self, table_name, rule_name, qualifiers, intf, priority="2020"):
-        fvs = {
-            "priority": priority,
-            "REDIRECT_ACTION": intf
-        }
+    def _get_acl_rule_id(self) -> str:
+        num_keys = len(self.asic_db.default_acl_entries) + 1
+        keys = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", num_keys)
 
-        for k, v in qualifiers.items():
-            fvs[k] = v
+        acl_entries = [k for k in keys if k not in self.asic_db.default_acl_entries]
+        return acl_entries[0]
 
-        self.config_db.create_entry("ACL_RULE", "{}|{}".format(table_name, rule_name), fvs)
+    def _check_acl_entry_base(
+            self,
+            entry: Dict[str, str],
+            qualifiers: Dict[str, str],
+            action: str, priority: str
+    ) -> None:
+        acl_table_id = self.get_acl_table_ids(1)[0]
+
+        for k, v in entry.items():
+            if k == "SAI_ACL_ENTRY_ATTR_TABLE_ID":
+                assert v == acl_table_id
+            elif k == "SAI_ACL_ENTRY_ATTR_ADMIN_STATE":
+                assert v == "true"
+            elif k == "SAI_ACL_ENTRY_ATTR_PRIORITY":
+                assert v == priority
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_COUNTER":
+                assert True
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION":
+                assert action in self.ADB_PACKET_ACTION_LOOKUP
+            elif k == "SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT":
+                assert action == "REDIRECT"
+            elif "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR" in k:
+                assert action == "MIRROR"
+            elif k in qualifiers:
+                assert qualifiers[k](v)
+            else:
+                assert False
+
+    def _check_acl_entry_packet_action(self, entry: Dict[str, str], action: str) -> None:
+        assert "SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION" in entry
+        assert self.ADB_PACKET_ACTION_LOOKUP.get(action, None) == entry["SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION"]
+
+    def _check_acl_entry_redirect_action(self, entry: Dict[str, str], expected_destination: str) -> None:
+        assert entry.get("SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT", None) == expected_destination
+
+    def _check_acl_entry_mirror_action(self, entry: Dict[str, str], session_oid: str, stage: str) -> None:
+        assert stage in self.ADB_MIRROR_ACTION_LOOKUP
+        assert entry.get(self.ADB_MIRROR_ACTION_LOOKUP[stage]) == session_oid

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -1,216 +1,257 @@
-import time
 import pytest
 
-@pytest.mark.usefixtures('dvs_acl_manager')
+L3_TABLE_TYPE = "L3"
+L3_TABLE_NAME = "L3_TEST"
+L3_BIND_PORTS = ["Ethernet0", "Ethernet4", "Ethernet8", "Ethernet12"]
+L3_RULE_NAME = "L3_TEST_RULE"
+
+L3V6_TABLE_TYPE = "L3V6"
+L3V6_TABLE_NAME = "L3_V6_TEST"
+L3V6_BIND_PORTS = ["Ethernet0", "Ethernet4", "Ethernet8"]
+L3V6_RULE_NAME = "L3V6_TEST_RULE"
+
+
 class TestAcl():
-    def test_AclTableCreation(self, dvs):
+    @pytest.yield_fixture
+    def l3_acl_table(self, dvs_acl):
+        try:
+            dvs_acl.create_acl_table(L3_TABLE_NAME, L3_TABLE_TYPE, L3_BIND_PORTS)
+            yield dvs_acl.get_acl_table_ids(1)[0]
+        finally:
+            dvs_acl.remove_acl_table(L3_TABLE_NAME)
+            dvs_acl.verify_acl_table_count(0)
 
-        bind_ports = ["Ethernet0", "Ethernet4"]
-        self.dvs_acl.create_acl_table("test", "L3", bind_ports)
+    @pytest.yield_fixture
+    def l3v6_acl_table(self, dvs_acl):
+        try:
+            dvs_acl.create_acl_table(L3V6_TABLE_NAME,
+                                     L3V6_TABLE_TYPE,
+                                     L3V6_BIND_PORTS)
+            yield dvs_acl.get_acl_table_ids(1)[0]
+        finally:
+            dvs_acl.remove_acl_table(L3V6_TABLE_NAME)
+            dvs_acl.verify_acl_table_count(0)
 
-        self.dvs_acl.verify_acl_group_num(len(bind_ports))
-        acl_group_ids = self.dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
-        self.dvs_acl.verify_acl_group_member(acl_group_ids, self.dvs_acl.get_acl_table_id())
-        self.dvs_acl.verify_acl_port_binding(bind_ports)
+    @pytest.yield_fixture
+    def setup_teardown_neighbor(self, dvs):
+        try:
+            # NOTE: set_interface_status has a dependency on cdb within dvs,
+            # so we still need to setup the db. This should be refactored.
+            dvs.setup_db()
 
-    def test_AclRuleL4SrcPort(self, dvs):
+            # Bring up an IP interface with a neighbor
+            dvs.set_interface_status("Ethernet4", "up")
+            dvs.add_ip_address("Ethernet4", "10.0.0.1/24")
+            dvs.add_neighbor("Ethernet4", "10.0.0.2", "00:01:02:03:04:05")
 
+            yield dvs.get_asic_db().wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", 1)[0]
+        finally:
+            # Clean up the IP interface and neighbor
+            dvs.remove_neighbor("Ethernet4", "10.0.0.2")
+            dvs.remove_ip_address("Ethernet4", "10.0.0.1/24")
+            dvs.set_interface_status("Ethernet4", "down")
+
+    def test_AclTableCreationDeletion(self, dvs_acl):
+        try:
+            dvs_acl.create_acl_table(L3_TABLE_NAME, L3_TABLE_TYPE, L3_BIND_PORTS)
+
+            acl_table_id = dvs_acl.get_acl_table_ids(1)[0]
+            acl_table_group_ids = dvs_acl.get_acl_table_group_ids(len(L3_BIND_PORTS))
+            dvs_acl.verify_acl_table_group_members(acl_table_id, acl_table_group_ids, 1)
+            dvs_acl.verify_acl_table_port_binding(acl_table_id, L3_BIND_PORTS, 1)
+        finally:
+            dvs_acl.remove_acl_table(L3_TABLE_NAME)
+            dvs_acl.verify_acl_table_count(0)
+
+    def test_AclRuleL4SrcPort(self, dvs_acl, l3_acl_table):
         config_qualifiers = {"L4_SRC_PORT": "65000"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")
+        }
 
-        self.dvs_acl.create_acl_rule("test", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_AclRuleInOutPorts(self, dvs):
-
+    def test_AclRuleInOutPorts(self, dvs_acl, l3_acl_table):
         config_qualifiers = {
             "IN_PORTS": "Ethernet0,Ethernet4",
             "OUT_PORTS": "Ethernet8,Ethernet12"
         }
 
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": self.dvs_acl.get_port_list_comparator(["Ethernet0", "Ethernet4"]),
-            "SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORTS": self.dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
+            "SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS": dvs_acl.get_port_list_comparator(["Ethernet0", "Ethernet4"]),
+            "SAI_ACL_ENTRY_ATTR_FIELD_OUT_PORTS": dvs_acl.get_port_list_comparator(["Ethernet8", "Ethernet12"])
         }
 
-        self.dvs_acl.create_acl_rule("test", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_AclRuleInPortsNonExistingInterface(self, dvs):
-
+    def test_AclRuleInPortsNonExistingInterface(self, dvs_acl, l3_acl_table):
         config_qualifiers = {
             "IN_PORTS": "FOO_BAR_BAZ"
         }
 
-        self.dvs_acl.create_acl_rule("test", "acl_test_rule", config_qualifiers)
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
 
-        self.dvs_acl.verify_no_acl_rules()
-        self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
+        dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
 
-    def test_AclRuleOutPortsNonExistingInterface(self, dvs):
-
+    def test_AclRuleOutPortsNonExistingInterface(self, dvs_acl, l3_acl_table):
         config_qualifiers = {
             "OUT_PORTS": "FOO_BAR_BAZ"
         }
 
-        self.dvs_acl.create_acl_rule("test", "acl_test_rule", config_qualifiers)
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
 
-        self.dvs_acl.verify_no_acl_rules()
-        self.dvs_acl.remove_acl_rule("test", "acl_test_rule")
+        dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
 
-    def test_AclTableDeletion(self, dvs):
+    def test_V6AclTableCreationDeletion(self, dvs_acl):
+        try:
+            dvs_acl.create_acl_table(L3V6_TABLE_NAME,
+                                     L3V6_TABLE_TYPE,
+                                     L3V6_BIND_PORTS)
 
-        self.dvs_acl.remove_acl_table("test")
-        self.dvs_acl.verify_acl_table_count(0)
+            acl_table_id = dvs_acl.get_acl_table_ids(1)[0]
+            acl_table_group_ids = dvs_acl.get_acl_table_group_ids(len(L3V6_BIND_PORTS))
+            dvs_acl.verify_acl_table_group_members(acl_table_id, acl_table_group_ids, 1)
+            dvs_acl.verify_acl_table_port_binding(acl_table_id, L3V6_BIND_PORTS, 1)
+        finally:
+            dvs_acl.remove_acl_table(L3V6_TABLE_NAME)
+            dvs_acl.verify_acl_table_count(0)
 
-    def test_V6AclTableCreation(self, dvs):
-
-        bind_ports = ["Ethernet0", "Ethernet4", "Ethernet8"]
-        self.dvs_acl.create_acl_table("test_aclv6", "L3V6", bind_ports)
-
-        self.dvs_acl.verify_acl_group_num(len(bind_ports))
-        acl_group_ids = self.dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP", len(bind_ports))
-        self.dvs_acl.verify_acl_group_member(acl_group_ids, self.dvs_acl.get_acl_table_id())
-        self.dvs_acl.verify_acl_port_binding(bind_ports)
-
-    def test_V6AclRuleIPv6Any(self, dvs):
-
+    def test_V6AclRuleIPv6Any(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"IP_TYPE": "IPv6ANY"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE": self.dvs_acl.get_simple_qualifier_comparator("SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE": dvs_acl.get_simple_qualifier_comparator("SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff")
         }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleIPv6AnyDrop(self, dvs):
-
+    def test_V6AclRuleIPv6AnyDrop(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"IP_TYPE": "IPv6ANY"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE": self.dvs_acl.get_simple_qualifier_comparator("SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE": dvs_acl.get_simple_qualifier_comparator("SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff")
         }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers, action="DROP")
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers, action="DROP")
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME,
+                                L3V6_RULE_NAME,
+                                config_qualifiers,
+                                action="DROP")
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers, action="DROP")
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleIpProtocol(self, dvs):
-
+    def test_V6AclRuleIpProtocol(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"IP_PROTOCOL": "6"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL": self.dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL": dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
+        }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleSrcIPv6(self, dvs):
+    def test_V6AclRuleSrcIPv6(self, dvs_acl, l3v6_acl_table):
 
         config_qualifiers = {"SRC_IPV6": "2777::0/64"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6": self.dvs_acl.get_simple_qualifier_comparator("2777::&mask:ffff:ffff:ffff:ffff::")
+            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IPV6": dvs_acl.get_simple_qualifier_comparator("2777::&mask:ffff:ffff:ffff:ffff::")
         }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleDstIPv6(self, dvs):
-
+    def test_V6AclRuleDstIPv6(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"DST_IPV6": "2002::2/128"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6": self.dvs_acl.get_simple_qualifier_comparator("2002::2&mask:ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_DST_IPV6": dvs_acl.get_simple_qualifier_comparator("2002::2&mask:ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
         }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleL4SrcPort(self, dvs):
-
+    def test_V6AclRuleL4SrcPort(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"L4_SRC_PORT": "65000"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")
+        }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleL4DstPort(self, dvs):
-
+    def test_V6AclRuleL4DstPort(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"L4_DST_PORT": "65001"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT": self.dvs_acl.get_simple_qualifier_comparator("65001&mask:0xffff")}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_L4_DST_PORT": dvs_acl.get_simple_qualifier_comparator("65001&mask:0xffff")
+        }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleTCPFlags(self, dvs):
-
+    def test_V6AclRuleTCPFlags(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"TCP_FLAGS": "0x07/0x3f"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS": self.dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f")}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS":
+                dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f")
+        }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleL4SrcPortRange(self, dvs):
-
+    def test_V6AclRuleL4SrcPortRange(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"L4_SRC_PORT_RANGE": "1-100"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_RANGE_TYPE": self.dvs_acl.get_acl_range_comparator("SAI_ACL_RANGE_TYPE_L4_SRC_PORT_RANGE", "1,100")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_RANGE_TYPE": dvs_acl.get_acl_range_comparator("SAI_ACL_RANGE_TYPE_L4_SRC_PORT_RANGE", "1,100")
         }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleL4DstPortRange(self, dvs):
-
+    def test_V6AclRuleL4DstPortRange(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"L4_DST_PORT_RANGE": "101-200"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_RANGE_TYPE": self.dvs_acl.get_acl_range_comparator("SAI_ACL_RANGE_TYPE_L4_DST_PORT_RANGE", "101,200")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ACL_RANGE_TYPE": dvs_acl.get_acl_range_comparator("SAI_ACL_RANGE_TYPE_L4_DST_PORT_RANGE", "101,200")
         }
 
-        self.dvs_acl.create_acl_rule("test_aclv6", "acl_test_rule", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_aclv6", "acl_test_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclTableDeletion(self, dvs):
-
-        self.dvs_acl.remove_acl_table("test_aclv6")
-        self.dvs_acl.verify_acl_table_count(0)
-
-    def test_InsertAclRuleBetweenPriorities(self, dvs):
-
-        bind_ports = ["Ethernet0", "Ethernet4"]
-        self.dvs_acl.create_acl_table("test_priorities", "L3", bind_ports)
-
+    def test_InsertAclRuleBetweenPriorities(self, dvs_acl, l3_acl_table):
         rule_priorities = ["10", "20", "30", "40"]
 
         config_qualifiers = {
@@ -228,43 +269,40 @@ class TestAcl():
         }
 
         expected_sai_qualifiers = {
-            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.dvs_acl.get_simple_qualifier_comparator("10.0.0.0&mask:255.255.255.255")},
-            "20": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("104.44.94.0&mask:255.255.254.0")},
-            "30": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("192.168.0.16&mask:255.255.255.255")},
-            "40": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("100.64.0.0&mask:255.192.0.0")},
+            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("10.0.0.0&mask:255.255.255.255")},
+            "20": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": dvs_acl.get_simple_qualifier_comparator("104.44.94.0&mask:255.255.254.0")},
+            "30": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": dvs_acl.get_simple_qualifier_comparator("192.168.0.16&mask:255.255.255.255")},
+            "40": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": dvs_acl.get_simple_qualifier_comparator("100.64.0.0&mask:255.192.0.0")},
         }
 
         for rule in rule_priorities:
-            self.dvs_acl.create_acl_rule("test_priorities", "acl_test_rule_{}".format(rule),
-                                 config_qualifiers[rule], action=config_actions[rule],
-                                 priority=rule)
+            dvs_acl.create_acl_rule(L3_TABLE_NAME,
+                                    f"PRIORITY_TEST_RULE_{rule}",
+                                    config_qualifiers[rule], action=config_actions[rule],
+                                    priority=rule)
 
-        self.dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
+        dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
         odd_priority = "21"
         odd_rule = {"ETHER_TYPE": "4660"}
-        odd_sai_qualifier = {"SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE": self.dvs_acl.get_simple_qualifier_comparator("4660&mask:0xffff")}
+        odd_sai_qualifier = {"SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE": dvs_acl.get_simple_qualifier_comparator("4660&mask:0xffff")}
 
         rule_priorities.append(odd_priority)
         config_actions[odd_priority] = "DROP"
         expected_sai_qualifiers[odd_priority] = odd_sai_qualifier
 
-        self.dvs_acl.create_acl_rule("test_priorities", "acl_test_rule_{}".format(odd_priority),
-                             odd_rule, action="DROP", priority=odd_priority)
-        self.dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3_TABLE_NAME,
+                                f"PRIORITY_TEST_RULE_{odd_priority}",
+                                odd_rule,
+                                action="DROP",
+                                priority=odd_priority)
+        dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
         for rule in rule_priorities:
-            self.dvs_acl.remove_acl_rule("test_priorities", "acl_test_rule_{}".format(rule))
-        self.dvs_acl.verify_no_acl_rules()
+            dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"PRIORITY_TEST_RULE_{rule}")
+        dvs_acl.verify_no_acl_rules()
 
-        self.dvs_acl.remove_acl_table("test_priorities")
-        self.dvs_acl.verify_acl_table_count(0)
-
-    def test_RulesWithDiffMaskLengths(self, dvs):
-
-        bind_ports = ["Ethernet0", "Ethernet4"]
-        self.dvs_acl.create_acl_table("test_masks", "L3", bind_ports)
-
+    def test_RulesWithDiffMaskLengths(self, dvs_acl, l3_acl_table):
         rule_priorities = ["10", "20", "30", "40", "50", "60"]
 
         config_qualifiers = {
@@ -286,155 +324,103 @@ class TestAcl():
         }
 
         expected_sai_qualifiers = {
-            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.dvs_acl.get_simple_qualifier_comparator("23.103.0.0&mask:255.255.192.0")},
-            "20": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.dvs_acl.get_simple_qualifier_comparator("104.44.94.0&mask:255.255.254.0")},
-            "30": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("172.16.0.0&mask:255.240.0.0")},
-            "40": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("100.64.0.0&mask:255.192.0.0")},
-            "50": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": self.dvs_acl.get_simple_qualifier_comparator("104.146.32.0&mask:255.255.224.0")},
-            "60": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": self.dvs_acl.get_simple_qualifier_comparator("21.0.0.0&mask:255.0.0.0")},
+            "10": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("23.103.0.0&mask:255.255.192.0")},
+            "20": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("104.44.94.0&mask:255.255.254.0")},
+            "30": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": dvs_acl.get_simple_qualifier_comparator("172.16.0.0&mask:255.240.0.0")},
+            "40": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": dvs_acl.get_simple_qualifier_comparator("100.64.0.0&mask:255.192.0.0")},
+            "50": {"SAI_ACL_ENTRY_ATTR_FIELD_DST_IP": dvs_acl.get_simple_qualifier_comparator("104.146.32.0&mask:255.255.224.0")},
+            "60": {"SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("21.0.0.0&mask:255.0.0.0")},
         }
 
         for rule in rule_priorities:
-            self.dvs_acl.create_acl_rule("test_masks", "acl_test_rule_{}".format(rule),
-                                 config_qualifiers[rule], action=config_actions[rule],
-                                 priority=rule)
-        self.dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
+            dvs_acl.create_acl_rule(L3_TABLE_NAME,
+                                    f"MASK_TEST_RULE_{rule}",
+                                    config_qualifiers[rule],
+                                    action=config_actions[rule],
+                                    priority=rule)
+        dvs_acl.verify_acl_rule_set(rule_priorities, config_actions, expected_sai_qualifiers)
 
         for rule in rule_priorities:
-            self.dvs_acl.remove_acl_rule("test_masks", "acl_test_rule_{}".format(rule))
-        self.dvs_acl.verify_no_acl_rules()
+            dvs_acl.remove_acl_rule(L3_TABLE_NAME, f"MASK_TEST_RULE_{rule}")
+        dvs_acl.verify_no_acl_rules()
 
-        self.dvs_acl.remove_acl_table("test_masks")
-        self.dvs_acl.verify_acl_table_count(0)
-
-    def test_AclRuleIcmp(self, dvs):
-
-        bind_ports = ["Ethernet0", "Ethernet4"]
-        self.dvs_acl.create_acl_table("test_icmp", "L3", bind_ports)
-
+    def test_AclRuleIcmp(self, dvs_acl, l3_acl_table):
         config_qualifiers = {
             "ICMP_TYPE": "8",
             "ICMP_CODE": "9"
         }
 
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE": self.dvs_acl.get_simple_qualifier_comparator("8&mask:0xff"),
-            "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_CODE": self.dvs_acl.get_simple_qualifier_comparator("9&mask:0xff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_TYPE": dvs_acl.get_simple_qualifier_comparator("8&mask:0xff"),
+            "SAI_ACL_ENTRY_ATTR_FIELD_ICMP_CODE": dvs_acl.get_simple_qualifier_comparator("9&mask:0xff")
         }
 
-        self.dvs_acl.create_acl_rule("test_icmp", "test_icmp_fields", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_icmp", "test_icmp_fields")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-        self.dvs_acl.remove_acl_table("test_icmp")
-        self.dvs_acl.verify_acl_table_count(0)
+        dvs_acl.remove_acl_table(L3_TABLE_NAME)
+        dvs_acl.verify_acl_table_count(0)
 
-    def test_AclRuleIcmpV6(self, dvs):
-
-        bind_ports = ["Ethernet0", "Ethernet4"]
-        self.dvs_acl.create_acl_table("test_icmpv6", "L3V6", bind_ports)
-
+    def test_AclRuleIcmpV6(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {
             "ICMPV6_TYPE": "8",
             "ICMPV6_CODE": "9"
         }
 
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_ICMPV6_TYPE": self.dvs_acl.get_simple_qualifier_comparator("8&mask:0xff"),
-            "SAI_ACL_ENTRY_ATTR_FIELD_ICMPV6_CODE": self.dvs_acl.get_simple_qualifier_comparator("9&mask:0xff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_ICMPV6_TYPE": dvs_acl.get_simple_qualifier_comparator("8&mask:0xff"),
+            "SAI_ACL_ENTRY_ATTR_FIELD_ICMPV6_CODE": dvs_acl.get_simple_qualifier_comparator("9&mask:0xff")
         }
 
-        self.dvs_acl.create_acl_rule("test_icmpv6", "test_icmpv6_fields", config_qualifiers)
-        self.dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
 
-        self.dvs_acl.remove_acl_rule("test_icmpv6", "test_icmpv6_fields")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-        self.dvs_acl.remove_acl_table("test_icmpv6")
-        self.dvs_acl.verify_acl_table_count(0)
-
-    def test_AclRuleRedirectToNextHop(self, dvs):
-        # NOTE: set_interface_status has a dependency on cdb within dvs,
-        # so we still need to setup the db. This should be refactored.
-        dvs.setup_db()
-
-        # Bring up an IP interface with a neighbor
-        dvs.set_interface_status("Ethernet4", "up")
-        dvs.add_ip_address("Ethernet4", "10.0.0.1/24")
-        dvs.add_neighbor("Ethernet4", "10.0.0.2", "00:01:02:03:04:05")
-
-        next_hop_id = self.dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", 1)[0]
-
-        bind_ports = ["Ethernet0"]
-        self.dvs_acl.create_acl_table("test_redirect", "L3", bind_ports)
-
+    def test_AclRuleRedirect(self, dvs, dvs_acl, l3_acl_table, setup_teardown_neighbor):
         config_qualifiers = {"L4_SRC_PORT": "65000"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")
+        }
 
-        self.dvs_acl.create_acl_rule("test_redirect", "redirect_rule", config_qualifiers, action="REDIRECT:10.0.0.2@Ethernet4", priority="20")
+        dvs_acl.create_redirect_acl_rule(L3_TABLE_NAME,
+                                         L3_RULE_NAME,
+                                         config_qualifiers,
+                                         intf="Ethernet4",
+                                         ip="10.0.0.2",
+                                         priority="20")
 
-        acl_rule_id = self.dvs_acl.get_acl_rule_id()
-        entry = self.dvs_acl.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
-        self.dvs_acl._check_acl_entry(entry, expected_sai_qualifiers, "REDIRECT:10.0.0.2@Ethernet4", "20")
-        assert entry.get("SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT", None) == next_hop_id
+        next_hop_id = setup_teardown_neighbor
+        dvs_acl.verify_redirect_acl_rule(expected_sai_qualifiers, next_hop_id, priority="20")
 
-        self.dvs_acl.remove_acl_rule("test_redirect", "redirect_rule")
-        self.dvs_acl.verify_no_acl_rules()
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-        self.dvs_acl.remove_acl_table("test_redirect")
-        self.dvs_acl.verify_acl_table_count(0)
+        dvs_acl.create_redirect_acl_rule(L3_TABLE_NAME,
+                                         L3_RULE_NAME,
+                                         config_qualifiers,
+                                         intf="Ethernet4",
+                                         priority="20")
 
-        # Clean up the IP interface and neighbor
-        dvs.remove_neighbor("Ethernet4", "10.0.0.2")
-        dvs.remove_ip_address("Ethernet4", "10.0.0.1/24")
-        dvs.set_interface_status("Ethernet4", "down")
+        intf_id = dvs.asic_db.port_name_map["Ethernet4"]
+        dvs_acl.verify_redirect_acl_rule(expected_sai_qualifiers, intf_id, priority="20")
 
-    def test_AclRedirectRule(self, dvs):        
-        dvs.setup_db()
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
 
-        # Bring up an IP interface with a neighbor
-        dvs.set_interface_status("Ethernet4", "up")
-        dvs.add_ip_address("Ethernet4", "10.0.0.1/24")
-        dvs.add_neighbor("Ethernet4", "10.0.0.2", "00:01:02:03:04:05")
 
-        next_hop_id = self.dvs_acl.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP", 1)[0]
-            
-        bind_ports = ["Ethernet0", "Ethernet8"]
-        self.dvs_acl.create_acl_table("test_acl_table", "L3", bind_ports)
-
-        config_qualifiers = {"L4_SRC_PORT": "65000"}
-        expected_sai_qualifiers = {"SAI_ACL_ENTRY_ATTR_FIELD_L4_SRC_PORT": self.dvs_acl.get_simple_qualifier_comparator("65000&mask:0xffff")}
-        self.dvs_acl.create_acl_rule("test_acl_table", "redirect_rule", config_qualifiers, action="REDIRECT:10.0.0.2@Ethernet4", priority="20")
-        acl_rule_id = self.dvs_acl.get_acl_rule_id()
-        entry = self.dvs_acl.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
-        self.dvs_acl._check_acl_entry(entry, expected_sai_qualifiers, "REDIRECT:10.0.0.2@Ethernet4", "20")
-        assert entry.get("SAI_ACL_ENTRY_ATTR_ACTION_REDIRECT", None) == next_hop_id
-
-        self.dvs_acl.remove_acl_rule("test_acl_table", "redirect_rule")
-
-        self.dvs_acl.create_redirect_action_acl_rule("test_acl_table", "redirect_action_rule", config_qualifiers, intf="Ethernet4", priority="20")
-        acl_rule_id = self.dvs_acl.get_acl_rule_id()
-        entry = self.dvs_acl.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
-        self.dvs_acl._check_acl_entry(entry, expected_sai_qualifiers, "Ethernet4", "20")
-        self.dvs_acl.remove_acl_rule("test_acl_table", "redirect_action_rule")
-        self.dvs_acl.verify_no_acl_rules()
-        self.dvs_acl.remove_acl_table("test_acl_table")
-        self.dvs_acl.verify_acl_table_count(0)
-
-@pytest.mark.usefixtures('dvs_acl_manager')
 class TestAclRuleValidation():
-    """
-        Test class for cases that check if orchagent corectly validates
-        ACL rules input
-    """
+    """Test class for cases that check if orchagent corectly validates ACL rules input."""
 
     SWITCH_CAPABILITY_TABLE = "SWITCH_CAPABILITY"
 
-    def get_acl_actions_supported(self, stage):
-        switch_id = self.dvs_acl.state_db.wait_for_n_keys(self.SWITCH_CAPABILITY_TABLE, 1)[0]
-        switch = self.dvs_acl.state_db.wait_for_entry(self.SWITCH_CAPABILITY_TABLE, switch_id)
+    def get_acl_actions_supported(self, dvs_acl, stage):
+        switch_id = dvs_acl.state_db.wait_for_n_keys(self.SWITCH_CAPABILITY_TABLE, 1)[0]
+        switch = dvs_acl.state_db.wait_for_entry(self.SWITCH_CAPABILITY_TABLE, switch_id)
 
         field = "ACL_ACTIONS|{}".format(stage.upper())
 
@@ -447,7 +433,7 @@ class TestAclRuleValidation():
 
         return supported_actions
 
-    def test_AclActionValidation(self, dvs):
+    def test_AclActionValidation(self, dvs, dvs_acl):
         """
             The test overrides R/O SAI_SWITCH_ATTR_ACL_STAGE_INGRESS/EGRESS switch attributes
             to check the case when orchagent refuses to process rules with action that is not
@@ -460,7 +446,7 @@ class TestAclRuleValidation():
         }
 
         for stage in stage_name_map:
-            action_values = self.get_acl_actions_supported(stage)
+            action_values = self.get_acl_actions_supported(dvs_acl, stage)
 
             # virtual switch supports all actions
             assert action_values
@@ -481,31 +467,28 @@ class TestAclRuleValidation():
             # reinit ASIC DB validator object
             dvs.init_asicdb_validator()
 
-            action_values = self.get_acl_actions_supported(stage)
-            # now, PACKET_ACTION is not supported
-            # and REDIRECT_ACTION is supported
+            action_values = self.get_acl_actions_supported(dvs_acl, stage)
+            # Now, PACKET_ACTION is not supported and REDIRECT_ACTION is supported
             assert "PACKET_ACTION" not in action_values
             assert "REDIRECT_ACTION" in action_values
 
             # try to create a forward rule
+            try:
+                dvs_acl.create_acl_table(L3_TABLE_NAME,
+                                         L3_TABLE_TYPE,
+                                         L3_BIND_PORTS,
+                                         stage=stage)
 
-            acl_table = "TEST_TABLE"
-            acl_rule = "TEST_RULE"
+                config_qualifiers = {
+                    "ICMP_TYPE": "8"
+                }
 
-            bind_ports = ["Ethernet0", "Ethernet4"]
+                dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+                dvs_acl.verify_no_acl_rules()
+            finally:
+                dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+                dvs_acl.remove_acl_table(L3_TABLE_NAME)
 
-            self.dvs_acl.create_acl_table(acl_table, "L3", bind_ports, stage=stage)
-
-            config_qualifiers = {
-                "ICMP_TYPE": "8"
-            }
-
-            self.dvs_acl.create_acl_rule(acl_table, acl_rule, config_qualifiers)
-            self.dvs_acl.verify_no_acl_rules()
-            self.dvs_acl.remove_acl_rule(acl_table, acl_rule)
-
-            self.dvs_acl.remove_acl_table(acl_table)
-
-            dvs.runcmd("supervisorctl restart syncd")
-            dvs.stop_swss()
-            dvs.start_swss()
+                dvs.runcmd("supervisorctl restart syncd")
+                dvs.stop_swss()
+                dvs.start_swss()

--- a/tests/test_port_dpb_acl.py
+++ b/tests/test_port_dpb_acl.py
@@ -1,10 +1,5 @@
-import redis
-import time
-import os
 import pytest
-from pytest import *
-import json
-import re
+
 from port_dpb import DPB
 
 maxPorts = 32
@@ -12,156 +7,133 @@ maxBreakout = 4
 maxRootPorts = maxPorts/maxBreakout
 maxAclTables = 16
 
+
 @pytest.mark.usefixtures('dpb_setup_fixture')
-@pytest.mark.usefixtures('dvs_acl_manager')
 class TestPortDPBAcl(object):
-
-    '''
-    @pytest.mark.skip()
-    '''
-    def test_acl_table_empty_port_list(self, dvs):
-
+    def test_acl_table_empty_port_list(self, dvs_acl):
         # Create ACL table "test" and bind it to Ethernet0
         bind_ports = []
-        self.dvs_acl.create_acl_table("test", "L3", bind_ports)
-        self.dvs_acl.verify_acl_table_count(1)
-        self.dvs_acl.verify_acl_group_num(0)
+        dvs_acl.create_acl_table("test", "L3", bind_ports)
+        dvs_acl.verify_acl_table_count(1)
+        dvs_acl.verify_acl_table_groups(0)
 
         bind_ports = ["Ethernet0"]
-        self.dvs_acl.update_acl_table("test", bind_ports)
+        dvs_acl.update_acl_table_port_list("test", bind_ports)
 
         # Verify table, group, and member have been created
-        self.dvs_acl.verify_acl_table_count(1)
-        self.dvs_acl.verify_acl_group_num(1)
-        acl_table_ids = self.dvs_acl.get_acl_table_ids()
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        dvs_acl.verify_acl_table_count(1)
+        dvs_acl.verify_acl_table_groups(1)
+        acl_table_ids = dvs_acl.get_acl_table_ids(1)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[0], bind_ports, 1)
 
         bind_ports = []
-        self.dvs_acl.update_acl_table("test", bind_ports)
-        self.dvs_acl.verify_acl_table_count(1)
-        self.dvs_acl.verify_acl_group_num(0)
+        dvs_acl.update_acl_table_port_list("test", bind_ports)
+        dvs_acl.verify_acl_table_count(1)
+        dvs_acl.verify_acl_table_groups(0)
 
-    '''
-    @pytest.mark.skip()
-    '''
-    def test_one_port_two_acl_tables(self, dvs):
-
+    def test_one_port_two_acl_tables(self, dvs_acl):
         # Create ACL table "test" and bind it to Ethernet0
         bind_ports = ["Ethernet0"]
-        self.dvs_acl.create_acl_table("test", "L3", bind_ports)
-        self.dvs_acl.verify_acl_table_count(1)
-        self.dvs_acl.verify_acl_group_num(1)
-        acl_table_ids = self.dvs_acl.get_acl_table_ids()
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        dvs_acl.create_acl_table("test", "L3", bind_ports)
+        dvs_acl.verify_acl_table_count(1)
+        dvs_acl.verify_acl_table_groups(1)
+        acl_table_ids = dvs_acl.get_acl_table_ids(1)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[0], bind_ports, 1)
 
         # Create ACL table "test1" and bind it to Ethernet0
         bind_ports = ["Ethernet0"]
-        self.dvs_acl.create_acl_table("test1", "L3", bind_ports)
-        self.dvs_acl.verify_acl_table_count(2)
-        self.dvs_acl.verify_acl_group_num(1)
-        acl_table_ids = self.dvs_acl.get_acl_table_ids(2)
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[1])
+        dvs_acl.create_acl_table("test1", "L3", bind_ports)
+        dvs_acl.verify_acl_table_count(2)
+        dvs_acl.verify_acl_table_groups(1)
+        acl_table_ids = dvs_acl.get_acl_table_ids(2)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[0], bind_ports, 2)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[1], bind_ports, 2)
 
-        #Delete ACL tables
-        self.dvs_acl.remove_acl_table("test")
-        self.dvs_acl.verify_acl_table_count(1)
-        self.dvs_acl.verify_acl_group_num(1)
+        # Delete ACL tables
+        dvs_acl.remove_acl_table("test")
+        dvs_acl.verify_acl_table_count(1)
+        dvs_acl.verify_acl_table_groups(1)
 
-        self.dvs_acl.remove_acl_table("test1")
-        self.dvs_acl.verify_acl_table_count(0)
-        self.dvs_acl.verify_acl_group_num(0)
+        dvs_acl.remove_acl_table("test1")
+        dvs_acl.verify_acl_table_count(0)
+        dvs_acl.verify_acl_table_groups(0)
 
-    '''
-    @pytest.mark.skip()
-    '''
-    def test_one_acl_table_many_ports(self, dvs):
-
+    def test_one_acl_table_many_ports(self, dvs, dvs_acl):
         # Create ACL table and bind it to Ethernet0 and Ethernet4
         bind_ports = ["Ethernet0", "Ethernet4"]
-        self.dvs_acl.create_acl_table("test", "L3", bind_ports)
-        self.dvs_acl.verify_acl_table_count(1)
-        self.dvs_acl.verify_acl_group_num(2)
-        acl_table_ids = self.dvs_acl.get_acl_table_ids()
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        dvs_acl.create_acl_table("test", "L3", bind_ports)
+        dvs_acl.verify_acl_table_count(1)
+        dvs_acl.verify_acl_table_groups(2)
+        acl_table_ids = dvs_acl.get_acl_table_ids(1)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[0], bind_ports, 1)
 
         # Update bind list and verify
         bind_ports = ["Ethernet4"]
-        self.dvs_acl.update_acl_table("test", bind_ports)
-        self.dvs_acl.verify_acl_group_num(1)
-        acl_table_ids = self.dvs_acl.get_acl_table_ids()
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        dvs_acl.update_acl_table_port_list("test", bind_ports)
+        dvs_acl.verify_acl_table_groups(1)
+        acl_table_ids = dvs_acl.get_acl_table_ids(1)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[0], bind_ports, 1)
 
         # Breakout Ethernet0
         dpb = DPB()
         dpb.breakout(dvs, "Ethernet0", maxBreakout)
-        time.sleep(2)
 
-        #Update bind list and verify
-        bind_ports = ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3","Ethernet4"]
-        self.dvs_acl.update_acl_table("test", bind_ports)
-        self.dvs_acl.verify_acl_group_num(5)
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        # Update bind list and verify
+        bind_ports = ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3", "Ethernet4"]
+        dvs_acl.update_acl_table_port_list("test", bind_ports)
+        dvs_acl.verify_acl_table_groups(5)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[0], bind_ports, 1)
 
         # Update bind list and verify
         bind_ports = ["Ethernet4"]
-        self.dvs_acl.update_acl_table("test", bind_ports)
-        self.dvs_acl.verify_acl_group_num(1)
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        dvs_acl.update_acl_table_port_list("test", bind_ports)
+        dvs_acl.verify_acl_table_groups(1)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[0], bind_ports, 1)
 
-        #Breakin Ethernet0, 1, 2, 3
+        # Breakin Ethernet0, 1, 2, 3
         dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
-        time.sleep(2)
 
         # Update bind list and verify
         bind_ports = ["Ethernet0", "Ethernet4"]
-        self.dvs_acl.update_acl_table("test", bind_ports)
-        self.dvs_acl.verify_acl_group_num(2)
-        self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_table_ids[0])
+        dvs_acl.update_acl_table_port_list("test", bind_ports)
+        dvs_acl.verify_acl_table_groups(2)
+        dvs_acl.verify_acl_table_port_binding(acl_table_ids[0], bind_ports, 1)
 
-        #Delete ACL table
-        self.dvs_acl.remove_acl_table("test")
-        self.dvs_acl.verify_acl_group_num(0)
+        # Delete ACL table
+        dvs_acl.remove_acl_table("test")
+        dvs_acl.verify_acl_table_groups(0)
 
-    '''
-    @pytest.mark.skip()
-    '''
-    def test_one_port_many_acl_tables(self, dvs):
-
+    def test_one_port_many_acl_tables(self, dvs, dvs_acl):
         # Create 4 ACL tables and bind them to Ethernet0
         bind_ports = ["Ethernet0"]
         acl_tables = ["test1", "test2", "test3", "test4"]
         for acl_tbl in acl_tables:
-            self.dvs_acl.create_acl_table(acl_tbl, "L3", bind_ports)
+            dvs_acl.create_acl_table(acl_tbl, "L3", bind_ports)
 
-        self.dvs_acl.verify_acl_table_count(len(acl_tables))
-        self.dvs_acl.verify_acl_group_num(len(bind_ports))
-        acl_table_ids = self.dvs_acl.get_acl_table_ids(len(acl_tables))
+        dvs_acl.verify_acl_table_count(len(acl_tables))
+        dvs_acl.verify_acl_table_groups(len(bind_ports))
+        acl_table_ids = dvs_acl.get_acl_table_ids(len(acl_tables))
         for acl_tbl_id in acl_table_ids:
-            self.dvs_acl.verify_acl_table_ports_binding(bind_ports, acl_tbl_id)
+            dvs_acl.verify_acl_table_port_binding(acl_tbl_id, bind_ports, len(acl_tables))
 
         # Update bind list and verify
         bind_ports = []
         for acl_tbl in acl_tables:
-            self.dvs_acl.update_acl_table(acl_tbl, bind_ports)
+            dvs_acl.update_acl_table_port_list(acl_tbl, bind_ports)
 
-        self.dvs_acl.verify_acl_group_num(0)
+        dvs_acl.verify_acl_table_groups(0)
 
         # Breakout Ethernet0
         dpb = DPB()
         dpb.breakout(dvs, "Ethernet0", maxBreakout)
 
-        #Breakin Ethernet0, 1, 2, 3
+        # Breakin Ethernet0, 1, 2, 3
         dpb.breakin(dvs, ["Ethernet0", "Ethernet1", "Ethernet2", "Ethernet3"])
 
         for acl_tbl in acl_tables:
-            self.dvs_acl.remove_acl_table(acl_tbl)
+            dvs_acl.remove_acl_table(acl_tbl)
 
-    '''
-    @pytest.mark.skip()
-    '''
-    def test_many_ports_many_acl_tables(self, dvs):
-
+    def test_many_ports_many_acl_tables(self, dvs, dvs_acl):
         # Prepare ACL table names
         aclTableNames = []
         for i in range(maxAclTables):
@@ -179,36 +151,34 @@ class TestPortDPBAcl(object):
 
         # Create ACL tables and bind root ports
         for aclTable in aclTableNames:
-            self.dvs_acl.create_acl_table(aclTable, "L3", rootPortNames)
-        self.dvs_acl.verify_acl_group_num(maxRootPorts)
+            dvs_acl.create_acl_table(aclTable, "L3", rootPortNames)
+        dvs_acl.verify_acl_table_groups(maxRootPorts)
 
         # Remove the dependency on all root ports by
         # unbinding them from all ACL tables.
         bind_ports = []
         for aclTable in aclTableNames:
-            self.dvs_acl.update_acl_table(aclTable, bind_ports)
-        self.dvs_acl.verify_acl_group_num(0)
+            dvs_acl.update_acl_table_port_list(aclTable, bind_ports)
+        dvs_acl.verify_acl_table_groups(0)
 
         # Breakout all root ports
         dpb = DPB()
         for pName in rootPortNames:
-            #print "Breaking out %s"%pName
             dpb.breakout(dvs, pName, maxBreakout)
 
         # Add all ports to aclTable1
-        self.dvs_acl.update_acl_table(aclTableNames[0], portNames)
-        self.dvs_acl.verify_acl_group_num(maxPorts)
+        dvs_acl.update_acl_table_port_list(aclTableNames[0], portNames)
+        dvs_acl.verify_acl_table_groups(maxPorts)
 
         # Remove all ports from aclTable1
         bind_ports = []
-        self.dvs_acl.update_acl_table(aclTableNames[0], bind_ports)
-        self.dvs_acl.verify_acl_group_num(0)
+        dvs_acl.update_acl_table_port_list(aclTableNames[0], bind_ports)
+        dvs_acl.verify_acl_table_groups(0)
 
         # Breakin all ports
         for i in range(0, maxPorts, maxBreakout):
-            #print "Breaking in %s"%portNames[i:i+maxBreakout]
             dpb.breakin(dvs, portNames[i:i+maxBreakout])
 
         for aclTable in aclTableNames:
-            self.dvs_acl.remove_acl_table(aclTable)
-        self.dvs_acl.verify_acl_table_count(0)
+            dvs_acl.remove_acl_table(aclTable)
+        dvs_acl.verify_acl_table_count(0)


### PR DESCRIPTION
- Add docstrings to dvs_acl
- Revert dvs_acl to a vanilla fixture
- Combine redundant dvs_acl methods
- Refactor test_acl, test_port_dpb_acl, and test_mirror_port_span to use new interface

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did/why I did it**
1. I changed `dvs_acl` back into an explicit fixture that is passed in to the test methods. The reason for this is because I figured out that tools like `pylint` and `flake8` do not handle the `request.cls...` update very well, which is going to be problematic very soon. In addition, this change makes it a little easier for new contributers/new `dvslib` adopters to see what is going on by making the inclusion of the `dvs_acl` module a little more explicit.

2. I merged a few methods together in `dvs_acl` that were checking the same things (primarily the ACL group and port binding checks). This is for maintainability and to keep the public interface cleaner.

3. I added a bunch of type hints and docstrings to `dvs_acl` to make the usage more clear.

4. I created some fixtures in `test_acl` so that each individual test case can be run standalone, if the user asks for it. This should also make the PR tests more stable as it will be easier for `flaky` to re-run test cases in a controlled manner. Fixes #1154

5. I deleted some dead ACL code from `conftest` as it wasn't being used by `test_acl` or `test_port_dpb_acl` anymore with the `dvslib` additions.

**How I verified it**
Ran the test suite locally and it passes w/ the refactor.

**Details if related**
Once this refactor is merged we can begin converting the rest of `test_acl_*` and `test_mirror_*` to use `dvslib`.