### PR TITLE
[orchagent][port] In case of successful port creation set log level to INFO

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1853,7 +1853,7 @@ bool PortsOrch::initPort(const string &alias, const int index, const set<int> &l
 
                 m_portList[alias].m_init = true;
 
-                SWSS_LOG_ERROR("Initialized port %s", alias.c_str());
+                SWSS_LOG_INFO("Initialized port %s", alias.c_str());
             }
             else
             {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1809,7 +1809,7 @@ bool PortsOrch::initPort(const string &alias, const int index, const set<int> &l
         /* Determine if the port has already been initialized before */
         if (m_portList.find(alias) != m_portList.end() && m_portList[alias].m_port_id == id)
         {
-            SWSS_LOG_INFO("Port has already been initialized before alias:%s", alias.c_str());
+            SWSS_LOG_DEBUG("Port has already been initialized before alias:%s", alias.c_str());
         }
         else
         {
@@ -1853,7 +1853,7 @@ bool PortsOrch::initPort(const string &alias, const int index, const set<int> &l
 
                 m_portList[alias].m_init = true;
 
-                SWSS_LOG_INFO("Initialized port %s", alias.c_str());
+                SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
             }
             else
             {


### PR DESCRIPTION

**What I did**
In case of successful creation set log level to INFO instead of ERR

**Why I did it**
For successful port creation the log level is set to ERR.

```
Nov 11 00:57:13.403421 str-s6000-acs-8 ERR swss#orchagent: :- initPort: Initialized port Ethernet36
Nov 11 00:57:13.518152 str-s6000-acs-8 ERR swss#orchagent: :- initPort: Initialized port Ethernet32
Nov 11 00:57:13.693872 str-s6000-acs-8 ERR swss#orchagent: :- initPort: Initialized port Ethernet40
Nov 11 00:57:13.901144 str-s6000-acs-8 ERR swss#orchagent: :- initPort: Initialized port Ethernet44
Nov 11 00:57:14.061818 str-s6000-acs-8 ERR swss#orchagent: :- initPort: Initialized port Ethernet0
Nov 11 00:57:14.225700 str-s6000-acs-8 ERR swss#orchagent: :- initPort: Initialized port Ethernet4
Nov 11 00:57:14.376864 str-s6000-acs-8 ERR swss#orchagent: :- initPort: Initialized port Ethernet8
```

**How I verified it**
Visual code review

**Details if related**
