### PR TITLE
[bitmap_vnet] Fix VNET route priority issue

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -335,11 +335,20 @@ void VNetBitmapObject::recycleBitmapId(const string& vnet)
     }
 }
 
-uint32_t VNetBitmapObject::getFreeTunnelRouteTableOffset()
+uint32_t VNetBitmapObject::getFreeTunnelRouteTableOffset(IpPrefix ipPfx)
 {
     SWSS_LOG_ENTER();
 
-    for (uint32_t i = 0; i < tunnelOffsets_.size(); i++)
+    uint32_t offsetStart = VNET_ROUTE_FULL_MASK_OFFSET_MAX + 1;
+    uint32_t offsetEnd = tunnelOffsets_.size();
+
+    if (ipPfx.isFullMask())
+    {
+        offsetStart = 0;
+        offsetEnd = VNET_ROUTE_FULL_MASK_OFFSET_MAX;
+    }
+
+    for (uint32_t i = offsetStart; i < offsetEnd; i++)
     {
         if (tunnelOffsets_[i] == false)
         {
@@ -958,7 +967,7 @@ bool VNetBitmapObject::addTunnelRoute(IpPrefix& ipPrefix, tunnelEndpoint& endp)
     attr.value.s32 = SAI_TABLE_BITMAP_ROUTER_ENTRY_ACTION_TO_NEXTHOP;
     tr_attrs.push_back(attr);
 
-    tunnelRouteInfo.offset = getFreeTunnelRouteTableOffset();
+    tunnelRouteInfo.offset = getFreeTunnelRouteTableOffset(ipPrefix);
     attr.id = SAI_TABLE_BITMAP_ROUTER_ENTRY_ATTR_PRIORITY;
     attr.value.u32 = tunnelRouteInfo.offset;
     tr_attrs.push_back(attr);
@@ -1175,7 +1184,7 @@ bool VNetBitmapObject::addRoute(IpPrefix& ipPrefix, nextHop& nh)
         return true;
     }
 
-    routeInfo.offset = getFreeTunnelRouteTableOffset();
+    routeInfo.offset = getFreeTunnelRouteTableOffset(ipPrefix);
     attr.id = SAI_TABLE_BITMAP_ROUTER_ENTRY_ATTR_PRIORITY;
     attr.value.u32 = routeInfo.offset;
     attrs.push_back(attr);

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -15,6 +15,7 @@
 
 #define VNET_BITMAP_SIZE 32
 #define VNET_TUNNEL_SIZE 40960
+#define VNET_ROUTE_FULL_MASK_OFFSET_MAX 3000
 #define VNET_NEIGHBOR_MAX 0xffff
 #define VXLAN_ENCAP_TTL 128
 #define VNET_BITMAP_RIF_MTU 9100
@@ -266,7 +267,7 @@ private:
     static uint32_t getBitmapId(const string& name);
     static void recycleBitmapId(const string& name);
     
-    static uint32_t getFreeTunnelRouteTableOffset();
+    static uint32_t getFreeTunnelRouteTableOffset(IpPrefix ipPfx);
     static void recycleTunnelRouteTableOffset(uint32_t offset);
 
     static uint16_t getFreeTunnelId();


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Provided logic to create "full mask" routes with highest priority.

**Why I did it**
To fix VNET route priority issue in order to support flow when some IPs from the subnet are defined by another route (nexthop tunnel) .

**How I verified it**
* Create VxLAN tunnel
* Create VNET
* Create VNET interface (```192.168.1.1/24```)
* Create neighbor for VNET interface (```192.168.1.2```)
* Create VNET tunnel route for the host from the local subnet (```192.168.1.10/32 via tunnel```)
* Send TCP packet to the switch with destination IP equal to ```192.168.1.2```
* Verify packet was routed correctly and received on the neighbor host
* Send TCP packet to the switch with destination IP equal to ```192.168.1.10```
* Verify that encapsulated packet was received on the tunnel host (instead of neighbor host)

**Details if related**
N/A