### PR TITLE
[Portmgrd]: Remove deleted port from portList

### DIFF
--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -155,6 +155,7 @@ void PortMgr::doTask(Consumer &consumer)
         {
             SWSS_LOG_NOTICE("Delete Port: %s", alias.c_str());
             m_appPortTable.del(alias);
+            m_portList.erase(alias);
         }
 
         it = consumer.m_toSync.erase(it);


### PR DESCRIPTION
Delete port alias from portList set in portmgr. So that when the por is re-created we can identify it as new configuration and set the default MTU.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove port from portList in portmgrd on deleting a port

**Why I did it**
If we did NOT, when we re-create the port, it wont be considered as new port, and some of the default initializations wont happend

**How I verified it**
As we were observing that MTU was NOT being set correctly on re-creating port, we fixed the issue and verified.
**Details if related**
```
admin@lnos:~$ show int status Ethernet0
  Interface        Lanes    Speed    MTU    Alias    Vlan    Oper    Admin    Type    Asym PFC



Ethernet0  65,66,67,68     100G   9100   Eth1/1   trunk    down       up     N/A         N/A
admin@lnos:~$ sudo config interface breakout Ethernet0 4x25G[10G] -f -l -v -y


Running Breakout Mode : 1x100G[40G]
Target Breakout Mode : 4x25G[10G]


Ports to be deleted :
 {
    "Ethernet0": "100000"
}
Ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}


After running Logic to limit the impact


Final list of ports to be deleted :
 {
    "Ethernet0": "100000"
}
Final list of ports to be added :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, CRM,
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'CRM']


Start Port Deletion
Find dependecies for port Ethernet0
Deleting Port: Ethernet0
Data Validation successful
Generate Final Config to write in DB


Start Port Addition
Generating default config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Merge Default Config for ['Ethernet2', 'Ethernet3', 'Ethernet0', 'Ethernet1']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
sudo redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_PORT:oid:0x1000000000012"
(empty list or set)
Writing in Config DB
Breakout process got successfully completed.
admin@lnos:~$ show int status Ethernet0
  Interface    Lanes    Speed    MTU    Alias    Vlan    Oper    Admin    Type    Asym PFC



Ethernet0       65      25G   9100   Eth1/1   trunk    down       up     N/A         N/A
admin@lnos:~$ sudo config interface breakout Ethernet0 1x100G[40G] -f -l -y


Running Breakout Mode : 4x25G[10G]
Target Breakout Mode : 1x100G[40G]


Ports to be deleted :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Ports to be added :
 {
    "Ethernet0": "100000"
}


After running Logic to limit the impact


Final list of ports to be deleted :
 {
    "Ethernet2": "25000",
    "Ethernet3": "25000",
    "Ethernet0": "25000",
    "Ethernet1": "25000"
}
Final list of ports to be added :
 {
    "Ethernet0": "100000"
}
Loaded below Yang Models
['sonic-acl', 'sonic-breakout_cfg', 'sonic-device_metadata', 'sonic-device_neighbor', 'sonic-extension', 'sonic-flex_counter', 'sonic-interface', 'sonic-loopback-interface', 'sonic-port', 'sonic-portchannel', 'sonic-types', 'sonic-versions', 'sonic-vlan']
Reading data from Redis configDb
Note: Below table(s) have no YANG models:
CONTAINER_FEATURE, FEATURE, CRM,
Below Table(s) can not be verified using YANG models:
[u'CONTAINER_FEATURE', u'FEATURE', u'CRM']


Start Port Deletion
Find dependecies for port Ethernet2
Find dependecies for port Ethernet3
Find dependecies for port Ethernet0
Find dependecies for port Ethernet1
Deleting Port: Ethernet2
Deleting Port: Ethernet3
Deleting Port: Ethernet0
Deleting Port: Ethernet1
Data Validation successful
Generate Final Config to write in DB


Start Port Addition
Generating default config for ['Ethernet0']
Merge Default Config for ['Ethernet0']
Data Validation successful
Generate Final Config to write in DB
Writing in Config DB
Writing in Config DB
Verify Port Deletion from Asic DB, Wait...
Writing in Config DB
Breakout process got successfully completed.
admin@lnos:~$ show int status Ethernet0
  Interface        Lanes    Speed    MTU    Alias    Vlan    Oper    Admin    Type    Asym PFC



Ethernet0  65,66,67,68     100G   9100   Eth1/1   trunk    down       up     N/A         N/A
admin@lnos1:~$
```