### PR TITLE
[neighorch] Remove pending DEL operation after SET operation for the same key

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -377,7 +377,7 @@ void NeighOrch::doTask(Consumer &consumer)
             if (it_rem != consumer.m_toSync.end() && kfvOp(it_rem->second) == DEL_COMMAND)
             {
                 it = consumer.m_toSync.erase(it_rem);
-                SWSS_LOG_NOTICE("Removed unfinished DEL operation for %s after SET operation", key.c_str());
+                SWSS_LOG_NOTICE("Removed unfinished neighbor DEL operation for %s after SET operation", key.c_str());
             }
         }
         else if (op == DEL_COMMAND)

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -377,7 +377,7 @@ void NeighOrch::doTask(Consumer &consumer)
             if (it_rem != consumer.m_toSync.end() && kfvOp(it_rem->second) == DEL_COMMAND)
             {
                 it = consumer.m_toSync.erase(it_rem);
-                SWSS_LOG_NOTICE("Removed unfinished neighbor DEL operation for %s after SET operation", key.c_str());
+                SWSS_LOG_NOTICE("Removed pending neighbor DEL operation for %s after SET operation", key.c_str());
             }
         }
         else if (op == DEL_COMMAND)

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -373,11 +373,15 @@ void NeighOrch::doTask(Consumer &consumer)
              * Since DEL operation is supposed to be executed before SET for the same neighbor
              * A remaining DEL after the SET operation means the DEL operation failed previously and should not be executed anymore
              */
-            auto it_rem = consumer.m_toSync.find(key);
-            if (it_rem != consumer.m_toSync.end() && kfvOp(it_rem->second) == DEL_COMMAND)
+            if (it != consumer.m_toSync.begin())
             {
-                it = consumer.m_toSync.erase(it_rem);
-                SWSS_LOG_NOTICE("Removed pending neighbor DEL operation for %s after SET operation", key.c_str());
+                auto it_rem = it;
+                it_rem--;
+                if (it_rem->first == key && kfvOp(it_rem->second) == DEL_COMMAND)
+                {
+                    consumer.m_toSync.erase(it_rem);
+                    SWSS_LOG_NOTICE("Removed pending neighbor DEL operation for %s after SET operation", key.c_str());
+                }
             }
         }
         else if (op == DEL_COMMAND)

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -373,15 +373,11 @@ void NeighOrch::doTask(Consumer &consumer)
              * Since DEL operation is supposed to be executed before SET for the same neighbor
              * A remaining DEL after the SET operation means the DEL operation failed previously and should not be executed anymore
              */
-            if (it != consumer.m_toSync.begin())
+            auto rit = make_reverse_iterator(it);
+            while (rit != consumer.m_toSync.rend() && rit->first == key && kfvOp(rit->second) == DEL_COMMAND)
             {
-                auto it_rem = it;
-                it_rem--;
-                if (it_rem->first == key && kfvOp(it_rem->second) == DEL_COMMAND)
-                {
-                    consumer.m_toSync.erase(it_rem);
-                    SWSS_LOG_NOTICE("Removed pending neighbor DEL operation for %s after SET operation", key.c_str());
-                }
+                consumer.m_toSync.erase(next(rit).base());
+                SWSS_LOG_NOTICE("Removed pending neighbor DEL operation for %s after SET operation", key.c_str());
             }
         }
         else if (op == DEL_COMMAND)

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -370,7 +370,7 @@ void NeighOrch::doTask(Consumer &consumer)
             }
 
             /* Remove remaining DEL operation in m_toSync for the same neighbor.
-             * Since DEL operation is supposed to be executed before SET for the same neighbor [ref: https://github.com/Azure/sonic-swss/pull/1184]
+             * Since DEL operation is supposed to be executed before SET for the same neighbor
              * A remaining DEL after the SET operation means the DEL operation failed previously and should not be executed anymore
              */
             auto it_rem = consumer.m_toSync.find(key);

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -354,13 +354,31 @@ void NeighOrch::doTask(Consumer &consumer)
             if (m_syncdNeighbors.find(neighbor_entry) == m_syncdNeighbors.end() || m_syncdNeighbors[neighbor_entry] != mac_address)
             {
                 if (addNeighbor(neighbor_entry, mac_address))
+                {
                     it = consumer.m_toSync.erase(it);
+                }
                 else
+                {
                     it++;
+                    continue;
+                }
             }
             else
+            {
                 /* Duplicate entry */
                 it = consumer.m_toSync.erase(it);
+            }
+
+            /* Remove remaining DEL operation in m_toSync for the same neighbor.
+             * Since DEL operation is supposed to be executed before SET for the same neighbor [ref: https://github.com/Azure/sonic-swss/pull/1184]
+             * A remaining DEL after the SET operation means the DEL operation failed previously and should not be executed anymore
+             */
+            auto it_rem = consumer.m_toSync.find(key);
+            if (it_rem != consumer.m_toSync.end() && kfvOp(it_rem->second) == DEL_COMMAND)
+            {
+                it = consumer.m_toSync.erase(it_rem);
+                SWSS_LOG_NOTICE("Removed unfinished DEL operation for %s after SET operation", key.c_str());
+            }
         }
         else if (op == DEL_COMMAND)
         {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove unfinished DEL operation after SET operation for the same key in neighbor orch.

**Why I did it**
Since DEL operation is supposed to be executed before SET for the same neighbor [ref: #1184 ],  a remaining DEL after the SET operation means the DEL operation failed previously and should not be executed anymore. The remaining DEL operation will be kept for retrying and block following warm-reboot.

**How I verified it**
Verified on kvm.

**Details if related**
Log messages in the presence of failed  DEL operation
```
Oct 26 22:23:15.259851 vlab-01 INFO swss#orchagent: :- removeNeighbor: Failed to remove still referenced neighbor 26:74:37:ff:3b:fa on PortChannel0004
Oct 26 22:23:15.260014 vlab-01 NOTICE swss#orchagent: :- doTask: Removed unfinished DEL operation for PortChannel0004:10.0.0.63 after SET operation
Oct 26 22:23:17.953626 vlab-01 INFO swss#orchagent: :- removeNeighbor: Failed to remove still referenced neighbor 1e:92:d0:9e:6d:64 on PortChannel0002
Oct 26 22:23:17.953626 vlab-01 NOTICE swss#orchagent: :- doTask: Removed unfinished DEL operation for PortChannel0002:10.0.0.59 after SET operation
```
This PR aims to fix the following issue.
https://github.com/Azure/sonic-buildimage/issues/4400
Two other related issues remain to be resolved.
https://github.com/Azure/sonic-swss/issues/1483
https://github.com/Azure/sonic-swss/issues/1484
