### PR TITLE
[syncd][Drop Counters] Check for string length before calling substr

### DIFF
--- a/orchagent/debug_counter/drop_counter.cpp
+++ b/orchagent/debug_counter/drop_counter.cpp
@@ -318,11 +318,21 @@ unordered_set<string> DropCounter::getSupportedDropReasons(sai_debug_counter_att
         if (drop_reason_type == SAI_DEBUG_COUNTER_ATTR_IN_DROP_REASON_LIST)
         {
             drop_reason = sai_serialize_ingress_drop_reason(static_cast<sai_in_drop_reason_t>(drop_reason_list.list[i]));
+            // in case of unsupported counter, enum value is returned as a str
+            if (drop_reason.length() < INGRESS_DROP_REASON_PREFIX_LENGTH)
+            {
+                continue;
+            }
             drop_reason = drop_reason.substr(INGRESS_DROP_REASON_PREFIX_LENGTH);
         }
         else
         {
             drop_reason = sai_serialize_egress_drop_reason(static_cast<sai_out_drop_reason_t>(drop_reason_list.list[i]));
+            // in case of unsupported counter, enum value is returned as a str
+            if (drop_reason.length() < INGRESS_DROP_REASON_PREFIX_LENGTH)
+            {
+                continue;
+            }
             drop_reason = drop_reason.substr(EGRESS_DROP_REASON_PREFIX_LENGTH);
         }
 

--- a/orchagent/debug_counter/drop_counter.cpp
+++ b/orchagent/debug_counter/drop_counter.cpp
@@ -329,7 +329,7 @@ unordered_set<string> DropCounter::getSupportedDropReasons(sai_debug_counter_att
         {
             drop_reason = sai_serialize_egress_drop_reason(static_cast<sai_out_drop_reason_t>(drop_reason_list.list[i]));
             // in case of unsupported counter, enum value is returned as a str
-            if (drop_reason.length() < INGRESS_DROP_REASON_PREFIX_LENGTH)
+            if (drop_reason.length() < EGRESS_DROP_REASON_PREFIX_LENGTH)
             {
                 continue;
             }


### PR DESCRIPTION
**What I did**
Check for string length before calling sustring with a specific length.

**Why I did it**

For unsupported DROP counters the string returned is the enum value as a string, whose max length is 2. 
Calling a substring with a length greater than 2 was crashing syncd.

**How I verified it**

Verified syncd doesn't crash after the fix.

**Details if related**

Oct  1 16:07:39.387872 str-s6000-acs-9 INFO swss#supervisord: orchagent terminate called after throwing an instance of 'std::out_of_range'
Oct  1 16:07:39.387872 str-s6000-acs-9 INFO swss#supervisord: orchagent   what():  basic_string::substr: __pos (which is 19) > this->size() (which is 2)
