### PR TITLE
[dvs/copp] Adjust policer checks in VS tests for default COPP policers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,8 @@ class AsicDbValidator(DVSDatabase):
         self.default_acl_tables = self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE")
         self.default_acl_entries = self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
 
+        self.default_copp_policers = self.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
+
 
 class ApplDbValidator(DVSDatabase):
     NEIGH_TABLE = "NEIGH_TABLE"
@@ -1102,6 +1104,7 @@ class DockerVirtualSwitch:
             db = DVSDatabase(self.ASIC_DB_ID, self.redis_sock)
             db.default_acl_tables = self.asicdb.default_acl_tables
             db.default_acl_entries = self.asicdb.default_acl_entries
+            db.default_copp_policers = self.asicdb.default_copp_policers
             db.port_name_map = self.asicdb.portnamemap
             db.default_vlan_id = self.asicdb.default_vlan_id
             db.port_to_id_map = self.asicdb.portoidmap

--- a/tests/dvslib/dvs_policer.py
+++ b/tests/dvslib/dvs_policer.py
@@ -12,8 +12,10 @@ class DVSPolicer(object):
         self.config_db.delete_entry("POLICER", name)
 
     def verify_policer(self, name, expected=1):
-        self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_POLICER", expected)
+        self.asic_db.wait_for_n_keys(
+            "ASIC_STATE:SAI_OBJECT_TYPE_POLICER",
+            expected + len(self.asic_db.default_copp_policers)
+        )
 
     def verify_no_policer(self):
         self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY", 0)
-

--- a/tests/test_mirror_policer.py
+++ b/tests/test_mirror_policer.py
@@ -103,7 +103,7 @@ class TestMirror(object):
 
         # check asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
-        policer_entries = tbl.getKeys()
+        policer_entries = [p for p in tbl.getKeys() if p not in dvs.asicdb.default_copp_policers]
         assert len(policer_entries) == 1
         policer_oid = policer_entries[0]
 

--- a/tests/test_policer.py
+++ b/tests/test_policer.py
@@ -22,7 +22,7 @@ class TestPolicer(object):
 
         # check asic database
         tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
-        policer_entries = tbl.getKeys()
+        policer_entries = [p for p in tbl.getKeys() if p not in dvs.asicdb.default_copp_policers]
         assert len(policer_entries) == 1
 
         (status, fvs) = tbl.get(policer_entries[0])
@@ -70,7 +70,7 @@ class TestPolicer(object):
 
         # check asic database
         tbl = swsscommon.Table(dvs.adb, "ASIC_STATE:SAI_OBJECT_TYPE_POLICER")
-        policer_entries = tbl.getKeys()
+        policer_entries = [p for p in tbl.getKeys() if p not in dvs.asicdb.default_copp_policers]
         assert len(policer_entries) == 0
 
 


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I updated the DVS tests to take into account the default COPP configuration when checking for policers.

**Why I did it**
https://github.com/Azure/sonic-buildimage/pull/4861 added a COPP config to the DVS and this is causing a few policer related tests to fail in PR builds across repos b/c there is a mismatch between the expected number of policers and the actual number.

**How I verified it**
Re-ran the failing tests locally w/ my changes.

**Details if related**
