### PR TITLE
with multiset SET may get replace with DEL. Need to make sure bring  down the port before remove.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1775,6 +1775,16 @@ sai_status_t PortsOrch::removePort(sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
 
+    /* Make sure to bring down admin state.
+     * SET would have replaced with DEL
+    */
+    Port   port;
+    if (getPort(port_id, port))
+    {
+        setPortAdminStatus(port, false);
+    }
+    /* else : port is in default state or not yet created */
+
     sai_status_t status = sai_port_api->remove_port(port_id);
     if (status != SAI_STATUS_SUCCESS)
     {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1775,10 +1775,12 @@ sai_status_t PortsOrch::removePort(sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
 
-    /* Make sure to bring down admin state.
+    Port port;
+
+    /* 
+     * Make sure to bring down admin state.
      * SET would have replaced with DEL
-    */
-    Port   port;
+     */
     if (getPort(port_id, port))
     {
         setPortAdminStatus(port, false);


### PR DESCRIPTION
with multiset SET may get replace with DEL. Need to make sure bring  down the port before remove.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Bring down the port before remove. During DPB SET request to bring down the port may get replaced DEL. Make sure to bring down the port before remove.

**Why I did it**

To make sure port is in admin down state before remove port.

**How I verified it**

config interface breakout Ethernet8 4x25G -y -f

**Details if related**

UT logs:

Nov  5 19:40:27.774309 sonic INFO lldp#lldpmgrd[38]: Unable to retrieve description for port 'Ethernet8'. Not adding port description
Nov  5 19:40:40.606602 sonic INFO lldp#lldpmgrd[38]: Port name Ethernet8 oper status: up
Nov  5 19:40:40.606721 sonic NOTICE swss#orchagent: :- doPortTask: Set port Ethernet8 admin status to down
Nov  5 19:40:40.607883 sonic INFO lldp#lldpmgrd[38]: Unable to retrieve description for port 'Ethernet8'. Not adding port description
Nov  5 19:40:40.611482 sonic NOTICE swss#orchagent: :- updatePortOperStatus: Port Ethernet8 oper state set from up to down
Nov  5 19:40:40.611772 sonic NOTICE swss#orchagent: :- setHostIntfsOperStatus: Set operation status DOWN to host interface Ethernet8
Nov  5 19:40:40.612510 sonic NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet8 admin:1 oper:0 addr:3c:2c:99:f0:c5:80 ifindex:28 master:0
Nov  5 19:40:40.612739 sonic NOTICE swss#portsyncd: :- onMsg: Publish Ethernet8(ok) to state db
Nov  5 19:40:40.613935 sonic NOTICE swss#portmgrd: :- doTask: Configure Ethernet8 MTU to 9100
Nov  5 19:40:40.616869 sonic NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet8 admin:0 oper:0 addr:3c:2c:99:f0:c5:80 ifindex:28 master:0
Nov  5 19:40:40.617137 sonic NOTICE swss#portsyncd: :- onMsg: Publish Ethernet8(ok) to state db
Nov  5 19:40:40.617684 sonic NOTICE swss#portmgrd: :- doTask: Configure Ethernet8 admin status to down
Nov  5 19:40:40.693948 sonic NOTICE swss#portmgrd: :- doTask: Delete Port: Ethernet8
Nov  5 19:40:40.694303 sonic NOTICE swss#orchagent: :- doPortTask: Deleting Port Ethernet8
Nov  5 19:40:40.694551 sonic NOTICE swss#orchagent: :- deInitPort: De-Initialized port Ethernet8
Nov  5 19:40:40.694551 sonic NOTICE swss#orchagent: :- doPortTask: Removing hostif d000000000ae3 for Port Ethernet8
Nov  5 19:40:40.695126 sonic NOTICE swss#orchagent: :- removePortFromLanesMap: Removing port Ethernet8 from lanes map
Nov  5 19:40:40.695819 sonic NOTICE swss#portsyncd: :- onMsg: nlmsg type:17 key:Ethernet8 admin:0 oper:0 addr:3c:2c:99:f0:c5:80 ifindex:28 master:0
Nov  5 19:40:40.695998 sonic NOTICE swss#portsyncd: :- onMsg: Delete Ethernet8(ok) from state db
Nov  5 19:40:41.707251 sonic NOTICE swss#orchagent: :- initializePort: Initializing port alias:Ethernet8 pid:1000000000bc7
Nov  5 19:40:42.917501 sonic NOTICE swss#orchagent: :- addHostIntfs: Create host interface for port Ethernet8
Nov  5 19:40:42.918765 sonic NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet8 admin:0 oper:0 addr:3c:2c:99:f0:c5:80 ifindex:78 master:0
Nov  5 19:40:42.919050 sonic NOTICE swss#portsyncd: :- onMsg: Publish Ethernet8(ok) to state db
Nov  5 19:40:42.928831 sonic INFO syncd#syncd: [0] SAI_API_HOSTIF:_brcm_sai_hostif_speed_set:11890 cmd ethtool -s Ethernet8 speed 10000 rc:32512
Nov  5 19:40:42.929676 sonic NOTICE swss#orchagent: :- setHostIntfsOperStatus: Set operation status DOWN to host interface Ethernet8
Nov  5 19:40:42.930202 sonic ERR swss#orchagent: :- initPort: Initialized port Ethernet8
Nov  5 19:40:42.930572 sonic NOTICE swss#orchagent: :- doPortTask: Set port Ethernet8 admin status to up
Nov  5 19:40:43.715056 sonic NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet8 admin:0 oper:0 addr:3c:2c:99:f0:c5:80 ifindex:78 master:0
Nov  5 19:40:43.715493 sonic NOTICE swss#portsyncd: :- onMsg: Publish Ethernet8(ok) to state db
Nov  5 19:40:43.715744 sonic NOTICE swss#portmgrd: :- doTask: Configure Ethernet8 MTU to 9100
Nov  5 19:40:43.719051 sonic NOTICE swss#portsyncd: :- onMsg: nlmsg type:16 key:Ethernet8 admin:1 oper:0 addr:3c:2c:99:f0:c5:80 ifindex:78 master:0
Nov  5 19:40:43.719264 sonic NOTICE swss#portsyncd: :- onMsg: Publish Ethernet8(ok) to state db
Nov  5 19:40:43.719630 sonic NOTICE swss#portmgrd: :- doTask: Configure Ethernet8 admin status to up
Nov  5 19:40:43.990618 sonic NOTICE swss#orchagent: :- doPortTask: Set port Ethernet8 MTU to 9100
