### PR TITLE
[dvs/chassis] Bring up SONiC interfaces in virtual chassis

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1266,13 +1266,13 @@ class DockerVirtualChassisTopology(object):
 
     def create_vct_ctn(self, ctndir):
         cwd = os.getcwd()
-        cfgdir = cwd + "/virtual_chassis/" + ctndir
-        cfgfile =  cfgdir + "/default_config.json"
-        with open(cfgfile, "r") as cfg:
+        chassis_config_dir = cwd + "/virtual_chassis/" + ctndir
+        chassis_config_file =  chassis_config_dir + "/default_config.json"
+        with open(chassis_config_file, "r") as cfg:
             defcfg = json.load(cfg)["DEVICE_METADATA"]["localhost"]
             ctnname = defcfg["hostname"] + "." + self.ns
             vol = {}
-            vol[cfgdir] = {"bind": "/usr/share/sonic/virtual_chassis", "mode": "ro"}
+            vol[chassis_config_dir] = {"bind": "/usr/share/sonic/virtual_chassis", "mode": "ro"}
 
             # pass self.ns into the vs to be use for vs restarts by swss conftest.
             # connection to chassbr is setup by chassis_connect.py within the vs
@@ -1300,57 +1300,69 @@ class DockerVirtualChassisTopology(object):
         return {}
 
     def get_topo_neigh(self):
-        cwd = os.getcwd()
-        neighs_by_ctn = {}
+        instance_to_neighbor_map = {}
         if "neighbor_connections" not in self.virt_topo:
-            return neighs_by_ctn
-        for nck, ncv in self.virt_topo["neighbor_connections"].items():
-            ctndir = nck.split("-")[0]
-            nbrctndir = nck.split("-")[1]
-            nbrvethintf = int(ncv[nbrctndir].split("eth")[1])
-            nbrintf = "ethernet%d|" % ((nbrvethintf - 1) * 4)
-            vethintf = int(ncv[ctndir].split("eth")[1])
-            cfgdir = cwd + "/virtual_chassis/" + ctndir
-            cfgfile = cfgdir + "/default_config.json"
-            ctnname = ""
-            with open(cfgfile, "r") as cfg:
-                defcfg = json.load(cfg)["DEVICE_METADATA"]["localhost"]
-                ctnname = defcfg["hostname"] + "." + self.ns
-            cfgfile = cwd + "/virtual_chassis/" + nbrctndir + "/default_config.json"
-            with open(cfgfile, "r") as cfg:
-                intfCfg = json.load(cfg)["INTERFACE"]
-                for key in intfCfg:
-                    nbraddr = ""
-                    if key.lower().startswith(nbrintf):
-                        intfaddr = re.split("/|\\|", key)
-                        if len(intfaddr) > 1:
-                            nbraddr = intfaddr[1]
-                        if nbraddr == "":
+            return instance_to_neighbor_map
+
+        working_dir = os.getcwd()
+        for conn, endpoints in self.virt_topo["neighbor_connections"].items():
+            chassis_instance = conn.split('-')[0]
+            neighbor_instance = conn.split('-')[1]
+
+            chassis_config_dir = os.path.join(working_dir, "virtual_chassis", chassis_instance)
+            chassis_config_file = os.path.join(chassis_config_dir, "default_config.json")
+            instance_container_name = ""
+            with open(chassis_config_file, "r") as cfg:
+                device_info = json.load(cfg)["DEVICE_METADATA"]["localhost"]
+                instance_container_name = device_info["hostname"] + "." + self.ns
+
+            chassis_veth_intf = int(endpoints[chassis_instance].split("eth")[1])
+            chassis_host_intf = f"Ethernet{(chassis_veth_intf - 1) * 4}"
+
+            chassis_config_file = os.path.join(working_dir, "virtual_chassis", neighbor_instance, "default_config.json")
+            with open(chassis_config_file, "r") as cfg:
+                intf_config = json.load(cfg)["INTERFACE"]
+                for key in intf_config:
+                    neighbor_address = ""
+                    if key.lower().startswith(f"{chassis_host_intf}|".lower()):
+                        host_intf_address = re.split("/|\\|", key)
+
+                        if len(host_intf_address) > 1:
+                            neighbor_address = host_intf_address[1]
+
+                        if neighbor_address == "":
                             continue
-                        if ctnname not in neighs_by_ctn:
-                            neighs_by_ctn[ctnname] = []
-                        neighs_by_ctn[ctnname].append((vethintf - 1, nbraddr))
-        return neighs_by_ctn
+
+                        if instance_container_name not in instance_to_neighbor_map:
+                            instance_to_neighbor_map[instance_container_name] = []
+
+                        instance_to_neighbor_map[instance_container_name].append((chassis_veth_intf - 1,
+                                                                                  neighbor_address,
+                                                                                  chassis_host_intf))
+
+        return instance_to_neighbor_map
 
     def handle_neighconn(self):
         if self.oper != "create":
             return
-        neighs_by_ctn = self.get_topo_neigh()
-        for ctnname, nbraddrs in neighs_by_ctn.items():
+
+        instance_to_neighbor_map = self.get_topo_neigh()
+        for ctnname, nbraddrs in instance_to_neighbor_map.items():
             if ctnname not in self.dvss:
                 continue
-            for idx, nbraddr in nbraddrs:
-                self.dvss[ctnname].servers[idx].runcmd("ifconfig eth0 down ")
-                self.dvss[ctnname].servers[idx].runcmd("ifconfig eth0 up")
-                self.dvss[ctnname].servers[idx].runcmd("ifconfig eth0 " + nbraddr)
-        return
+
+            for server, neighbor_address, host_intf in nbraddrs:
+                self.dvss[ctnname].servers[server].runcmd("ifconfig eth0 down")
+                self.dvss[ctnname].servers[server].runcmd("ifconfig eth0 up")
+                self.dvss[ctnname].servers[server].runcmd(f"ifconfig eth0 {neighbor_address}")
+                self.dvss[ctnname].runcmd(f"config interface startup {host_intf}")
 
     def verify_conns(self):
         passed = True
         if "neighbor_connections" not in self.virt_topo:
             return passed
-        neighs_by_ctn = self.get_topo_neigh()
-        for ctnname, nbraddrs in neighs_by_ctn.items():
+        instance_to_neighbor_map = self.get_topo_neigh()
+        for ctnname, nbraddrs in instance_to_neighbor_map.items():
             for item in nbraddrs:
                 nbraddr = item[1]
                 print("verify neighbor connectivity from %s to %s nbrAddr " % (


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did/why I did it**
While testing https://github.com/Azure/sonic-buildimage/pull/5192 we figured out that the port config that is generated from `port_config.ini` does not include any information about the admin status of the ports on the virtual switch.

However, with this PR, ports are set to `DOWN` by default in the DVS. This causes the connectivity checks in `test_virtual_chassis.py` to fail indefinitely.

This PR ensures that the necessary ports in the chassis are admin UP so that pings can be sent from the LC instances to the neighboring servers.

I kept mixing up which interface was which while working on this PR, so I also refactored some of the variable names to be more descriptive.

**How I verified it**
Ran the chassis tests against the current master `docker-sonic-vs` as well as the one from https://github.com/Azure/sonic-buildimage/pull/5192. Both are successful on all chassis topologies.

**Details if related**
