### PR TITLE
[tlm_teamd]: Fix segfault, when retrying to do teamd_connect() again

### DIFF
--- a/tlm_teamd/teamdctl_mgr.cpp
+++ b/tlm_teamd/teamdctl_mgr.cpp
@@ -145,8 +145,8 @@ bool TeamdCtlMgr::remove_lag(const std::string & lag_name)
 void TeamdCtlMgr::process_add_queue()
 {
     std::vector<std::string> lag_names_to_add;
-    std::transform(m_lags_to_add.begin(), m_lags_to_add.end(), lag_names_to_add.begin(), [](auto pair) { return pair.first; });
-    for (const auto lag_name: lag_names_to_add)
+    std::transform(m_lags_to_add.begin(), m_lags_to_add.end(), std::back_inserter(lag_names_to_add), [](const auto & pair) { return pair.first; });
+    for (const auto & lag_name: lag_names_to_add)
     {
         bool result = try_add_lag(lag_name);
         if (!result)


### PR DESCRIPTION
Fixes: https://github.com/Azure/sonic-buildimage/issues/5755
Fixes: https://github.com/Azure/sonic-buildimage/issues/5433
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Make the destination for std::transform() to use std::back_inserter() for allocating new space for the copied objects

**Why I did it**
To fix a bug which causes a segfault.

**How I verified it**
-  Manually
```
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel0040      
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel00E0
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel00EB
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel00EC
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel00E5
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel00E6
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel00E6
7admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel00E7
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel0057
admin@str-s6100-acs-1:~$ sudo config portchannel add PortChannel0057
admin@str-s6100-acs-1:~$ ls -la /var/core
total 8
drwxr-xr-x 1 root root 4096 Oct 31 01:20 .
drwxr-xr-x 1 root root 4096 Oct 30 20:28 ..
```
syslog
```
admin@str-s6100-acs-1:~$ sudo tail -F /var/log/syslog | grep tlm_
Oct 31 01:23:21.152456 str-s6100-acs-1 NOTICE teamd#tlm_teamd: :- try_add_lag: The LAG 'PortChannel00E0' has been added.
Oct 31 01:23:24.136100 str-s6100-acs-1 NOTICE teamd#tlm_teamd: :- try_add_lag: The LAG 'PortChannel00EB' has been added.
Oct 31 01:23:25.226382 str-s6100-acs-1 NOTICE teamd#tlm_teamd: :- try_add_lag: The LAG 'PortChannel00EC' has been added.
Oct 31 01:23:31.052312 str-s6100-acs-1 NOTICE teamd#tlm_teamd: :- try_add_lag: The LAG 'PortChannel00E5' has been added.
Oct 31 01:23:34.061052 str-s6100-acs-1 NOTICE teamd#tlm_teamd: :- try_add_lag: The LAG 'PortChannel00E6' has been added.
Oct 31 01:23:40.294726 str-s6100-acs-1 NOTICE teamd#tlm_teamd: :- try_add_lag: The LAG 'PortChannel00E7' has been added.
Oct 31 01:23:52.171978 str-s6100-acs-1 NOTICE teamd#tlm_teamd: :- try_add_lag: The LAG 'PortChannel0057' has been added.
```
-  It is better to cover tlm_teamd with tests. This is ToDo: for the future.

**Details if related**
