### PR TITLE
[fec] Get FEC mode when port is already admin down

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2386,6 +2386,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             else
                             {
                                 /* Port is already down, setting fec mode*/
+                                p.m_fec_mode = fec_mode_map[fec_mode]
                                 if (setPortFec(p, p.m_fec_mode))
                                 {
                                     m_portList[alias] = p;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2386,7 +2386,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             else
                             {
                                 /* Port is already down, setting fec mode*/
-                                p.m_fec_mode = fec_mode_map[fec_mode]
+                                p.m_fec_mode = fec_mode_map[fec_mode];
                                 if (setPortFec(p, p.m_fec_mode))
                                 {
                                     m_portList[alias] = p;


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I added a line to fetch the FEC mode from the map before setting it.

**Why I did it**
This check was missed in an earlier PR, causing tests to fail in sairedis like so: https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/sonic-sairedis-build/1196/testReport/junit/test_port/TestPort/test_PortFec/

**How I verified it**
Re-run VS tests with this change.

**Details if related**
We're not totally sure why this was caught in the sairedis PR tests and not the swss PR tests. Investigation ongoing.
