### PR TITLE
[dtel] Initialize uninitialized member in DTelQueueReportEntry

### DIFF
--- a/orchagent/dtelorch.h
+++ b/orchagent/dtelorch.h
@@ -80,7 +80,8 @@ struct DTelQueueReportEntry
 
     DTelQueueReportEntry() :
         queueReportOid(0),
-        q_ind(0)
+        q_ind(0),
+        queueOid(0)
     {
     }
 };


### PR DESCRIPTION
Initialize uninitialized member in DTelQueueReportEntry, which
cause compilation error when build with compilation flag
-Werror=maybe-uninitialized.

Signed-off-by: Icarus Chau <icarus.chau@broadcom.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**
 
**How I verified it**

**Details if related**
