### PR TITLE
[201911] Avoid adding loopback interface (ip link add) when setting nat zone on loopback interface

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -495,7 +495,12 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
 
         if (is_lo)
         {
-            addLoopbackIntf(alias);
+            if (m_loopbackIntfList.find(alias) == m_loopbackIntfList.end())
+            {
+                addLoopbackIntf(alias);
+                m_loopbackIntfList.insert(alias);
+                SWSS_LOG_INFO("Added %s loopback interface", alias.c_str());
+            }
         }
         else
         {
@@ -598,6 +603,7 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
         if (is_lo)
         {
             delLoopbackIntf(alias);
+            m_loopbackIntfList.erase(alias);
         }
 
         if (!subIntfAlias.empty())

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -22,6 +22,7 @@ private:
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateVrfTable, m_stateIntfTable;
 
     std::set<std::string> m_subIntfList;
+    std::set<std::string> m_loopbackIntfList;
 
     void setIntfIp(const std::string &alias, const std::string &opCmd, const IpPrefix &ipPrefix);
     void setIntfVrf(const std::string &alias, const std::string &vrfName);


### PR DESCRIPTION
This is a clone for the PR https://github.com/Azure/sonic-swss/pull/1411

Issue (#1311) :

Add Loopback interface to NAT zone 1
sudo config nat add interface Loopback0 -nat_zone 1

Seeing below error logs when NAT zone for Loopback changed to 1.

Apr 21 11:44:33.805637 cab18-3-dut INFO swss#supervisord: intfmgrd RTNETLINK answers: File exists
Apr 21 11:44:33.805637 cab18-3-dut ERR swss#intfmgrd: :- exec: /sbin/ip link add Loopback0 mtu 65536 type dummy && /sbin/ip link set Loopback0 up: Success
Apr 21 11:44:33.805637 cab18-3-dut ERR swss#intfmgrd: :- addLoopbackIntf: Command '/sbin/ip link add Loopback0 mtu 65536 type dummy && /sbin/ip link set Loopback0 up' failed with rc 512

Root cause for logs:

Whenever the ip address is assigned to Loopback1 using below command, "ip link" gets added for Loopback1 like shown below
config interface ip add Loopback1 20.20.20.20/32

82: Loopback1: <BROADCAST,NOARP,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
link/ether 86:68:3c:f4:25:b7 brd ff:ff:ff:ff:ff:ff

Then when setting the nat zone for the Loopback1 interface to 1, it tries to add "ip link" for Loopback1 again and leads to syslog errors.

Note : These syslog errors for Loopback will seen for all fields like vrf_name, mac_addr, admin_status, proxy_arp, errors are not specific to nat_zone field. Fields are https://github.com/Azure/sonic-swss/blob/master/cfgmgr/intfmgr.cpp#L383

Fix:

Added a set container to hold the Loopback string whenever loopback interface is created and using it to avoid the "addLoopbackIntf" call for the fields setting like nat_zone.

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>