### PR TITLE
[dvs] Add options to limit CPU usage

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -79,6 +79,18 @@ For those developing new features for SWSS or the DVS framework, you might find 
     ```
 
 ## Other useful test parameters
+- You can specify a maximum amount of cores for the DVS to use (we recommend 2):
+    ```
+    sudo pytest --max_cpu 2
+    ```
+
+    For a persistent DVS:
+    ```
+    docker run --privileged -v /var/run/redis-vs/sw:/var/run/redis --network container:sw -d --name vs --cpus 2 docker-sonic-vs
+    ```
+
+    For specific details about the performance impact of this, see [the Docker docs.](https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler)
+
 - You can see the output of all test cases that have been run by adding the verbose flag:
 
     ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,10 @@ def pytest_addoption(parser):
                       help="keep testbed after test")
     parser.addoption("--imgname", action="store", default="docker-sonic-vs",
                       help="image name")
+    parser.addoption("--max_cpu",
+                     action="store",
+                     default=2,
+                     help="Max number of CPU cores to use, if available. (default = 2)")
 
 
 class AsicDbValidator(DVSDatabase):
@@ -158,7 +162,15 @@ class DockerVirtualSwitch(object):
     FLEX_COUNTER_DB_ID = 5
     STATE_DB_ID = 6
 
-    def __init__(self, name=None, imgname=None, keeptb=False, fakeplatform=None, log_path=None):
+    def __init__(
+            self,
+            name=None,
+            imgname=None,
+            keeptb=False,
+            fakeplatform=None,
+            log_path=None,
+            max_cpu=2
+    ):
         self.basicd = ['redis-server',
                        'rsyslogd']
         self.swssd = ['orchagent',
@@ -243,10 +255,13 @@ class DockerVirtualSwitch(object):
             self.environment = ["fake_platform={}".format(fakeplatform)] if fakeplatform else []
 
             # create virtual switch container
-            self.ctn = self.client.containers.run(imgname, privileged=True, detach=True,
-                    environment=self.environment,
-                    network_mode="container:%s" % self.ctn_sw.name,
-                    volumes={ self.mount: { 'bind': '/var/run/redis', 'mode': 'rw' } })
+            self.ctn = self.client.containers.run(imgname,
+                                                  privileged=True,
+                                                  detach=True,
+                                                  environment=self.environment,
+                                                  network_mode=f"container:{self.ctn_sw.name}",
+                                                  volumes={self.mount: {"bind": "/var/run/redis", "mode": "rw"}},
+                                                  cpu_shares=max_cpu)
 
         self.redis_sock = self.mount + '/' + "redis.sock"
 
@@ -973,11 +988,11 @@ def dvs(request) -> DockerVirtualSwitch:
     name = request.config.getoption("--dvsname")
     keeptb = request.config.getoption("--keeptb")
     imgname = request.config.getoption("--imgname")
+    max_cpu = request.config.getoption("--max_cpu")
     fakeplatform = getattr(request.module, "DVS_FAKE_PLATFORM", None)
-
     log_path = name if name else request.module.__name__
 
-    dvs = DockerVirtualSwitch(name, imgname, keeptb, fakeplatform, log_path)
+    dvs = DockerVirtualSwitch(name, imgname, keeptb, fakeplatform, log_path, max_cpu)
 
     yield dvs
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ def pytest_addoption(parser):
     parser.addoption("--max_cpu",
                      action="store",
                      default=2,
+                     type=int,
                      help="Max number of CPU cores to use, if available. (default = 2)")
 
 
@@ -261,7 +262,7 @@ class DockerVirtualSwitch(object):
                                                   environment=self.environment,
                                                   network_mode=f"container:{self.ctn_sw.name}",
                                                   volumes={self.mount: {"bind": "/var/run/redis", "mode": "rw"}},
-                                                  cpu_shares=max_cpu)
+                                                  cpu_count=max_cpu)
 
         self.redis_sock = self.mount + '/' + "redis.sock"
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I added a flag to limit the CPU usage of a DVS container.

**Why I did it**
I did it to try to set an expectation of how much CPU the DVS container /should/ be using, and to try to make the performance more deterministic b/w the PR runners and different peoples' local setups (without a limit Docker just uses as much as it can from the host).

**How I verified it**
Ran tests locally, still passing. Typical CPU usage was <1 core, but need to experiment/monitor more with the PR runner to see if that is sufficient.

**Details if related**
