### PR TITLE
[fdborch] Fix FDB flush issues

### DIFF
--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -58,6 +58,7 @@ private:
     Table m_fdbStateTable;
     NotificationConsumer* m_flushNotificationsConsumer;
     NotificationConsumer* m_fdbNotificationConsumer;
+    int flush_count = 0;
 
     void doTask(Consumer& consumer);
     void doTask(NotificationConsumer& consumer);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add a reference count to ensure that the FDB is not added or deleted during FDB flush.


**Why I did it**
In the mclag scenario, restart one of a pair of leaf switches. After completing the information exchange between leaf switches, the leaf switch will flush the fdb and then add the fdb, and then if  the downlink port down, the fdb will be redirected.
At this point, a bug may appear:

ERR swss#orchagent: :- meta_sai_validate_fdb_entry: object key SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x26000000000943","mac":"B4:56:B9:F0:00:3E","switch_id":"oid:0x21000000000000"} already exists
ERR swss#orchagent: :- addFdbEntry: Failed to create dynamic FDB b4:56:b9:f0:00:3e on Ethernet16, rv:-6 


analysis：
flush fdb, there are three steps
1. Call ASI api after fdborch is processed; sairedis deletes the local cache; deletes fdb in the chip
2. After deleting fdb in the chip, a flush notification will be sent to sairedis, and the fdb entry in ASIC_DB will be deleted
3. When fdborch receives the notification, the fdb cached in orch is deleted

If between step 1 and step 3, fdborch processes the event of adding fdb, it may cause the fdb cache in sairedis to be incorrect or the entries in ASIC_DB are incorrect.
In this way, subsequent additions and deletions will cause larger e exceptions.

**How I verified it**
flush fdb
add fdb to APPL_DB immediately
set this fdb again after

