### PR TITLE
[drop counters] Clarify log messages for initial counter setup

### DIFF
--- a/orchagent/debugcounterorch.cpp
+++ b/orchagent/debugcounterorch.cpp
@@ -322,9 +322,9 @@ task_process_status DebugCounterOrch::addDropReason(const string& counter_name, 
         // are received before the create counter update, we keep track of reasons
         // we've seen in the free_drop_reasons table.
         addFreeDropReason(counter_name, drop_reason);
-        reconcileFreeDropCounters(counter_name);
+        SWSS_LOG_NOTICE("Added drop reason %s to drop counter %s", drop_reason.c_str(), counter_name.c_str());
 
-        SWSS_LOG_NOTICE("Succesfully created drop counter %s", counter_name.c_str());
+        reconcileFreeDropCounters(counter_name);
         return task_process_status::task_success;
     }
 
@@ -451,7 +451,7 @@ void DebugCounterOrch::reconcileFreeDropCounters(const string& counter_name)
         createDropCounter(counter_name, counter_it->second, reasons_it->second);
         free_drop_counters.erase(counter_it);
         free_drop_reasons.erase(reasons_it);
-        SWSS_LOG_NOTICE("Succesfully created new drop counter %s", counter_name.c_str());
+        SWSS_LOG_NOTICE("Succesfully matched drop reasons to counter %s", counter_name.c_str());
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I updated the logging messages in debugcounterorch to:
1) Clearly display that drop reasons have been added to counters if they haven't been created yet.
2) Differentiate between counter creation and free counter reconciliation

**Why I did it**
Fixes https://github.com/Azure/sonic-buildimage/issues/4434

**How I verified it**
Create counter from the CLI and verify that all drop reasons are shown in the syslog and that there is a "counter created" and a "counter matched" message.

**Details if related**
