### PR TITLE
[vlanmgr] Support Jumbo Frame By Default

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -51,15 +51,17 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     // The command should be generated as:
     // /bin/bash -c "/sbin/ip link del Bridge 2>/dev/null ;
     //               /sbin/ip link add Bridge up type bridge &&
+    //               /sbin/ip link set Bridge mtu {{ mtu_size }} &&
     //               /sbin/bridge vlan del vid 1 dev Bridge self;
     //               /sbin/ip link del dummy 2>/dev/null;
     //               /sbin/ip link add dummy type dummy &&
-    //               sbin/ip link set dummy master Bridge"
+    //               /sbin/ip link set dummy master Bridge"
 
     const std::string cmds = std::string("")
       + BASH_CMD + " -c \""
       + IP_CMD + " link del " + DOT1Q_BRIDGE_NAME + " 2>/dev/null; "
       + IP_CMD + " link add " + DOT1Q_BRIDGE_NAME + " up type bridge && "
+      + IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " mtu " + DEFAULT_MTU_STR + " && "
       + BRIDGE_CMD + " vlan del vid " + DEFAULT_VLAN_ID + " dev " + DOT1Q_BRIDGE_NAME + " self; "
       + IP_CMD + " link del dev dummy 2>/dev/null; "
       + IP_CMD + " link add dummy type dummy && "


### PR DESCRIPTION
The bridge created for vlans has a a default MTU of 1500 which is
serving as default for vlans added to the bridge. This PR changes
the default MTU to 9100 to be inline with portchannels and other
interfaces.

signed-off-by: Tamer Ahmed <tamer.ahmed@microsoft.com>

**What I did**
Change the default mtu size of the host bridge interface

**Why I did it**
Adding support for jumbo frames

**How I verified it**
building an image with the change and could see Vlan100 having mtu set as 9100
```
admin@str-s6000-acs-14:~$ sudo ifconfig Vlan1000
Vlan1000: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet 192.168.0.1  netmask 255.255.248.0  broadcast 192.168.7.255
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 4  bytes 520 (520.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
```

Adding/removal of different vlan members with mtu 1500 did not affect the Bridge MTU settings.
```
admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 9  bytes 1170 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo brctl show
bridge name	bridge id		STP enabled	interfaces
Bridge		8000.06b62e247645	no		Ethernet12
							Ethernet16
							Ethernet20
							Ethernet24
							Ethernet28
							Ethernet32
							Ethernet36
							Ethernet4
							Ethernet40
							Ethernet44
							Ethernet48
							Ethernet52
							Ethernet56
							Ethernet60
							Ethernet64
							Ethernet68
							Ethernet72
							Ethernet76
							Ethernet8
							Ethernet80
							Ethernet84
							Ethernet88
							Ethernet92
							Ethernet96
							dummy
docker0		8000.0242f67040d3	no		
admin@str-s6000-acs-14:~$ sudo brctl delif Bridge dummy
admin@str-s6000-acs-14:~$ sudo brctl addif Bridge dummy
admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 9  bytes 1170 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig dummy
dummy: flags=130<BROADCAST,NOARP>  mtu 1500
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig dummy up
admin@str-s6000-acs-14:~$ sudo ifconfig dummy
dummy: flags=195<UP,BROADCAST,RUNNING,NOARP>  mtu 1500
        inet6 fe80::4b6:2eff:fe24:7645  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 9  bytes 1170 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo brctl delif Bridge Ethernet12
admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet12
Ethernet12: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 23  bytes 4535 (4.4 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ip link set Ethernet12 mtu 1500
admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet12
Ethernet12: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 24  bytes 4765 (4.6 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo brctl addif Bridge Ethernet12
admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet12
Ethernet12: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 25  bytes 4995 (4.8 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 9  bytes 1170 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo brctl delif Bridge Ethernet12 Ethernet16
admin@str-s6000-acs-14:~$ sudo brctl delif Bridge Ethernet20 Ethernet24 Ethernet28 Ethernet32 Ethernet36 Ethernet4 Ethernet40 Ethernet44 Ethernet48 Ethernet52 Ethernet56 Ethernet60 Ethernet64 Ethernet68 Ethernet72 Ethernet76 Ethernet8 Ethernet80 Ethernet84 Ethernet88 Ethernet92 Ethernet96 
admin@str-s6000-acs-14:~$ sudo brctl show
bridge name	bridge id		STP enabled	interfaces
Bridge		8000.06b62e247645	no		dummy
docker0		8000.0242f67040d3	no		
admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 9  bytes 1170 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet12
Ethernet12: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 34  bytes 7065 (6.8 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet4
Ethernet4: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 34  bytes 7022 (6.8 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo brctl addif Bridge Ethernet12
admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet4
Ethernet4: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 35  bytes 7251 (7.0 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet12
Ethernet12: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 35  bytes 7295 (7.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 9  bytes 1170 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet12 down
admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 9  bytes 1170 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig dummy
dummy: flags=195<UP,BROADCAST,RUNNING,NOARP>  mtu 1500
        inet6 fe80::4b6:2eff:fe24:7645  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 0  bytes 0 (0.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig dummy down
admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4099<UP,BROADCAST,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 9  bytes 1170 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet12 up
admin@str-s6000-acs-14:~$ sudo ifconfig Bridge
Bridge: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet6 fe80::8071:f9ff:fe1b:e8d1  prefixlen 64  scopeid 0x20<link>
        ether 06:b6:2e:24:76:45  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 13  bytes 1690 (1.6 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Ethernet12
Ethernet12: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 46  bytes 9441 (9.2 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

admin@str-s6000-acs-14:~$ sudo ifconfig Vlan1000
Vlan1000: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9100
        inet 192.168.0.1  netmask 255.255.248.0  broadcast 192.168.7.255
        inet6 fe80::f68e:38ff:fe16:bc8d  prefixlen 64  scopeid 0x20<link>
        ether f4:8e:38:16:bc:8d  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 6  bytes 780 (780.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

```


**Details if related**
