### PR TITLE
[Routeorch] Fix next hop group reference count in bulk operation

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1404,7 +1404,10 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         increaseNextHopRefCount(nextHops);
 
         decreaseNextHopRefCount(it_route->second);
-        bulkNhgReducedRefCnt.emplace(it_route->second);
+        if (it_route->second.getSize() > 1)
+        {
+            bulkNhgReducedRefCnt.emplace(it_route->second);
+        }
         SWSS_LOG_INFO("Post set route %s with next hop(s) %s",
                 ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
     }
@@ -1543,7 +1546,10 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
      * Decrease the reference count only when the route is pointing to a next hop.
      */
     decreaseNextHopRefCount(it_route->second);
-    bulkNhgReducedRefCnt.emplace(it_route->second);
+    if (it_route->second.getSize() > 1)
+    {
+        bulkNhgReducedRefCnt.emplace(it_route->second);
+    }
 
     SWSS_LOG_INFO("Remove route %s with next hop(s) %s",
             ipPrefix.to_string().c_str(), it_route->second.to_string().c_str());

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -126,6 +126,8 @@ private:
     RouteTables m_syncdRoutes;
     NextHopGroupTable m_syncdNextHopGroups;
 
+    std::set<NextHopGroupKey> m_bulkNhgReducedRefCnt;
+
     NextHopObserverTable m_nextHopObservers;
 
     EntityBulker<sai_route_api_t>           gRouteBulker;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove next-hop groups after updating the reference counter for a bulk of routes instead of removing next-hop groups in the loop of updating the reference counter.
Fix https://github.com/Azure/sonic-buildimage/issues/5813

**Why I did it**
The bulk route API has two loops of updating the reference counter: 
1. update the sairedis reference counter
2. update the orchagent reference counter

Currently, the removal of next-hop groups is triggered in the second loop of updating the orchagent reference counter when the reference counter decreases to zero. This may result in a reference counter mismatch between orchagent and sairedis since the sairedis reference counter has already included the operation of the whole bulk but the orchagent reference counter has not. Therefore, the removal of next-hop group may fail due to the mismatch in reference counter (e.g., there are some other routes point to the next-hop group but has not been counted in orchagent yet). 

To fix this problem, the next-hop group removal operation should be done after updating the reference counter of the whole bulk to make sure the reference counters sairedis and orchagent matches.

**How I verified it**

**Details if related**
