### PR TITLE
[vs test bug fix] Restore eth0 up in post-test clean up

### DIFF
--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -264,6 +264,10 @@ class TestPortchannel(object):
         tbl._del("PortChannel004")
         time.sleep(1)
 
+        # Restore eth0 up
+        dvs.servers[0].runcmd("ip link set up dev eth0")
+        time.sleep(1)
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
As per https://github.com/Azure/sonic-swss/pull/1030#discussion_r496319518

Signed-off-by: Wenda Ni <wonda.ni@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**
test_port.py test failure if follows test_portchannel.py using persistent vs container
```
$ sudo pytest -v --dvsname=vs -s test_portchannel.py 
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.13, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python2
cachedir: .pytest_cache
rootdir: /home/wendani/sonic-buildimage-201911/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 2 items                                                                                                                                    

test_portchannel.py::TestPortchannel::test_Portchannel remove extra link dummy
PASSED
test_portchannel.py::TestPortchannel::test_Portchannel_oper_down PASSED

$ sudo ip netns exec sw-srv0 ip -d link show eth0
1408: eth0@if1407: <BROADCAST,MULTICAST> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether e2:62:28:06:a9:84 brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 0 
    veth addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 

$ sudo pytest -v --dvsname=vs -s test_port.py
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.13, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python2
cachedir: .pytest_cache
rootdir: /home/wendani/sonic-buildimage-201911/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 6 items                                                                                                                                    

test_port.py::TestPort::test_PortMtu remove extra link dummy
PASSED
test_port.py::TestPort::test_PortNotification FAILED
test_port.py::TestPort::test_PortFec FAILED
test_port.py::TestPort::test_PortPreemp PASSED
test_port.py::TestPort::test_PortIdriver PASSED
test_port.py::TestPort::test_PortIpredriver PASSED
```

**How I verified it**
201911 branch

```
$ sudo pytest -v --dvsname=vs -s test_portchannel.py 
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.13, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python2
cachedir: .pytest_cache
rootdir: /home/wendani/sonic-buildimage-201911/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 2 items                                                                                                                                    

test_portchannel.py::TestPortchannel::test_Portchannel remove extra link dummy
PASSED
test_portchannel.py::TestPortchannel::test_Portchannel_oper_down PASSED

$ sudo ip netns exec sw-srv0 ip -d link show eth0
1408: eth0@if1407: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether e2:62:28:06:a9:84 brd ff:ff:ff:ff:ff:ff link-netnsid 1 promiscuity 0 
    veth addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 

$ sudo pytest -v --dvsname=vs -s test_port.py 
================================================================ test session starts =================================================================
platform linux2 -- Python 2.7.13, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/bin/python2
cachedir: .pytest_cache
rootdir: /home/wendani/sonic-buildimage-201911/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 6 items                                                                                                                                    

test_port.py::TestPort::test_PortMtu remove extra link dummy
PASSED
test_port.py::TestPort::test_PortNotification PASSED
test_port.py::TestPort::test_PortFec PASSED
test_port.py::TestPort::test_PortPreemp PASSED
test_port.py::TestPort::test_PortIdriver PASSED
test_port.py::TestPort::test_PortIpredriver PASSED

============================================================= 6 passed in 55.92 seconds ==============================================================

```
**Details if related**
