### PR TITLE
[dvs] Fix unstable DPB and NAT test cases

### DIFF
--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -1,6 +1,10 @@
 import time
 import pytest
 
+from dvslib.dvs_common import wait_for_result
+from dvslib.dvs_database import DVSDatabase
+
+
 class TestNat(object):
     def setup_db(self, dvs):
         self.app_db = dvs.get_app_db()
@@ -279,11 +283,8 @@ class TestNat(object):
         # clear interfaces
         self.clear_interfaces(dvs)
 
-    @pytest.mark.xfail(reason="Test unstable, blocking PR builds")
+    @pytest.mark.skip("See FIXME comment")
     def test_VerifyConntrackTimeoutForNatEntry(self, dvs, testlog):
-        # initialize
-        self.setup_db(dvs)
-
         # get neighbor and arp entry
         dvs.servers[0].runcmd("ping -c 1 18.18.18.2")
 
@@ -291,33 +292,31 @@ class TestNat(object):
         dvs.runcmd("config nat add static basic 67.66.65.1 18.18.18.2")
 
         # check the conntrack timeout for static entry
-        output = dvs.runcmd("conntrack -j -L -s 18.18.18.2 -p udp -q 67.66.65.1")
-        assert len(output) == 2
+        def _check_conntrack_for_static_entry():
+            output = dvs.runcmd("conntrack -j -L -s 18.18.18.2 -p udp -q 67.66.65.1")
+            if len(output) != 2:
+                return (False, None)
 
-        conntrack_list = list(output[1].split(" "))
+            conntrack_list = list(output[1].split(" "))
 
-        src_exists = dst_exists = proto_exists = False
-        proto_index = 0
+            src_exists = "src=18.18.18.2" in conntrack_list
+            dst_exists = "dst=67.66.65.1" in conntrack_list
+            proto_exists = "udp" in conntrack_list
 
-        for i in conntrack_list:
-            if i == "src=18.18.18.2":
-                src_exists = True
-            elif i == "dst=67.66.65.1":
-                dst_exists = True
-            elif i == "udp":
-                proto_exists = True
-                proto_index = conntrack_list.index(i)
+            if not src_exists or not dst_exists or not proto_exists:
+                return (False, None)
 
-        assert src_exists == True
-        assert dst_exists == True
-        assert proto_exists == True
+            proto_index = conntrack_list.index("udp")
 
-        if conntrack_list[proto_index + 7] < 432000 and conntrack_list[proto_index + 7] > 431900:
-            assert False
+            # FIXME: conntrack_list[proto_index + 7] is consistently returning 431995. Need the feature owner
+            # to confirm if this check is wrong or if the behavior is wrong.
+            if int(conntrack_list[proto_index + 7]) < 432000 and int(conntrack_list[proto_index + 7]) > 431900:
+                return (False, None)
+
+        wait_for_result(_check_conntrack_for_static_entry, DVSDatabase.DEFAULT_POLLING_CONFIG)
 
         # delete a static nat entry
         dvs.runcmd("config nat remove static basic 67.66.65.1 18.18.18.2")
-
 
 
 # Add Dummy always-pass test at end as workaroud

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -283,7 +283,7 @@ class TestNat(object):
         # clear interfaces
         self.clear_interfaces(dvs)
 
-    @pytest.mark.skip("See FIXME comment")
+    @pytest.mark.skip("Issue #1409")
     def test_VerifyConntrackTimeoutForNatEntry(self, dvs, testlog):
         # get neighbor and arp entry
         dvs.servers[0].runcmd("ping -c 1 18.18.18.2")

--- a/tests/test_port_dpb.py
+++ b/tests/test_port_dpb.py
@@ -40,9 +40,6 @@ class TestPortDPB(object):
     Empty --> Not Tested
     '''
 
-    '''
-    @pytest.mark.skip()
-    '''
     def test_port_breakout_one(self, dvs):
         dpb = DPB()
         dpb.breakout(dvs, "Ethernet0", maxBreakOut)
@@ -70,10 +67,6 @@ class TestPortDPB(object):
         dpb.change_speed_and_verify(dvs, ["Ethernet0"], speed40G)
         #print "**** 1X100G --> 1X40G passed ****"
 
-    '''
-    @pytest.mark.skip()
-    '''
-    @pytest.mark.xfail(reason="test stability issue: Azure/sonic-swss#1222")
     def test_port_breakout_multiple(self, dvs):
         dpb = DPB()
         port_names = ["Ethernet0", "Ethernet12", "Ethernet64", "Ethernet112"]
@@ -84,7 +77,7 @@ class TestPortDPB(object):
         dpb.breakin(dvs, ["Ethernet64", "Ethernet65", "Ethernet66", "Ethernet67"])
         dpb.breakin(dvs, ["Ethernet112", "Ethernet113", "Ethernet114", "Ethernet115"])
 
-    @pytest.mark.skip()
+    @pytest.mark.skip("breakout_all takes too long to execute")
     def test_port_breakout_all(self, dvs):
         dpb = DPB()
         port_names = []


### PR DESCRIPTION
- Re-enable test_port_dpb
- Add polling to NAT

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I re-enabled the DPB test because it is now passing consistently and I added a skip to the NAT test because it is broken.

**Why I did it**
To un-block two tests that have been removed from the test suite for an extended period of time.

**How I verified it**
Ran both locally x10.

**Details if related**
Fixes #1222 
