### PR TITLE
[teamsyncd]: Fix LAG add: write MTU configuration

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -148,8 +148,10 @@ void TeamSync::addLag(const string &lagName, int ifindex, bool admin_state,
     std::vector<FieldValueTuple> fvVector;
     FieldValueTuple a("admin_status", admin_state ? "up" : "down");
     FieldValueTuple o("oper_status", oper_state ? "up" : "down");
+    FieldValueTuple m("mtu", std::to_string(mtu));
     fvVector.push_back(a);
     fvVector.push_back(o);
+    fvVector.push_back(m);
     m_lagTable.set(lagName, fvVector);
 
     SWSS_LOG_INFO("Add %s admin_status:%s oper_status:%s, mtu: %d",


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Propagating PR #1423

The current `apply_temp_view` logic doesn't handle MTU configuration during warm-reboot:

Before warm-reboot:
```
root@sonic:/home/admin# redis-cli -n 0 HGETALL 'LAG_TABLE:PortChannel0001'
1) "admin_status"
2) "up"
3) "oper_status"
4) "up"
5) "mtu"
6) "9100"
```

After warm-reboot:
```
root@sonic:/home/admin# redis-cli -n 0 HGETALL 'LAG_TABLE:PortChannel0001'
1) "admin_status"
2) "up"
3) "oper_status"
4) "up"
```

Apply state logs:
```
Aug 31 09:46:37.787959 sonic NOTICE teamd#teamsyncd: :- applyState: Applying state
Aug 31 09:46:37.789065 sonic NOTICE teamd#teamsyncd: :- dump: getting took 0.000322 sec
Aug 31 09:46:37.789065 sonic INFO teamd#teamsyncd: :- apply_temp_view: View switch of table LAG_TABLE required.
Aug 31 09:46:37.789065 sonic INFO teamd#teamsyncd: :- apply_temp_view: Objects in current view:
Aug 31 09:46:37.789065 sonic INFO teamd#teamsyncd: :- apply_temp_view:     PortChannel0001: 3 fields;
Aug 31 09:46:37.789065 sonic INFO teamd#teamsyncd: :- apply_temp_view: Objects in target view:
Aug 31 09:46:37.789065 sonic INFO teamd#teamsyncd: :- apply_temp_view:     PortChannel0001: 2 fields;
Aug 31 09:46:37.790676 sonic NOTICE teamd#teamsyncd: :- dump: getting took 0.000214 sec
Aug 31 09:46:37.790676 sonic INFO teamd#teamsyncd: :- apply_temp_view: View switch of table LAG_MEMBER_TABLE required.
Aug 31 09:46:37.790676 sonic INFO teamd#teamsyncd: :- apply_temp_view: Objects in current view:
Aug 31 09:46:37.790676 sonic INFO teamd#teamsyncd: :- apply_temp_view:     PortChannel0001:Ethernet16: 1 fields;
Aug 31 09:46:37.790676 sonic INFO teamd#teamsyncd: :- apply_temp_view: Objects in target view:
Aug 31 09:46:37.790722 sonic INFO teamd#teamsyncd: :- apply_temp_view:     PortChannel0001:Ethernet16: 1 fields;
Aug 31 09:46:37.791751 sonic NOTICE teamd#teamsyncd: :- setWarmStartState: teamsyncd warm start state changed to reconciled
```

This ends up in traffic disruption after ISSU end:
```
Aug 31 07:57:07.043050 sonic NOTICE swss#orchagent: :- addRouterIntfs: Create router interface Ethernet116 MTU 9100
Aug 31 07:57:07.052926 sonic NOTICE swss#orchagent: :- addRouterIntfs: Create router interface PortChannel0001 MTU 1492
Aug 31 07:57:07.204451 sonic NOTICE swss#orchagent: :- addRouterIntfs: Create router interface Vlan23 MTU 9100

Aug 31 07:57:07.554444 sonic INFO syncd#supervisord: syncd Aug 31 07:57:07 NOTICE  SAI_RIF: mlnx_sai_rif.c[566]- mlnx_create_router_interface: Create rif, #0 VIRTUAL_ROUTER_ID=VIRTUAL_ROUTER,(0:0),0,0000,0 #1 SRC_MAC_ADDRESS=[50:6b:4b:96:5e:00] #2 TYPE=PORT #3 PORT_ID=PORT,(0:0),11b00,0000,0 #4 MTU=9100
Aug 31 07:57:07.573953 sonic INFO syncd#supervisord: syncd Aug 31 07:57:07 NOTICE  SAI_RIF: mlnx_sai_rif.c[566]- mlnx_create_router_interface: Create rif, #0 VIRTUAL_ROUTER_ID=VIRTUAL_ROUTER,(0:0),0,0000,0 #1 SRC_MAC_ADDRESS=[50:6b:4b:96:5e:00] #2 TYPE=PORT #3 PORT_ID=LAG,(0:0),40,0000,0 #4 MTU=1492
Aug 31 07:57:07.599988 sonic INFO syncd#supervisord: syncd Aug 31 07:57:07 NOTICE  SAI_RIF: mlnx_sai_rif.c[566]- mlnx_create_router_interface: Create rif, #0 VIRTUAL_ROUTER_ID=VIRTUAL_ROUTER,(0:0),0,0000,0 #1 SRC_MAC_ADDRESS=[50:6b:4b:96:5e:00] #2 TYPE=VLAN #3 VLAN_ID=VLAN,(0:0),17,0000,0 #4 MTU=9100

Aug 31 07:57:11.967761 sonic INFO syncd#supervisord: syncd Aug 31 07:57:11 NOTICE  SAI_UTILS: mlnx_sai_utils.c[2397]- set_dispatch_attrib_handler: Set FAST_API_ENABLE, key:Switch ID 1, val:false

Aug 31 07:57:22.013521 sonic NOTICE swss#orchagent: :- setRouterIntfsMtu: Set router interface Vlan23 MTU to 9100
Aug 31 07:57:22.016550 sonic INFO syncd#supervisord: syncd Aug 31 07:57:22 NOTICE  SAI_UTILS: mlnx_sai_utils.c[2397]- set_dispatch_attrib_handler: Set MTU, key:rif idx 3, val:9100
Aug 31 07:57:22.017188 sonic NOTICE swss#orchagent: :- setRouterIntfsMtu: Set router interface PortChannel0001 MTU to 9100
Aug 31 07:57:22.021689 sonic INFO syncd#supervisord: syncd Aug 31 07:57:22 NOTICE  SAI_UTILS: mlnx_sai_utils.c[2397]- set_dispatch_attrib_handler: Set MTU, key:rif idx 2, val:9100
```

**What I did**
* Added missing MTU filed

**Why I did it**
* To fix warm-reboot `apply_temp_view` logic

**How I verified it**
* Did warm-reboot several times with frame size equal to 9100 - no traffic disruption is observed

**Details if related**
