### PR TITLE
[teamsyncd][teammgrd] Graceful exit after receiving SIGTERM

### DIFF
--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -71,6 +71,7 @@ int main(int argc, char **argv)
             {
                 teammgr.cleanTeamProcesses(SIGTERM);
                 received_sigterm = false;
+                break;
             }
             
             Selectable *sel;
@@ -91,6 +92,7 @@ int main(int argc, char **argv)
             auto *c = (Executor *)sel;
             c->execute();
         }
+        SWSS_LOG_NOTICE("Exiting");
     }
     catch (const exception &e)
     {

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -65,15 +65,8 @@ int main(int argc, char **argv)
             s.addSelectables(o->getSelectables());
         }
 
-        while (true)
-        {
-            if(received_sigterm)
-            {
-                teammgr.cleanTeamProcesses(SIGTERM);
-                received_sigterm = false;
-                break;
-            }
-            
+        while (!received_sigterm)
+        {            
             Selectable *sel;
             int ret;
 
@@ -92,6 +85,7 @@ int main(int argc, char **argv)
             auto *c = (Executor *)sel;
             c->execute();
         }
+        teammgr.cleanTeamProcesses(SIGTERM);
         SWSS_LOG_NOTICE("Exiting");
     }
     catch (const exception &e)

--- a/teamsyncd/teamsyncd.cpp
+++ b/teamsyncd/teamsyncd.cpp
@@ -48,12 +48,17 @@ int main(int argc, char **argv)
                 if(received_sigterm)
                 {
                   sync.cleanTeamSync();
-                  received_sigterm = false;
+                  break;
                 }
 
                 Selectable *temps;
                 s.select(&temps, 1000); // block for a second
                 sync.periodic();
+            }
+            if(received_sigterm)
+            {
+                SWSS_LOG_NOTICE("Received SIGTERM Exiting");
+                break;
             }
         }
         catch (const std::exception& e)

--- a/teamsyncd/teamsyncd.cpp
+++ b/teamsyncd/teamsyncd.cpp
@@ -32,41 +32,28 @@ int main(int argc, char **argv)
     /* Register the signal handler for SIGTERM */
     signal(SIGTERM, sig_handler);
 
-    while (1)
+    try
     {
-        try
+        NetLink netlink;
+        netlink.registerGroup(RTNLGRP_LINK);
+        cout << "Listens to teamd events..." << endl;
+        netlink.dumpRequest(RTM_GETLINK);
+
+        s.addSelectable(&netlink);
+        while (!received_sigterm)
         {
-            NetLink netlink;
-
-            netlink.registerGroup(RTNLGRP_LINK);
-            cout << "Listens to teamd events..." << endl;
-            netlink.dumpRequest(RTM_GETLINK);
-
-            s.addSelectable(&netlink);
-            while (true)
-            {
-                if(received_sigterm)
-                {
-                  sync.cleanTeamSync();
-                  break;
-                }
-
-                Selectable *temps;
-                s.select(&temps, 1000); // block for a second
-                sync.periodic();
-            }
-            if(received_sigterm)
-            {
-                SWSS_LOG_NOTICE("Received SIGTERM Exiting");
-                break;
-            }
+            Selectable *temps;
+            s.select(&temps, 1000); // block for a second
+            sync.periodic();
         }
-        catch (const std::exception& e)
-        {
-            cout << "Exception \"" << e.what() << "\" had been thrown in deamon" << endl;
-            return 0;
-        }
+        sync.cleanTeamSync();
+        SWSS_LOG_NOTICE("Received SIGTERM Exiting");
+    }
+    catch (const std::exception& e)
+    {
+        cout << "Exception \"" << e.what() << "\" had been thrown in deamon" << endl;
+        return 0;
     }
 
-    return 1;
+    return 0;
 }


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When SIGTERM is received, gracefully exist teamsyncd and teammgrd after cleaning up teamd processes and resources.

**Why I did it**

Below errors are after config reload
1. portchannel interfaces in kernel were not cleaned up.
2. teamsyncd gets netlink messages with old ifIndex.
3. Error - "TeamPortSync: Failed to initialize team handler".

**How I verified it**
I did multiple config reloads and docker stop teamd. 
Verified all portchannel intf are cleaned up in kernel and all teamd processes exists cleanly.

**Details if related**
