### PR TITLE
[sub intf] Inherit parent port mtu changes

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -716,6 +716,33 @@ bool PortsOrch::removeSubPort(const string &alias)
     return true;
 }
 
+void PortsOrch::updateChildPortsMtu(const Port &p, const uint32_t mtu)
+{
+    if (p.m_type != Port::PHY && p.m_type != Port::LAG)
+    {
+        return;
+    }
+
+    for (const auto &child_port : p.m_child_ports)
+    {
+        Port subp;
+        if (!getPort(child_port, subp))
+        {
+            SWSS_LOG_WARN("Sub interface %s Port object not found", child_port.c_str());
+            continue;
+        }
+
+        subp.m_mtu = mtu;
+        m_portList[child_port] = subp;
+        SWSS_LOG_NOTICE("Sub interface %s inherits mtu change %u from parent port %s", child_port.c_str(), mtu, p.m_alias.c_str());
+
+        if (subp.m_rif_id)
+        {
+            gIntfsOrch->setRouterIntfsMtu(subp);
+        }
+    }
+}
+
 void PortsOrch::setPort(string alias, Port p)
 {
     m_portList[alias] = p;
@@ -2318,6 +2345,8 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         {
                             gIntfsOrch->setRouterIntfsMtu(p);
                         }
+                        // Sub interfaces inherit parent physical port mtu
+                        updateChildPortsMtu(p, mtu);
                     }
                     else
                     {
@@ -2861,6 +2890,8 @@ void PortsOrch::doLagTask(Consumer &consumer)
                     {
                         gIntfsOrch->setRouterIntfsMtu(l);
                     }
+                    // Sub interfaces inherit parent LAG mtu
+                    updateChildPortsMtu(l, mtu);
                 }
 
                 if (!learn_mode.empty() && (l.m_learn_mode != learn_mode))

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -113,7 +113,7 @@ public:
                         acl_stage_type_t acl_stage);
     bool bindUnbindAclTableGroup(Port &port,
                                  bool ingress,
-     bool bind);
+                                 bool bind);
     bool getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask);
     bool setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask);
 
@@ -126,6 +126,8 @@ public:
     bool addSubPort(Port &port, const string &alias, const bool &adminUp = true, const uint32_t &mtu = 0);
     bool removeSubPort(const string &alias);
     void getLagMember(Port &lag, vector<Port> &portv);
+    void updateChildPortsMtu(const Port &p, const uint32_t mtu);
+
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -264,6 +264,10 @@ class TestPortchannel(object):
         tbl._del("PortChannel004")
         time.sleep(1)
 
+        # Restore eth0 up
+        dvs.servers[0].runcmd("ip link set up dev eth0")
+        time.sleep(1)
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**
Sub interface inherits mtu from parent physical port or port channel according to https://github.com/Azure/SONiC/blob/master/doc/subport/sonic-sub-port-intf-hld.md#1-requirements

This inheritance should include the scenario of mtu changes on parent physical port or port channel.



**How I verified it**
In newly added vs unit test on both master and 201911 branches:
Before the change:
```
E           AssertionError: Expected field/value pairs not found: expected={'SAI_ROUTER_INTERFACE_ATTR_MTU': '8888'},                 received={'SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID': 'oid:0x3000000000022', 'SAI_ROUTER_INTERFACE_ATTR_SRC_MAC_ADDRESS': '02:42:AC:11:00:05', 'SAI_ROUTER_INTERFACE_ATTR_TYPE': 'SAI_ROUTER_INTERFACE_TYPE_SUB_PORT', 'SAI_ROUTER_INTERFACE_ATTR_PORT_ID': 'oid:0x1000000000012', 'SAI_ROUTER_INTERFACE_ATTR_OUTER_VLAN_ID': '10', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE': 'true', 'SAI_ROUTER_INTERFACE_ATTR_MTU': '9100', 'SAI_ROUTER_INTERFACE_ATTR_NAT_ZONE_ID': '0'}, key="oid:0x60000000005c6", table="ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE"
```
After the change:
```
test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_mtu remove extra link dummy
PASSED
```

**Details if related**
