### PR TITLE
Vlan interface can bind vrf after set the valn interface ip.

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -420,8 +420,9 @@ bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,
         /* if to change vrf then skip */
         if (isIntfChangeVrf(alias, vrf_name))
         {
-            SWSS_LOG_ERROR("%s can not change to %s directly, skipping", alias.c_str(), vrf_name.c_str());
-            return true;
+            SWSS_LOG_NOTICE("%s change to %s", alias.c_str(), vrf_name.c_str());
+            FieldValueTuple fvTuple("vrf_name", vrf_name);
+            data.push_back(fvTuple);
         }
 
         if (is_lo)

--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -383,6 +383,21 @@ bool IntfsOrch::setIntf(const string& alias, sai_object_id_t vrf_id, const IpPre
                 gPortsOrch->setPort(alias, port);
             }
         }
+        else if ( !ip_prefix )
+        {
+            if (port.m_vr_id != vrf_id)
+            {
+                Port port_tmp = port;
+
+                m_vrfOrch->decreaseVrfRefCount(port.m_vr_id);
+                removeRouterIntfs(port);
+                port_tmp.m_vr_id = vrf_id;
+                port_tmp.m_rif_id = 0;
+                addRouterIntfs(vrf_id, port_tmp);
+                m_vrfOrch->increaseVrfRefCount(vrf_id);
+                m_syncdIntfses[alias].vrf_id = vrf_id;
+            }
+        }
     }
 
     if (!ip_prefix || m_syncdIntfses[alias].ip_addresses.count(*ip_prefix))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Vlan interface can bind vrf after set the valn interface ip.
I want to set SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID to modify vrf of vlan intf, 
but SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID attr is create only and cannot be modified.
If perfix is not null and vrf id is different then re-create vlan intf to modify vrf id of vlan intf.  
**Why I did it**
follow  the cmd,  the vrf id of the vlan interface can't be set to Vrf1.

cmd:
- sudo config vlan add 2000
- sudo config vlan member add 2000 Ethernet8
- sudo config vrf add Vrf1
- sudo config interface ip add Vlan2000 10.0.0.66/31
- sudo config interface vrf bind Vlan2000 Vrf1

**How I verified it**
follow cmd to set and check syslog and check intf setting of bcm
### syslog
```
 
Sep 14 06:33:25.236680 as7726-32x-3 INFO lldp#supervisord: lldpd 2020-09-14T06:33:25 [INFO/netlink] removal request for address of 10.0.0.66%49, but no knowledge of it
Sep 14 06:33:25.241807 sonic NOTICE swss#intfmgrd: :- doIntfGeneralTask: Vlan2000 change to Vrf1
Sep 14 06:33:25.241807 sonic NOTICE swss#orchagent: :- removeIp2MeRoute: Remove packet action trap route ip:10.0.0.66
Sep 14 06:33:25.246689 as7726-32x-3 INFO lldp#lldpd[97]: removal request for address of fe80::6a21:5fff:fe7b:636%49, but no knowledge of it
Sep 14 06:33:25.246982 as7726-32x-3 INFO lldp#supervisord: lldpd 2020-09-14T06:33:25 [INFO/netlink] removal request for address of fe80::6a21:5fff:fe7b:636%49, but no knowledge of it
Sep 14 06:33:25.248272 as7726-32x-3 NOTICE iccpd#iccpd: [iccp_event_handler_obj_input_newlink.NOTICE] Update local port Vlan2000 state down
Sep 14 06:33:25.257121 as7726-32x-3 NOTICE iccpd#iccpd: [iccp_event_handler_obj_input_newlink.NOTICE] Update local port Vlan2000 state up
Sep 14 06:33:25.260402 sonic NOTICE swss#orchagent: :- removeRouterIntfs: Remove router interface for port Vlan2000
Sep 14 06:33:25.260504 as7726-32x-3 INFO syncd#syncd: message repeated 12 times: [ [none] _brcm_sai_fdb_event_cb:180 move event fdb count global data not change]
Sep 14 06:33:25.260504 as7726-32x-3 NOTICE syncd#syncd: :- removeRif: Trying to remove nonexisting router interface counter from Id 0x60000000006bb
Sep 14 06:33:25.260594 sonic NOTICE swss#orchagent: :- addRouterIntfs: Create router interface Vlan2000 MTU 9100
```
### l3 intf show
```

l3 intf show
Free L3INTF entries: 16370
Unit  Intf  VRF Group VLAN    Source Mac     MTU TTL Tunnel InnerVlan  NATRealm
0     4096  0     0     1    68:21:5f:7b:06:36  9100 0    0     0     0
0     4097  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4098  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4099  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4100  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4101  0     0     1000 68:21:5f:7b:06:36  9100 0    0     0     0
0     4102  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4103  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4104  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4105  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4106  0     0     4095 68:21:5f:7b:06:36  9100 0    0     0     0
0     4107  1     0     2000 68:21:5f:7b:06:36  9100 0    0     0     0
```
