### PR TITLE
[tlm_teamd]: Force tlm_teamd to connect using usock method only

### DIFF
--- a/tlm_teamd/teamdctl_mgr.cpp
+++ b/tlm_teamd/teamdctl_mgr.cpp
@@ -92,7 +92,7 @@ bool TeamdCtlMgr::try_add_lag(const std::string & lag_name)
 
     teamdctl_set_log_fn(tdc, &teamdctl_log_function);
 
-    int err = teamdctl_connect(tdc, lag_name.c_str(), nullptr, nullptr);
+    int err = teamdctl_connect(tdc, lag_name.c_str(), nullptr, "usock");
     if (err)
     {
         if (attempt != 0)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Fixes: https://github.com/Azure/sonic-buildimage/issues/5306

**What I did**
Force tlm_teamd to connect to teamd using usock method only.

**Why I did it**
Previously libteamdctl had only one method enabled: "usock". After we introduced zmq inside of our sonic-slave, libteamdctl is being build with two teamd connection method enabled: "usock" and "zmq", Autoselect crashes because we need to put a [connection string](https://github.com/jpirko/libteam/blob/master/libteamdctl/libteamdctl.c#L286) for zmq method.

**How I verified it**
1. Check that tlm_teamd is working
```
admin@str-s6100-acs-1:~$ ps ax | grep tlm
 2961 pts/0    Sl     0:00 /usr/bin/tlm_teamd
 4902 pts/0    S+     0:00 grep tlm
```
2, Issue command `sudo config portchannel add PortChannel0010`
3. Check that tlm_teamd is still working
```
admin@str-s6100-acs-1:~$ ps ax | grep tlm
 2961 pts/0    Sl     0:00 /usr/bin/tlm_teamd
 5189 pts/0    S+     0:00 grep tlm
```

**Details if related**
