### PR TITLE
Fix log/syslog not being correct when last test fails for given module

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -163,3 +163,8 @@ For those developing new features for SWSS or the DVS framework, you might find 
     ```
 
     You can mitigate this by upgrading to a newer version of Docker CE or editing the `DEFAULT_DOCKER_API_VERSION` in `/usr/local/lib/python3/dist-packages/docker/constants.py`, or by upgrading to a newer version of Docker CE. See [relevant GitHub discussion](https://github.com/drone/drone/issues/2048).
+
+-   Currently when pytest are run using --force-flaky and if the last test case fails pytest tear-down the module before retrying the failed test case and invoke module
+    setup again to run fail test case. This is know issue of pytest w.r.t flaky as tracked here (https://github.com/box/flaky/issues/128) and 
+    (https://github.com/pytest-dev/pytest-rerunfailures/issues/51). Because of this issue all the logs are lost till last test case run as modules is teardown and setup again.
+    To avoid this as workaround a dummy always-pass test case is added in all modules/test files. 

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -492,3 +492,7 @@ class TestAclRuleValidation():
                 dvs.runcmd("supervisorctl restart syncd")
                 dvs.stop_swss()
                 dvs.start_swss()
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -492,6 +492,8 @@ class TestAclRuleValidation():
                 dvs.runcmd("supervisorctl restart syncd")
                 dvs.stop_swss()
                 dvs.start_swss()
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_acl_ctrl.py
+++ b/tests/test_acl_ctrl.py
@@ -69,6 +69,8 @@ class TestPortChannelAcl(object):
         self.remove_acl_table(dvs)
         self.remove_acl_rule(dvs)
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_acl_ctrl.py
+++ b/tests/test_acl_ctrl.py
@@ -69,3 +69,7 @@ class TestPortChannelAcl(object):
         self.remove_acl_table(dvs)
         self.remove_acl_rule(dvs)
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_acl_egress_table.py
+++ b/tests/test_acl_egress_table.py
@@ -340,6 +340,8 @@ class TestEgressAclTable(object):
         # Remove Acl table
         self.remove_acl_table("egress_acl_table")
         self.check_asic_table_absent(dvs)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_acl_egress_table.py
+++ b/tests/test_acl_egress_table.py
@@ -340,3 +340,7 @@ class TestEgressAclTable(object):
         # Remove Acl table
         self.remove_acl_table("egress_acl_table")
         self.check_asic_table_absent(dvs)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_acl_mclag.py
+++ b/tests/test_acl_mclag.py
@@ -197,3 +197,7 @@ class TestMclagAcl(object):
         # check acl in asic db
         acl_table_id = self.get_acl_table_id(dvs)
         assert acl_table_id is None
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_acl_mclag.py
+++ b/tests/test_acl_mclag.py
@@ -197,6 +197,8 @@ class TestMclagAcl(object):
         # check acl in asic db
         acl_table_id = self.get_acl_table_id(dvs)
         assert acl_table_id is None
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_acl_portchannel.py
+++ b/tests/test_acl_portchannel.py
@@ -215,6 +215,8 @@ class TestPortChannelAcl(object):
 
         # remove port channel
         self.remove_port_channel(dvs, "PortChannel01")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_acl_portchannel.py
+++ b/tests/test_acl_portchannel.py
@@ -215,3 +215,7 @@ class TestPortChannelAcl(object):
 
         # remove port channel
         self.remove_port_channel(dvs, "PortChannel01")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_admin_status.py
+++ b/tests/test_admin_status.py
@@ -78,6 +78,8 @@ class TestAdminStatus(object):
 
         # remove port channel
         self.remove_port_channel(dvs, "PortChannel6")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_admin_status.py
+++ b/tests/test_admin_status.py
@@ -78,3 +78,7 @@ class TestAdminStatus(object):
 
         # remove port channel
         self.remove_port_channel(dvs, "PortChannel6")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -904,6 +904,8 @@ class TestCrm(object):
         assert threshold_high == 90
         threshold_type = getCrmConfigStr(dvs, 'Config', 'fdb_entry_threshold_type')
         assert threshold_type == 'percentage'
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -904,3 +904,7 @@ class TestCrm(object):
         assert threshold_high == 90
         threshold_type = getCrmConfigStr(dvs, 'Config', 'fdb_entry_threshold_type')
         assert threshold_type == 'percentage'
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -94,3 +94,7 @@ class TestDirectedBroadcast(object):
 
             if neigh['ip'] == "192.169.0.30":
                 assert False
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_dirbcast.py
+++ b/tests/test_dirbcast.py
@@ -94,6 +94,8 @@ class TestDirectedBroadcast(object):
 
             if neigh['ip'] == "192.169.0.30":
                 assert False
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_drop_counters.py
+++ b/tests/test_drop_counters.py
@@ -705,6 +705,8 @@ class TestDropCounters(object):
         # Cleanup for the next test.
         self.delete_drop_counter(name1)
         self.remove_drop_reason(name1, reason1)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_drop_counters.py
+++ b/tests/test_drop_counters.py
@@ -705,3 +705,7 @@ class TestDropCounters(object):
         # Cleanup for the next test.
         self.delete_drop_counter(name1)
         self.remove_drop_reason(name1, reason1)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_dtel.py
+++ b/tests/test_dtel.py
@@ -295,6 +295,8 @@ class TestDtel(object):
         tbl._del("EVENT_TYPE_QUEUE_REPORT_THRESHOLD_BREACH")
         tbl._del("EVENT_TYPE_QUEUE_REPORT_TAIL_DROP")
         tbl._del("EVENT_TYPE_DROP_REPORT")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_dtel.py
+++ b/tests/test_dtel.py
@@ -295,3 +295,7 @@ class TestDtel(object):
         tbl._del("EVENT_TYPE_QUEUE_REPORT_THRESHOLD_BREACH")
         tbl._del("EVENT_TYPE_QUEUE_REPORT_TAIL_DROP")
         tbl._del("EVENT_TYPE_DROP_REPORT")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -382,6 +382,8 @@ class TestFdb(object):
         dvs.runcmd("sonic-clear fdb all")
         dvs.remove_vlan_member("2", "Ethernet0")
         dvs.remove_vlan("2")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_fdb.py
+++ b/tests/test_fdb.py
@@ -382,3 +382,7 @@ class TestFdb(object):
         dvs.runcmd("sonic-clear fdb all")
         dvs.remove_vlan_member("2", "Ethernet0")
         dvs.remove_vlan("2")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_fdb_update.py
+++ b/tests/test_fdb_update.py
@@ -322,3 +322,7 @@ class TestFdbUpdate(object):
 
         # restore the default value of the servers
         dvs.servers[server].runcmd("ifconfig eth0 0 down")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_fdb_update.py
+++ b/tests/test_fdb_update.py
@@ -322,6 +322,8 @@ class TestFdbUpdate(object):
 
         # restore the default value of the servers
         dvs.servers[server].runcmd("ifconfig eth0 0 down")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1962,6 +1962,8 @@ class TestRouterInterface(object):
             route = json.loads(key)
             if route["dest"] == "10.0.0.4/32":
                 assert False
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1962,3 +1962,7 @@ class TestRouterInterface(object):
             route = json.loads(key)
             if route["dest"] == "10.0.0.4/32":
                 assert False
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_intf_mac.py
+++ b/tests/test_intf_mac.py
@@ -252,3 +252,7 @@ class TestLagRouterInterfaceMac(object):
 
         # remove port channel
         self.remove_port_channel(dvs, "PortChannel002")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_intf_mac.py
+++ b/tests/test_intf_mac.py
@@ -252,6 +252,8 @@ class TestLagRouterInterfaceMac(object):
 
         # remove port channel
         self.remove_port_channel(dvs, "PortChannel002")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -872,3 +872,7 @@ class TestMirror(object):
         self.remove_neighbor("Ethernet32", "20.0.0.1")
         self.remove_ip_address("Ethernet32", "20.0.0.0/31")
         self.set_interface_status(dvs, "Ethernet32", "down")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -872,6 +872,8 @@ class TestMirror(object):
         self.remove_neighbor("Ethernet32", "20.0.0.1")
         self.remove_ip_address("Ethernet32", "20.0.0.0/31")
         self.set_interface_status(dvs, "Ethernet32", "down")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_mirror_ipv6_combined.py
+++ b/tests/test_mirror_ipv6_combined.py
@@ -556,6 +556,8 @@ class TestMirror(object):
         self.set_interface_status("Ethernet32", "down")
 
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_mirror_ipv6_combined.py
+++ b/tests/test_mirror_ipv6_combined.py
@@ -556,3 +556,7 @@ class TestMirror(object):
         self.set_interface_status("Ethernet32", "down")
 
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -663,3 +663,7 @@ class TestMirror(object):
         self.set_interface_status("Ethernet32", "down")
 
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -663,6 +663,8 @@ class TestMirror(object):
         self.set_interface_status("Ethernet32", "down")
 
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_mirror_policer.py
+++ b/tests/test_mirror_policer.py
@@ -238,3 +238,7 @@ class TestMirror(object):
 
         # remove policer
         self.remove_policer(policer)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_mirror_policer.py
+++ b/tests/test_mirror_policer.py
@@ -238,6 +238,8 @@ class TestMirror(object):
 
         # remove policer
         self.remove_policer(policer)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_mirror_port_erspan.py
+++ b/tests/test_mirror_port_erspan.py
@@ -542,6 +542,8 @@ class TestMirror(object):
         self.dvs_mirror.remove_mirror_session(session)
         self.dvs_mirror.verify_no_mirror()
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_mirror_port_erspan.py
+++ b/tests/test_mirror_port_erspan.py
@@ -542,3 +542,7 @@ class TestMirror(object):
         self.dvs_mirror.remove_mirror_session(session)
         self.dvs_mirror.verify_no_mirror()
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_mirror_port_span.py
+++ b/tests/test_mirror_port_span.py
@@ -470,3 +470,7 @@ class TestMirror(object):
         self.dvs_lag.get_and_verify_port_channel(0)
         self.dvs_vlan.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_LAG", 0)
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_mirror_port_span.py
+++ b/tests/test_mirror_port_span.py
@@ -470,6 +470,8 @@ class TestMirror(object):
         self.dvs_lag.get_and_verify_port_channel(0)
         self.dvs_vlan.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_LAG", 0)
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -318,3 +318,7 @@ class TestNat(object):
         # delete a static nat entry
         dvs.runcmd("config nat remove static basic 67.66.65.1 18.18.18.2")
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -318,6 +318,8 @@ class TestNat(object):
         # delete a static nat entry
         dvs.runcmd("config nat remove static basic 67.66.65.1 18.18.18.2")
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -390,6 +390,8 @@ class TestNeighbor(object):
             current_neigh_entries_cnt = len(tbl.getKeys())
             dec_neigh_entries_cnt = (old_neigh_entries_cnt - current_neigh_entries_cnt)
             assert dec_neigh_entries_cnt == 1
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -389,7 +389,8 @@ class TestNeighbor(object):
             tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
             current_neigh_entries_cnt = len(tbl.getKeys())
             dec_neigh_entries_cnt = (old_neigh_entries_cnt - current_neigh_entries_cnt)
-            assert dec_neigh_entries_cnt == 1# Add Dummy always-pass test at end as workaroud
+            assert dec_neigh_entries_cnt == 1
+# Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():
     pass

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -389,4 +389,7 @@ class TestNeighbor(object):
             tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
             current_neigh_entries_cnt = len(tbl.getKeys())
             dec_neigh_entries_cnt = (old_neigh_entries_cnt - current_neigh_entries_cnt)
-            assert dec_neigh_entries_cnt == 1
+            assert dec_neigh_entries_cnt == 1# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -319,3 +319,7 @@ class TestNextHopGroup(object):
         assert k is not None
         fvs = asic_route_nhg_fvs(k)
         assert fvs is not None
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -319,6 +319,8 @@ class TestNextHopGroup(object):
         assert k is not None
         fvs = asic_route_nhg_fvs(k)
         assert fvs is not None
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_pfc.py
+++ b/tests/test_pfc.py
@@ -101,6 +101,8 @@ class TestPfc(object):
         pfc = getPortAttr(dvs, port_oid, 'SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL')
         assert pfc == pfc_tx
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_pfc.py
+++ b/tests/test_pfc.py
@@ -101,3 +101,7 @@ class TestPfc(object):
         pfc = getPortAttr(dvs, port_oid, 'SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL')
         assert pfc == pfc_tx
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_policer.py
+++ b/tests/test_policer.py
@@ -72,3 +72,7 @@ class TestPolicer(object):
         tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
         policer_entries = tbl.getKeys()
         assert len(policer_entries) == 0
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_policer.py
+++ b/tests/test_policer.py
@@ -72,6 +72,8 @@ class TestPolicer(object):
         tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
         policer_entries = tbl.getKeys()
         assert len(policer_entries) == 0
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -221,3 +221,7 @@ class TestPort(object):
         for fv in fvs:
             if fv[0] == "SAI_PORT_ATTR_SERDES_IPREDRIVER":
                 assert fv[1] == ipre_val_asic
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port.py
+++ b/tests/test_port.py
@@ -221,6 +221,8 @@ class TestPort(object):
         for fv in fvs:
             if fv[0] == "SAI_PORT_ATTR_SERDES_IPREDRIVER":
                 assert fv[1] == ipre_val_asic
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -174,3 +174,7 @@ class TestPortAutoNeg(object):
             dvs.runcmd("config warm_restart disable swss")
             # slow down crm polling
             dvs.runcmd("crm config polling interval 10000")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -174,6 +174,8 @@ class TestPortAutoNeg(object):
             dvs.runcmd("config warm_restart disable swss")
             # slow down crm polling
             dvs.runcmd("crm config polling interval 10000")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port_buffer_rel.py
+++ b/tests/test_port_buffer_rel.py
@@ -34,6 +34,8 @@ class TestPortBuffer(object):
                     num_set += 1
         # make sure that state is set for all "num_ports" ports
         assert num_set == num_ports, "Not all ports are up"
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port_buffer_rel.py
+++ b/tests/test_port_buffer_rel.py
@@ -34,3 +34,7 @@ class TestPortBuffer(object):
                     num_set += 1
         # make sure that state is set for all "num_ports" ports
         assert num_set == num_ports, "Not all ports are up"
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port_config.py
+++ b/tests/test_port_config.py
@@ -155,3 +155,7 @@ class TestPortConfig(object):
             assert hw_lane_value == "1:%s" % (new_lanes[i])
 
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port_config.py
+++ b/tests/test_port_config.py
@@ -155,6 +155,8 @@ class TestPortConfig(object):
             assert hw_lane_value == "1:%s" % (new_lanes[i])
 
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port_dpb.py
+++ b/tests/test_port_dpb.py
@@ -104,6 +104,8 @@ class TestPortDPB(object):
             start = i*maxBreakOut
             end = start+maxBreakOut
             dpb.breakin(dvs, child_port_names[start:end])
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port_dpb.py
+++ b/tests/test_port_dpb.py
@@ -104,3 +104,7 @@ class TestPortDPB(object):
             start = i*maxBreakOut
             end = start+maxBreakOut
             dpb.breakin(dvs, child_port_names[start:end])
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port_dpb_acl.py
+++ b/tests/test_port_dpb_acl.py
@@ -182,6 +182,8 @@ class TestPortDPBAcl(object):
         for aclTable in aclTableNames:
             dvs_acl.remove_acl_table(aclTable)
         dvs_acl.verify_acl_table_count(0)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port_dpb_acl.py
+++ b/tests/test_port_dpb_acl.py
@@ -182,3 +182,7 @@ class TestPortDPBAcl(object):
         for aclTable in aclTableNames:
             dvs_acl.remove_acl_table(aclTable)
         dvs_acl.verify_acl_table_count(0)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port_dpb_vlan.py
+++ b/tests/test_port_dpb_vlan.py
@@ -237,3 +237,7 @@ class TestPortDPBVlan(object):
         for vlan_name in vlan_names:
             self.dvs_vlan.remove_vlan(vlan_name)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port_dpb_vlan.py
+++ b/tests/test_port_dpb_vlan.py
@@ -237,6 +237,8 @@ class TestPortDPBVlan(object):
         for vlan_name in vlan_names:
             self.dvs_vlan.remove_vlan(vlan_name)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port_mac_learn.py
+++ b/tests/test_port_mac_learn.py
@@ -181,6 +181,8 @@ class TestPortMacLearn(object):
         tbl = swsscommon.Table(self.cdb, "PORTCHANNEL")
         tbl._del("PortChannel001")
         time.sleep(1)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_port_mac_learn.py
+++ b/tests/test_port_mac_learn.py
@@ -181,3 +181,7 @@ class TestPortMacLearn(object):
         tbl = swsscommon.Table(self.cdb, "PORTCHANNEL")
         tbl._del("PortChannel001")
         time.sleep(1)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -263,6 +263,8 @@ class TestPortchannel(object):
         tbl._del("PortChannel003")
         tbl._del("PortChannel004")
         time.sleep(1)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -263,3 +263,7 @@ class TestPortchannel(object):
         tbl._del("PortChannel003")
         tbl._del("PortChannel004")
         time.sleep(1)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -104,6 +104,8 @@ class TestDot1p(object):
 
         port_cnt = len(swsscommon.Table(self.config_db, CFG_PORT_TABLE_NAME).getKeys())
         assert port_cnt == cnt
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -104,3 +104,7 @@ class TestDot1p(object):
 
         port_cnt = len(swsscommon.Table(self.config_db, CFG_PORT_TABLE_NAME).getKeys())
         assert port_cnt == cnt
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -623,6 +623,8 @@ class TestRoute(object):
         dvs.servers[2].runcmd("ip address del 20.0.0.2/24 dev eth0")
         dvs.servers[3].runcmd("ip route del default dev eth0")
         dvs.servers[3].runcmd("ip address del 20.0.1.2/24 dev eth0")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -623,3 +623,7 @@ class TestRoute(object):
         dvs.servers[2].runcmd("ip address del 20.0.0.2/24 dev eth0")
         dvs.servers[3].runcmd("ip route del default dev eth0")
         dvs.servers[3].runcmd("ip address del 20.0.1.2/24 dev eth0")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_setro.py
+++ b/tests/test_setro.py
@@ -44,6 +44,8 @@ class TestSetRo(object):
 
         # make action on appdb so orchagent will get RO value
         # read asic db to see if orchagent behaved correctly
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_setro.py
+++ b/tests/test_setro.py
@@ -44,3 +44,7 @@ class TestSetRo(object):
 
         # make action on appdb so orchagent will get RO value
         # read asic db to see if orchagent behaved correctly
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -136,3 +136,7 @@ class TestSflow:
 
         self.cdb.delete_entry("SFLOW", "global")
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -136,6 +136,8 @@ class TestSflow:
 
         self.cdb.delete_entry("SFLOW", "global")
         self.adb.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_SAMPLEPACKET", 0)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -57,6 +57,8 @@ class TestSpeedSet:
 
                 expected_fields = {"profile": "[BUFFER_PROFILE|{}]".format(expected_new_profile_name)}
                 cdb.wait_for_field_match("BUFFER_PG", expected_pg_table, expected_fields)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -57,3 +57,7 @@ class TestSpeedSet:
 
                 expected_fields = {"profile": "[BUFFER_PROFILE|{}]".format(expected_new_profile_name)}
                 cdb.wait_for_field_match("BUFFER_PG", expected_pg_table, expected_fields)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -424,3 +424,7 @@ class TestSubPortIntf(object):
 
         self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
         self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -424,6 +424,8 @@ class TestSubPortIntf(object):
 
         self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
         self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -71,6 +71,8 @@ class TestSwitch(object):
         vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05")
 
         vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -71,3 +71,7 @@ class TestSwitch(object):
         vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05")
 
         vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -229,6 +229,8 @@ class TestSymmetricTunnel(TestTunnelBase):
                                     ecn_mode="standard", ttl_mode="pipe")
         self.remove_and_test_tunnel(db, asicdb, "IPINIPv6Symmetric")
 
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_tunnel.py
+++ b/tests/test_tunnel.py
@@ -229,3 +229,7 @@ class TestSymmetricTunnel(TestTunnelBase):
                                     ecn_mode="standard", ttl_mode="pipe")
         self.remove_and_test_tunnel(db, asicdb, "IPINIPv6Symmetric")
 
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -418,3 +418,7 @@ class TestVlan(object):
 
         self.dvs_vlan.remove_vlan(vlan)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -418,6 +418,8 @@ class TestVlan(object):
 
         self.dvs_vlan.remove_vlan(vlan)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -1352,6 +1352,8 @@ class TestVnetOrch(object):
 
         vnet_obj.check_default_vnet_entry(dvs, 'Vnet_5')
         vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet_5', '4789')
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -1352,3 +1352,7 @@ class TestVnetOrch(object):
 
         vnet_obj.check_default_vnet_entry(dvs, 'Vnet_5')
         vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet_5', '4789')
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_vnet_bitmap.py
+++ b/tests/test_vnet_bitmap.py
@@ -25,3 +25,7 @@ class TestVnetBitmapOrch(vnet.TestVnetOrch):
     '''
     def get_vnet_obj(self):
         return vnet.VnetBitmapVxlanTunnel()
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_vnet_bitmap.py
+++ b/tests/test_vnet_bitmap.py
@@ -25,6 +25,8 @@ class TestVnetBitmapOrch(vnet.TestVnetOrch):
     '''
     def get_vnet_obj(self):
         return vnet.VnetBitmapVxlanTunnel()
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -304,6 +304,8 @@ class TestVrf(object):
         # check linux kernel
         (exitcode, num) = dvs.runcmd(['sh', '-c', "ip link show | grep Vrf | wc -l"])
         assert num.strip() == '0'
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_vrf.py
+++ b/tests/test_vrf.py
@@ -304,3 +304,7 @@ class TestVrf(object):
         # check linux kernel
         (exitcode, num) = dvs.runcmd(['sh', '-c', "ip link show | grep Vrf | wc -l"])
         assert num.strip() == '0'
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -309,6 +309,8 @@ class TestVxlan(object):
 
         create_vxlan_tunnel_entry(dvs, 'tunnel_4', 'entry_2', tunnel_map_map, 'Vlan57', '857',
                                   tunnel_map_ids, tunnel_map_entry_ids, tunnel_ids, tunnel_term_ids)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -309,3 +309,7 @@ class TestVxlan(object):
 
         create_vxlan_tunnel_entry(dvs, 'tunnel_4', 'entry_2', tunnel_map_map, 'Vlan57', '857',
                                   tunnel_map_ids, tunnel_map_entry_ids, tunnel_ids, tunnel_term_ids)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -2190,6 +2190,8 @@ class TestWarmReboot(object):
         dvs.servers[0].runcmd("ifconfig eth0 0")
         dvs.servers[1].runcmd("ifconfig eth0 0")
         time.sleep(2)
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -2190,3 +2190,7 @@ class TestWarmReboot(object):
         dvs.servers[0].runcmd("ifconfig eth0 0")
         dvs.servers[1].runcmd("ifconfig eth0 0")
         time.sleep(2)
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -231,3 +231,7 @@ class TestWatermark(object):
         self.verify_value(dvs, self.mc_q, WmTables.user, SaiWmStats.queue_shared, "288")
 
         self.enable_unittests(dvs, "false")
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -231,6 +231,8 @@ class TestWatermark(object):
         self.verify_value(dvs, self.mc_q, WmTables.user, SaiWmStats.queue_shared, "288")
 
         self.enable_unittests(dvs, "false")
+
+
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying
 def test_nonflaky_dummy():


### PR DESCRIPTION
What/Why I did:-
As reported by this issue PR#https://github.com/box/flaky/issues/128
and PR#https://github.com/pytest-dev/pytest-rerunfailures/issues/51
currently pytest will call session/module tear-down before flaky
can retry the test when last test case fails. And Session/Module will be setup again to run last test 
retry.
Because of above behaviour when last test fail for given module
all the logs are lost for all test-case upto that point since when
tear down is called dvs container is destroyed and to run retry instance
DVS container is setup up again and logs only belonging to this instance
of run are captured and overwrite all previous logs.

Workaround to have default dummy pass (as suggested in above Issue also)  test case at end always so we
avoid module tear-down and setup again and logs are not lost.
