### PR TITLE
[acl] Refactor port OID retrieval into aclorch

### DIFF
--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -430,6 +430,9 @@ public:
     map<acl_table_type_t, bool> m_mirrorTableCapabilities;
 
     static sai_acl_action_type_t getAclActionFromAclEntry(sai_acl_entry_attr_t attr);
+    
+    // Get the OID for the ACL bind point for a given port
+    static bool getAclBindPortId(Port& port, sai_object_id_t& port_id);
 
 private:
     SwitchOrch *m_switchOrch;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -609,46 +609,6 @@ bool PortsOrch::getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port
     return false;
 }
 
-// TODO: move this into AclOrch
-bool PortsOrch::getAclBindPortId(string alias, sai_object_id_t &port_id)
-{
-    SWSS_LOG_ENTER();
-
-    Port port;
-    if (getPort(alias, port))
-    {
-        switch (port.m_type)
-        {
-        case Port::PHY:
-            if (port.m_lag_member_id != SAI_NULL_OBJECT_ID)
-            {
-                SWSS_LOG_WARN("Invalid configuration. Bind table to LAG member %s is not allowed", alias.c_str());
-                return false;
-            }
-            else
-            {
-                port_id = port.m_port_id;
-            }
-            break;
-        case Port::LAG:
-            port_id = port.m_lag_id;
-            break;
-        case Port::VLAN:
-            port_id = port.m_vlan_info.vlan_oid;
-            break;
-        default:
-            SWSS_LOG_ERROR("Failed to process port. Incorrect port %s type %d", alias.c_str(), port.m_type);
-            return false;
-        }
-
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
 bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp, const uint32_t &mtu)
 {
     size_t found = alias.find(VLAN_SUB_INTERFACE_SEPARATOR);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -93,7 +93,6 @@ public:
     void setPort(string alias, Port port);
     void getCpuPort(Port &port);
     bool getVlanByVlanId(sai_vlan_id_t vlan_id, Port &vlan);
-    bool getAclBindPortId(string alias, sai_object_id_t &port_id);
 
     bool setHostIntfsOperStatus(const Port& port, bool up) const;
     void updateDbPortOperStatus(const Port& port, sai_port_oper_status_t status) const;


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I moved getAclBindPortId from portsorch to aclorch.

**Why I did it**
This serves two purposes:
1. There was a bug wherein AclTable::update would fail to handle port deletion events because the getAclBindPortId method lived in portsorch. Because this method was using the provided alias to get the OID internally, this method would fail in the delete case because the port had already been deleted from portsorch. As a result, all delete events would fail and print a "Unable to retrieve OID" method. This was caught by the `test_po_update` pytest because it deletes the PortChannel at the end of the test case, which triggers a delete event, which triggers this bug.

2. The behavior implemented in this method is specific to the ACL implementation in SONiC, and it doesn't really make sense to include it in the more generic AclOrch. Furthermore, we have access to all the port info in AclOrch, so there is no need to take a dependency on PortsOrch to fetch the port OID info and perform the parsing logic. There was a `TODO` indicating the same.

**How I verified it**
`test_po_update` passes in the master image now. I also re-ran the `acl` and `everflow` tests and everything looks good to go.

**Details if related**
Fixes https://github.com/Azure/sonic-buildimage/issues/5273