### PR TITLE
[aclorch]: fix bug for AclRange::remove

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2109,11 +2109,11 @@ bool AclRange::remove(sai_object_id_t *oids, int oidsCnt)
 {
     SWSS_LOG_ENTER();
 
-    for (int oidIdx = 0; oidIdx < oidsCnt; oidsCnt++)
+    for (int oidIdx = 0; oidIdx < oidsCnt; oidIdx++)
     {
         for (auto it : m_ranges)
         {
-            if (it.second->m_oid == oids[oidsCnt])
+            if (it.second->m_oid == oids[oidIdx])
             {
                 return it.second->remove();
             }


### PR DESCRIPTION
- fix bug for AclRange::remove(sai_object_id_t *oids, int oidsCnt) when oidsCnt > 0

Signed-off-by: yerenyue <yerenyue@foxmail.com>

**What I did**
Fix bug for aclorch.

**Why I did it**
I added some codes in AclRange::create() with return value NULL.
When the range_object_list.count in AclRule::create() equals to 1 and AclRange::create() returns NULL, the orchagent program crashed.

**How I verified it**
AclRange::remove returns correctly in AclRule::create()

**Details if related**
