### PR TITLE
[dvs] Mark DPB tests as xfail

### DIFF
--- a/tests/test_port_dpb.py
+++ b/tests/test_port_dpb.py
@@ -18,6 +18,7 @@ maxRootPorts = 32
 maxBreakOut = 4
 
 @pytest.mark.usefixtures('dpb_setup_fixture')
+@pytest.mark.xfail(reason="sonic cfggen bug: buildimage#5263")
 class TestPortDPB(object):
 
     '''

--- a/tests/test_port_dpb_acl.py
+++ b/tests/test_port_dpb_acl.py
@@ -9,6 +9,7 @@ maxAclTables = 16
 
 
 @pytest.mark.usefixtures('dpb_setup_fixture')
+@pytest.mark.xfail(reason="sonic cfggen bug: buildimage#5263")
 class TestPortDPBAcl(object):
     def test_acl_table_empty_port_list(self, dvs_acl):
         # Create ACL table "test" and bind it to Ethernet0

--- a/tests/test_port_dpb_vlan.py
+++ b/tests/test_port_dpb_vlan.py
@@ -5,6 +5,7 @@ from port_dpb import DPB
 
 @pytest.mark.usefixtures('dpb_setup_fixture')
 @pytest.mark.usefixtures('dvs_vlan_manager')
+@pytest.mark.xfail(reason="sonic cfggen bug: buildimage#5263")
 class TestPortDPBVlan(object):
     def check_syslog(self, dvs, marker, log, expected_cnt):
         (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \"%s\" | wc -l" % (marker, log)])


### PR DESCRIPTION
There is a known regression in the VS docker image that is impacting the DPB tests (buildimage#5263). While this is being fixed, we will xfail this set of tests so that 1) the PRs are not blocked and 2) so we can continue to run the tests and verify that the fix is complete.

Signed-off-by: Danny Allen <daall@microsoft.com>

**Details if related**
https://github.com/Azure/sonic-buildimage/issues/5263