### PR TITLE
[vnet] Add ref_count of router interfaces for vnet

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -115,6 +115,7 @@ bool VNetVrfObject::createObj(vector<sai_attribute_t>& attrs)
         }
     }
 
+    ref_count = 0;
     SWSS_LOG_INFO("VNET '%s' router object created ", vnet_name_.c_str());
     return true;
 }
@@ -1348,6 +1349,18 @@ bool VNetOrch::setIntf(const string& alias, const string name, const IpPrefix *p
         auto *vnet_obj = getTypePtr<VNetVrfObject>(name);
         sai_object_id_t vrf_id = vnet_obj->getVRidIngress();
 
+        if (!prefix )
+        {
+            if (gIntfsOrch->setIntf(alias, vrf_id, prefix, adminUp, mtu))
+            {
+                vnet_obj->increaseVnetRefCount();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
         return gIntfsOrch->setIntf(alias, vrf_id, prefix, adminUp, mtu);
     }
     else
@@ -1374,6 +1387,18 @@ bool VNetOrch::delIntf(const string& alias, const string name, const IpPrefix *p
         auto *vnet_obj = getTypePtr<VNetVrfObject>(name);
         sai_object_id_t vrf_id = vnet_obj->getVRidIngress();
 
+        if (!prefix )
+        {
+            if (gIntfsOrch->removeIntf(alias, vrf_id, prefix))
+            {
+                vnet_obj->decreaseVnetRefCount();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
         return gIntfsOrch->removeIntf(alias, vrf_id, prefix);
     }
     else
@@ -1534,6 +1559,12 @@ bool VNetOrch::delOperation(const Request& request)
             if (vrf_obj->getRouteCount())
             {
                 SWSS_LOG_ERROR("VNET '%s': Routes are still present", vnet_name.c_str());
+                return false;
+            }
+
+            if (vrf_obj->getRefCount())
+            {
+                SWSS_LOG_ERROR("VNET '%s': Interfaces are still present", vnet_name.c_str());
                 return false;
             }
 

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -177,6 +177,20 @@ public:
     void increaseNextHopRefCount(const nextHop&);
     void decreaseNextHopRefCount(const nextHop&);
 
+    void increaseVnetRefCount()
+    {
+        ref_count++;
+    }
+    void decreaseVnetRefCount()
+    {
+        if(ref_count > 0)
+            ref_count--;
+    }
+    int getRefCount()
+    {
+        return ref_count;
+    }
+
     ~VNetVrfObject();
 
 private:
@@ -185,6 +199,7 @@ private:
 
     TunnelRoutes tunnels_;
     RouteMap routes_;
+    int ref_count;
 };
 
 struct VnetBridgeInfo


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add ref_count of router interfaces for vnet.

**Why I did it**
Due to sequence problems or other reasons, deleting a vnet earlier than deleting the interface bound to this vnet will cause an error.

Aug 26 15:00:35.521764 leaf-237 ERR swss#orchagent: :- meta_generic_validation_remove: object 0x3000000000938 reference count is 1, can't remove
Aug 26 15:00:35.522349 leaf-237 ERR swss#orchagent: :- ~VNetVrfObject: Failed to remove virtual router name: Vnet1, rv:-5

**How I verified it**
add Vnet1
bind Ethernet1 to Vnet1
remove Vnet1
remove Ethernet1
