### PR TITLE
[vlanmgr] Set the dot1q_bridge MAC address to gMacaddress instead of random MAC address.

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -52,6 +52,7 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     // /bin/bash -c "/sbin/ip link del Bridge 2>/dev/null ;
     //               /sbin/ip link add Bridge up type bridge &&
     //               /sbin/ip link set Bridge mtu {{ mtu_size }} &&
+    //               /sbin/ip link set Bridge address {{gMacAddress}} &&
     //               /sbin/bridge vlan del vid 1 dev Bridge self;
     //               /sbin/ip link del dummy 2>/dev/null;
     //               /sbin/ip link add dummy type dummy &&
@@ -62,6 +63,7 @@ VlanMgr::VlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
       + IP_CMD + " link del " + DOT1Q_BRIDGE_NAME + " 2>/dev/null; "
       + IP_CMD + " link add " + DOT1Q_BRIDGE_NAME + " up type bridge && "
       + IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " mtu " + DEFAULT_MTU_STR + " && "
+      + IP_CMD + " link set " + DOT1Q_BRIDGE_NAME + " address " + gMacAddress.to_string() + " && "
       + BRIDGE_CMD + " vlan del vid " + DEFAULT_VLAN_ID + " dev " + DOT1Q_BRIDGE_NAME + " self; "
       + IP_CMD + " link del dev dummy 2>/dev/null; "
       + IP_CMD + " link add dummy type dummy && "


### PR DESCRIPTION

**What I did**
Set the dot1q_bridge MAC address to gMacaddress instead of random MAC address.

**Why I did it**
The dot1q_bridge is created without setting mac_address now, when we execute reboot or reload, the mac_address will be set to different random mac_address. 
```
admin@leaf-229:~$ ip link show Bridge
14: Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether 5a:15:aa:19:17:22 brd ff:ff:ff:ff:ff:ff

admin@leaf-229:~$ sudo config reload -y
admin@leaf-229:~$ ip link show Bridge
175: Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default qlen 1000
    link/ether aa:f7:76:39:c2:d3 brd ff:ff:ff:ff:ff:ff
```

**How I verified it**
reload and see the mac_address of Bridge


**Details if related**
