### PR TITLE
Use .clear() after std::move()

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -556,14 +556,12 @@ void FdbOrch::updateVlanMember(const VlanMemberUpdate& update)
 
     string port_name = update.member.m_alias;
     auto fdb_list = std::move(saved_fdb_entries[port_name]);
-    if(!fdb_list.empty())
+    saved_fdb_entries[port_name].clear();
+    for (const auto& fdb: fdb_list)
     {
-        for (const auto& fdb: fdb_list)
-        {
-            // try to insert an FDB entry. If the FDB entry is not ready to be inserted yet,
-            // it would be added back to the saved_fdb_entries structure by addFDBEntry()
-            (void)addFdbEntry(fdb.entry, fdb.type);
-        }
+        // try to insert an FDB entry. If the FDB entry is not ready to be inserted yet,
+        // it would be added back to the saved_fdb_entries structure by addFDBEntry()
+        (void)addFdbEntry(fdb.entry, fdb.type);
     }
 }
 


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Use .clear() on a vector after using std::move() from it to make sure that the vector is in a correct state.
2. Remove the if condition which is not required here.

**Why I did it**
1. std::move() from an object leaves the object in correct state. The correct state could be not empty. So I clear the vector to make sure that the vector is empty.
2. We don't need to check the vector on the emptiness. The for loop will do nothing, if there is no elements in the vector.

**How I verified it**
Make a draft PR and wait to make sure that there is no regression.

**Details if related**
