### PR TITLE
ASIC internal temperature sensors support

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -73,8 +73,15 @@ bool OrchDaemon::init()
 
     string platform = getenv("platform") ? getenv("platform") : "";
     TableConnector stateDbSwitchTable(m_stateDb, "SWITCH_CAPABILITY");
+    TableConnector app_switch_table(m_applDb, APP_SWITCH_TABLE_NAME);
+    TableConnector conf_asic_sensors(m_configDb, CFG_ASIC_SENSORS_TABLE_NAME);
 
-    gSwitchOrch = new SwitchOrch(m_applDb, APP_SWITCH_TABLE_NAME, stateDbSwitchTable);
+    vector<TableConnector> switch_tables = {
+        conf_asic_sensors,
+        app_switch_table
+    };
+
+    gSwitchOrch = new SwitchOrch(m_applDb, switch_tables, stateDbSwitchTable);
 
     const int portsorch_base_pri = 40;
 

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -64,7 +64,6 @@ void SwitchOrch::doCfgSensorsTableTask(Consumer &consumer)
         if (op == SET_COMMAND)
         {
             FieldValueTuple fvt = kfvFieldsValues(t)[0];
-
             SWSS_LOG_NOTICE("ASIC sensors : set %s(%s) to %s", table_attr.c_str(), fvField(fvt).c_str(), fvValue(fvt).c_str());
 
             if (table_attr == ASIC_SENSORS_POLLER_STATUS)

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -33,17 +33,101 @@ const map<string, sai_packet_action_t> packet_action_map =
     {"trap",    SAI_PACKET_ACTION_TRAP}
 };
 
-SwitchOrch::SwitchOrch(DBConnector *db, string tableName, TableConnector switchTable):
-        Orch(db, tableName),
+SwitchOrch::SwitchOrch(DBConnector *db, vector<TableConnector>& connectors, TableConnector switchTable):
+        Orch(connectors),
         m_switchTable(switchTable.first, switchTable.second),
-        m_db(db)
+        m_db(db),
+        m_stateDb(new DBConnector(STATE_DB, DBConnector::DEFAULT_UNIXSOCKET, 0)),
+        m_asicSensorsTable(new Table(m_stateDb.get(), ASIC_TEMPERATURE_INFO_TABLE_NAME)),
+        m_sensorsPollerTimer (new SelectableTimer((timespec { .tv_sec = DEFAULT_ASIC_SENSORS_POLLER_INTERVAL, .tv_nsec = 0 })))
 {
     m_restartCheckNotificationConsumer = new NotificationConsumer(db, "RESTARTCHECK");
     auto restartCheckNotifier = new Notifier(m_restartCheckNotificationConsumer, this, "RESTARTCHECK");
     Orch::addExecutor(restartCheckNotifier);
+
+    initSensorsTable();
+    auto executorT = new ExecutableTimer(m_sensorsPollerTimer, this, "ASIC_SENSORS_POLL_TIMER");
+    Orch::addExecutor(executorT);
 }
 
-void SwitchOrch::doTask(Consumer &consumer)
+void SwitchOrch::doCfgSensorsTableTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+
+    auto it = consumer.m_toSync.begin();
+    while (it != consumer.m_toSync.end())
+    {
+        KeyOpFieldsValuesTuple t = it->second;
+        string table_attr = kfvKey(t);
+        string op = kfvOp(t);
+
+        if (op == SET_COMMAND)
+        {
+            FieldValueTuple fvt = kfvFieldsValues(t)[0];
+
+            SWSS_LOG_NOTICE("ASIC sensors : set %s(%s) to %s", table_attr.c_str(), fvField(fvt).c_str(), fvValue(fvt).c_str());
+
+            if (table_attr == ASIC_SENSORS_POLLER_STATUS)
+            {
+                if (fvField(fvt) == "admin_status")
+                {
+                    if (fvValue(fvt) == "enable" && !m_sensorsPollerEnabled)
+                    {
+                        m_sensorsPollerTimer->start();
+                        m_sensorsPollerEnabled = true;
+                    }
+                    else if (fvValue(fvt) == "disable")
+                    {
+                        m_sensorsPollerEnabled = false;
+                    }
+                    else
+                    {
+                        SWSS_LOG_ERROR("ASIC sensors : unsupported operation for poller state %d",m_sensorsPollerEnabled);
+                    }
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("ASIC sensors : unsupported field");
+                }
+            }
+            else if (table_attr == ASIC_SENSORS_POLLER_INTERVAL)
+            {
+                uint32_t interval=to_uint<uint32_t>(fvValue(fvt));
+
+                if (fvField(fvt) == "interval")
+                {
+                    if (interval != m_sensorsPollerInterval)
+                    {
+                        auto intervT = timespec { .tv_sec = interval , .tv_nsec = 0 };
+                        m_sensorsPollerTimer->setInterval(intervT);
+                        m_sensorsPollerInterval = interval;
+                        m_sensorsPollerIntervalChanged = true;
+                    }
+                    else
+                    {
+                        SWSS_LOG_INFO("ASIC sensors : poller interval unchanged : %d seconds",m_sensorsPollerInterval);
+                    }
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("ASIC sensors : unsupported field");
+                }
+            }
+            else
+            {
+                SWSS_LOG_ERROR("ASIC sensors : unsupported attribute");
+            }
+        }
+        else
+        {
+            SWSS_LOG_ERROR("ASIC sensors : unsupported op %s",op.c_str());
+        }
+
+        it = consumer.m_toSync.erase(it);
+    }
+}
+
+void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
 
@@ -145,6 +229,27 @@ void SwitchOrch::doTask(Consumer &consumer)
     }
 }
 
+void SwitchOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+    const string & db_name = consumer.getDbName();
+    const string & table_name = consumer.getTableName();
+
+    if ((db_name == "APPL_DB") && (table_name == APP_SWITCH_TABLE_NAME ))
+    {
+        doAppSwitchTableTask(consumer);
+    }
+    else if ((db_name == "CONFIG_DB") && (table_name == CFG_ASIC_SENSORS_TABLE_NAME))
+    {
+        doCfgSensorsTableTask(consumer);
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown table : %s", table_name.c_str());
+    }
+
+}
+
 void SwitchOrch::doTask(NotificationConsumer& consumer)
 {
     SWSS_LOG_ENTER();
@@ -207,6 +312,175 @@ bool SwitchOrch::setAgingFDB(uint32_t sec)
     }
     SWSS_LOG_NOTICE("Set switch %" PRIx64 " fdb_aging_time %u sec", gSwitchId, sec);
     return true;
+}
+
+void SwitchOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+
+    if (&timer == m_sensorsPollerTimer)
+    {
+        if (m_sensorsPollerIntervalChanged)
+        {
+            m_sensorsPollerTimer->reset();
+            m_sensorsPollerIntervalChanged = false;
+        }
+
+        if (!m_sensorsPollerEnabled)
+        {
+            m_sensorsPollerTimer->stop();
+            return;
+        }
+
+        sai_attribute_t attr;
+        sai_status_t status;
+        std::vector<FieldValueTuple> values;
+
+        if (m_numTempSensors)
+        {
+            std::vector<int32_t> temp_list(m_numTempSensors);
+
+            memset(&attr, 0, sizeof(attr));
+            attr.id = SAI_SWITCH_ATTR_TEMP_LIST;
+            attr.value.s32list.count = m_numTempSensors;
+            attr.value.s32list.list = temp_list.data();
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId , 1, &attr);
+            if (status == SAI_STATUS_SUCCESS)
+            {
+                for (size_t i = 0; i < attr.value.s32list.count ; i++) {
+                    const std::string &fieldName = "temperature_" + std::to_string(i);
+                    values.emplace_back(fieldName, std::to_string(temp_list[i]));
+                }
+                m_asicSensorsTable->set("",values);
+            }
+            else
+            {
+                SWSS_LOG_ERROR("ASIC sensors : failed to get SAI_SWITCH_ATTR_TEMP_LIST: %d", status);
+            }
+        }
+
+        if (m_sensorsMaxTempSupported)
+        {
+            memset(&attr, 0, sizeof(attr));
+            attr.id = SAI_SWITCH_ATTR_MAX_TEMP;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            if (status == SAI_STATUS_SUCCESS)
+            {
+                const std::string &fieldName = "maximum_temperature";
+                values.emplace_back(fieldName, std::to_string(attr.value.s32));
+                m_asicSensorsTable->set("",values);
+            }
+            else if (status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
+            {
+                m_sensorsMaxTempSupported = false;
+                SWSS_LOG_INFO("ASIC sensors : SAI_SWITCH_ATTR_MAX_TEMP is not supported");
+            }
+            else
+            {
+                m_sensorsMaxTempSupported = false;
+                SWSS_LOG_ERROR("ASIC sensors : failed to get SAI_SWITCH_ATTR_MAX_TEMP: %d", status);
+            }
+        }
+
+        if (m_sensorsAvgTempSupported)
+        {
+            memset(&attr, 0, sizeof(attr));
+            attr.id = SAI_SWITCH_ATTR_AVERAGE_TEMP;
+
+            status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+            if (status == SAI_STATUS_SUCCESS)
+            {
+                const std::string &fieldName = "average_temperature";
+                values.emplace_back(fieldName, std::to_string(attr.value.s32));
+                m_asicSensorsTable->set("",values);
+            }
+            else if (status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
+            {
+                m_sensorsAvgTempSupported = false;
+                SWSS_LOG_INFO("ASIC sensors : SAI_SWITCH_ATTR_AVERAGE_TEMP is not supported");
+            }
+            else
+            {
+                m_sensorsAvgTempSupported = false;
+                SWSS_LOG_ERROR("ASIC sensors : failed to get SAI_SWITCH_ATTR_AVERAGE_TEMP: %d", status);
+            }
+        }
+    }
+}
+
+void SwitchOrch::initSensorsTable()
+{
+    SWSS_LOG_ENTER();
+
+    sai_attribute_t attr;
+    sai_status_t status;
+    std::vector<FieldValueTuple> values;
+
+    if (!m_numTempSensorsInitialized)
+    {
+        memset(&attr, 0, sizeof(attr));
+        attr.id = SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS;
+
+        status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            m_numTempSensors = attr.value.u8;
+            m_numTempSensorsInitialized = true;
+        }
+        else if (status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
+        {
+            m_numTempSensorsInitialized = true;
+            SWSS_LOG_INFO("ASIC sensors : SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS is not supported");
+        }
+        else
+        {
+            SWSS_LOG_ERROR("ASIC sensors : failed to get SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS: %d", status);
+        }
+    }
+
+    if (m_numTempSensors)
+    {
+        std::vector<int32_t> temp_list(m_numTempSensors);
+
+        memset(&attr, 0, sizeof(attr));
+        attr.id = SAI_SWITCH_ATTR_TEMP_LIST;
+        attr.value.s32list.count = m_numTempSensors;
+        attr.value.s32list.list = temp_list.data();
+
+        status = sai_switch_api->get_switch_attribute(gSwitchId , 1, &attr);
+        if (status == SAI_STATUS_SUCCESS)
+        {
+            for (size_t i = 0; i < attr.value.s32list.count ; i++) {
+                const std::string &fieldName = "temperature_" + std::to_string(i);
+                values.emplace_back(fieldName, std::to_string(0));
+            }
+            m_asicSensorsTable->set("",values);
+        }
+        else
+        {
+            SWSS_LOG_ERROR("ASIC sensors : failed to get SAI_SWITCH_ATTR_TEMP_LIST: %d", status);
+        }
+    }
+
+    if (m_sensorsMaxTempSupported)
+    {
+        memset(&attr, 0, sizeof(attr));
+
+        const std::string &fieldName = "maximum_temperature";
+        values.emplace_back(fieldName, std::to_string(0));
+        m_asicSensorsTable->set("",values);
+    }
+
+    if (m_sensorsAvgTempSupported)
+    {
+        memset(&attr, 0, sizeof(attr));
+
+        const std::string &fieldName = "average_temperature";
+        values.emplace_back(fieldName, std::to_string(0));
+        m_asicSensorsTable->set("",values);
+    }
 }
 
 void SwitchOrch::set_switch_capability(const std::vector<FieldValueTuple>& values)

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -86,7 +86,7 @@ void SwitchOrch::doCfgSensorsTableTask(Consumer &consumer)
                 }
                 else
                 {
-                    SWSS_LOG_ERROR("ASIC sensors : unsupported field");
+                    SWSS_LOG_ERROR("ASIC sensors : unsupported field in attribute %s", ASIC_SENSORS_POLLER_STATUS);
                 }
             }
             else if (table_attr == ASIC_SENSORS_POLLER_INTERVAL)
@@ -109,17 +109,17 @@ void SwitchOrch::doCfgSensorsTableTask(Consumer &consumer)
                 }
                 else
                 {
-                    SWSS_LOG_ERROR("ASIC sensors : unsupported field");
+                    SWSS_LOG_ERROR("ASIC sensors : unsupported field in attribute %s", ASIC_SENSORS_POLLER_INTERVAL);
                 }
             }
             else
             {
-                SWSS_LOG_ERROR("ASIC sensors : unsupported attribute");
+                SWSS_LOG_ERROR("ASIC sensors : unsupported attribute %s", table_attr.c_str());
             }
         }
         else
         {
-            SWSS_LOG_ERROR("ASIC sensors : unsupported op %s",op.c_str());
+            SWSS_LOG_ERROR("ASIC sensors : unsupported operation %s",op.c_str());
         }
 
         it = consumer.m_toSync.erase(it);
@@ -231,14 +231,13 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
 void SwitchOrch::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
-    const string & db_name = consumer.getDbName();
     const string & table_name = consumer.getTableName();
 
-    if ((db_name == "APPL_DB") && (table_name == APP_SWITCH_TABLE_NAME ))
+    if (table_name == APP_SWITCH_TABLE_NAME)
     {
         doAppSwitchTableTask(consumer);
     }
-    else if ((db_name == "CONFIG_DB") && (table_name == CFG_ASIC_SENSORS_TABLE_NAME))
+    else if (table_name == CFG_ASIC_SENSORS_TABLE_NAME)
     {
         doCfgSensorsTableTask(consumer);
     }
@@ -465,8 +464,6 @@ void SwitchOrch::initSensorsTable()
 
     if (m_sensorsMaxTempSupported)
     {
-        memset(&attr, 0, sizeof(attr));
-
         const std::string &fieldName = "maximum_temperature";
         values.emplace_back(fieldName, std::to_string(0));
         m_asicSensorsTable->set("",values);
@@ -474,8 +471,6 @@ void SwitchOrch::initSensorsTable()
 
     if (m_sensorsAvgTempSupported)
     {
-        memset(&attr, 0, sizeof(attr));
-
         const std::string &fieldName = "average_temperature";
         values.emplace_back(fieldName, std::to_string(0));
         m_asicSensorsTable->set("",values);

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -1,6 +1,11 @@
 #pragma once
 
 #include "orch.h"
+#include "timer.h"
+
+#define DEFAULT_ASIC_SENSORS_POLLER_INTERVAL 60
+#define ASIC_SENSORS_POLLER_STATUS "ASIC_SENSORS_POLLER_STATUS"
+#define ASIC_SENSORS_POLLER_INTERVAL "ASIC_SENSORS_POLLER_INTERVAL"
 
 struct WarmRestartCheck
 {
@@ -12,7 +17,7 @@ struct WarmRestartCheck
 class SwitchOrch : public Orch
 {
 public:
-    SwitchOrch(swss::DBConnector *db, std::string tableName, TableConnector switchTable);
+    SwitchOrch(swss::DBConnector *db, std::vector<TableConnector>& connectors, TableConnector switchTable);
     bool checkRestartReady() { return m_warmRestartCheck.checkRestartReadyState; }
     bool checkRestartNoFreeze() { return m_warmRestartCheck.noFreeze; }
     bool skipPendingTaskCheck() { return m_warmRestartCheck.skipPendingTaskCheck; }
@@ -22,11 +27,27 @@ public:
     void set_switch_capability(const std::vector<swss::FieldValueTuple>& values);
 private:
     void doTask(Consumer &consumer);
+    void doTask(swss::SelectableTimer &timer);
+    void doCfgSensorsTableTask(Consumer &consumer);
+    void doAppSwitchTableTask(Consumer &consumer);
+    void initSensorsTable();
 
     swss::NotificationConsumer* m_restartCheckNotificationConsumer;
     void doTask(swss::NotificationConsumer& consumer);
     swss::DBConnector *m_db;
     swss::Table m_switchTable;
+
+    // ASIC temperature sensors
+    std::shared_ptr<swss::DBConnector> m_stateDb = nullptr;
+    std::shared_ptr<swss::Table> m_asicSensorsTable= nullptr;
+    swss::SelectableTimer* m_sensorsPollerTimer = nullptr;
+    bool m_sensorsPollerEnabled = false;
+    uint32_t m_sensorsPollerInterval = DEFAULT_ASIC_SENSORS_POLLER_INTERVAL;
+    bool m_sensorsPollerIntervalChanged = false;
+    uint8_t m_numTempSensors = 0;
+    bool m_numTempSensorsInitialized = false;
+    bool m_sensorsMaxTempSupported = true;
+    bool m_sensorsAvgTempSupported = true;
 
     // Information contained in the request from
     // external program for orchagent pre-shutdown state check

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -286,8 +286,16 @@ namespace aclorch_test
             gVirtualRouterId = attr.value.oid;
 
             TableConnector stateDbSwitchTable(m_state_db.get(), "SWITCH_CAPABILITY");
+            TableConnector conf_asic_sensors(m_config_db.get(), CFG_ASIC_SENSORS_TABLE_NAME);
+            TableConnector app_switch_table(m_app_db.get(),  APP_SWITCH_TABLE_NAME);
+
+            vector<TableConnector> switch_tables = {
+                conf_asic_sensors,
+                app_switch_table
+            };
+
             ASSERT_EQ(gSwitchOrch, nullptr);
-            gSwitchOrch = new SwitchOrch(m_app_db.get(), APP_SWITCH_TABLE_NAME, stateDbSwitchTable);
+            gSwitchOrch = new SwitchOrch(m_app_db.get(), switch_tables, stateDbSwitchTable);
 
             // Create dependencies ...
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1) ASICs have multiple internal thermal sensors.
2) With the help of configuration, a poller is introduced in Orchagent that will periodically retrieve values of these sensors with the help of SAI APIs (opencomputeproject/SAI#880).
3) These retrieved values are being populated to the state DB (In "ASIC_TEMPERATURE_INFO" table).

**Why I did it**
As part of ASIC Thermal Monitoring HLD.

**How I verified it**
Tested out in below platforms.
[asic_thermal_log.s6100.txt](https://github.com/Azure/sonic-swss/files/5582296/asic_thermal_log.s6100.txt)
[asic_thermal_log.z9264.txt](https://github.com/Azure/sonic-swss/files/5582297/asic_thermal_log.z9264.txt)
[asic_thermal_log.s5232.txt](https://github.com/Azure/sonic-swss/files/5582298/asic_thermal_log.s5232.txt)
[asic_thermal_log.s6000.txt](https://github.com/Azure/sonic-swss/files/5582295/asic_thermal_log.s6000.txt)

## Do not merge until Azure/sonic-swss-common#419 is committed and synced.

### Configuration Sample(config_db.json)
1) To enable the poller:
```
  "ASIC_SENSORS": {
          "ASIC_SENSORS_POLLER_STATUS": {
                 "admin_status": "enable"                              
          }
   }
```
2) To disable the poller:
```
  "ASIC_SENSORS": {
          "ASIC_SENSORS_POLLER_STATUS": {
                 "admin_status": "disable"                              
          }
   }
```
3) To change the poller interval(Default time interval = 60 seconds):
```
  "ASIC_SENSORS": {
          "ASIC_SENSORS_POLLER_STATUS": {
                 "admin_status": "enable"                              
          },
          "ASIC_SENSORS_POLLER_INTERVAL": {
                 "interval": "30"
          }
   }
```

### Test cases and their observations

Steps | Test Case   scenarios | Result
-- | -- | --
(1) | Enabling the poller with default time interval in   config-db.json and do “config reload” | Poller populated the “ASIC_TEMPERATURE_INFO” table in the state DB and updated the table every default interval.
(2) | Disabling the poller in config-db.json and do “config   reload” | Poller disabled and the thermal sensors readings in   “ASIC_TEMPERATURE_INFO” table are reset to 0
(3) | Enabling the poller and setting the interval to “30” in   config-db.json and do “config reload” | Poller populated the “ASIC_TEMPERATURE_INFO” table in the state DB and updated the table every 30 seconds.
(4) | Disabling the poller by removing the configs from the   config-db.json and do “config reload” | Poller disabled and the thermal sensors readings in   “ASIC_TEMPERATURE_INFO” table are reset to 0
(5) | Repeating the steps (1), (2), (3), and (4) but with   “reboot” instead of “config reload” | Same results as above
(6) | Repeating the steps (1), (2), (3), and (4) but with   “fast-reboot” instead of “config reload” | Same results as above
(7) | Downgrading the SONiC with config enabling the poller | Configuration got neglected since not supported in the older   version
(8) | Upgrading the SONiC with config enabling the poller | Poller ran and updated the “ASIC_TEMPERATURE_INFO” table in the state DB and updated the table every default interval.

### Sample RedisDB ASIC Sensors Table Output(S6100)
Output: 443 => 44.3 degC
```
root@sonic:~# redis-cli -n 6 hgetall "ASIC_TEMPERATURE_INFO"
1) "temperature_0"
2) "443"
3) "temperature_1"
4) "452"
5) "temperature_2"
6) "457"
7) "temperature_3"
8) "447"
9) "temperature_4"
10) "433"
11) "temperature_5"
12) "457"
13) "temperature_6"
14) "423"
15) "temperature_7"
16) "443"
17) "maximum_temperature"
18) "477"
19) "average_temperature"
20) "451"
root@sonic:~#
```
**Details if related**
HLD Location: https://github.com/Azure/SONiC/blob/master/doc/asic_thermal_monitoring_hld.md