### PR TITLE
[portsorch]: Set proper initial forwarding state for LAG member

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2577,7 +2577,7 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
                 /* Assert the port doesn't belong to any LAG already */
                 assert(!port.m_lag_id && !port.m_lag_member_id);
 
-                if (!addLagMember(lag, port))
+                if (!addLagMember(lag, port, (status == "disabled")))
                 {
                     it++;
                     continue;
@@ -3349,7 +3349,7 @@ void PortsOrch::getLagMember(Port &lag, vector<Port> &portv)
     }
 }
 
-bool PortsOrch::addLagMember(Port &lag, Port &port)
+bool PortsOrch::addLagMember(Port &lag, Port &port, bool disableForwarding)
 {
     SWSS_LOG_ENTER();
 
@@ -3369,6 +3369,17 @@ bool PortsOrch::addLagMember(Port &lag, Port &port)
     attr.id = SAI_LAG_MEMBER_ATTR_PORT_ID;
     attr.value.oid = port.m_port_id;
     attrs.push_back(attr);
+
+    if (disableForwarding)
+    {
+        attr.id = SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE;
+        attr.value.booldata = true;
+        attrs.push_back(attr);
+
+        attr.id = SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE;
+        attr.value.booldata = true;
+        attrs.push_back(attr);
+    }
 
     sai_object_id_t lag_member_id;
     sai_status_t status = sai_lag_api->create_lag_member(&lag_member_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());
@@ -3461,6 +3472,10 @@ bool PortsOrch::setCollectionOnLagMember(Port &lagMember, bool enableCollection)
         return false;
     }
 
+    SWSS_LOG_NOTICE("%s collection on LAG member %s",
+        enableCollection ? "Enable" : "Disable",
+        lagMember.m_alias.c_str());
+
     return true;
 }
 
@@ -3483,6 +3498,10 @@ bool PortsOrch::setDistributionOnLagMember(Port &lagMember, bool enableDistribut
             lagMember.m_alias.c_str());
         return false;
     }
+
+    SWSS_LOG_NOTICE("%s distribution on LAG member %s",
+        enableDistribution ? "Enable" : "Disable",
+        lagMember.m_alias.c_str());
 
     return true;
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -171,7 +171,7 @@ private:
 
     bool addLag(string lag);
     bool removeLag(Port lag);
-    bool addLagMember(Port &lag, Port &port);
+    bool addLagMember(Port &lag, Port &port, bool disableForwarding);
     bool removeLagMember(Port &lag, Port &port);
     bool setCollectionOnLagMember(Port &lagMember, bool enableCollection);
     bool setDistributionOnLagMember(Port &lagMember, bool enableDistribution);


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

This PR provides a fix for the next situation:
Suppose switch was configured with a LAG of two members.
The min links was set to one. The traffic is running and everything is ok.
One of the LAG members was set to down. The LAG is still operational.
Then warm-reboot was issued. The NOS loads a new kernel and starts DB recovery.
At this point a LAG members will be configured with the default forwarding state - allowed.
This will cause a short traffic disruption.

Sample logs:
```
Sep 17 14:26:55.109000 sonic NOTICE swss#orchagent: :- addLagMember: Add member Ethernet16 to LAG PortChannel0001 lid:20000000005de pid:100000000056f
Sep 17 14:26:55.112803 sonic NOTICE swss#orchagent: :- setCollectionOnLagMember: Enable collection on LAG member Ethernet16
Sep 17 14:26:55.116021 sonic NOTICE swss#orchagent: :- setDistributionOnLagMember: Enable distribution on LAG member Ethernet16

Sep 17 14:26:55.116809 sonic NOTICE swss#orchagent: :- addLagMember: Add member Ethernet18 to LAG PortChannel0001 lid:20000000005de pid:1000000000599
Sep 17 14:26:55.117100 sonic NOTICE swss#orchagent: :- setDistributionOnLagMember: Disable distribution on LAG member Ethernet18
Sep 17 14:26:55.117353 sonic NOTICE swss#orchagent: :- setCollectionOnLagMember: Disable collection on LAG member Ethernet18

Sep 17 14:26:55.350768 sonic INFO syncd#supervisord: syncd Sep 17 14:26:55 NOTICE  SAI_LAG: mlnx_sai_lag.c[1313]- mlnx_create_lag_member: Create lag member,
 #0 LAG_ID=LAG,(0:0),40,0000,0 #1 PORT_ID=PORT,(0:0),13500,0000,0
Sep 17 14:26:55.356459 sonic INFO syncd#supervisord: syncd Sep 17 14:26:55 NOTICE  SAI_LAG: mlnx_sai_lag.c[1538]- mlnx_create_lag_member: Created LAG member
 LAG member (13500,0,0)

Sep 17 14:26:55.356889 sonic INFO syncd#supervisord: syncd Sep 17 14:26:55 NOTICE  SAI_UTILS: mlnx_sai_utils.c[2397]- set_dispatch_attrib_handler: Set INGRE
SS_DISABLE, key:LAG member (13500,0,0), val:false
Sep 17 14:26:55.358337 sonic INFO syncd#supervisord: syncd Sep 17 14:26:55 NOTICE  SAI_UTILS: mlnx_sai_utils.c[2397]- set_dispatch_attrib_handler: Set EGRES
S_DISABLE, key:LAG member (13500,0,0), val:false

Sep 17 14:26:55.358512 sonic INFO syncd#supervisord: syncd Sep 17 14:26:55 NOTICE  SAI_LAG: mlnx_sai_lag.c[1313]- mlnx_create_lag_member: Create lag member,
 #0 LAG_ID=LAG,(0:0),40,0000,0 #1 PORT_ID=PORT,(0:0),13600,0000,0 #2 EGRESS_DISABLE=true #3 INGRESS_DISABLE=true
Sep 17 14:26:55.361060 sonic INFO syncd#supervisord: syncd Sep 17 14:26:55 NOTICE  SAI_LAG: mlnx_sai_lag.c[1538]- mlnx_create_lag_member: Created LAG member
 LAG member (13600,0,0)

Sep 17 14:26:55.361060 sonic INFO syncd#supervisord: syncd Sep 17 14:26:55 NOTICE  SAI_UTILS: mlnx_sai_utils.c[2397]- set_dispatch_attrib_handler: Set EGRES
S_DISABLE, key:LAG member (13600,0,0), val:true
Sep 17 14:26:55.374503 sonic INFO syncd#supervisord: syncd Sep 17 14:26:55 NOTICE  SAI_UTILS: mlnx_sai_utils.c[2397]- set_dispatch_attrib_handler: Set INGRE
SS_DISABLE, key:LAG member (13600,0,0), val:true
```

**What I did**
* Aligned LAG member configuration with DB state

**Why I did it**
* To fix short traffic disruption

**How I verified it**
1. config interface shutdown <lag_member>
2. warm-reboot

**Details if related**
https://github.com/opencomputeproject/SAI/blob/v1.6/inc/sailag.h#L263
```
/**
 * @brief Disable traffic distribution to this port as part of LAG
 *
 * @type bool
 * @flags CREATE_AND_SET
 * @default false
 */
SAI_LAG_MEMBER_ATTR_EGRESS_DISABLE,

/**
 * @brief Disable traffic collection from this port as part of LAG
 *
 * @type bool
 * @flags CREATE_AND_SET
 * @default false
 */
SAI_LAG_MEMBER_ATTR_INGRESS_DISABLE,
```