### PR TITLE
[acl] Replace IP_PROTOCOL with NEXT_HEADER for IPv6 ACL tables

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -387,12 +387,12 @@ bool AclRule::validateAddMatch(string attr_name, string attr_value)
         return false;
     }
 
-    // NOTE: For backwards compatibility, allow users to substitute IP_PROTOCOL for NEXT_HEADER.
-    // This should be removed after the 202012 release.
+    // TODO: For backwards compatibility, users can substitute IP_PROTOCOL for NEXT_HEADER.
+    // This should be removed in a future release.
     if ((m_tableType == ACL_TABLE_MIRRORV6 || m_tableType == ACL_TABLE_L3V6)
             && attr_name == MATCH_IP_PROTOCOL)
     {
-        SWSS_LOG_WARN("Support for IP protocol on IPv6 tables will be removed in the next release, please switch to using NEXT_HEADER instead!");
+        SWSS_LOG_WARN("Support for IP protocol on IPv6 tables will be removed in a future release, please switch to using NEXT_HEADER instead!");
         attr_name = MATCH_NEXT_HEADER;
     }
 
@@ -1046,13 +1046,8 @@ bool AclRuleL3V6::validateAddMatch(string attr_name, string attr_value)
         return false;
     }
 
-    // NOTE: For backwards compatibility, allow users to substitute IP_PROTOCOL for NEXT_HEADER.
-    // This check should be added after the 202012 release.
-    // if (attr_name == MATCH_IP_PROTOCOL)
-    // {
-    //    SWSS_LOG_ERROR("IP Protocol match is not supported for table type L3V6");
-    //    return false;
-    // }
+    // TODO: For backwards compatibility, users can substitute IP_PROTOCOL for NEXT_HEADER.
+    // Should add a check for IP_PROTOCOL in a future release.
 
     return AclRule::validateAddMatch(attr_name, attr_value);
 }
@@ -1149,8 +1144,8 @@ bool AclRuleMirror::validateAddMatch(string attr_name, string attr_value)
         return false;
     }
 
-    // NOTE: For backwards compatibility, allow users to substitute IP_PROTOCOL for NEXT_HEADER.
-    // This check should be expanded after the 202012 release.
+    // TODO: For backwards compatibility, users can substitute IP_PROTOCOL for NEXT_HEADER.
+    // This check should be expanded to include IP_PROTOCOL in a future release.
     if (m_tableType == ACL_TABLE_MIRRORV6 &&
             (attr_name == MATCH_SRC_IP || attr_name == MATCH_DST_IP ||
              attr_name == MATCH_ICMP_TYPE || attr_name == MATCH_ICMP_CODE ||

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -400,7 +400,6 @@ namespace aclorch_test
 
             fields.push_back({ "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST", "2:SAI_ACL_BIND_POINT_TYPE_PORT,SAI_ACL_BIND_POINT_TYPE_LAG" });
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE", "true" });
-            fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL", "true" });
 
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT", "true" });
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT", "true" });
@@ -413,11 +412,13 @@ namespace aclorch_test
                     fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE", "true" });
                     fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_SRC_IP", "true" });
                     fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_DST_IP", "true" });
+                    fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL", "true" });
                     break;
 
                 case ACL_TABLE_L3V6:
                     fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6", "true" });
                     fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6", "true" });
+                    fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_IPV6_NEXT_HEADER", "true" });
                     break;
 
                 default:

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -76,6 +76,28 @@ class TestAcl:
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
         dvs_acl.verify_no_acl_rules()
 
+    def test_AclRuleIpProtocol(self, dvs_acl, l3_acl_table):
+        config_qualifiers = {"IP_PROTOCOL": "6"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL": dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
+        }
+
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_AclRuleNextHeader(self, dvs_acl, l3_acl_table):
+        config_qualifiers = {"NEXT_HEADER": "6"}
+
+        # Shouldn't allow NEXT_HEADER on vanilla L3 tables.
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_no_acl_rules()
+
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
     def test_AclRuleInOutPorts(self, dvs_acl, l3_acl_table):
         config_qualifiers = {
             "IN_PORTS": "Ethernet0,Ethernet4",
@@ -154,10 +176,24 @@ class TestAcl:
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
         dvs_acl.verify_no_acl_rules()
 
+    # This test validates that backwards compatibility works as expected, it should
+    # be converted to a negative test after the 202012 release.
     def test_V6AclRuleIpProtocol(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"IP_PROTOCOL": "6"}
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL": dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
+            "SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER": dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
+        }
+
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_V6AclRuleNextHeader(self, dvs_acl, l3v6_acl_table):
+        config_qualifiers = {"NEXT_HEADER": "6"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER": dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
         }
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)

--- a/tests/test_mirror_ipv6_combined.py
+++ b/tests/test_mirror_ipv6_combined.py
@@ -1,10 +1,7 @@
 # This test suite covers the functionality of mirror feature in SwSS
-import platform
-import pytest
 import time
 
 from swsscommon import swsscommon
-from distutils.version import StrictVersion
 
 DVS_FAKE_PLATFORM = "broadcom"
 
@@ -165,6 +162,7 @@ class TestMirror(object):
         expected_sai_attributes = [
             "SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE",
             "SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL",
+            "SAI_ACL_TABLE_ATTR_FIELD_IPV6_NEXT_HEADER",
             "SAI_ACL_TABLE_ATTR_FIELD_SRC_IP",
             "SAI_ACL_TABLE_ATTR_FIELD_DST_IP",
             "SAI_ACL_TABLE_ATTR_FIELD_ICMP_TYPE",
@@ -554,8 +552,6 @@ class TestMirror(object):
         self.remove_neighbor("Ethernet32", "20.0.0.1")
         self.remove_ip_address("Ethernet32", "20.0.0.0/31")
         self.set_interface_status("Ethernet32", "down")
-
-
 
 
 # Add Dummy always-pass test at end as workaroud

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -1,8 +1,5 @@
 # This test suite covers the functionality of mirror feature in SwSS
-import platform
-import pytest
 import time
-from distutils.version import StrictVersion
 
 from swsscommon import swsscommon
 
@@ -230,7 +227,7 @@ class TestMirror(object):
         # dscp mirror tables.
         expected_sai_attributes = [
             "SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE",
-            "SAI_ACL_TABLE_ATTR_FIELD_IPV6_NEXT_HEADER",  # NOTE: We use the MLNX2700 VS implementation for this test suite.
+            "SAI_ACL_TABLE_ATTR_FIELD_IPV6_NEXT_HEADER",
             "SAI_ACL_TABLE_ATTR_FIELD_SRC_IPV6",
             "SAI_ACL_TABLE_ATTR_FIELD_DST_IPV6",
             "SAI_ACL_TABLE_ATTR_FIELD_ICMPV6_TYPE",


### PR DESCRIPTION
- Update qualifiers for all platforms
- Fix C++ unit tests
- Add new VS test cases

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I updated aclorch to use NEXT_HEADER rather than IP_PROTOCOL for all IPv6 ACL tables.

The 202012 release will still allow users to specify IP_PROTOCOL in config DB, but it will use the new SAI attributes under the hood and print a deprecation warning to the logs.

**Why I did it**
Fixes https://github.com/Azure/sonic-buildimage/issues/4570
Fixes https://github.com/Azure/sonic-swss/issues/1316

**How I verified it**
Added new test cases and updated the old VS/C++ unit test cases. Change looks good on physical devices as well.

**Details if related**
