### PR TITLE
Create vnet tunnel map only if it doesn't exist

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1391,6 +1391,7 @@ bool VNetOrch::addOperation(const Request& request)
                 {
                     SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
                                     vnet_name.c_str(), tunnel.c_str());
+                    return false;
                 }
 
                 SWSS_LOG_NOTICE("VNET '%s' was added ", vnet_name.c_str());

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1384,17 +1384,21 @@ bool VNetOrch::addOperation(const Request& request)
                 VNetInfo vnet_info = { tunnel, vni, peer_list, scope };
                 obj = createObject<VNetVrfObject>(vnet_name, vnet_info, attrs);
                 create = true;
-            }
 
-            VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
-            if (!vxlan_orch->createVxlanTunnelMap(tunnel, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
-                                                  vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
+                VNetVrfObject *vrf_obj = dynamic_cast<VNetVrfObject*>(obj.get());
+                if (!vxlan_orch->createVxlanTunnelMap(tunnel, TUNNEL_MAP_T_VIRTUAL_ROUTER, vni,
+                                                      vrf_obj->getEncapMapId(), vrf_obj->getDecapMapId(), VXLAN_ENCAP_TTL))
+                {
+                    SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
+                                    vnet_name.c_str(), tunnel.c_str());
+                }
+
+                SWSS_LOG_NOTICE("VNET '%s' was added ", vnet_name.c_str());
+            }
+            else
             {
-                SWSS_LOG_ERROR("VNET '%s', tunnel '%s', map create failed",
-                                vnet_name.c_str(), tunnel.c_str());
+                SWSS_LOG_NOTICE("VNET '%s' already exists ", vnet_name.c_str());
             }
-
-            SWSS_LOG_NOTICE("VNET '%s' was added ", vnet_name.c_str());
         }
         else
         {


### PR DESCRIPTION
**What I did**
There was a bug that accessed nullpointer, if a vnet config is pushed and it already exist.  This is to check if vnet exists before creating tunnel map

**Why I did it**
Fix issue https://github.com/Azure/sonic-buildimage/issues/5706

**How I verified it**

**Details if related**
