### PR TITLE
new BGP Monitor Daemon to pull BGP peer state and store in State DB for MIB consumption

### DIFF
--- a/debian/swss.install
+++ b/debian/swss.install
@@ -1,3 +1,4 @@
 swssconfig/sample/netbouncer.json etc/swss/config.d
 neighsyncd/restore_neighbors.py usr/bin
 fpmsyncd/bgp_eoiu_marker.py  usr/bin
+fpmsyncd/bgpmon.py  usr/bin

--- a/fpmsyncd/bgpmon.py
+++ b/fpmsyncd/bgpmon.py
@@ -29,7 +29,6 @@ import os
 import syslog
 import swsssdk
 import time
-import traceback
 
 PIPE_BATCH_MAX_COUNT = 50
 

--- a/fpmsyncd/bgpmon.py
+++ b/fpmsyncd/bgpmon.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python
+
+""""
+Description: bgpmon.py -- populating bgp related information in stateDB.
+    script is started by supervisord in bgp docker when the docker is started.
+
+    Initial creation of this daemon is to assist SNMP agent in obtaining the 
+    BGP related information for its MIB support. The MIB that this daemon is
+    assiting is for the CiscoBgp4MIB (Neighbor state only). If there are other
+    BGP related items that needs to be updated in a periodic manner in the 
+    future, then more can be added into this process.
+
+    The script check if there are any bgp activities by monitoring the bgp
+    frr.log file timestamp.  If activity is detected, then it will request bgp
+    neighbor state via vtysh cli interface. This bgp activity monitoring is 
+    done periodically (every 15 second). When triggered, it looks specifically
+    for the neighbor state in the json output of show ip bgp neighbors json
+    and update the state DB for each neighbor accordingly.
+    In order to not disturb and hold on to the State DB access too long and
+    removal of the stale neighbors (neighbors that was there previously on 
+    previous get request but no longer there in the current get request), a
+    "previous" neighbor dictionary will be kept and used to determine if there
+    is a need to perform update or the peer is stale to be removed from the
+    state DB
+"""
+
+import commands
+import copy
+import errno
+import json
+import os
+import sys
+import syslog
+import swsssdk
+import time
+import traceback
+from swsscommon import swsscommon
+from time import gmtime, strftime
+
+class BgpStateGet():
+    def __init__(self):
+        self.ipv4_n = []
+        self.ipv4_n_state = {}
+        self.ipv6_n = []
+        self.ipv6_n_state = {}
+        self.new_ipv4_n = []
+        self.new_ipv4_n_state = {}
+        self.new_ipv6_n = []
+        self.new_ipv6_n_state = {}
+        self.retrieve_fail_cnt = 0
+        self.cached_timestamp = 0
+        self.db = swsssdk.SonicV2Connector(host='127.0.0.1')
+        self.db.connect(self.db.STATE_DB, False)
+        self.db.delete_all_by_pattern(self.db.STATE_DB, "NEIGH_STATE_TABLE|*" )
+
+    # A quick way to check if there are anything happening within BGP is to
+    # check its log file has any activities. This is by checking its modified
+    # timestamp against the cached timestamp that we keep and if there is a
+    # difference, there is activity detected. In case the log file got wiped
+    # out, it will default back to constant pulling every 15 seconds
+    def bgp_activity_detected(self):
+        try:
+            timestamp = os.stat("/var/log/frr/frr.log").st_mtime
+            if timestamp != self.cached_timestamp:
+                #syslog.syslog("bgpmon timestamp diff detected: {}".format(timestamp))
+                self.cached_timestamp = timestamp
+                return True
+            else:
+                return False
+        except Exception, e:
+            return True
+
+    # Get a new snapshot of BGP neighbors and store them in the "new" location
+    def get_all_neigh_states(self):
+        # Clean up the "new" dictionaries
+        del self.new_ipv4_n[:]
+        self.new_ipv4_n_state.clear()
+        del self.new_ipv6_n[:]
+        self.new_ipv6_n_state.clear()
+        try:
+            cmd = "vtysh -c 'show bgp summary json'"
+            output = commands.getoutput(cmd)
+            peer_info = json.loads(output)
+            if "ipv4Unicast" in peer_info and "peers" in peer_info["ipv4Unicast"]:
+                self.new_ipv4_n = peer_info["ipv4Unicast"]["peers"].keys()
+                for i in range (0, len(self.new_ipv4_n)):
+                    self.new_ipv4_n_state[self.new_ipv4_n[i]] =
+                    peer_info["ipv4Unicast"]["peers"][self.new_ipv4_n[i]]["state"]
+
+            if "ipv6Unicast" in peer_info and "peers" in peer_info["ipv6Unicast"]:
+                self.new_ipv6_n = peer_info["ipv6Unicast"]["peers"].keys()
+                for i in range (0, len(self.new_ipv6_n)):
+                    self.new_ipv6_n_state[self.new_ipv6_n[i]] =
+                    peer_info["ipv6Unicast"]["peers"][self.new_ipv6_n[i]]["state"]
+
+        except Exception:
+            self.retrieve_fail_cnt += 1
+            syslog.syslog(syslog.LOG_ERR, "*ERROR* get_all_neigh_states Exception: %s"
+                    % (traceback.format_exc()))
+
+    def update_neigh_states(self):
+        # handle IPV4 case
+        for i in range (0, len(self.new_ipv4_n)):
+            neighb = self.new_ipv4_n[i]
+            key = "NEIGH_STATE_TABLE|%s" % neighb
+            if neighb in self.ipv4_n:
+                # only update the entry if sate changed
+                if self.ipv4_n_state[neighb] != self.new_ipv4_n_state[neighb]:
+                    # state changed. Update state DB for this entry
+                    state = self.new_ipv4_n_state[neighb]
+                    self.db.set(self.db.STATE_DB, key, 'state', state)
+                    self.ipv4_n_state[neighb] = state
+                # remove this neighbor from old list since it is accounted for
+                self.ipv4_n.remove(neighb)
+            else:
+                # New neighbor found case. Add to dictionary and state DB
+                state = self.new_ipv4_n_state[neighb]
+                self.db.set(self.db.STATE_DB, key, 'state', state)
+                self.ipv4_n_state[neighb] = state
+        # Check for stale state entries to be cleaned up
+        while len(self.ipv4_n) > 0:
+            # remove this from the stateDB and the current nighbor state entry
+            neighb = self.ipv4_n.pop(0)
+            del_key = "NEIGH_STATE_TABLE|%s" % neighb
+            self.db.delete(self.db.STATE_DB, del_key)
+            del self.ipv4_n_state[neighb]
+        # Save the new List
+        self.ipv4_n = self.new_ipv4_n[:]
+
+        # handle IPV6 case
+        for i in range (0, len(self.new_ipv6_n)):
+            neighb = self.new_ipv6_n[i]
+            key = "NEIGH_STATE_TABLE|%s" % neighb
+            if neighb in self.ipv6_n:
+                # only update the entry if sate changed
+                if self.ipv6_n_state[neighb] != self.new_ipv6_n_state[neighb]:
+                    # state changed. Update state DB for this entry
+                    state = self.new_ipv6_n_state[neighb]
+                    self.db.set(self.db.STATE_DB, key, 'state', state)
+                    self.ipv6_n_state[neighb] = state
+                # remove this neighbor from old list since it is accounted for
+                self.ipv6_n.remove(neighb)
+            else:
+                # New neighbor found case. Add to dictionary and state DB
+                state = self.new_ipv6_n_state[neighb]
+                self.db.set(self.db.STATE_DB, key, 'state', state)
+                self.ipv6_n_state[neighb] = state
+        # Check for stale state entries to be cleaned up
+        while len(self.ipv6_n) > 0:
+            # remove this from the stateDB and the current nighbor state entry
+            neighb = self.ipv6_n.pop(0)
+            del_key = "NEIGH_STATE_TABLE|%s" % neighb
+            self.db.delete(self.db.STATE_DB, del_key)
+            del self.ipv6_n_state[neighb]
+        # Save the new List
+        self.ipv6_n = self.new_ipv6_n[:]
+
+def main():
+
+    print "bgpmon service started"
+
+    try:
+        bgp_state_get = BgpStateGet()
+    except Exception, e:
+        syslog.syslog(syslog.LOG_ERR, "{}: error exit 1, reason {}".format(THIS_MODULE, str(e)))
+        exit(1)
+
+    # periodically obtain the new neighbor infomraton and update if necessary
+    while True:
+        time.sleep(15)
+        if bgp_state_get.bgp_activity_detected():
+            bgp_state_get.get_all_neigh_states()
+            bgp_state_get.update_neigh_states()
+
+if __name__ == '__main__':
+    main()

--- a/fpmsyncd/bgpmon.py
+++ b/fpmsyncd/bgpmon.py
@@ -84,13 +84,13 @@ class BgpStateGet():
             if "ipv4Unicast" in peer_info and "peers" in peer_info["ipv4Unicast"]:
                 self.new_ipv4_n = peer_info["ipv4Unicast"]["peers"].keys()
                 for i in range (0, len(self.new_ipv4_n)):
-                    self.new_ipv4_n_state[self.new_ipv4_n[i]] =
+                    self.new_ipv4_n_state[self.new_ipv4_n[i]] = \
                     peer_info["ipv4Unicast"]["peers"][self.new_ipv4_n[i]]["state"]
 
             if "ipv6Unicast" in peer_info and "peers" in peer_info["ipv6Unicast"]:
                 self.new_ipv6_n = peer_info["ipv6Unicast"]["peers"].keys()
                 for i in range (0, len(self.new_ipv6_n)):
-                    self.new_ipv6_n_state[self.new_ipv6_n[i]] =
+                    self.new_ipv6_n_state[self.new_ipv6_n[i]] = \
                     peer_info["ipv6Unicast"]["peers"][self.new_ipv6_n[i]]["state"]
 
         except Exception:

--- a/fpmsyncd/bgpmon.py
+++ b/fpmsyncd/bgpmon.py
@@ -25,17 +25,12 @@ Description: bgpmon.py -- populating bgp related information in stateDB.
 """
 
 import commands
-import copy
-import errno
 import json
 import os
-import sys
 import syslog
 import swsssdk
 import time
 import traceback
-from swsscommon import swsscommon
-from time import gmtime, strftime
 
 class BgpStateGet():
     def __init__(self):


### PR DESCRIPTION
Added bgpmon (BGP Monitor Daemon) support to assist gathering BGP related information periodically based on BGP activity detection to store those information into State DB.  For components such as SNMP agent that uses this new BGP related DB in  state DB to support the MIB operation.
This PR has the implementation of the bgpmon processing code. There is another PR (https://github.com/Azure/sonic-buildimage/pull/5329) needed in the dockers/docker-fpm-frr to start up this bgpmon inside of the BGP docker.
Both of these PRs are needed to achieve the full functionality of bgpmon running inside of BGP docker.

The HLD doc PR can be found here:
- [Azure-SONiC] (https://github.com/Azure/SONiC/pull/667)

The following PR (SNMP Agent Changes to use State DB for BGP MIB )has a dependency on this PR:
- [Azure-sonic-snmpagent] (https://github.com/Azure/sonic-snmpagent/pull/158)

Signed-off-by: Gen-Hwa Chiang <gechiang@microsoft.com>

**- What I did**

Added a new daemon to be run under BGP docker periodically to gather the BGP peer state information and update them in 
the state DB.  In order not to continuously running even when there are no BGP peer activities, this new daemon will use the BGP frr.log file timestamp as an indicator whether there are any activities in BGP that warrants it to inspect the peer state info for possible updates.

**- How I did it**

- Start a periodic timer to get triggered every 15 second.
- Check if there is a change in the timestamp of the frr.log file against a cached timestamp from the previous update.
- Request the back-end handler (FRR/Zebra) to dump out the "show bgp summary json"
- For each peer state that it just received, check it against the previous state that was cached and if there is a change or this is new peer, update/add the corresponding state DB table entry.  
- At the end of processing all the peer info, check if there are any stale peer entry present and delete the corresponding state DB entry accordingly.

**- How to verify it**
For IPV4 You can perform "show ip bgp summary" and use that output to check against the state DB for each peer.
The state DB key would be something like "NEIGH_STATE_TABLE|10.0.0.33"  where 10.0.0.33 is the peer ip address.
you can then read out the state information by issuing the redis cmd hgetall "NEIGH_STATE_TABLE|10.0.0.33". Compare that with the corresponding output of "show ip bgp summary".
Here is a sample output from the State DB:
admin@str-s6000-acs-8:~$ redis-cli -n 6
127.0.0.1:6379[6]> keys "NEIGH*"
 1) "NEIGH_STATE_TABLE|fc00::1a"
 2) "NEIGH_STATE_TABLE|fc00::32"
 3) "NEIGH_STATE_TABLE|10.0.0.33"
 4) "NEIGH_STATE_TABLE|fc00::66"
 5) "NEIGH_STATE_TABLE|fc00::62"
 6) "NEIGH_STATE_TABLE|fc00::46"
 7) "NEIGH_STATE_TABLE|10.0.0.35"
 8) "NEIGH_STATE_TABLE|10.0.0.53"
 9) "NEIGH_STATE_TABLE|10.0.0.47"
10) "NEIGH_STATE_TABLE|10.0.0.9"
11) "NEIGH_STATE_TABLE|fc00::6e"
12) "NEIGH_STATE_TABLE|10.0.0.41"
13) "NEIGH_STATE_TABLE|10.0.0.63"
14) "NEIGH_STATE_TABLE|10.0.0.17"
15) "NEIGH_STATE_TABLE|fc00::4a"
16) "NEIGH_STATE_TABLE|fc00::52"
17) "NEIGH_STATE_TABLE|fc00::5e"
18) "NEIGH_STATE_TABLE|10.0.0.29"
19) "NEIGH_STATE_TABLE|10.0.0.45"
20) "NEIGH_STATE_TABLE|fc00::2a"
21) "NEIGH_STATE_TABLE|fc00::42"
22) "NEIGH_STATE_TABLE|10.0.0.1"
23) "NEIGH_STATE_TABLE|10.0.0.59"
127.0.0.1:6379[6]> hgetall "NEIGH_STATE_TABLE|10.0.0.1"
1) "state"
2) "Established"
127.0.0.1:6379[6]>

you can do the same for ipv6 by performing "show ipv6 bgp summary" and follow the same steps  above to validate with the corresponding peer states stored in state DB.
