### PR TITLE
[dvs] Clean-up conftest.py

### DIFF
--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -466,7 +466,7 @@ class TestAclRuleValidation:
             dvs.stop_swss()
             dvs.start_swss()
             # reinit ASIC DB validator object
-            dvs.init_asicdb_validator()
+            dvs.init_asic_db_validator()
 
             action_values = self.get_acl_actions_supported(dvs_acl, stage)
             # Now, PACKET_ACTION is not supported and REDIRECT_ACTION is supported


### PR DESCRIPTION
- Refactor check_services to use common polling method
- Convert remaining python 2 code to python 3 (f-strings, type hints, etc.)
- Make the formatting consistent
- Note remaining test dependencies in dvs

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did/Why I did it**
I cleaned-up/refactored `conftest.py`:

1. `check_services` implemented its own polling mechanism, so I refactored it to use `wait_for_result` instead.
2. There was some left-over python2 code from using `2to3` for the conversion. Because we are using python3 syntax in a lot of places now, and because python2 is EOL, it no longer makes sense to include the python2 support, so I refactored the rest of it out. This includes swapping `format` for `f-string`, `subprocess` for `command`, and adding type hints.
3. The formatting was a little all over the place so I refactored it to be consistent throughout (except for a chunk of methods in the middle that we are planning on replacing with `dvslib`).
4. I added a `dep` comment to a big chunk of the methods in DockerVirtualSwitch that are still being used by the test cases. The plan is to deprecate these and have the tests rely on `dvslib` for common code. The comments are there to keep track of which external dependencies are still needed. The comments, and their respective methods, should be removed as more functionality is added to `dvslib`.

**How I verified it**
Ran the tests in 3 different configurations:
- No persistent container
- Persistent container w/ 32 ports
- Persistent container w/ 2 ports (w/ and w/o the `--forcedvs` flag)

All work as expected.

**Details if related**
N/A
