### PR TITLE
Added DBConnector::newConnection API for Mock table.

### DIFF
--- a/tests/mock_tests/mock_dbconnector.cpp
+++ b/tests/mock_tests/mock_dbconnector.cpp
@@ -61,6 +61,14 @@ namespace swss
         }
     }
 
+    DBConnector *DBConnector::newConnector(unsigned int timeout) const
+    {
+          DBConnector *ret;
+          ret = new DBConnector(getDbName(), timeout, (m_conn->connection_type == REDIS_CONN_TCP));
+          return ret;
+    }
+
+
     int DBConnector::getDbId() const
     {
         return m_dbId;


### PR DESCRIPTION
What Id did:-
Added DBConnector::newConnection API for Mock table 
Otherwise it uses libswsscommon API context.

Why I did:
Hopefully this should fix current swss build failure using latest libswsscommon
that has namespace change. 
Based on gdb I saw DB Connector constructor is being invoke 
both from mock_dbconnector.cpp and libswsscommon (via newConnection API)

How I verified:-
Local swss build is fine for VS Platform.


