### PR TITLE
Sflow fixes during DEL processing

### DIFF
--- a/cfgmgr/sflowmgr.cpp
+++ b/cfgmgr/sflowmgr.cpp
@@ -328,7 +328,10 @@ void SflowMgr::doTask(Consumer &consumer)
                     }
                     sflowCheckAndFillValues(key,values);
                     m_sflowPortConfMap[key].local_conf = true;
-                    m_appSflowSessionTable.set(key, values);
+                    if (m_gEnable)
+                    {
+                        m_appSflowSessionTable.set(key, values);
+                    }
                 }
             }
         }
@@ -340,6 +343,7 @@ void SflowMgr::doTask(Consumer &consumer)
                 {
                     sflowHandleService(false);
                     sflowHandleSessionAll(false);
+                    sflowHandleSessionLocal(false);
                 }
                 m_gEnable = false;
                 m_appSflowTable.del(key);
@@ -350,7 +354,10 @@ void SflowMgr::doTask(Consumer &consumer)
                 {
                     if (!m_intfAllConf)
                     {
-                        sflowHandleSessionAll(true);
+                        if (m_gEnable)
+                        {
+                            sflowHandleSessionAll(true);
+                        }
                     }
                     m_intfAllConf = true;
                 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed SFLOW handling in the DEL path. Below issues reported
https://github.com/Azure/sonic-swss/pull/1012#discussion_r479609637

https://github.com/Azure/sonic-swss/pull/1012#discussion_r479610706

**Why I did it**
Fixed the DEL sequence in the handling of sflow global and sflow interface all commands

**How I verified it**
1) Perform config sflow interface level command
   Execute redis-cli -n 4 del "SFLOW|global"
   The above command should remove the local level entry along with global entries. (Earlier local interface level entries are not removed)
2) sudo config sflow interface disable all
    redis-cli -n 4 del "SFLOW|global"
    redis-cli -n 4 del "SFLOW_SESSION|all"
    redis-cli -n 0 keys *SFLOW*
(empty array)
 (Earlier the above command was listing all the entries)

**Details if related**
