### PR TITLE
[vnet] Maintain the reference count of the nexthop when creating a vn…

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -163,6 +163,47 @@ bool VNetVrfObject::addRoute(IpPrefix& ipPrefix, tunnelEndpoint& endp)
     return true;
 }
 
+void VNetVrfObject::increaseNextHopRefCount(const nextHop& nh)
+{
+    /* Return when there is no next hop (dropped) */
+    if (nh.ips.getSize() == 0)
+    {
+        return;
+    }
+    else if (nh.ips.getSize() == 1)
+    {
+        NextHopKey nexthop(nh.ips.to_string(), nh.ifname);
+        if (nexthop.ip_address.isZero())
+            gIntfsOrch->increaseRouterIntfsRefCount(nexthop.alias);
+        else
+            gNeighOrch->increaseNextHopRefCount(nexthop);
+    }
+    else
+    {
+        /* FIXME - Handle ECMP routes */
+    }
+}
+void VNetVrfObject::decreaseNextHopRefCount(const nextHop& nh)
+{
+    /* Return when there is no next hop (dropped) */
+    if (nh.ips.getSize() == 0)
+    {
+        return;
+    }
+    else if (nh.ips.getSize() == 1)
+    {
+        NextHopKey nexthop(nh.ips.to_string(), nh.ifname);
+        if (nexthop.ip_address.isZero())
+            gIntfsOrch->decreaseRouterIntfsRefCount(nexthop.alias);
+        else
+            gNeighOrch->decreaseNextHopRefCount(nexthop);
+    }
+    else
+    {
+        /* FIXME - Handle ECMP routes */
+    }
+}
+
 bool VNetVrfObject::addRoute(IpPrefix& ipPrefix, nextHop& nh)
 {
     if (hasRoute(ipPrefix))
@@ -171,6 +212,7 @@ bool VNetVrfObject::addRoute(IpPrefix& ipPrefix, nextHop& nh)
         return false;
     }
 
+    increaseNextHopRefCount(nh);
     routes_[ipPrefix] = nh;
     return true;
 }
@@ -194,6 +236,8 @@ bool VNetVrfObject::removeRoute(IpPrefix& ipPrefix)
     }
     else
     {
+        nextHop nh = routes_[ipPrefix];
+        decreaseNextHopRefCount(nh);
         routes_.erase(ipPrefix);
     }
     return true;

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -180,7 +180,7 @@ void VNetVrfObject::increaseNextHopRefCount(const nextHop& nh)
     }
     else
     {
-        /* FIXME - Handle ECMP routes */
+        /* Handle ECMP routes */
     }
 }
 void VNetVrfObject::decreaseNextHopRefCount(const nextHop& nh)
@@ -200,7 +200,7 @@ void VNetVrfObject::decreaseNextHopRefCount(const nextHop& nh)
     }
     else
     {
-        /* FIXME - Handle ECMP routes */
+        /* Handle ECMP routes */
     }
 }
 

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -174,9 +174,13 @@ void VNetVrfObject::increaseNextHopRefCount(const nextHop& nh)
     {
         NextHopKey nexthop(nh.ips.to_string(), nh.ifname);
         if (nexthop.ip_address.isZero())
+        {
             gIntfsOrch->increaseRouterIntfsRefCount(nexthop.alias);
+        }
         else
+        {
             gNeighOrch->increaseNextHopRefCount(nexthop);
+        }
     }
     else
     {
@@ -194,9 +198,13 @@ void VNetVrfObject::decreaseNextHopRefCount(const nextHop& nh)
     {
         NextHopKey nexthop(nh.ips.to_string(), nh.ifname);
         if (nexthop.ip_address.isZero())
+        {
             gIntfsOrch->decreaseRouterIntfsRefCount(nexthop.alias);
+        }
         else
+        {
             gNeighOrch->decreaseNextHopRefCount(nexthop);
+        }
     }
     else
     {

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -174,6 +174,8 @@ public:
 
     sai_object_id_t getTunnelNextHop(tunnelEndpoint& endp);
     bool removeTunnelNextHop(tunnelEndpoint& endp);
+    void increaseNextHopRefCount(const nextHop&);
+    void decreaseNextHopRefCount(const nextHop&);
 
     ~VNetVrfObject();
 


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
 Maintain the reference count of the nexthop when creating  a vnet route


**Why I did it**
Due to sequence problems or other reasons, the vnet route in ASIC_DB has not been deleted, and if you directly delete the related nexthop or interface, syncd will report an error.

swss#orchagent: :- meta_generic_validation_remove: object 0x600000000099a reference count is 1, can't remove
swss#orchagent: :- removeRouterIntfs: Failed to remove router interface for port Ethernet0, rv:-5
swss#supervisord: orchagent terminate called after throwing an instance of 'std::runtime_error'
swss#supervisord: orchagent   what():  Failed to remove router interface.


**How I verified it**
Create a Vnet1
bind Ethernet0 to Vnet1
add ip for Ethernet0
add a route with the Ethernet0 as the next hop in Vnet1

delete ip and unbind Ethernet0
delete the route




