### PR TITLE
[NAT] ACL Rule with DO_NOT_NAT action is getting failed.

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -124,7 +124,8 @@ static const acl_capabilities_t defaultAclActionsSupported =
         ACL_STAGE_INGRESS,
         {
             SAI_ACL_ACTION_TYPE_PACKET_ACTION,
-            SAI_ACL_ACTION_TYPE_MIRROR_INGRESS
+            SAI_ACL_ACTION_TYPE_MIRROR_INGRESS,
+            SAI_ACL_ACTION_TYPE_NO_NAT
         }
     },
     {

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -403,7 +403,6 @@ class DVSAcl:
 
         fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
         self._check_acl_entry_base(fvs, sai_qualifiers, "DO_NOT_NAT", priority)
-        self._check_acl_entry_nat_action(fvs)
 
     def verify_mirror_acl_rule(
             self,
@@ -545,6 +544,7 @@ class DVSAcl:
                 assert action == "MIRROR"
             elif "SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT" in k:
                 assert action == "DO_NOT_NAT"
+                assert v == "true"
             elif k in qualifiers:
                 assert qualifiers[k](v)
             else:
@@ -560,6 +560,3 @@ class DVSAcl:
     def _check_acl_entry_mirror_action(self, entry: Dict[str, str], session_oid: str, stage: str) -> None:
         assert stage in self.ADB_MIRROR_ACTION_LOOKUP
         assert entry.get(self.ADB_MIRROR_ACTION_LOOKUP[stage]) == session_oid
-
-    def _check_acl_entry_nat_action(self, entry: Dict[str, str]) -> None:
-        assert entry.get("SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT", None) == entry["true"]

--- a/tests/dvslib/dvs_acl.py
+++ b/tests/dvslib/dvs_acl.py
@@ -384,6 +384,27 @@ class DVSAcl:
         self._check_acl_entry_base(fvs, sai_qualifiers, "REDIRECT", priority)
         self._check_acl_entry_redirect_action(fvs, expected_destination)
 
+    def verify_nat_acl_rule(
+            self,
+            sai_qualifiers: Dict[str, str],
+            priority: str = "2020",
+            acl_rule_id=None
+    ) -> None:
+        """Verify that an ACL nat rule has the correct ASIC DB representation.
+
+        Args:
+            sai_qualifiers: The expected set of SAI qualifiers to be found in ASIC DB.
+            priority: The priority of the rule.
+            acl_rule_id: A specific OID to check in ASIC DB. If left empty, this method
+                         assumes that only one rule exists in ASIC DB.
+        """
+        if not acl_rule_id:
+            acl_rule_id = self._get_acl_rule_id()
+
+        fvs = self.asic_db.wait_for_entry("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", acl_rule_id)
+        self._check_acl_entry_base(fvs, sai_qualifiers, "DO_NOT_NAT", priority)
+        self._check_acl_entry_nat_action(fvs)
+
     def verify_mirror_acl_rule(
             self,
             sai_qualifiers: Dict[str, str],
@@ -522,6 +543,8 @@ class DVSAcl:
                 assert action == "REDIRECT"
             elif "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR" in k:
                 assert action == "MIRROR"
+            elif "SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT" in k:
+                assert action == "DO_NOT_NAT"
             elif k in qualifiers:
                 assert qualifiers[k](v)
             else:
@@ -537,3 +560,6 @@ class DVSAcl:
     def _check_acl_entry_mirror_action(self, entry: Dict[str, str], session_oid: str, stage: str) -> None:
         assert stage in self.ADB_MIRROR_ACTION_LOOKUP
         assert entry.get(self.ADB_MIRROR_ACTION_LOOKUP[stage]) == session_oid
+
+    def _check_acl_entry_nat_action(self, entry: Dict[str, str]) -> None:
+        assert entry.get("SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT", None) == entry["true"]

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -3,6 +3,10 @@ import time
 from dvslib.dvs_common import wait_for_result
 from dvslib.dvs_database import DVSDatabase
 
+L3_TABLE_TYPE = "L3"
+L3_TABLE_NAME = "L3_TEST"
+L3_BIND_PORTS = ["Ethernet0"]
+L3_RULE_NAME = "L3_TEST_RULE"
 
 class TestNat(object):
     def setup_db(self, dvs):
@@ -320,6 +324,38 @@ class TestNat(object):
 
         # delete a static nat entry
         dvs.runcmd("config nat remove static basic 67.66.65.1 18.18.18.2")
+
+    def test_DoNotNatAclAction(self, dvs, testlog):
+        # initialize
+        self.setup_db(dvs)
+
+        # Creating the ACL Table
+        dvs_acl.create_acl_table(L3_TABLE_NAME, L3_TABLE_TYPE, L3_BIND_PORTS, stage="ingress")
+
+        acl_table_id = dvs_acl.get_acl_table_ids(1)[0]
+        acl_table_group_ids = dvs_acl.get_acl_table_group_ids(len(L3_BIND_PORTS))
+
+        dvs_acl.verify_acl_table_group_members(acl_table_id, acl_table_group_ids, 1)
+        dvs_acl.verify_acl_table_port_binding(acl_table_id, L3_BIND_PORTS, 1)
+
+        # Create a ACL Rule with "do_not_nat" packet action
+        config_qualifiers = {"SRC_IP": "14.1.0.1/32"}
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers, action="DO_NOT_NAT", priority="97")
+
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("14.1.0.1&mask:255.255.255.255"),
+            "SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT": dvs_acl.get_simple_qualifier_comparator("true") 
+        }
+
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+
+        # Deleting the ACL Rule
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+        # Deleting the ACL Table
+        dvs_acl.remove_acl_table(L3_TABLE_NAME)
+        dvs_acl.verify_acl_table_count(0)
 
 
 # Add Dummy always-pass test at end as workaroud

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -2,6 +2,7 @@ import time
 
 from dvslib.dvs_common import wait_for_result
 from dvslib.dvs_database import DVSDatabase
+from dvslib import dvs_acl
 
 L3_TABLE_TYPE = "L3"
 L3_TABLE_NAME = "L3_TEST"
@@ -325,9 +326,7 @@ class TestNat(object):
         # delete a static nat entry
         dvs.runcmd("config nat remove static basic 67.66.65.1 18.18.18.2")
 
-    def test_DoNotNatAclAction(self, dvs, testlog):
-        # initialize
-        self.setup_db(dvs)
+    def test_DoNotNatAclAction(self, dvs_acl, testlog):
 
         # Creating the ACL Table
         dvs_acl.create_acl_table(L3_TABLE_NAME, L3_TABLE_TYPE, L3_BIND_PORTS, stage="ingress")

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -2,7 +2,6 @@ import time
 
 from dvslib.dvs_common import wait_for_result
 from dvslib.dvs_database import DVSDatabase
-from dvslib import dvs_acl
 
 L3_TABLE_TYPE = "L3"
 L3_TABLE_NAME = "L3_TEST"
@@ -342,11 +341,10 @@ class TestNat(object):
         dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers, action="DO_NOT_NAT", priority="97")
 
         expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("14.1.0.1&mask:255.255.255.255"),
-            "SAI_ACL_ENTRY_ATTR_ACTION_NO_NAT": dvs_acl.get_simple_qualifier_comparator("true") 
+            "SAI_ACL_ENTRY_ATTR_FIELD_SRC_IP": dvs_acl.get_simple_qualifier_comparator("14.1.0.1&mask:255.255.255.255")
         }
 
-        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+        dvs_acl.verify_nat_acl_rule(expected_sai_qualifiers, priority="97")
 
         # Deleting the ACL Rule
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)


### PR DESCRIPTION
Issue : Applied below ACL Table and Rule

printf '{"ACL_TABLE": {"in_nat_eg":{"stage": "INGRESS", "type": "L3", "policy_desc": "ingress-acl", "ports": ["Ethernet0"]}}}\n' > /tmp/apply_json.json
config load -y /tmp/apply_json.json

printf '{"ACL_RULE": {"in_nat_eg|rule-33":{"PRIORITY": "97", "PACKET_ACTION": "DO_NOT_NAT", "SRC_IP": "14.1.0.1/32"}}}\n' > /tmp/apply_json.json
config load -y /tmp/apply_json.json

Seeing below OA errors when Rule is applied:

root@sonic:/home/admin# printf '{"ACL_RULE": {"in_nat_eg|rule-33":{"PRIORITY": "97", "PACKET_ACTION": "DO_NOT_NAT", "SRC_IP": "14.1.0.1/32"}}}\n' > /tmp/apply_json.json
root@sonic:/home/admin# config load -y /tmp/apply_json.json
Running command: /usr/local/bin/sonic-cfggen -j /tmp/apply_json.json --write-to-db
Nov 09 06:03:35.914100 sonic ERR swss#orchagent: :- validateAddAction: Action PACKET_ACTION:DO_NOT_NAT is not supported by ASIC
Nov 09 06:03:35.914100 sonic ERR swss#orchagent: :- doAclRuleTask: Unknown or invalid rule attribute 'PACKET_ACTION : DO_NOT_NAT'
Nov 09 06:03:35.914100 sonic ERR swss#orchagent: :- doAclRuleTask: Failed to create ACL rule. Rule configuration is invalid

Rootcause:
The Rule addition is getting failed as the SAI acl "no-nat" action not supported for INGRESS stage.

Fix:
Made changes to add "SAI_ACL_ACTION_TYPE_NO_NAT" action as supported for INGRESS stage.

After the fix, verified that ACL Table and rule is created.

root@sonic:/home/admin# tail -f /var/log/syslog | grep orchagent &
[1] 7324
root@sonic:/home/admin#
root@sonic:/home/admin# printf '{"ACL_TABLE": {"in_nat_eg":{"stage": "INGRESS", "type": "L3", "policy_desc": "ingress-acl", "ports": ["Ethernet0"]}}}\n' > /tmp/apply_json.json
root@sonic:/home/admin# config load -y /tmp/apply_json.json
Running command: /usr/local/bin/sonic-cfggen -j /tmp/apply_json.json --write-to-db
Nov 12 15:48:49.204590 sonic NOTICE swss#orchagent: message repeated 891 times: [ :- set: setting attribute 0x10000004 status: SAI_STATUS_SUCCESS]
Nov 12 15:48:49.204590 sonic NOTICE swss#orchagent: :- bindAclTable: Bind table in_nat_eg to ports
Nov 12 15:48:49.205819 sonic NOTICE swss#orchagent: :- createBindAclTableGroup: Create ingress ACL table group and bind port Ethernet0 to it
Nov 12 15:48:49.206671 sonic NOTICE swss#orchagent: :- bind: Successfully bound port oid: 100000000000e, group member oid:c000000000608
Nov 12 15:48:49.206671 sonic NOTICE swss#orchagent: :- addAclTable: Created ACL table in_nat_eg oid:7000000000606
Nov 12 15:48:49.206889 sonic NOTICE swss#orchagent: :- set: setting attribute 0x10000004 status: SAI_STATUS_SUCCESS
root@sonic:/home/admin#
root@sonic:/home/admin# printf '{"ACL_RULE": {"in_nat_eg|rule-33":{"PRIORITY": "97", "PACKET_ACTION": "DO_NOT_NAT", "SRC_IP": "14.1.0.1/32"}}}\n' > /tmp/apply_json.json
root@sonic:/home/admin# config load -y /tmp/apply_json.json
Running command: /usr/local/bin/sonic-cfggen -j /tmp/apply_json.json --write-to-db
Nov 12 15:49:19.117346 sonic NOTICE swss#orchagent: message repeated 63 times: [ :- set: setting attribute 0x10000004 status: SAI_STATUS_SUCCESS]
Nov 12 15:49:19.117346 sonic NOTICE swss#orchagent: :- add: Successfully created ACL rule rule-33 in table in_nat_eg
Nov 12 15:49:19.118091 sonic NOTICE swss#orchagent: :- set: setting attribute 0x10000004 status: SAI_STATUS_SUCCESS
root@sonic:/home/admin#

Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
