### PR TITLE
[dvs/NAT] Fix for test_VerifyConntrackTimeoutForNatEntry test case

### DIFF
--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -1,5 +1,4 @@
 import time
-import pytest
 
 from dvslib.dvs_common import wait_for_result
 from dvslib.dvs_database import DVSDatabase
@@ -309,6 +308,8 @@ class TestNat(object):
 
             if int(conntrack_list[proto_index + 7]) > 432000 or int(conntrack_list[proto_index + 7]) < 431900:
                 return (False, None)
+
+            return (True, None)
 
         wait_for_result(_check_conntrack_for_static_entry, DVSDatabase.DEFAULT_POLLING_CONFIG)
 

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -283,7 +283,6 @@ class TestNat(object):
         # clear interfaces
         self.clear_interfaces(dvs)
 
-    @pytest.mark.skip("Issue #1409")
     def test_VerifyConntrackTimeoutForNatEntry(self, dvs, testlog):
         # get neighbor and arp entry
         dvs.servers[0].runcmd("ping -c 1 18.18.18.2")
@@ -308,9 +307,7 @@ class TestNat(object):
 
             proto_index = conntrack_list.index("udp")
 
-            # FIXME: conntrack_list[proto_index + 7] is consistently returning 431995. Need the feature owner
-            # to confirm if this check is wrong or if the behavior is wrong.
-            if int(conntrack_list[proto_index + 7]) < 432000 and int(conntrack_list[proto_index + 7]) > 431900:
+            if int(conntrack_list[proto_index + 7]) > 432000 or int(conntrack_list[proto_index + 7]) < 431900:
                 return (False, None)
 
         wait_for_result(_check_conntrack_for_static_entry, DVSDatabase.DEFAULT_POLLING_CONFIG)


### PR DESCRIPTION
This PR is to address the issue https://github.com/Azure/sonic-swss/issues/1409.

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>