### PR TITLE
[dvs] Validate that SWSS is ready to receive input before starting tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,8 @@ if sys.version_info < (3, 0):
 
 from datetime import datetime
 from swsscommon import swsscommon
-from dvslib import dvs_database as dvs_db
+from dvslib.dvs_database import DVSDatabase
+from dvslib.dvs_common import PollingConfig
 from dvslib.dvs_acl import DVSAcl
 from dvslib import dvs_vlan
 from dvslib import dvs_lag
@@ -38,54 +39,37 @@ def pytest_addoption(parser):
     parser.addoption("--imgname", action="store", default="docker-sonic-vs",
                       help="image name")
 
-class AsicDbValidator(object):
-    def __init__(self, dvs):
-        self.adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
 
-        # get default dot1q vlan id
-        atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_VLAN")
+class AsicDbValidator(DVSDatabase):
+    def __init__(self, db_id: str, connector: str):
+        DVSDatabase.__init__(self, db_id, connector)
 
-        keys = atbl.getKeys()
-        assert len(keys) == 1
-        self.default_vlan_id = keys[0]
+        # Get default .1Q Vlan ID
+        self.default_vlan_id = self.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_VLAN", 1)[0]
 
-        # build port oid to front port name mapping
+        # Build port OID to front port name mapping
         self.portoidmap = {}
         self.portnamemap = {}
         self.hostifoidmap = {}
         self.hostifnamemap = {}
-        atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF")
-        keys = atbl.getKeys()
 
-        assert len(keys) == 32
+        keys = self.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF", 32)
         for k in keys:
-            (status, fvs) = atbl.get(k)
-
-            assert status == True
-
-            for fv in fvs:
-                if fv[0] == "SAI_HOSTIF_ATTR_OBJ_ID":
-                    port_oid = fv[1]
-                elif fv[0] == "SAI_HOSTIF_ATTR_NAME":
-                    port_name = fv[1]
+            fvs = self.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF", k)
+            port_oid = fvs.get("SAI_HOSTIF_ATTR_OBJ_ID")
+            port_name = fvs.get("SAI_HOSTIF_ATTR_NAME")
 
             self.portoidmap[port_oid] = port_name
             self.portnamemap[port_name] = port_oid
             self.hostifoidmap[k] = port_name
             self.hostifnamemap[port_name] = k
 
-        # get default acl table and acl rules
-        atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
-        keys = atbl.getKeys()
+        # Get default ACL table and ACL rules
+        self.default_acl_tables = self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
+        assert len(self.default_acl_tables) >= 0
 
-        assert len(keys) >= 0
-        self.default_acl_tables = keys
+        self.default_acl_entries = self.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", 0)
 
-        atbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
-        keys = atbl.getKeys()
-
-        assert len(keys) == 0
-        self.default_acl_entries = keys
 
 class ApplDbValidator(object):
     def __init__(self, dvs):
@@ -256,7 +240,6 @@ class DockerVirtualSwitch(object):
                     volumes={ self.mount: { 'bind': '/var/run/redis', 'mode': 'rw' } })
 
         self.redis_sock = self.mount + '/' + "redis.sock"
-        self.check_ctn_status_and_db_connect()
 
         # DB wrappers are declared here, lazy-loaded in the tests
         self.app_db = None
@@ -265,6 +248,9 @@ class DockerVirtualSwitch(object):
         self.config_db = None
         self.flex_db = None
         self.state_db = None
+
+        # Make sure everything is up and running before turning over control to the caller
+        self.check_ready_status_and_init_db()
 
     def destroy(self):
         if self.appldb:
@@ -276,24 +262,30 @@ class DockerVirtualSwitch(object):
             for s in self.servers:
                 s.destroy()
 
-    def check_ctn_status_and_db_connect(self):
+    def check_ready_status_and_init_db(self):
         try:
             # temp fix: remove them once they are moved to vs start.sh
             self.ctn.exec_run("sysctl -w net.ipv6.conf.default.disable_ipv6=0")
             for i in range(0, 128, 4):
                 self.ctn.exec_run("sysctl -w net.ipv6.conf.eth%d.disable_ipv6=1" % (i + 1))
-            self.check_ready()
+
+            # Verify that all of the device services have started.
+            self.check_services_ready()
+
+            # Initialize the databases.
             self.init_asicdb_validator()
             self.appldb = ApplDbValidator(self)
-        except:
+
+            # Verify that SWSS has finished initializing.
+            self.check_swss_ready()
+
+        except Exception:
             self.get_logs()
             self.destroy()
             raise
 
-
-    def check_ready(self, timeout=30):
-        '''check if all processes in the dvs is ready'''
-
+    def check_services_ready(self, timeout=30):
+        """"Check if all processes in the DVS are ready."""
         re_space = re.compile('\s+')
         process_status = {}
         ready = False
@@ -333,6 +325,29 @@ class DockerVirtualSwitch(object):
 
             time.sleep(1)
 
+    # FIXME: For the sake of stabilizing the PR pipeline this method currently assumes 32 ports
+    # (much like the rest of the test suite). This should be adjusted to accomodate a dynamic
+    # number of ports. GitHub Issue: Azure/sonic-swss#1384.
+    def check_swss_ready(self, timeout=60):
+        """Verify that SWSS is ready to receive inputs.
+
+        Almost every part of orchagent depends on ports being created and initialized
+        before they can proceed with their processing. If we start the tests after orchagent
+        has started running but before it has had time to initialize all the ports, then the
+        first several tests will fail.
+        """
+        num_ports = 32
+
+        # Verify that all ports have been initialized and configured
+        app_db = self.get_app_db()
+        startup_polling_config = PollingConfig(2, timeout, strict=True)
+        app_db.wait_for_entry("PORT_TABLE", "PortInitDone", startup_polling_config)
+        app_db.wait_for_entry("PORT_TABLE", "PortConfigDone", startup_polling_config)
+
+        # Verify that all ports have been created
+        asic_db = self.get_asic_db()
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT", num_ports + 1)  # +1 CPU Port
+
     def net_cleanup(self):
         """clean up network, remove extra links"""
 
@@ -363,7 +378,7 @@ class DockerVirtualSwitch(object):
         if self.appldb:
             del self.appldb
         self.ctn_restart()
-        self.check_ctn_status_and_db_connect()
+        self.check_ready_status_and_init_db()
 
     # start processes in SWSS
     def start_swss(self):
@@ -401,7 +416,7 @@ class DockerVirtualSwitch(object):
         time.sleep(1)
 
     def init_asicdb_validator(self):
-        self.asicdb = AsicDbValidator(self)
+        self.asicdb = AsicDbValidator(self.ASIC_DB_ID, self.redis_sock)
 
     def runcmd(self, cmd):
         res = self.ctn.exec_run(cmd)
@@ -898,13 +913,15 @@ class DockerVirtualSwitch(object):
 
     def get_app_db(self):
         if not self.app_db:
-            self.app_db = dvs_db.DVSDatabase(self.APP_DB_ID, self.redis_sock)
+            self.app_db = DVSDatabase(self.APP_DB_ID, self.redis_sock)
 
         return self.app_db
 
+    # FIXME: Now that AsicDbValidator is using DVSDatabase we should converge this with
+    # that implementation. Save it for a follow-up PR.
     def get_asic_db(self):
         if not self.asic_db:
-            db = dvs_db.DVSDatabase(self.ASIC_DB_ID, self.redis_sock)
+            db = DVSDatabase(self.ASIC_DB_ID, self.redis_sock)
             db.default_acl_tables = self.asicdb.default_acl_tables
             db.default_acl_entries = self.asicdb.default_acl_entries
             db.port_name_map = self.asicdb.portnamemap
@@ -917,25 +934,25 @@ class DockerVirtualSwitch(object):
 
     def get_counters_db(self):
         if not self.counters_db:
-            self.counters_db = dvs_db.DVSDatabase(self.COUNTERS_DB_ID, self.redis_sock)
+            self.counters_db = DVSDatabase(self.COUNTERS_DB_ID, self.redis_sock)
 
         return self.counters_db
 
     def get_config_db(self):
         if not self.config_db:
-            self.config_db = dvs_db.DVSDatabase(self.CONFIG_DB_ID, self.redis_sock)
+            self.config_db = DVSDatabase(self.CONFIG_DB_ID, self.redis_sock)
 
         return self.config_db
 
     def get_flex_db(self):
         if not self.flex_db:
-            self.flex_db = dvs_db.DVSDatabase(self.FLEX_COUNTER_DB_ID, self.redis_sock)
+            self.flex_db = DVSDatabase(self.FLEX_COUNTER_DB_ID, self.redis_sock)
 
         return self.flex_db
 
     def get_state_db(self):
         if not self.state_db:
-            self.state_db = dvs_db.DVSDatabase(self.STATE_DB_ID, self.redis_sock)
+            self.state_db = DVSDatabase(self.STATE_DB_ID, self.redis_sock)
 
         return self.state_db
 


### PR DESCRIPTION
- Enhance AsicDbValidator to be stricter
- Add a new SWSS ready-check to validate that orchagent is done processing ports

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I added some additional ready-checks during the DVS initialization to ensure that the virtual switch is fully initialized before starting the tests.

**Why I did it**
We've noticed recently that a lot of tests are failing from the very first test case, even ones that we have gone through and stabilized in the past. We figured out by checking the logs that, even though orchagent was running, it was still busy processing the initial port config when the tests started running. Since most things in orchagent depend on portsorch initializing everything before they can proceed, nothing was ever written to ASIC DB, causing the tests to fail.

**How I verified it**
Ran tests locally.

**Details if related**
