### PR TITLE
[orch] Fix the logic of judging malformed reference

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -284,7 +284,7 @@ bool Orch::parseReference(type_map &type_maps, string &ref_in, string &type_name
         SWSS_LOG_ERROR("invalid reference received:%s\n", ref_in.c_str());
         return false;
     }
-    if ((ref_in[0] != ref_start) && (ref_in[ref_in.size()-1] != ref_end))
+    if ((ref_in[0] != ref_start) || (ref_in[ref_in.size()-1] != ref_end))
     {
         SWSS_LOG_ERROR("malformed reference:%s. Must be surrounded by [ ]\n", ref_in.c_str());
         return false;


### PR DESCRIPTION
Signed-off-by: tengfei <tengfei@asterfusion.com>

**What I did**
Fix the logic of judging malformed reference. Change 'if ((ref_in[0] != ref_start) && (ref_in[ref_in.size()-1] != ref_end))' to 'if ((ref_in[0] != ref_start) || (ref_in[ref_in.size()-1] != ref_end))'
**Why I did it**
The reference must be surrounded by [ ], so the relationship of 'ref_in[0] != ref_start' and 'ref_in[ref_in.size()-1] != ref_end' should be 'OR'
**How I verified it**
I load a wrong format qos map configuration , such as:
    "PORT_QOS_MAP": {
        "Ethernet0": {
            "dscp_to_tc_map": "[DSCP_TO_TC_MAP:default", 
        }
And verify if orchagent can make error log
**Details if related**
