### PR TITLE
Added Max Nexthopgroup/ECMP Count supported by device into State DB.

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2220,7 +2220,7 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
                 break;
         }
     }
-    m_switchTable.set("switch", fvVector);
+    m_switchOrch->set_switch_capability(fvVector);
 
     sai_attribute_t attrs[2];
     attrs[0].id = SAI_SWITCH_ATTR_ACL_ENTRY_MINIMUM_PRIORITY;
@@ -2362,7 +2362,7 @@ void AclOrch::putAclActionCapabilityInDB(acl_stage_type_t stage)
     }
 
     fvVector.emplace_back(field, acl_action_value_stream.str());
-    m_switchTable.set("switch", fvVector);
+    m_switchOrch->set_switch_capability(fvVector);
 }
 
 void AclOrch::initDefaultAclActionCapabilities(acl_stage_type_t stage)
@@ -2464,7 +2464,7 @@ void AclOrch::queryAclActionAttrEnumValues(const string &action_name,
         fvVector.emplace_back(field, acl_action_value_stream.str());
     }
 
-    m_switchTable.set("switch", fvVector);
+    m_switchOrch->set_switch_capability(fvVector);
 }
 
 sai_acl_action_type_t AclOrch::getAclActionFromAclEntry(sai_acl_entry_attr_t attr)
@@ -2477,10 +2477,10 @@ sai_acl_action_type_t AclOrch::getAclActionFromAclEntry(sai_acl_entry_attr_t att
     return static_cast<sai_acl_action_type_t>(attr - SAI_ACL_ENTRY_ATTR_ACTION_START);
 };
 
-AclOrch::AclOrch(vector<TableConnector>& connectors, TableConnector switchTable,
+AclOrch::AclOrch(vector<TableConnector>& connectors, SwitchOrch *switchOrch,
         PortsOrch *portOrch, MirrorOrch *mirrorOrch, NeighOrch *neighOrch, RouteOrch *routeOrch, DTelOrch *dtelOrch) :
         Orch(connectors),
-        m_switchTable(switchTable.first, switchTable.second),
+        m_switchOrch(switchOrch),
         m_mirrorOrch(mirrorOrch),
         m_neighOrch(neighOrch),
         m_routeOrch(routeOrch),

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <condition_variable>
 #include "orch.h"
+#include "switchorch.h"
 #include "portsorch.h"
 #include "mirrororch.h"
 #include "dtelorch.h"
@@ -391,7 +392,7 @@ class AclOrch : public Orch, public Observer
 {
 public:
     AclOrch(vector<TableConnector>& connectors,
-            TableConnector          switchTable,
+            SwitchOrch              *m_switchOrch,
             PortsOrch               *portOrch,
             MirrorOrch              *mirrorOrch,
             NeighOrch               *neighOrch,
@@ -408,7 +409,6 @@ public:
         return m_countersTable;
     }
 
-    Table m_switchTable;
 
     // FIXME: Add getters for them? I'd better to add a common directory of orch objects and use it everywhere
     MirrorOrch *m_mirrorOrch;
@@ -432,6 +432,7 @@ public:
     static sai_acl_action_type_t getAclActionFromAclEntry(sai_acl_entry_attr_t attr);
 
 private:
+    SwitchOrch *m_switchOrch;
     void doTask(Consumer &consumer);
     void doAclTableTask(Consumer &consumer);
     void doAclRuleTask(Consumer &consumer);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -71,8 +71,9 @@ bool OrchDaemon::init()
     SWSS_LOG_ENTER();
 
     string platform = getenv("platform") ? getenv("platform") : "";
+    TableConnector stateDbSwitchTable(m_stateDb, "SWITCH_CAPABILITY");
 
-    gSwitchOrch = new SwitchOrch(m_applDb, APP_SWITCH_TABLE_NAME);
+    gSwitchOrch = new SwitchOrch(m_applDb, APP_SWITCH_TABLE_NAME, stateDbSwitchTable);
 
     const int portsorch_base_pri = 40;
 
@@ -125,7 +126,7 @@ bool OrchDaemon::init()
 
     gIntfsOrch = new IntfsOrch(m_applDb, APP_INTF_TABLE_NAME, vrf_orch);
     gNeighOrch = new NeighOrch(m_applDb, APP_NEIGH_TABLE_NAME, gIntfsOrch);
-    gRouteOrch = new RouteOrch(m_applDb, APP_ROUTE_TABLE_NAME, gNeighOrch, gIntfsOrch, vrf_orch);
+    gRouteOrch = new RouteOrch(m_applDb, APP_ROUTE_TABLE_NAME, gSwitchOrch, gNeighOrch, gIntfsOrch, vrf_orch);
 
     TableConnector confDbSflowTable(m_configDb, CFG_SFLOW_TABLE_NAME);
     TableConnector appCoppTable(m_applDb, APP_COPP_TABLE_NAME);
@@ -267,8 +268,7 @@ bool OrchDaemon::init()
         dtel_orch = new DTelOrch(m_configDb, dtel_tables, gPortsOrch);
         m_orchList.push_back(dtel_orch);
     }
-    TableConnector stateDbSwitchTable(m_stateDb, "SWITCH_CAPABILITY");
-    gAclOrch = new AclOrch(acl_table_connectors, stateDbSwitchTable, gPortsOrch, mirror_orch, gNeighOrch, gRouteOrch, dtel_orch);
+    gAclOrch = new AclOrch(acl_table_connectors, gSwitchOrch, gPortsOrch, mirror_orch, gNeighOrch, gRouteOrch, dtel_orch);
 
     m_orchList.push_back(gFdbOrch);
     m_orchList.push_back(mirror_orch);

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -22,10 +22,11 @@ extern CrmOrch *gCrmOrch;
 
 const int routeorch_pri = 5;
 
-RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch) :
+RouteOrch::RouteOrch(DBConnector *db, string tableName, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch) :
         gRouteBulker(sai_route_api),
         gNextHopGroupMemberBulker(sai_next_hop_group_api, gSwitchId),
         Orch(db, tableName, routeorch_pri),
+        m_switchOrch(switchOrch),
         m_neighOrch(neighOrch),
         m_intfsOrch(intfsOrch),
         m_vrfOrch(vrfOrch),
@@ -63,6 +64,10 @@ RouteOrch::RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch, In
             m_maxNextHopGroupCount /= DEFAULT_MAX_ECMP_GROUP_SIZE;
         }
     }
+    vector<FieldValueTuple> fvTuple;
+    fvTuple.emplace_back("MAX_NEXTHOP_GROUP_COUNT", to_string(m_maxNextHopGroupCount));
+    m_switchOrch->set_switch_capability(fvTuple);
+
     SWSS_LOG_NOTICE("Maximum number of ECMP groups supported is %d", m_maxNextHopGroupCount);
 
     IpPrefix default_ip_prefix("0.0.0.0/0");

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -3,6 +3,7 @@
 
 #include "orch.h"
 #include "observer.h"
+#include "switchorch.h"
 #include "intfsorch.h"
 #include "neighorch.h"
 
@@ -88,7 +89,7 @@ struct RouteBulkContext
 class RouteOrch : public Orch, public Subject
 {
 public:
-    RouteOrch(DBConnector *db, string tableName, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch);
+    RouteOrch(DBConnector *db, string tableName, SwitchOrch *switchOrch, NeighOrch *neighOrch, IntfsOrch *intfsOrch, VRFOrch *vrfOrch);
 
     bool hasNextHopGroup(const NextHopGroupKey&) const;
     sai_object_id_t getNextHopGroupId(const NextHopGroupKey&);
@@ -108,6 +109,7 @@ public:
 
     void notifyNextHopChangeObservers(sai_object_id_t, const IpPrefix&, const NextHopGroupKey&, bool);
 private:
+    SwitchOrch *m_switchOrch;
     NeighOrch *m_neighOrch;
     IntfsOrch *m_intfsOrch;
     VRFOrch *m_vrfOrch;

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -33,7 +33,7 @@ const map<string, sai_packet_action_t> packet_action_map =
     {"trap",    SAI_PACKET_ACTION_TRAP}
 };
 
-SwitchOrch::SwitchOrch(DBConnector *db, string tableName) :
+SwitchOrch::SwitchOrch(DBConnector *db, string tableName, TableConnector switchTable):
         Orch(db, tableName),
         m_switchTable(switchTable.first, switchTable.second),
         m_db(db)

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -35,6 +35,7 @@ const map<string, sai_packet_action_t> packet_action_map =
 
 SwitchOrch::SwitchOrch(DBConnector *db, string tableName) :
         Orch(db, tableName),
+        m_switchTable(switchTable.first, switchTable.second),
         m_db(db)
 {
     m_restartCheckNotificationConsumer = new NotificationConsumer(db, "RESTARTCHECK");
@@ -206,4 +207,9 @@ bool SwitchOrch::setAgingFDB(uint32_t sec)
     }
     SWSS_LOG_NOTICE("Set switch %" PRIx64 " fdb_aging_time %u sec", gSwitchId, sec);
     return true;
+}
+
+void SwitchOrch::set_switch_capability(const std::vector<FieldValueTuple>& values)
+{
+     m_switchTable.set("switch", values);
 }

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -12,20 +12,21 @@ struct WarmRestartCheck
 class SwitchOrch : public Orch
 {
 public:
-    SwitchOrch(swss::DBConnector *db, std::string tableName);
-
+    SwitchOrch(swss::DBConnector *db, std::string tableName, TableConnector switchTable);
     bool checkRestartReady() { return m_warmRestartCheck.checkRestartReadyState; }
     bool checkRestartNoFreeze() { return m_warmRestartCheck.noFreeze; }
     bool skipPendingTaskCheck() { return m_warmRestartCheck.skipPendingTaskCheck; }
     void checkRestartReadyDone() { m_warmRestartCheck.checkRestartReadyState = false; }
     void restartCheckReply(const std::string &op, const std::string &data, std::vector<swss::FieldValueTuple> &values);
     bool setAgingFDB(uint32_t sec);
+    void set_switch_capability(const std::vector<swss::FieldValueTuple>& values);
 private:
     void doTask(Consumer &consumer);
 
     swss::NotificationConsumer* m_restartCheckNotificationConsumer;
     void doTask(swss::NotificationConsumer& consumer);
     swss::DBConnector *m_db;
+    swss::Table m_switchTable;
 
     // Information contained in the request from
     // external program for orchagent pre-shutdown state check

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -2,6 +2,7 @@
 
 extern sai_object_id_t gSwitchId;
 
+extern SwitchOrch *gSwitchOrch;
 extern CrmOrch *gCrmOrch;
 extern PortsOrch *gPortsOrch;
 extern RouteOrch *gRouteOrch;
@@ -122,7 +123,7 @@ namespace aclorch_test
         AclOrch *m_aclOrch;
         swss::DBConnector *config_db;
 
-        MockAclOrch(swss::DBConnector *config_db, swss::DBConnector *state_db,
+        MockAclOrch(swss::DBConnector *config_db, swss::DBConnector *state_db, SwitchOrch *switchOrch,
                     PortsOrch *portsOrch, MirrorOrch *mirrorOrch, NeighOrch *neighOrch, RouteOrch *routeOrch) :
             config_db(config_db)
         {
@@ -131,9 +132,7 @@ namespace aclorch_test
 
             vector<TableConnector> acl_table_connectors = { confDbAclTable, confDbAclRuleTable };
 
-            TableConnector stateDbSwitchTable(state_db, "SWITCH_CAPABILITY");
-
-            m_aclOrch = new AclOrch(acl_table_connectors, stateDbSwitchTable, portsOrch, mirrorOrch,
+            m_aclOrch = new AclOrch(acl_table_connectors, switchOrch, portsOrch, mirrorOrch,
                                     neighOrch, routeOrch);
         }
 
@@ -285,6 +284,10 @@ namespace aclorch_test
 
             gVirtualRouterId = attr.value.oid;
 
+            TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+            ASSERT_EQ(gSwitchOrch, nullptr);
+            gSwitchOrch = new SwitchOrch(m_app_db.get(), APP_SWITCH_TABLE_NAME, stateDbSwitchTable);
+
             // Create dependencies ...
 
             const int portsorch_base_pri = 40;
@@ -313,7 +316,7 @@ namespace aclorch_test
             gNeighOrch = new NeighOrch(m_app_db.get(), APP_NEIGH_TABLE_NAME, gIntfsOrch);
 
             ASSERT_EQ(gRouteOrch, nullptr);
-            gRouteOrch = new RouteOrch(m_app_db.get(), APP_ROUTE_TABLE_NAME, gNeighOrch, gIntfsOrch, gVrfOrch);
+            gRouteOrch = new RouteOrch(m_app_db.get(), APP_ROUTE_TABLE_NAME, gSwitchOrch, gNeighOrch, gIntfsOrch, gVrfOrch);
 
             TableConnector applDbFdb(m_app_db.get(), APP_FDB_TABLE_NAME);
             TableConnector stateDbFdb(m_state_db.get(), STATE_FDB_TABLE_NAME);
@@ -341,6 +344,8 @@ namespace aclorch_test
         {
             AclTestBase::TearDown();
 
+            delete gSwitchOrch;
+            gSwitchOrch = nullptr;
             delete gFdbOrch;
             gFdbOrch = nullptr;
             delete gMirrorOrch;
@@ -374,7 +379,7 @@ namespace aclorch_test
 
         shared_ptr<MockAclOrch> createAclOrch()
         {
-            return make_shared<MockAclOrch>(m_config_db.get(), m_state_db.get(), gPortsOrch, gMirrorOrch,
+            return make_shared<MockAclOrch>(m_config_db.get(), m_state_db.get(), gSwitchOrch, gPortsOrch, gMirrorOrch,
                                             gNeighOrch, gRouteOrch);
         }
 


### PR DESCRIPTION
**What I did**
Added Max Nexthopgroup/ECMP Count supported by device into State DB
as part of Switch Capability Table.

Since we are using SWITCH_CAPABILITY Table moved the setting of table
field from aclorch to switchorch via public function
so that in future this can used by any agent.

**Why I did it**
Motivation for adding this to StateDB was to make sure
we can query this value (n) from external test case and make sure
we add (n) number of ECMP Group successfully and (n+1) should fail
without termination of orchagent.

**How I verified it**
admin@str-s6000-on-2:~$ redis-cli -n 6
127.0.0.1:6379[6]> hgetall "SWITCH_CAPABILITY|switch"
 1) "MIRROR"
 2) "true"
 3) "MIRRORV6"
 4) "true"
 5) "ACL_ACTIONS|INGRESS"
 6) "PACKET_ACTION,MIRROR_INGRESS_ACTION"
 7) "ACL_ACTIONS|EGRESS"
 8) "PACKET_ACTION"
 9) "ACL_ACTION|PACKET_ACTION"
10) "DROP,FORWARD"
11) "MAX_NEXTHOP_GROUP_COUNT"
12) "1024"