### PR TITLE
[fast-reboot] Add a check for warmstart before cleaning up neigh table

### DIFF
--- a/warmrestart/warmRestartAssist.cpp
+++ b/warmrestart/warmRestartAssist.cpp
@@ -79,7 +79,10 @@ void AppRestartAssist::registerAppTable(const std::string &tableName, ProducerSt
     m_psTables[tableName]  = psTable;
 
     // Clear the producerstate table to make sure no pending data for the AppTable
-    psTable->clear();
+    if (m_warmStartInProgress)
+    {
+        psTable->clear();
+    }
     m_appTables[tableName] = new Table(m_pipeLine, tableName, false);
 }
 
@@ -150,7 +153,7 @@ void AppRestartAssist::readTablesToMap()
     }
     return;
 }
- 
+
 /*
  * Check and insert to CacheMap Logic:
  * if delete_key:


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix https://github.com/Azure/sonic-buildimage/issues/5841 and https://github.com/Azure/sonic-buildimage/issues/5580

We found that neighbor table loaded by ```swssconfig``` from ```arp.json``` after ```fast-reboot``` is cleared by ```neighsyncd``` mistakenly at the initial stage. This PR adds a check for ```WarmStart``` before cleaning up, and only do that if ```WarmStart``` is enable.

**Why I did it**
This PR is to fix the issue that arp table is not recovered after fast-reboot.

**How I verified it**
Verified on Arista-7260, running 201911 image.
1. Run some test to populate ARP entries on DUT, such as ```test_fast_reboot```
2. Issue a fast-reboot
3. Verify the ```arp.json``` backed up by ```fast-reboot-dump.py``` is loaded and NEIGH_TABLE is restored.
```
admin@str-7260cx3-acs-2:~$ redis-cli -n 0 keys '*NEIGH_TABLE*'
  1) "NEIGH_TABLE:Vlan1000:192.168.0.231"
  2) "NEIGH_TABLE:Vlan1000:192.168.0.106"
  3) "NEIGH_TABLE:Vlan1000:192.168.1.102"
  ....
509) "NEIGH_TABLE:Vlan1000:192.168.0.47"
510) "NEIGH_TABLE:Vlan1000:192.168.1.92"
```

```
py.test --inventory ../ansible/str,../ansible/veos --host-pattern str-7260cx3-acs-2 --module-path ../ansible --testbed vms7-t0-7260-2 --testbed_file ../ansible/testbed.csv --junit-xml=tr.xml --log-cli-level info --collect_techsupport=False --topology=t0,any,util platform_tests/test_advanced_reboot.py::test_fast_reboot
========================================================================================= test session starts =========================================================================================                                                                                                                        
platform_tests/test_advanced_reboot.py::test_fast_reboot 
------------------------------------------------------------------------------------------- live log setup --------------------------------------------------------------------------------------------
PASSED                                                                                                                                                                                          [100%]
------------------------------------------------------------------------------------------ live log teardown ------------------------------------------------------------------------------------------
===================================================================================== 1 passed in 404.24 seconds ======================================================================================
```
**Details if related**
