### PR TITLE
[rates] fix issue with rates init

### DIFF
--- a/orchagent/port_rates.lua
+++ b/orchagent/port_rates.lua
@@ -18,6 +18,10 @@ local rates_table_name = "RATES"
 redis.call('SELECT', counters_db)
 local smooth_interval = redis.call('HGET', rates_table_name .. ':' .. 'PORT', 'PORT_SMOOTH_INTERVAL')
 local alpha = redis.call('HGET', rates_table_name .. ':' .. 'PORT', 'PORT_ALPHA')
+if not alpha then
+  logit("Alpha is not defined")
+  return logtable
+end
 local one_minus_alpha = 1.0 - alpha
 local delta = tonumber(ARGV[3])
 
@@ -25,7 +29,7 @@ logit(alpha)
 logit(one_minus_alpha)
 logit(delta)
 
-local initialized = redis.call('HGET', rates_table_name, 'INIT_DONE')
+local initialized = redis.call('HGET', rates_table_name .. ':' .. 'PORT', 'INIT_DONE')
 
 logit(initialized)
 
@@ -72,7 +76,7 @@ for i = 1, n do
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_PPS', rx_pps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_BPS', tx_bps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', tx_pps_new)
-            redis.call('HSET', rates_table_name, 'INIT_DONE', 'DONE')
+            redis.call('HSET', rates_table_name .. ':' .. 'PORT', 'INIT_DONE', 'DONE')
         end        
     else
         -- Set old COUNTERS values
@@ -82,7 +86,7 @@ for i = 1, n do
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS_last', out_non_ucast_pkts)
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_OCTETS_last', in_octets)
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_OCTETS_last', out_octets)        
-        redis.call('HSET', rates_table_name, 'INIT_DONE', 'COUNTERS_LAST')
+        redis.call('HSET', rates_table_name .. ':' .. 'PORT', 'INIT_DONE', 'COUNTERS_LAST')
     end
 end
 

--- a/orchagent/rif_rates.lua
+++ b/orchagent/rif_rates.lua
@@ -18,10 +18,14 @@ local rates_table_name = "RATES"
 redis.call('SELECT', counters_db)
 local smooth_interval = redis.call('HGET', rates_table_name .. ':' .. 'RIF', 'RIF_SMOOTH_INTERVAL')
 local alpha = redis.call('HGET', rates_table_name .. ':' .. 'RIF', 'RIF_ALPHA')
+if not alpha then
+  logit("Alpha is not defined")
+  return logtable
+end
 local one_minus_alpha = 1.0 - alpha
 local delta = tonumber(ARGV[3])
 
-local initialized = redis.call('HGET', rates_table_name, 'INIT_DONE')
+local initialized = redis.call('HGET', rates_table_name .. ':' .. 'RIF', 'INIT_DONE')
 logit(initialized)
 
 local n = table.getn(KEYS)
@@ -63,7 +67,7 @@ for i = 1, n do
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_PPS', rx_pps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_BPS', tx_bps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', tx_pps_new)
-            redis.call('HSET', rates_table_name, 'INIT_DONE', 'DONE')
+            redis.call('HSET', rates_table_name .. ':' .. 'RIF', 'INIT_DONE', 'DONE')
         end        
     else
         -- Set old COUNTERS values
@@ -71,7 +75,7 @@ for i = 1, n do
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last', in_pkts)
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last', out_octets)
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last', out_pkts)      
-        redis.call('HSET', rates_table_name, 'INIT_DONE', 'COUNTERS_LAST')
+        redis.call('HSET', rates_table_name .. ':' .. 'RIF', 'INIT_DONE', 'COUNTERS_LAST')
     end
 end
 


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Fix 2 issues with the lua scripts:
 - introduce separate INIT flag for PORT and RIF. Previously could cause problems on init of one of the groups.
 - skip if there is no initial config (alpha in DB). When reboot/config reload, it happens that alpha is not set until the `enable_counters.py` is executed

**What I did**

**Why I did it**

**How I verified it**
reboot, config reload, 
check rates initialized correctly, w/o errors in log
**Details if related**
