### PR TITLE
[mock tests] Update MockDBConnector to match new swsscommon interface

### DIFF
--- a/tests/mock_tests/mock_dbconnector.cpp
+++ b/tests/mock_tests/mock_dbconnector.cpp
@@ -9,33 +9,25 @@
 
 namespace swss
 {
-    DBConnector::~DBConnector()
-    {
-        close(m_conn->fd);
-        if (m_conn->connection_type == REDIS_CONN_TCP)
-            free(m_conn->tcp.host);
-        else
-            free(m_conn->unix_sock.path);
-        free(m_conn);
-    }
-
     DBConnector::DBConnector(int dbId, const std::string &hostname, int port, unsigned int timeout) :
         m_dbId(dbId)
     {
-        m_conn = (redisContext *)calloc(1, sizeof(redisContext));
-        m_conn->connection_type = REDIS_CONN_TCP;
-        m_conn->tcp.host = strdup(hostname.c_str());
-        m_conn->tcp.port = port;
-        m_conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+        auto conn = (redisContext *)calloc(1, sizeof(redisContext));
+        conn->connection_type = REDIS_CONN_TCP;
+        conn->tcp.host = strdup(hostname.c_str());
+        conn->tcp.port = port;
+        conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+        setContext(conn);
     }
 
     DBConnector::DBConnector(int dbId, const std::string &unixPath, unsigned int timeout) :
         m_dbId(dbId)
     {
-        m_conn = (redisContext *)calloc(1, sizeof(redisContext));
-        m_conn->connection_type = REDIS_CONN_UNIX;
-        m_conn->unix_sock.path = strdup(unixPath.c_str());
-        m_conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+        auto conn = (redisContext *)calloc(1, sizeof(redisContext));
+        conn->connection_type = REDIS_CONN_UNIX;
+        conn->unix_sock.path = strdup(unixPath.c_str());
+        conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+        setContext(conn);
     }
 
     DBConnector::DBConnector(const std::string& dbName, unsigned int timeout, bool isTcpConn)
@@ -46,18 +38,20 @@ namespace swss
         m_dbId = swss::SonicDBConfig::getDbId(dbName);
         if (isTcpConn)
         {
-             m_conn = (redisContext *)calloc(1, sizeof(redisContext));
-             m_conn->connection_type = REDIS_CONN_TCP;
-             m_conn->tcp.host = strdup(swss::SonicDBConfig::getDbHostname(dbName).c_str());
-             m_conn->tcp.port = swss::SonicDBConfig::getDbPort(dbName);
-             m_conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+            auto conn = (redisContext *)calloc(1, sizeof(redisContext));
+            conn->connection_type = REDIS_CONN_TCP;
+            conn->tcp.host = strdup(swss::SonicDBConfig::getDbHostname(dbName).c_str());
+            conn->tcp.port = swss::SonicDBConfig::getDbPort(dbName);
+            conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+            setContext(conn);
         }
         else
         {
-            m_conn = (redisContext *)calloc(1, sizeof(redisContext));
-            m_conn->connection_type = REDIS_CONN_UNIX;
-            m_conn->unix_sock.path = strdup(swss::SonicDBConfig::getDbSock(dbName).c_str());
-            m_conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+            auto conn = (redisContext *)calloc(1, sizeof(redisContext));
+            conn->connection_type = REDIS_CONN_UNIX;
+            conn->unix_sock.path = strdup(swss::SonicDBConfig::getDbSock(dbName).c_str());
+            conn->fd = socket(AF_UNIX, SOCK_DGRAM, 0);
+            setContext(conn);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I updated the MockDBConnector class to respect the access-level of the m_conn member variable.

**Why I did it**
https://github.com/Azure/sonic-swss-common/pull/387 refactored the DBConnector class and changed the access level of a few member fields. So, to make the mock implementation correct, we need to use the proper setter method to update the redis connection.

**How I verified it**
Built locally w/ latest sairedis and swsscommon changes.

**Details if related**
This should fix the following jenkins issue:
https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/sonic-sairedis-build/1344/console

Which will in turn fix this issue:
https://sonic-jenkins.westus2.cloudapp.azure.com/job/vs/job/sonic-swss-build/1944/console
