### PR TITLE
Some of Netdevice created by teamd are not cleaned up when teamd service is disabled.

### DIFF
--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -10,7 +10,6 @@
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <fstream>
 #include <thread>
 
 #include <net/if.h>
@@ -18,7 +17,6 @@
 #include <sys/stat.h>
 #include <signal.h>
 
-#define PID_FILE_PATH "/var/run/teamd/"
 
 using namespace std;
 using namespace swss;
@@ -115,75 +113,14 @@ void TeamMgr::doTask(Consumer &consumer)
 }
 
 
-pid_t TeamMgr::getTeamPid(const string &alias)
+void TeamMgr::cleanTeamProcesses()
 {
-    SWSS_LOG_ENTER();
-    pid_t pid = 0;
-
-    string file = string(PID_FILE_PATH) + alias + string(".pid");
-    ifstream infile(file);
-    if (!infile.is_open())
-    {
-        SWSS_LOG_WARN("The LAG PID file: %s is not readable", file.c_str());
-        return 0;
-    }
-
-    string line;
-    getline(infile, line);
-    if (line.empty())
-    {
-        SWSS_LOG_WARN("The LAG PID file: %s is empty", file.c_str());
-    }
-    else 
-    {
-        /*Store the PID value */
-        pid = stoi(line, nullptr, 10);
-    }
-
-    /* Close the file and return */
-    infile.close();
-
-    return pid;
-}
-
-
-void TeamMgr::addLagPid(const string &alias)
-{
-    SWSS_LOG_ENTER();
-    m_lagPIDList[alias] = getTeamPid(alias);
-}
-
-void TeamMgr::removeLagPid(const string &alias)
-{
-    SWSS_LOG_ENTER();
-    m_lagPIDList.erase(alias);
-}
-
-void TeamMgr::cleanTeamProcesses(int signo)
-{
-    pid_t pid = 0;
-
     SWSS_LOG_ENTER();
     SWSS_LOG_NOTICE("Cleaning up LAGs during shutdown...");
     for (const auto& it: m_lagList)
     {
-        pid = m_lagPIDList[it];
-        if(!pid) {
-            SWSS_LOG_WARN("Invalid PID found for LaG %s ", it.c_str());
-
-            /* Try to get the PID again */
-            pid = getTeamPid(it);
-        }
-
-        if(pid > 0)
-        {
-            SWSS_LOG_INFO("Sending TERM Signal to (PID: %d) for LaG %s ", pid, it.c_str());
-            kill(pid, signo);
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Can't send TERM signal to LAG %s. PID wasn't found", it.c_str());
-        }
+        //This will call team -k kill -t <teamdevicename> which internally send SIGTERM 
+        removeLag(it);
     }
 
     return;
@@ -252,7 +189,6 @@ void TeamMgr::doLagTask(Consumer &consumer)
                 }
 
                 m_lagList.insert(alias);
-                addLagPid(alias);
             }
 
             setLagAdminStatus(alias, admin_status);
@@ -269,7 +205,6 @@ void TeamMgr::doLagTask(Consumer &consumer)
             {
                 removeLag(alias);
                 m_lagList.erase(alias);
-                removeLagPid(alias);
             }
         }
 

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -18,7 +18,7 @@ public:
             const std::vector<TableConnector> &tables);
 
     using Orch::doTask;
-    void cleanTeamProcesses(int signo);
+    void cleanTeamProcesses();
 
 private:
     Table m_cfgMetadataTable;   // To retrieve MAC address
@@ -50,9 +50,6 @@ private:
     bool setLagMtu(const std::string &alias, const std::string &mtu);
     bool setLagLearnMode(const std::string &alias, const std::string &learn_mode);
  
-    pid_t getTeamPid(const std::string &alias);
-    void addLagPid(const std::string &alias);
-    void removeLagPid(const std::string &alias);
 
     bool isPortEnslaved(const std::string &);
     bool findPortMaster(std::string &, const std::string &);

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv)
             auto *c = (Executor *)sel;
             c->execute();
         }
-        teammgr.cleanTeamProcesses(SIGTERM);
+        teammgr.cleanTeamProcesses();
         SWSS_LOG_NOTICE("Exiting");
     }
     catch (const exception &e)


### PR DESCRIPTION
Why I did:

The Netdevice created by teamd process not getting clean when Teamd feature/docker/service is disabled/stop
as observed  and  fixed by 2PR's -

https://github.com/Azure/sonic-swss/pull/1159
https://github.com/Azure/sonic-swss/pull/1407

is still being observed on Multi-asic platforms consistently and also on KVM VS testbed ( it is not consistent but happens every few runs (https://github.com/Azure/sonic-buildimage/issues/5432)

Issue seems to be timing issue where
SIGTERM (generated by docker stop) and  send via kill() of teammgrd to teamd was not cleaning
all teamd process netdevice resources.


How I did:
So fix is Instead  of sending explicit SIGTERM via kill() system call to teamd we are calling
teamd -k. Using this teamd itself generate SIGTERM (https://github.com/jpirko/libteam/blob/master/teamd/teamd.c#L1861) and handle the processing.

With this change reverted (Lag alias <-> to pid mapping) done in PR https://github.com/Azure/sonic-swss/pull/1159  as these is not needed as we are not using using kill() call.

How I verified:
a) Executed the below script 50 times on Multu-asic platforms and things were fine.

       #!/bin/bash

        i=0
        while [ $i -lt 50 ]; do
            echo "iteration $i"
            sudo config feature state teamd disabled
            sleep 60
            rc=0
            (sudo ip -n asic0 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic1 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic2 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic3 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic4 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic5 link show | grep -qc PortChannel) && rc=$((rc+1))
            if [ $rc -ne 0 ]; then
               echo "Failed iteration $i for portchannel cleanup"
               break
            fi
            sudo config feature state teamd enabled
            sleep 60
            (sudo ip -n asic0 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic1 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic2 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic3 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic4 link show | grep -qc PortChannel) && rc=$((rc+1))
            (sudo ip -n asic5 link show | grep -qc PortChannel) && rc=$((rc+1))
            if [ $rc != 6 ]; then
               echo "Failed iteration $i for portchannel bringup"
               break
            fi
            i=$((i+1))
        done
        echo "Completed $i iteration sucessfully"


b) on KVM VS 

        #!/bin/bash

        i=0
        while [ $i -lt 50 ]; do
            echo "iteration $i"
            sudo config feature state teamd disabled
            sleep 60
            rc=0
            (sudo ip link show | grep -qc PortChannel) && rc=$((rc+1))
            if [ $rc -ne 0 ]; then
               echo "Failed iteration $i for portchannel cleanup"
               break
            fi
            sudo config feature state teamd enabled
            sleep 60
            (sudo ip link show | grep -qc PortChannel) && rc=$((rc+1))
            if [ $rc != 1 ]; then
               echo "Failed iteration $i for portchannel bringup"
               break
            fi
            i=$((i+1))
        done
        echo "Completed $i iteration sucessfully"

a) Before fix:
admin@vlab-01:~$ bash teamd_cleanup.sh
iteration 0
iteration 1
iteration 2
iteration 3
Failed iteration 3 for portchannel cleanup
Completed 3 iteration sucessfully

    admin@vlab-01:~$ docker ps | grep -c teamd
    0
    admin@vlab-01:~$ ip link show | grep PortChannel
    330: PortChannel0004: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 9100 qdisc noqueue state DOWN mode DEFAULT 
    group default qlen 1000

After fix looks fine.

c) Run script to make sure BGP is fine after config reload on multi-asic platforms

        #!/bin/bash

        i=0
        while [ $i -lt 25 ]; do
            echo "iteration $i"
            sudo config reload -y
            sleep 180
            rc=0
            (show ip bgp summary -n asic0 -d all | grep -qic Active) && rc=$((rc+1))
            (show ip bgp summary -n asic0 -d all | grep -qic Connect) && rc=$((rc+1))
            (show ip bgp summary -n asic1 -d all | grep -qic Active) && rc=$((rc+1))
            (show ip bgp summary -n asic1 -d all | grep -qic Connect) && rc=$((rc+1))
            (show ip bgp summary -n asic2 -d all | grep -qic Active) && rc=$((rc+1))
            (show ip bgp summary -n asic2 -d all | grep -qic Connect) && rc=$((rc+1))
            (show ip bgp summary -n asic3 -d all | grep -qic Active) && rc=$((rc+1))
            (show ip bgp summary -n asic3 -d all | grep -qic Connect) && rc=$((rc+1))
            (show ip bgp summary -n asic4 -d all | grep -qic Active) && rc=$((rc+1))
            (show ip bgp summary -n asic4 -d all | grep -qic Connect) && rc=$((rc+1))
            (show ip bgp summary -n asic5 -d all | grep -qic Active) && rc=$((rc+1))
            (show ip bgp summary -n asic5 -d all | grep -qic Connect) && rc=$((rc+1))
            if [ $rc -ne 0 ]; then
               echo "Failed iteration $i all BGP not up"
               break
            fi
            i=$((i+1))
        done
        echo "Completed $ iteration sucessfully"
