### PR TITLE
[acl] Remove Ethertype from L3V6 qualifiers

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1036,6 +1036,12 @@ bool AclRuleL3V6::validateAddMatch(string attr_name, string attr_value)
         return false;
     }
 
+    if (attr_name == MATCH_ETHER_TYPE)
+    {
+        SWSS_LOG_ERROR("Ethertype match is not supported for table type L3V6");
+        return false;
+    }
+
     return AclRule::validateAddMatch(attr_name, attr_value);
 }
 
@@ -1356,7 +1362,7 @@ bool AclTable::create()
         return status == SAI_STATUS_SUCCESS;
     }
 
-    if (type != ACL_TABLE_MIRRORV6)
+    if (type != ACL_TABLE_MIRRORV6 && type != ACL_TABLE_L3V6)
     {
         attr.id = SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE;
         attr.value.booldata = true;

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1146,12 +1146,6 @@ bool AclRuleMirror::validateAddMatch(string attr_name, string attr_value)
         return false;
     }
 
-    if (m_tableType == ACL_TABLE_MIRRORV6 && attr_name == MATCH_ETHER_TYPE)
-    {
-        SWSS_LOG_ERROR("ETHER_TYPE match is not supported for table of type MIRRORV6");
-        return false;
-    }
-
     return AclRule::validateAddMatch(attr_name, attr_value);
 }
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1146,6 +1146,12 @@ bool AclRuleMirror::validateAddMatch(string attr_name, string attr_value)
         return false;
     }
 
+    if (m_tableType == ACL_TABLE_MIRRORV6 && attr_name == MATCH_ETHER_TYPE)
+    {
+        SWSS_LOG_ERROR("ETHER_TYPE match is not supported for table of type MIRRORV6");
+        return false;
+    }
+
     return AclRule::validateAddMatch(attr_name, attr_value);
 }
 

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -388,7 +388,6 @@ namespace aclorch_test
             vector<swss::FieldValueTuple> fields;
 
             fields.push_back({ "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST", "2:SAI_ACL_BIND_POINT_TYPE_PORT,SAI_ACL_BIND_POINT_TYPE_LAG" });
-            fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE", "true" });
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE", "true" });
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL", "true" });
 
@@ -400,6 +399,7 @@ namespace aclorch_test
             switch (acl_table.type)
             {
                 case ACL_TABLE_L3:
+                    fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE", "true" });
                     fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_SRC_IP", "true" });
                     fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_DST_IP", "true" });
                     break;
@@ -898,7 +898,7 @@ namespace aclorch_test
     //
     // Using fixed ports = {"1,2"} for now.
     // The bind operations will be another separately test cases.
-    TEST_F(AclOrchTest, ACL_Creation_and_Destorying)
+    TEST_F(AclOrchTest, ACL_Creation_and_Destruction)
     {
         auto orch = createAclOrch();
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I removed ethertype from the qset for L3V6 tables.

**Why I did it**
This change was already done for MIRRORV6 tables a while back. ETHER_TYPE is unnecessary for V6 tables as the ethertype should always be the same (86DD) for IPv6 traffic. Additionally, this qualifier breaks IPv6 support on some platforms (e.g. Mellanox).

**How I verified it**
1. Update C++ unit tests
2. Test table behavior on BRCM and MLNX devices

**Details if related**
