### PR TITLE
Get initial speed from ASIC DB 

### DIFF
--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -7,7 +7,7 @@ class TestSpeedSet:
     NUM_PORTS = 32
 
     def test_SpeedAndBufferSet(self, dvs, testlog):
-        configured_speed_list = ["40000"]
+        configured_speed_list = []
         speed_list = ["10000", "25000", "40000", "50000", "100000"]
 
         # buffers_config.j2 is used for the test and defines 3 static profiles and 1 dynamic profile:
@@ -19,6 +19,20 @@ class TestSpeedSet:
 
         cdb = dvs.get_config_db()
         adb = dvs.get_asic_db()
+
+        # Get speed from the first port we hit in ASIC DB port walk, and
+        # assume that its the initial configured speed for all ports, and
+        # dynamic buffer profile has already been created for it.
+        asic_port_records = adb.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+        for k in asic_port_records:
+            fvs = adb.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", k)
+            for fv in fvs:
+                if fv[0] == "SAI_PORT_ATTR_SPEED":
+                    configured_speed_list.append(fv[1])
+                    break
+
+            if len(configured_speed_list):
+                break;
 
         # Check if the buffer profiles make it to Config DB
         cdb.wait_for_n_keys("BUFFER_PROFILE", num_buffer_profiles)

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -26,9 +26,9 @@ class TestSpeedSet:
         asic_port_records = adb.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT")
         for k in asic_port_records:
             fvs = adb.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", k)
-            for fv in fvs:
-                if fv[0] == "SAI_PORT_ATTR_SPEED":
-                    configured_speed_list.append(fv[1])
+            for fv in fvs.keys():
+                if fv == "SAI_PORT_ATTR_SPEED":
+                    configured_speed_list.append(fvs[fv])
                     break
 
             if len(configured_speed_list):

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -22,17 +22,18 @@ class TestSpeedSet:
 
         # Get speed from the first port we hit in ASIC DB port walk, and
         # assume that its the initial configured speed for all ports, and
-        # dynamic buffer profile has already been created for it.
+        # as new port configuration file i.e. 'platform.json' guarantees
+        # 100G as initial port speed for all ports and the dynamic buffer
+        # profile has already been created for it.
         asic_port_records = adb.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT")
         for k in asic_port_records:
             fvs = adb.get_entry("ASIC_STATE:SAI_OBJECT_TYPE_PORT", k)
-            for fv in fvs.keys():
-                if fv == "SAI_PORT_ATTR_SPEED":
-                    configured_speed_list.append(fvs[fv])
-                    break
+            if "SAI_PORT_ATTR_SPEED" in fvs.keys():
+                configured_speed_list.append(fvs["SAI_PORT_ATTR_SPEED"])
+                break
 
-            if len(configured_speed_list):
-                break;
+            if configured_speed_list:
+                break
 
         # Check if the buffer profiles make it to Config DB
         cdb.wait_for_n_keys("BUFFER_PROFILE", num_buffer_profiles)


### PR DESCRIPTION
Signed-off-by: Sangita Maity sangitamaity0211@gmail.com
Co-authored-by: Vasant Patil <vapatil@linkedin.com>

**What I did**
Initialized the configured speed list by reading port speed from ASIC DB
[sonic-buildimage #3910 PR](https://github.com/Azure/sonic-buildimage/pull/3910) has a dependency on it. 
Otherwise `test_speed` test is getting failed and other few test cases are dependent on it.
```
23:21:21  test_speed.py::TestSpeedSet::test_SpeedAndBufferSet FAILED  
```

**Why I did it**

Since Speed is introduced in port_config.ini of VS platform, one of the buffer profiles is already created(speed 40G). Hence the test case is modified by reading port speed from ASIC DB. The list of speeds is [10G, 25G, 40G, 50G, 100G], the initial number of buffer profiles present is 4 (including the one created for 40G)
Test case walks through each speed and configures that speed on all the ports. Expects that a new buffer profile is created when a new speed is set on all ports. But note that since 40G profiles are already created, it expects no new buffer profile to be created when we set 40G on all ports.

Now, when we walk through the speed list, This is what happens

10G - yes a new profile is created
25G - yes, a new profile is created
40G - yes, a new profile is created. This is the problem!

Root cause: however, once the DPB feature gets in, the initial created buffer profile is NOT for 40G, instead it is for 100G.
Because we are setting the different speed for ports in platform.json

**How I verified it**
By running the VS test case

```
samaity@server09:~/REPO_FACTORY/GIT_REPO/dpb_test/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -vv --dvsname=vs-sa  test_speed.py
 
 
samaity@server09:~/REPO_FACTORY/GIT_REPO/dpb_test/sonic-buildimage/src/sonic-swss/tests$ sudo pytest -s -vv --dvsname=vs-sa  test_speed.py
============================================================================================================ test session starts =============================================================================================================
platform linux2 -- Python 2.7.17, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python
cachedir: .pytest_cache
rootdir: /home/samaity/REPO_FACTORY/GIT_REPO/dpb_test/sonic-buildimage/src/sonic-swss/tests
plugins: repeat-0.8.0
collected 1 item
 
test_speed.py::TestSpeedSet::test_SpeedAndBufferSet remove extra link dummy
PASSED
 
```