### PR TITLE
[port_rates][rif_rates] Fix port_rates.lua

### DIFF
--- a/orchagent/port_rates.lua
+++ b/orchagent/port_rates.lua
@@ -31,7 +31,7 @@ logit(delta)
 
 local n = table.getn(KEYS)
 for i = 1, n do
-    local state_table = rates_table_name .. ':' .. 'PORT' .. ":" .. KEYS[i]
+    local state_table = rates_table_name .. ':' .. KEYS[i] .. ':' .. 'PORT'
     local initialized = redis.call('HGET', state_table, 'INIT_DONE')
     logit(initialized)
 

--- a/orchagent/port_rates.lua
+++ b/orchagent/port_rates.lua
@@ -29,12 +29,12 @@ logit(alpha)
 logit(one_minus_alpha)
 logit(delta)
 
-local initialized = redis.call('HGET', rates_table_name .. ':' .. 'PORT', 'INIT_DONE')
-
-logit(initialized)
-
 local n = table.getn(KEYS)
 for i = 1, n do
+    local state_table = rates_table_name .. ':' .. 'PORT' .. ":" .. KEYS[i]
+    local initialized = redis.call('HGET', state_table, 'INIT_DONE')
+    logit(initialized)
+
     -- Get new COUNTERS values
     local in_ucast_pkts = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_UCAST_PKTS')
     local in_non_ucast_pkts = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS')
@@ -76,7 +76,7 @@ for i = 1, n do
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_PPS', rx_pps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_BPS', tx_bps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', tx_pps_new)
-            redis.call('HSET', rates_table_name .. ':' .. 'PORT', 'INIT_DONE', 'DONE')
+            redis.call('HSET', state_table, 'INIT_DONE', 'DONE')
         end        
     else
         -- Set old COUNTERS values
@@ -86,7 +86,7 @@ for i = 1, n do
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS_last', out_non_ucast_pkts)
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_OCTETS_last', in_octets)
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_OCTETS_last', out_octets)        
-        redis.call('HSET', rates_table_name .. ':' .. 'PORT', 'INIT_DONE', 'COUNTERS_LAST')
+        redis.call('HSET', state_table, 'INIT_DONE', 'COUNTERS_LAST')
     end
 end
 

--- a/orchagent/rif_rates.lua
+++ b/orchagent/rif_rates.lua
@@ -25,11 +25,12 @@ end
 local one_minus_alpha = 1.0 - alpha
 local delta = tonumber(ARGV[3])
 
-local initialized = redis.call('HGET', rates_table_name .. ':' .. 'RIF', 'INIT_DONE')
-logit(initialized)
-
 local n = table.getn(KEYS)
 for i = 1, n do
+    local state_table = rates_table_name .. ':' .. 'RIF' .. ':' .. KEYS[i]
+    local initialized = redis.call('HGET', state_table, 'INIT_DONE')
+    logit(initialized)
+
     -- Get new COUNTERS values
     local in_octets = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_OCTETS')
     local in_pkts = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS')
@@ -67,7 +68,7 @@ for i = 1, n do
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_PPS', rx_pps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_BPS', tx_bps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', tx_pps_new)
-            redis.call('HSET', rates_table_name .. ':' .. 'RIF', 'INIT_DONE', 'DONE')
+            redis.call('HSET', state_table, 'INIT_DONE', 'DONE')
         end        
     else
         -- Set old COUNTERS values
@@ -75,7 +76,7 @@ for i = 1, n do
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last', in_pkts)
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last', out_octets)
         redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last', out_pkts)      
-        redis.call('HSET', rates_table_name .. ':' .. 'RIF', 'INIT_DONE', 'COUNTERS_LAST')
+        redis.call('HSET', state_table, 'INIT_DONE', 'COUNTERS_LAST')
     end
 end
 

--- a/orchagent/rif_rates.lua
+++ b/orchagent/rif_rates.lua
@@ -27,7 +27,7 @@ local delta = tonumber(ARGV[3])
 
 local n = table.getn(KEYS)
 for i = 1, n do
-    local state_table = rates_table_name .. ':' .. 'RIF' .. ':' .. KEYS[i]
+    local state_table = rates_table_name .. ':' .. KEYS[i] .. ':' .. 'RIF'
     local initialized = redis.call('HGET', state_table, 'INIT_DONE')
     logit(initialized)
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Set rate collect logic init state per port
**Why I did it**
Observing following syslog:
`Nov 26 19:34:28.821608 sonic ERR syncd[26]: :- guard: RedisReply catches system_error: command: *39#015#012$7#015#012EVALSHA#015#012$40#015#0121140a72bbf8e5306e589cb798796067294922901#015#012$2#015#01232#015#012$19#015#012oid:0x600000000034f#015#012$19#015#012oid:0x6000000000350#015#012$19#015#012oid:0x6000000000351#015#012$19#015#012oid:0x6000000000352#015#012$19#015#012oid:0x6000000000353#015#012$19#015#012oid:0x6000000000354#015#012$19#015#012oid:0x6000000000355#015#012$19#015#012oid:0x6000000000356#015#012$19#015#012oid:0x6000000000357#015#012$19#015#012oid:0x6000000000358#015#012$19#015#012oid:0x6000000000359#015#012$19#015#012oid:0x600000000035a#015#012$19#015#012oid:0x600000000035b#015#012$19#015#012oid:0x600000000035c#015#012$19#015#012oid:0x600000000035d#015#012$19#015#012oid:0x600000000035e#015#012$19#015#012oid:0x600000000035f#015#012$19#015#012oid:0x6000000000360#015#012$19#015#012oid:0x6000000000361#015#012$19#015#012oid:0x6000000000362#015#012$19#015#012oid:0x6000000000363#015#012$19#015#012oid:0x6000000000364#015#012$19#015#012oid:0x6000000000365#015#012$19#015#012oid:0x6000000000366#015#012$19#015#012oid:0x6000000000367#015#012$19#015#012oid:0x6000000000368#015#012$19#015#012oid:0x6000000000369#015#012$19#015#012oid:0x600000000036a#015#012$19#015#012oid:0x600000000036b#015#012$19#015#012oid:0x600000000036c#015#012$19#015#012oid:0x600000000036d#015#012$19#015#012oid:0x600000000036e#015#012$1#015#0122#015#012$8#015#012COUNTERS#015#012$7#015#0121000000#015#012$2#015#012''#015#012, reason: ERR Error running script (call to f_1140a72bbf8e5306e589cb798796067294922901): @user_script:47: user_script:47: attempt to perform arithmetic on local 'in_octets_last' (a boolean value) : Input/output error
Nov 26 19:34:28.821608 sonic ERR syncd[26]: :- runRedisScript: Caught exception while running Redis lua script: ERR Error running script (call to f_1140a72bbf8e5306e589cb798796067294922901): @user_script:47: user_script:47: attempt to perform arithmetic on local 'in_octets_last' (a boolean value) : Input/output error
`
loop sets DONE state on processing the first port, leaving the rest of the ports' states uninitialized.

**How I verified it**
Checked redis-cli -n 2 hgetall RATES:oid:<oid> to ensure `_last` fields are set.
**Details if related**