### PR TITLE
Fix issue #5157 by identifying the dependency among objects and avoiding releasing an object still being referenced

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -26,12 +26,12 @@ static const vector<sai_buffer_pool_stat_t> bufferPoolWatermarkStatIds =
 };
 
 type_map BufferOrch::m_buffer_type_maps = {
-    {CFG_BUFFER_POOL_TABLE_NAME, new object_map()},
-    {CFG_BUFFER_PROFILE_TABLE_NAME, new object_map()},
-    {CFG_BUFFER_QUEUE_TABLE_NAME, new object_map()},
-    {CFG_BUFFER_PG_TABLE_NAME, new object_map()},
-    {CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME, new object_map()},
-    {CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME, new object_map()}
+    {CFG_BUFFER_POOL_TABLE_NAME, new object_reference_map()},
+    {CFG_BUFFER_PROFILE_TABLE_NAME, new object_reference_map()},
+    {CFG_BUFFER_QUEUE_TABLE_NAME, new object_reference_map()},
+    {CFG_BUFFER_PG_TABLE_NAME, new object_reference_map()},
+    {CFG_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME, new object_reference_map()},
+    {CFG_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME, new object_reference_map()}
 };
 
 BufferOrch::BufferOrch(DBConnector *db, vector<string> &tableNames) :
@@ -175,7 +175,7 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
     for (const auto &it : *(m_buffer_type_maps[CFG_BUFFER_POOL_TABLE_NAME]))
     {
         sai_status_t status = sai_buffer_api->clear_buffer_pool_stats(
-                it.second,
+                it.second.m_saiObjectId,
                 static_cast<uint32_t>(bufferPoolWatermarkStatIds.size()),
                 reinterpret_cast<const sai_stat_id_t *>(bufferPoolWatermarkStatIds.data()));
         if (status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
@@ -201,7 +201,7 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
     bitMask = 1;
     for (const auto &it : *(m_buffer_type_maps[CFG_BUFFER_POOL_TABLE_NAME]))
     {
-        string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(it.second);
+        string key = BUFFER_POOL_WATERMARK_STAT_COUNTER_FLEX_COUNTER_GROUP ":" + sai_serialize_object_id(it.second.m_saiObjectId);
 
         if (noWmClrCapability)
         {
@@ -225,7 +225,7 @@ void BufferOrch::generateBufferPoolWatermarkCounterIdList(void)
     m_isBufferPoolWatermarkCounterIdListGenerated = true;
 }
 
-const object_map &BufferOrch::getBufferPoolNameOidMap(void)
+const object_reference_map &BufferOrch::getBufferPoolNameOidMap(void)
 {
     // In the case different Orches are running in
     // different threads, caller may need to grab a read lock
@@ -247,7 +247,7 @@ task_process_status BufferOrch::processBufferPool(Consumer &consumer)
     SWSS_LOG_DEBUG("object name:%s", object_name.c_str());
     if (m_buffer_type_maps[map_type_name]->find(object_name) != m_buffer_type_maps[map_type_name]->end())
     {
-        sai_object = (*(m_buffer_type_maps[map_type_name]))[object_name];
+        sai_object = (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId;
         SWSS_LOG_DEBUG("found existing object:%s of type:%s", object_name.c_str(), map_type_name.c_str());
     }
     SWSS_LOG_DEBUG("processing command:%s", op.c_str());
@@ -335,7 +335,7 @@ task_process_status BufferOrch::processBufferPool(Consumer &consumer)
                 SWSS_LOG_ERROR("Failed to create buffer pool %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
                 return task_process_status::task_failed;
             }
-            (*(m_buffer_type_maps[map_type_name]))[object_name] = sai_object;
+            (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId = sai_object;
             SWSS_LOG_NOTICE("Created buffer pool %s with type %s", object_name.c_str(), map_type_name.c_str());
             // Here we take the PFC watchdog approach to update the COUNTERS_DB metadata (e.g., PFC_WD_DETECTION_TIME per queue)
             // at initialization (creation and registration phase)
@@ -347,6 +347,14 @@ task_process_status BufferOrch::processBufferPool(Consumer &consumer)
     }
     else if (op == DEL_COMMAND)
     {
+        if (isObjectBeingReferenced(m_buffer_type_maps, map_type_name, object_name))
+        {
+            auto hint = objectReferenceInfo(m_buffer_type_maps, map_type_name, object_name);
+            SWSS_LOG_NOTICE("Can't remove object %s due to being referenced (%s)", object_name.c_str(), hint.c_str());
+
+            return task_process_status::task_need_retry;
+        }
+
         sai_status = sai_buffer_api->remove_buffer_pool(sai_object);
         if (SAI_STATUS_SUCCESS != sai_status)
         {
@@ -376,11 +384,12 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
     string map_type_name = consumer.getTableName();
     string object_name = kfvKey(tuple);
     string op = kfvOp(tuple);
+    string pool_name;
 
     SWSS_LOG_DEBUG("object name:%s", object_name.c_str());
     if (m_buffer_type_maps[map_type_name]->find(object_name) != m_buffer_type_maps[map_type_name]->end())
     {
-        sai_object = (*(m_buffer_type_maps[map_type_name]))[object_name];
+        sai_object = (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId;
         SWSS_LOG_DEBUG("found existing object:%s of type:%s", object_name.c_str(), map_type_name.c_str());
     }
     SWSS_LOG_DEBUG("processing command:%s", op.c_str());
@@ -397,7 +406,7 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
             if (field == buffer_pool_field_name)
             {
                 sai_object_id_t sai_pool;
-                ref_resolve_status resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_pool_field_name, tuple, sai_pool);
+                ref_resolve_status resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_pool_field_name, tuple, sai_pool, pool_name);
                 if (ref_resolve_status::success != resolve_result)
                 {
                     if(ref_resolve_status::not_resolved == resolve_result)
@@ -480,21 +489,32 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
                 SWSS_LOG_ERROR("Failed to create buffer profile %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
                 return task_process_status::task_failed;
             }
-            (*(m_buffer_type_maps[map_type_name]))[object_name] = sai_object;
+            (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId = sai_object;
             SWSS_LOG_NOTICE("Created buffer profile %s with type %s", object_name.c_str(), map_type_name.c_str());
         }
+
+        // Add reference to the buffer pool object
+        setObjectReference(m_buffer_type_maps, map_type_name, object_name, buffer_pool_field_name, pool_name);
     }
     else if (op == DEL_COMMAND)
     {
+        if (isObjectBeingReferenced(m_buffer_type_maps, map_type_name, object_name))
+        {
+            auto hint = objectReferenceInfo(m_buffer_type_maps, map_type_name, object_name);
+            SWSS_LOG_NOTICE("Can't remove object %s due to being referenced (%s)", object_name.c_str(), hint.c_str());
+
+            return task_process_status::task_need_retry;
+        }
+
         sai_status = sai_buffer_api->remove_buffer_profile(sai_object);
         if (SAI_STATUS_SUCCESS != sai_status)
         {
             SWSS_LOG_ERROR("Failed to remove buffer profile %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
             return task_process_status::task_failed;
         }
+
         SWSS_LOG_NOTICE("Remove buffer profile %s with type %s", object_name.c_str(), map_type_name.c_str());
-        auto it_to_delete = (m_buffer_type_maps[map_type_name])->find(object_name);
-        (m_buffer_type_maps[map_type_name])->erase(it_to_delete);
+        removeObject(m_buffer_type_maps, map_type_name, object_name);
     }
     else
     {
@@ -513,6 +533,7 @@ task_process_status BufferOrch::processQueue(Consumer &consumer)
     auto it = consumer.m_toSync.begin();
     KeyOpFieldsValuesTuple tuple = it->second;
     sai_object_id_t sai_buffer_profile;
+    string buffer_profile_name;
     const string key = kfvKey(tuple);
     string op = kfvOp(tuple);
     vector<string> tokens;
@@ -530,17 +551,38 @@ task_process_status BufferOrch::processQueue(Consumer &consumer)
     {
         return task_process_status::task_invalid_entry;
     }
-    ref_resolve_status  resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name, tuple, sai_buffer_profile);
-    if (ref_resolve_status::success != resolve_result)
+
+    if (op == SET_COMMAND)
     {
-        if(ref_resolve_status::not_resolved == resolve_result)
+        ref_resolve_status resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name, tuple, sai_buffer_profile, buffer_profile_name);
+        if (ref_resolve_status::success != resolve_result)
         {
-            SWSS_LOG_INFO("Missing or invalid queue buffer profile reference specified");
-            return task_process_status::task_need_retry;
+            if (ref_resolve_status::not_resolved == resolve_result)
+            {
+                SWSS_LOG_INFO("Missing or invalid queue buffer profile reference specified");
+                return task_process_status::task_need_retry;
+            }
+
+            SWSS_LOG_ERROR("Resolving queue profile reference failed");
+            return task_process_status::task_failed;
         }
-        SWSS_LOG_ERROR("Resolving queue profile reference failed");
-        return task_process_status::task_failed;
+
+        SWSS_LOG_NOTICE("Set buffer queue %s to %s", key.c_str(), buffer_profile_name.c_str());
+
+        setObjectReference(m_buffer_type_maps, consumer.getTableName(), key, buffer_profile_field_name, buffer_profile_name);
     }
+    else if (op == DEL_COMMAND)
+    {
+        sai_buffer_profile = SAI_NULL_OBJECT_ID;
+        SWSS_LOG_NOTICE("Remove buffer queue %s", key.c_str());
+        removeObject(m_buffer_type_maps, consumer.getTableName(), key);
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
     sai_attribute_t attr;
     attr.id = SAI_QUEUE_ATTR_BUFFER_PROFILE_ID;
     attr.value.oid = sai_buffer_profile;
@@ -611,15 +653,11 @@ task_process_status BufferOrch::processPriorityGroup(Consumer &consumer)
     auto it = consumer.m_toSync.begin();
     KeyOpFieldsValuesTuple tuple = it->second;
     sai_object_id_t sai_buffer_profile;
+    string buffer_profile_name;
     const string key = kfvKey(tuple);
     string op = kfvOp(tuple);
     vector<string> tokens;
     sai_uint32_t range_low, range_high;
-
-    if (op != SET_COMMAND)
-    {
-        return task_process_status::task_success;
-    }
 
     SWSS_LOG_DEBUG("processing:%s", key.c_str());
     tokens = tokenize(key, config_db_key_delimiter);
@@ -634,17 +672,38 @@ task_process_status BufferOrch::processPriorityGroup(Consumer &consumer)
         SWSS_LOG_ERROR("Failed to obtain pg range values");
         return task_process_status::task_invalid_entry;
     }
-    ref_resolve_status  resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name, tuple, sai_buffer_profile);
-    if (ref_resolve_status::success != resolve_result)
+
+    if (op == SET_COMMAND)
     {
-        if(ref_resolve_status::not_resolved == resolve_result)
+        ref_resolve_status  resolve_result = resolveFieldRefValue(m_buffer_type_maps, buffer_profile_field_name, tuple, sai_buffer_profile, buffer_profile_name);
+        if (ref_resolve_status::success != resolve_result)
         {
-            SWSS_LOG_INFO("Missing or invalid pg profile reference specified");
-            return task_process_status::task_need_retry;
+            if (ref_resolve_status::not_resolved == resolve_result)
+            {
+                SWSS_LOG_INFO("Missing or invalid pg profile reference specified");
+                return task_process_status::task_need_retry;
+            }
+
+            SWSS_LOG_ERROR("Resolving pg profile reference failed");
+            return task_process_status::task_failed;
         }
-        SWSS_LOG_ERROR("Resolving pg profile reference failed");
-        return task_process_status::task_failed;
+
+        SWSS_LOG_NOTICE("Set buffer PG %s to %s", key.c_str(), buffer_profile_name.c_str());
+
+        setObjectReference(m_buffer_type_maps, consumer.getTableName(), key, buffer_profile_field_name, buffer_profile_name);
     }
+    else if (op == DEL_COMMAND)
+    {
+        sai_buffer_profile = SAI_NULL_OBJECT_ID;
+        SWSS_LOG_NOTICE("Remove buffer PG %s", key.c_str());
+        removeObject(m_buffer_type_maps, consumer.getTableName(), key);
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+        return task_process_status::task_invalid_entry;
+    }
+
     sai_attribute_t attr;
     attr.id = SAI_INGRESS_PRIORITY_GROUP_ATTR_BUFFER_PROFILE;
     attr.value.oid = sai_buffer_profile;
@@ -726,7 +785,9 @@ task_process_status BufferOrch::processIngressBufferProfileList(Consumer &consum
     }
     vector<string> port_names = tokenize(key, list_item_delimiter);
     vector<sai_object_id_t> profile_list;
-    ref_resolve_status resolve_status = resolveFieldRefArray(m_buffer_type_maps, buffer_profile_list_field_name, tuple, profile_list);
+
+    string profile_name_list;
+    ref_resolve_status resolve_status = resolveFieldRefArray(m_buffer_type_maps, buffer_profile_list_field_name, tuple, profile_list, profile_name_list);
     if (ref_resolve_status::success != resolve_status)
     {
         if(ref_resolve_status::not_resolved == resolve_status)
@@ -737,6 +798,9 @@ task_process_status BufferOrch::processIngressBufferProfileList(Consumer &consum
         SWSS_LOG_ERROR("Failed resolving ingress buffer profile reference specified for:%s", key.c_str());
         return task_process_status::task_failed;
     }
+
+    setObjectReference(m_buffer_type_maps, consumer.getTableName(), key, buffer_profile_list_field_name, profile_name_list);
+
     sai_attribute_t attr;
     attr.id = SAI_PORT_ATTR_QOS_INGRESS_BUFFER_PROFILE_LIST;
     attr.value.objlist.count = (uint32_t)profile_list.size();
@@ -755,6 +819,7 @@ task_process_status BufferOrch::processIngressBufferProfileList(Consumer &consum
             return task_process_status::task_failed;
         }
     }
+
     return task_process_status::task_success;
 }
 
@@ -772,7 +837,9 @@ task_process_status BufferOrch::processEgressBufferProfileList(Consumer &consume
     SWSS_LOG_DEBUG("processing:%s", key.c_str());
     vector<string> port_names = tokenize(key, list_item_delimiter);
     vector<sai_object_id_t> profile_list;
-    ref_resolve_status resolve_status = resolveFieldRefArray(m_buffer_type_maps, buffer_profile_list_field_name, tuple, profile_list);
+
+    string profile_name_list;
+    ref_resolve_status resolve_status = resolveFieldRefArray(m_buffer_type_maps, buffer_profile_list_field_name, tuple, profile_list, profile_name_list);
     if (ref_resolve_status::success != resolve_status)
     {
         if(ref_resolve_status::not_resolved == resolve_status)
@@ -783,6 +850,9 @@ task_process_status BufferOrch::processEgressBufferProfileList(Consumer &consume
         SWSS_LOG_ERROR("Failed resolving egress buffer profile reference specified for:%s", key.c_str());
         return task_process_status::task_failed;
     }
+
+    setObjectReference(m_buffer_type_maps, consumer.getTableName(), key, buffer_profile_list_field_name, profile_name_list);
+
     sai_attribute_t attr;
     attr.id = SAI_PORT_ATTR_QOS_EGRESS_BUFFER_PROFILE_LIST;
     attr.value.objlist.count = (uint32_t)profile_list.size();
@@ -801,6 +871,7 @@ task_process_status BufferOrch::processEgressBufferProfileList(Consumer &consume
             return task_process_status::task_failed;
         }
     }
+
     return task_process_status::task_success;
 }
 

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -35,7 +35,7 @@ public:
     bool isPortReady(const std::string& port_name) const;
     static type_map m_buffer_type_maps;
     void generateBufferPoolWatermarkCounterIdList(void);
-    const object_map &getBufferPoolNameOidMap(void);
+    const object_reference_map &getBufferPoolNameOidMap(void);
 
 private:
     typedef task_process_status (BufferOrch::*buffer_table_handler)(Consumer& consumer);

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -417,7 +417,6 @@ ref_resolve_status Orch::resolveFieldRefValue(
 
 void Orch::removeMeFromObjsReferencedByMe(
     type_map &type_maps,
-    referenced_object &obj,
     const string &table,
     const string &obj_name,
     const string &field,
@@ -450,7 +449,7 @@ void Orch::setObjectReference(
     auto field_ref = obj.m_objsReferencingByMe.find(field);
 
     if (field_ref != obj.m_objsReferencingByMe.end())
-        removeMeFromObjsReferencedByMe(type_maps, obj, table, obj_name, field, field_ref->second);
+        removeMeFromObjsReferencedByMe(type_maps, table, obj_name, field, field_ref->second);
 
     obj.m_objsReferencingByMe[field] = referenced_obj;
 
@@ -479,7 +478,7 @@ void Orch::removeObject(
 
     for (auto field_ref : obj.m_objsReferencingByMe)
     {
-        removeMeFromObjsReferencedByMe(type_maps, obj, table, obj_name, field_ref.first, field_ref.second);
+        removeMeFromObjsReferencedByMe(type_maps, table, obj_name, field_ref.first, field_ref.second);
     }
 
     // Update the field store

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -502,7 +502,7 @@ string Orch::objectReferenceInfo(
     auto &objsDependingSet = (*type_maps[table])[obj_name].m_objsDependingOnMe;
     for (auto &depObjName : objsDependingSet)
     {
-        string hint = table + " " + obj_name + " first object: " + depObjName;
+        string hint = table + " " + obj_name + " one object: " + depObjName;
         hint += " reference count: " + to_string(objsDependingSet.size());
         return hint;
     }

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -377,7 +377,8 @@ ref_resolve_status Orch::resolveFieldRefValue(
     type_map &type_maps,
     const string &field_name,
     KeyOpFieldsValuesTuple &tuple,
-    sai_object_id_t &sai_object)
+    sai_object_id_t &sai_object,
+    string &referenced_object_name)
 {
     SWSS_LOG_ENTER();
 
@@ -401,7 +402,8 @@ ref_resolve_status Orch::resolveFieldRefValue(
             {
                 return ref_resolve_status::empty;
             }
-            sai_object = (*(type_maps[ref_type_name]))[object_name];
+            sai_object = (*(type_maps[ref_type_name]))[object_name].m_saiObjectId;
+            referenced_object_name = ref_type_name + delimiter + object_name;
             hit = true;
         }
     }
@@ -409,7 +411,103 @@ ref_resolve_status Orch::resolveFieldRefValue(
     {
         return ref_resolve_status::field_not_found;
     }
+
     return ref_resolve_status::success;
+}
+
+void Orch::removeMeFromObjsReferencedByMe(
+    type_map &type_maps,
+    referenced_object &obj,
+    const string &table,
+    const string &obj_name,
+    const string &field,
+    const string &old_referenced_obj_name)
+{
+    vector<string> objects = tokenize(old_referenced_obj_name, list_item_delimiter);
+    for (auto &obj : objects)
+    {
+        // obj_name references token
+        auto tokens = tokenize(obj, delimiter);
+        auto &referenced_table = tokens[0];
+        auto &ref_obj_name = tokens[1];
+        auto &old_referenced_obj = (*type_maps[referenced_table])[ref_obj_name];
+        old_referenced_obj.m_objsDependingOnMe.erase(obj_name);
+        SWSS_LOG_INFO("Obj %s.%s Field %s: Remove reference to %s %s (now %s)",
+                      table.c_str(), obj_name.c_str(), field.c_str(),
+                      referenced_table.c_str(), ref_obj_name.c_str(),
+                      to_string(old_referenced_obj.m_objsDependingOnMe.size()).c_str());
+    }
+}
+
+void Orch::setObjectReference(
+    type_map &type_maps,
+    const string &table,
+    const string &obj_name,
+    const string &field,
+    const string &referenced_obj)
+{
+    auto &obj = (*type_maps[table])[obj_name];
+    auto field_ref = obj.m_objsReferencingByMe.find(field);
+
+    if (field_ref != obj.m_objsReferencingByMe.end())
+        removeMeFromObjsReferencedByMe(type_maps, obj, table, obj_name, field, field_ref->second);
+
+    obj.m_objsReferencingByMe[field] = referenced_obj;
+
+    // Add the reference to the new object being referenced
+    vector<string> objs = tokenize(referenced_obj, list_item_delimiter);
+    for (auto &obj : objs)
+    {
+        auto tokens = tokenize(obj, delimiter);
+        auto &referenced_table = tokens[0];
+        auto &referenced_obj_name = tokens[1];
+        auto &new_obj_being_referenced = (*type_maps[referenced_table])[referenced_obj_name];
+        new_obj_being_referenced.m_objsDependingOnMe.insert(obj_name);
+        SWSS_LOG_INFO("Obj %s.%s Field %s: Add reference to %s %s (now %s)",
+                      table.c_str(), obj_name.c_str(), field.c_str(),
+                      referenced_table.c_str(), referenced_obj_name.c_str(),
+                      to_string(new_obj_being_referenced.m_objsDependingOnMe.size()).c_str());
+    }
+}
+
+void Orch::removeObject(
+    type_map &type_maps,
+    const string &table,
+    const string &obj_name)
+{
+    auto &obj = (*type_maps[table])[obj_name];
+
+    for (auto field_ref : obj.m_objsReferencingByMe)
+    {
+        removeMeFromObjsReferencedByMe(type_maps, obj, table, obj_name, field_ref.first, field_ref.second);
+    }
+
+    // Update the field store
+    (*type_maps[table]).erase(obj_name);
+    SWSS_LOG_INFO("Obj %s:%s is removed from store", table.c_str(), obj_name.c_str());
+}
+
+bool Orch::isObjectBeingReferenced(
+    type_map &type_maps,
+    const string &table,
+    const string &obj_name)
+{
+    return !(*type_maps[table])[obj_name].m_objsDependingOnMe.empty();
+}
+
+string Orch::objectReferenceInfo(
+    type_map &type_maps,
+    const string &table,
+    const string &obj_name)
+{
+    auto &objsDependingSet = (*type_maps[table])[obj_name].m_objsDependingOnMe;
+    for (auto &depObjName : objsDependingSet)
+    {
+        string hint = table + " " + obj_name + " first object: " + depObjName;
+        hint += " reference count: " + to_string(objsDependingSet.size());
+        return hint;
+    }
+    return "reference count: 0";
 }
 
 void Orch::doTask()
@@ -478,7 +576,8 @@ ref_resolve_status Orch::resolveFieldRefArray(
     type_map &type_maps,
     const string &field_name,
     KeyOpFieldsValuesTuple &tuple,
-    vector<sai_object_id_t> &sai_object_arr)
+    vector<sai_object_id_t> &sai_object_arr,
+    string &object_name_list)
 {
     // example: [BUFFER_PROFILE_TABLE:e_port.profile0],[BUFFER_PROFILE_TABLE:e_port.profile1]
     SWSS_LOG_ENTER();
@@ -511,9 +610,12 @@ ref_resolve_status Orch::resolveFieldRefArray(
                     SWSS_LOG_ERROR("Failed to parse profile reference:%s\n", list_items[ind].c_str());
                     return ref_resolve_status::not_resolved;
                 }
-                sai_object_id_t sai_obj = (*(type_maps[ref_type_name]))[object_name];
+                sai_object_id_t sai_obj = (*(type_maps[ref_type_name]))[object_name].m_saiObjectId;
                 SWSS_LOG_DEBUG("Resolved to sai_object:0x%" PRIx64 ", type:%s, name:%s", sai_obj, ref_type_name.c_str(), object_name.c_str());
                 sai_object_arr.push_back(sai_obj);
+                if (!object_name_list.empty())
+                    object_name_list += string(&list_item_delimiter);
+                object_name_list += ref_type_name + delimiter + object_name;
             }
             count++;
         }

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -237,7 +237,7 @@ protected:
     void addExecutor(Executor* executor);
     Executor *getExecutor(std::string executorName);
 private:
-    void removeMeFromObjsReferencedByMe(type_map &type_maps, referenced_object &obj, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);
+    void removeMeFromObjsReferencedByMe(type_map &type_maps, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);
     void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);
 };
 

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <map>
+#include <set>
 #include <memory>
 #include <utility>
 
@@ -52,11 +53,22 @@ typedef enum
     task_ignore
 } task_process_status;
 
+typedef struct
+{
+    // m_objsDependingOnMe stores names (without table name) of all objects depending on the current obj
+    std::set<std::string> m_objsDependingOnMe;
+    // m_objsReferencingByMe is a map from a field of the current object's to the object names it references
+    // the object names are with table name
+    // multiple objects being referenced are separated by ','
+    std::map<std::string, std::string> m_objsReferencingByMe;
+    sai_object_id_t m_saiObjectId;
+} referenced_object;
+
+typedef std::map<std::string, referenced_object> object_reference_map;
+typedef std::map<std::string, object_reference_map*> type_map;
+
 typedef std::map<std::string, sai_object_id_t> object_map;
 typedef std::pair<std::string, sai_object_id_t> object_map_pair;
-
-typedef std::map<std::string, object_map*> type_map;
-typedef std::pair<std::string, object_map*> type_map_pair;
 
 // Use multimap to support multiple OpFieldsValues for the same key (e,g, DEL and SET)
 // The order of the key-value pairs whose keys compare equivalent is the order of
@@ -212,15 +224,20 @@ protected:
 
     static void logfileReopen();
     std::string dumpTuple(Consumer &consumer, const swss::KeyOpFieldsValuesTuple &tuple);
-    ref_resolve_status resolveFieldRefValue(type_map&, const std::string&, swss::KeyOpFieldsValuesTuple&, sai_object_id_t&);
+    ref_resolve_status resolveFieldRefValue(type_map&, const std::string&, swss::KeyOpFieldsValuesTuple&, sai_object_id_t&, std::string&);
     bool parseIndexRange(const std::string &input, sai_uint32_t &range_low, sai_uint32_t &range_high);
     bool parseReference(type_map &type_maps, std::string &ref, std::string &table_name, std::string &object_name);
-    ref_resolve_status resolveFieldRefArray(type_map&, const std::string&, swss::KeyOpFieldsValuesTuple&, std::vector<sai_object_id_t>&);
+    ref_resolve_status resolveFieldRefArray(type_map&, const std::string&, swss::KeyOpFieldsValuesTuple&, std::vector<sai_object_id_t>&, std::string&);
+    void setObjectReference(type_map&, const std::string&, const std::string&, const std::string&, const std::string&);
+    void removeObject(type_map&, const std::string&, const std::string&);
+    bool isObjectBeingReferenced(type_map&, const std::string&, const std::string&);
+    std::string objectReferenceInfo(type_map&, const std::string&, const std::string&);
 
     /* Note: consumer will be owned by this class */
     void addExecutor(Executor* executor);
     Executor *getExecutor(std::string executorName);
 private:
+    void removeMeFromObjsReferencedByMe(type_map &type_maps, referenced_object &obj, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);
     void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);
 };
 

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -59,16 +59,16 @@ map<string, sai_meter_type_t> scheduler_meter_map = {
 };
 
 type_map QosOrch::m_qos_maps = {
-    {CFG_DSCP_TO_TC_MAP_TABLE_NAME, new object_map()},
-    {CFG_DOT1P_TO_TC_MAP_TABLE_NAME, new object_map()},
-    {CFG_TC_TO_QUEUE_MAP_TABLE_NAME, new object_map()},
-    {CFG_SCHEDULER_TABLE_NAME, new object_map()},
-    {CFG_WRED_PROFILE_TABLE_NAME, new object_map()},
-    {CFG_PORT_QOS_MAP_TABLE_NAME, new object_map()},
-    {CFG_QUEUE_TABLE_NAME, new object_map()},
-    {CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME, new object_map()},
-    {CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME, new object_map()},
-    {CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME, new object_map()}
+    {CFG_DSCP_TO_TC_MAP_TABLE_NAME, new object_reference_map()},
+    {CFG_DOT1P_TO_TC_MAP_TABLE_NAME, new object_reference_map()},
+    {CFG_TC_TO_QUEUE_MAP_TABLE_NAME, new object_reference_map()},
+    {CFG_SCHEDULER_TABLE_NAME, new object_reference_map()},
+    {CFG_WRED_PROFILE_TABLE_NAME, new object_reference_map()},
+    {CFG_PORT_QOS_MAP_TABLE_NAME, new object_reference_map()},
+    {CFG_QUEUE_TABLE_NAME, new object_reference_map()},
+    {CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME, new object_reference_map()},
+    {CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME, new object_reference_map()},
+    {CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME, new object_reference_map()}
 };
 
 task_process_status QosMapHandler::processWorkItem(Consumer& consumer)
@@ -84,7 +84,7 @@ task_process_status QosMapHandler::processWorkItem(Consumer& consumer)
 
     if (QosOrch::getTypeMap()[qos_map_type_name]->find(qos_object_name) != QosOrch::getTypeMap()[qos_map_type_name]->end())
     {
-        sai_object = (*(QosOrch::getTypeMap()[qos_map_type_name]))[qos_object_name];
+        sai_object = (*(QosOrch::getTypeMap()[qos_map_type_name]))[qos_object_name].m_saiObjectId;
     }
     if (op == SET_COMMAND)
     {
@@ -112,7 +112,7 @@ task_process_status QosMapHandler::processWorkItem(Consumer& consumer)
                 freeAttribResources(attributes);
                 return task_process_status::task_failed;
             }
-            (*(QosOrch::getTypeMap()[qos_map_type_name]))[qos_object_name] = sai_object;
+            (*(QosOrch::getTypeMap()[qos_map_type_name]))[qos_object_name].m_saiObjectId = sai_object;
             SWSS_LOG_NOTICE("Created [%s:%s]", qos_map_type_name.c_str(), qos_object_name.c_str());
         }
         freeAttribResources(attributes);
@@ -774,7 +774,7 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
 
     if (m_qos_maps[qos_map_type_name]->find(qos_object_name) != m_qos_maps[qos_map_type_name]->end())
     {
-        sai_object = (*(m_qos_maps[qos_map_type_name]))[qos_object_name];
+        sai_object = (*(m_qos_maps[qos_map_type_name]))[qos_object_name].m_saiObjectId;
         if (sai_object == SAI_NULL_OBJECT_ID)
         {
             SWSS_LOG_ERROR("Error sai_object must exist for key %s", qos_object_name.c_str());
@@ -878,7 +878,7 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
                 return task_process_status::task_failed;
             }
             SWSS_LOG_NOTICE("Created [%s:%s]", qos_map_type_name.c_str(), qos_object_name.c_str());
-            (*(m_qos_maps[qos_map_type_name]))[qos_object_name] = sai_object;
+            (*(m_qos_maps[qos_map_type_name]))[qos_object_name].m_saiObjectId = sai_object;
         }
     }
     else if (op == DEL_COMMAND)
@@ -1101,7 +1101,8 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
             queue_ind = ind;
             SWSS_LOG_DEBUG("processing queue:%zd", queue_ind);
             sai_object_id_t sai_scheduler_profile;
-            resolve_result = resolveFieldRefValue(m_qos_maps, scheduler_field_name, tuple, sai_scheduler_profile);
+            string scheduler_profile_name;
+            resolve_result = resolveFieldRefValue(m_qos_maps, scheduler_field_name, tuple, sai_scheduler_profile, scheduler_profile_name);
             if (ref_resolve_status::success == resolve_result)
             {
                 if (op == SET_COMMAND)
@@ -1137,7 +1138,8 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
             }
 
             sai_object_id_t sai_wred_profile;
-            resolve_result = resolveFieldRefValue(m_qos_maps, wred_profile_field_name, tuple, sai_wred_profile);
+            string wred_profile_name;
+            resolve_result = resolveFieldRefValue(m_qos_maps, wred_profile_field_name, tuple, sai_wred_profile, wred_profile_name);
             if (ref_resolve_status::success == resolve_result)
             {
                 if (op == SET_COMMAND)
@@ -1219,8 +1221,9 @@ task_process_status QosOrch::ResolveMapAndApplyToPort(
     SWSS_LOG_ENTER();
 
     sai_object_id_t sai_object = SAI_NULL_OBJECT_ID;
+    string object_name;
     bool result;
-    ref_resolve_status resolve_result = resolveFieldRefValue(m_qos_maps, field_name, tuple, sai_object);
+    ref_resolve_status resolve_result = resolveFieldRefValue(m_qos_maps, field_name, tuple, sai_object, object_name);
     if (ref_resolve_status::success == resolve_result)
     {
         if (op == SET_COMMAND)
@@ -1274,8 +1277,9 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
         if (qos_to_attr_map.find(fvField(*it)) != qos_to_attr_map.end())
         {
             sai_object_id_t id;
+            string object_name;
             string map_type_name = fvField(*it), map_name = fvValue(*it);
-            ref_resolve_status status = resolveFieldRefValue(m_qos_maps, map_type_name, tuple, id);
+            ref_resolve_status status = resolveFieldRefValue(m_qos_maps, map_type_name, tuple, id, object_name);
 
             if (status != ref_resolve_status::success)
             {

--- a/orchagent/watermarkorch.cpp
+++ b/orchagent/watermarkorch.cpp
@@ -305,7 +305,7 @@ void WatermarkOrch::clearSingleWm(Table *table, string wm_name, vector<sai_objec
     }
 }
 
-void WatermarkOrch::clearSingleWm(Table *table, string wm_name, const object_map &nameOidMap)
+void WatermarkOrch::clearSingleWm(Table *table, string wm_name, const object_reference_map &nameOidMap)
 {
     SWSS_LOG_ENTER();
     SWSS_LOG_DEBUG("clear WM %s, for %zu obj ids", wm_name.c_str(), nameOidMap.size());
@@ -314,6 +314,6 @@ void WatermarkOrch::clearSingleWm(Table *table, string wm_name, const object_map
 
     for (const auto &it : nameOidMap)
     {
-        table->set(sai_serialize_object_id(it.second), fvTuples);
+        table->set(sai_serialize_object_id(it.second.m_saiObjectId), fvTuples);
     }
 }

--- a/orchagent/watermarkorch.h
+++ b/orchagent/watermarkorch.h
@@ -35,7 +35,7 @@ public:
     void handleFcConfigUpdate(const std::string &key, const std::vector<swss::FieldValueTuple> &fvt);
 
     void clearSingleWm(swss::Table *table, std::string wm_name, std::vector<sai_object_id_t> &obj_ids);
-    void clearSingleWm(swss::Table *table, std::string wm_name, const object_map &nameOidMap);
+    void clearSingleWm(swss::Table *table, std::string wm_name, const object_reference_map &nameOidMap);
 
     std::shared_ptr<swss::Table> getCountersTable(void)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**
The issue is caused by the orchagent receiving notification in a different order in which they were sent.
orchagent doesn't have any dependency check and try notifying sai-redis to release an object which is still being referenced,
which causes sai-redis to complain and the object leaks.

The idea is to introduce a mechanism to identify the dependency thus preventing a referenced object from being released.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**Details if related**
1. Introduce a new type representing the dependency among the variant type of objects, including the following fields:
    - m_objsDependingOnMe, a set representing the objects that reference the current object.
    - m_objsReferencingByMe, a map from a field of the current object's to the object name it references.

    eg. given the following dependencies, 

    - `BUFFER_PROFILE.ingress_lossless_profile` references `BUFFER_POOL.ingress_lossless_pool`,
    - `BUFFER_PROFILE.pg_lossless_25000_5m_profile` references `BUFFER_POOL.ingress_lossless_pool`
    the objects should be like this:
```
obj(BUFFER_POOL.ingress_lossless_pool).m_objsDependingOnMe = [
        BUFFER_PROFILE.ingress_lossless_profile,
        BUFFER_PROFILE.pg_lossless_25000_5m_profile
]
obj(BUFFER_PROFILE.pg_lossless_25000_5m_profile).m_objsReferencingByMe[pool] = BUFFER_POOL.ingress_lossless_pool
obj(BUFFER_PROFILE.ingress_lossless_profile).m_objsReferencingByMe[pool] = BUFFER_POOL.ingress_lossless_pool
```
2. When a field of an object `A`
    - is referencing `B` now
    - is going to be updated with referencing another object `B'`,

    We will have the following steps:

    - obj[`A.m_objsReferencingByMe[field name]`].m_objsDependingOnMe.remove(`A`)
      where obj[`A.m_objsReferencingByMe[field name]`] should be `B`
    - `A.m_objsReferencingByMe[field name]` = `B'`
    - `B'.m_objsDependingOnMe.add(A)`
3. When an object `A` is about to be removed,
    - if `A.m_objsDependingOnMe` isn't empty set, return `task_need_retry`
    - else execute the normal remove flow, especially if the `A` is referencing someone else:
      - For each field in `A.m_objsReferencingByMe`: obj[A.m_objsReferencingByMe[field]].m_objsDependingOnMe.remove(`A`)

***Reference count vs. set***
When it comes to recording the references, the reference count approach is the solution a lot of developers come up with.
A frequently asked question is why the set is used to record dependency instead of the reference count.
So I'd like to compare these two approaches.
- for reference count
  - pro
    - small memory footprint
    - able to trace a large number of objects depending on the current object
  - con
    - need an extra flag for each referencing objects, indicating whether the reference count has been increased/decreased for the object
    - misoperate reference count leads to fatal error
- for the set of dependent objects
  - pro
    - able to provide more information to the user regarding the dependency, which is very helpful when debugging an error
    - no extra flag required. as the insert/erase operations are idempotent, misoperation on reference count is less likely to lead to fatal error
  - con
    - heavy memory footprint

As we don't have a big number of objects to trace and want to provide more detailed info, I prefer the set approach.

**How I verified it**
1. remove objects with non-zero reference.
  to create a buffer pool, a buffer profile and two buffer pgs in order and then remove the profile and then the pool and at last the two PGs. in this case, the profile and pool can't be removed because of non-zero referencing.
    - create the buffer pool by using the command `hset BUFFER_POOL|ingress_test_pool type ingress mode dynamic size 14542848`. the log is like following:
        ```
        NOTICE swss#orchagent: :- processBufferPool: Created buffer pool ingress_test_pool with type BUFFER_POOL
        ```
    - create the buffer profile referencing the pool by using the command `hset BUFFER_PROFILE|ingress_test_profile dynamic_th 1 pool [BUFFER_POOL|ingress_test_pool] size 0`.
        ```
        NOTICE swss#orchagent: :- processBufferProfile: Created buffer profile ingress_test_profile with type BUFFER_PROFILE
        INFO swss#orchagent: :- setObjectReference: Obj BUFFER_PROFILE.ingress_test_profile Field pool: Add reference to BUFFER_POOL ingress_test_pool (now 1)
        ```
    - create a buffer PG referencing the profile by using the command `hset BUFFER_PG|Ethernet8|1 profile [BUFFER_PROFILE|ingress_test_profile]`.
        ```
        NOTICE swss#orchagent: :- processPriorityGroup: Set buffer PG Ethernet8|1 to BUFFER_PROFILE:ingress_test_profile
        INFO swss#orchagent: :- setObjectReference: Obj BUFFER_PG.Ethernet8|1 Field profile: Add reference to BUFFER_PROFILE ingress_test_profile (now 1)
        ```
    - create the other buffer PG by using `hset BUFFER_PG|Ethernet16|2 profile [BUFFER_PROFILE|ingress_test_profile]`
        ```
        NOTICE swss#orchagent: :- processPriorityGroup: Set buffer PG Ethernet16|2 to BUFFER_PROFILE:ingress_test_profile
        INFO swss#orchagent: :- setObjectReference: Obj BUFFER_PG.Ethernet16|2 Field profile: Add reference to BUFFER_PROFILE ingress_test_profile (now 2)
        ```
    - remove the buffer profile by using the command `hdel BUFFER_PROFILE|ingress_test_profile dynamic_th pool size`. It can't be removed because of dependency.
        ```
        NOTICE swss#orchagent: :- processBufferProfile: Can't remove object ingress_test_profile due to being referenced (BUFFER_PROFILE ingress_test_profile first object: Ethernet16|2 reference count: 2)
        INFO swss#orchagent: :- doTask: Failed to process buffer task, retry it
        ```
    - remove the buffer pool by using the command `hdel BUFFER_POOL|ingress_test_pool type mode size`. It can't be removed because of dependency.
        ```
        NOTICE swss#orchagent: :- processBufferProfile: Can't remove object ingress_test_profile due to being referenced (BUFFER_PROFILE ingress_test_profile first object: Ethernet16|2 reference count: 2)
        INFO swss#orchagent: :- doTask: Failed to process buffer task, retry it
        ```
    - remove one buffer PG by using the command `hdel BUFFER_PG|Ethernet8|1 profile`. the reference count of buffer profile is reduced to 1.
        ```
        NOTICE swss#orchagent: :- processPriorityGroup: Remove buffer PG Ethernet8|1
        INFO swss#orchagent: :- removeMeFromObjsReferencedByMe: Obj BUFFER_PG.Ethernet8|1 Field profile: Remove reference to BUFFER_PROFILE ingress_test_profile (now 1)
        INFO swss#orchagent: :- removeObject: Obj BUFFER_PG:Ethernet8|1 is removed from store
        ```
    - remove the other buffer PG by using `hdel BUFFER_PG|Ethernet16|2 profile`. Now the reference of the profile is decreased to 0 and then the pool. Eventually, all objects are removed.
        ```
        NOTICE swss#orchagent: :- processPriorityGroup: Remove buffer PG Ethernet16|2
        INFO swss#orchagent: :- removeMeFromObjsReferencedByMe: Obj BUFFER_PG.Ethernet16|2 Field profile: Remove reference to BUFFER_PROFILE ingress_test_profile (now 0)
        INFO swss#orchagent: :- removeObject: Obj BUFFER_PG:Ethernet16|2 is removed from store
        ERR swss#orchagent: :- processPriorityGroup: PG profile 'Ethernet16|2' applied after port Ethernet16 is up
        NOTICE swss#orchagent: :- processBufferPool: Can't remove object ingress_test_pool due to being referenced (BUFFER_POOL ingress_test_pool first object: ingress_test_profile reference count: 1)
        INFO swss#orchagent: :- doTask: Failed to process buffer task, retry it
        NOTICE swss#orchagent: :- processBufferProfile: Remove buffer profile ingress_test_profile with type BUFFER_PROFILE
        INFO swss#orchagent: :- removeMeFromObjsReferencedByMe: Obj BUFFER_PROFILE.ingress_test_profile Field pool: Remove reference to BUFFER_POOL ingress_test_pool (now 0)
        INFO swss#orchagent: :- removeObject: Obj BUFFER_PROFILE:ingress_test_profile is removed from store
        NOTICE swss#orchagent: :- processBufferPool: Removed buffer pool ingress_test_pool with type BUFFER_POOL
        ```
2. remove the object with zero-reference.
  create the same objects and destroy buffer PGs first and then buffer profiles and at last buffer pools. In this case the objects are destroyed in order.
    - create the buffer pool: `hset BUFFER_POOL|ingress_test_pool type ingress mode dynamic size 14542848`
        ```
        NOTICE swss#orchagent: :- processBufferPool: Created buffer pool ingress_test_pool with type BUFFER_POOL
        ```
    - create the buffer profile: `hset BUFFER_PROFILE|ingress_test_profile dynamic_th 1 pool [BUFFER_POOL|ingress_test_pool] size 0`
        ```
        NOTICE swss#orchagent: :- processBufferProfile: Created buffer profile ingress_test_profile with type BUFFER_PROFILE
        INFO swss#orchagent: :- setObjectReference: Obj BUFFER_PROFILE.ingress_test_profile Field pool: Add reference to BUFFER_POOL ingress_test_pool (now 1)
        ```
    - create buffer PGs: `hset BUFFER_PG|Ethernet8|1 profile [BUFFER_PROFILE|ingress_test_profile]` and `hset BUFFER_PG|Ethernet16|2 profile [BUFFER_PROFILE|ingress_test_profile]`
        ```
        NOTICE swss#orchagent: :- processPriorityGroup: Set buffer PG Ethernet8|1 to BUFFER_PROFILE:ingress_test_profile
        INFO swss#orchagent: :- setObjectReference: Obj BUFFER_PG.Ethernet8|1 Field profile: Add reference to BUFFER_PROFILE ingress_test_profile (now 1)
        NOTICE swss#orchagent: :- processPriorityGroup: Set buffer PG Ethernet16|2 to BUFFER_PROFILE:ingress_test_profile
        INFO swss#orchagent: :- setObjectReference: Obj BUFFER_PG.Ethernet16|2 Field profile: Add reference to BUFFER_PROFILE ingress_test_profile (now 2)
        ```
    - destroy the buffer PGs: `hdel BUFFER_PG|Ethernet16|2 profile` and `hdel BUFFER_PG|Ethernet8|1 profile`
        ```
        NOTICE swss#orchagent: :- processPriorityGroup: Remove buffer PG Ethernet16|2
        INFO swss#orchagent: :- removeMeFromObjsReferencedByMe: Obj BUFFER_PG.Ethernet16|2 Field profile: Remove reference to BUFFER_PROFILE ingress_test_profile (now 1)
        INFO swss#orchagent: :- removeObject: Obj BUFFER_PG:Ethernet16|2 is removed from store
        NOTICE swss#orchagent: :- processPriorityGroup: Remove buffer PG Ethernet8|1
        INFO swss#orchagent: :- removeMeFromObjsReferencedByMe: Obj BUFFER_PG.Ethernet8|1 Field profile: Remove reference to BUFFER_PROFILE ingress_test_profile (now 0)
        INFO swss#orchagent: :- removeObject: Obj BUFFER_PG:Ethernet8|1 is removed from store
        ```
    - destroy the buffer profile: `hdel BUFFER_PROFILE|ingress_test_profile dynamic_th pool size`
        ```
        NOTICE swss#orchagent: :- processBufferProfile: Remove buffer profile ingress_test_profile with type BUFFER_PROFILE
        INFO swss#orchagent: :- removeMeFromObjsReferencedByMe: Obj BUFFER_PROFILE.ingress_test_profile Field pool: Remove reference to BUFFER_POOL ingress_test_pool (now 0)
        INFO swss#orchagent: :- removeObject: Obj BUFFER_PROFILE:ingress_test_profile is removed from store
        ```
    - destroy the buffer pool: `hdel BUFFER_POOL|ingress_test_pool type mode size`
        ```
        NOTICE swss#orchagent: :- processBufferPool: Removed buffer pool ingress_test_pool with type BUFFER_POOL
        ```