### PR TITLE
Ignore IPv6 link-local entries as Vnet routes

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -216,6 +216,15 @@ void RouteSync::onVnetRouteMsg(int nlmsg_type, struct nl_object *obj, string vne
     string vnet_dip =  vnet + string(":") + destipprefix;
     SWSS_LOG_DEBUG("Receive new vnet route message %s", vnet_dip.c_str());
 
+    /* Ignore IPv6 link-local and mc addresses as Vnet routes */
+    auto family = rtnl_route_get_family(route_obj);
+    if (family == AF_INET6 &&
+       (IN6_IS_ADDR_LINKLOCAL(nl_addr_get_binary_addr(dip)) || IN6_IS_ADDR_MULTICAST(nl_addr_get_binary_addr(dip))))
+    {
+        SWSS_LOG_INFO("Ignore linklocal vnet routes %d for %s", nlmsg_type, vnet_dip.c_str());
+        return;
+    }
+
     if (nlmsg_type == RTM_DELROUTE)
     {
         /* Duplicated delete as we do not know if it is a VXLAN tunnel route*/

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -537,6 +537,14 @@ class VnetVxlanVrfTunnel(object):
 
     def check_vnet_entry(self, dvs, name, peer_list=[]):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+        app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+
+        #Assert if there are linklocal entries
+        tbl = swsscommon.Table(app_db, "VNET_ROUTE_TUNNEL_TABLE")
+        route_entries = tbl.getKeys()
+        assert "ff00::/8" not in route_entries
+        assert "fe80::/64" not in route_entries
+
         #Check virtual router objects
         assert how_many_entries_exist(asic_db, self.ASIC_VRF_TABLE) == (len(self.vnet_vr_ids) + 1),\
                                      "The VR objects are not created"


### PR DESCRIPTION
**What I did**
Ignore IPv6 link-local and multicast entries as Vnet routes

**Why I did it**
Otherwise creating stale VNET route entries and displayed in "show vnet routes" command

**How I verified it**
Run in DUT

**Details if related**
