### PR TITLE
[pfcwd] Update PFC storm detection logic for Mellanox platforms

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,41 @@
+path_classifiers:
+  test:
+    exclude: tests
+extraction:
+  python:
+    python_setup:
+      version: "2"
+  cpp:
+    prepare:
+      packages:
+      - libxml-simple-perl
+      - aspell
+      - aspell-en
+      - libhiredis-dev
+      - libnl-3-dev
+      - libnl-genl-3-dev
+      - libnl-route-3-dev
+      - libnl-nf-3-dev
+      - libzmq3-dev
+      - libzmq5
+      - swig3.0
+      - libpython2.7-dev
+      - libgtest-dev
+      - dh-exec
+      - doxygen
+      - graphviz
+    after_prepare:
+      - git clone https://github.com/Azure/sonic-swss-common; pushd sonic-swss-common; ./autogen.sh; fakeroot dpkg-buildpackage -us -uc -b; popd
+      - dpkg-deb -x libswsscommon_1.0.0_amd64.deb $LGTM_WORKSPACE
+      - dpkg-deb -x libswsscommon-dev_1.0.0_amd64.deb $LGTM_WORKSPACE
+      - git clone --recursive https://github.com/Azure/sonic-sairedis; pushd sonic-sairedis; ./autogen.sh; DEB_BUILD_OPTIONS=nocheck SWSS_COMMON_INC="$LGTM_WORKSPACE/usr/include" SWSS_COMMON_LIB="$LGTM_WORKSPACE/usr/lib/x86_64-linux-gnu" fakeroot debian/rules binary-syncd-vs; popd
+      - dpkg-deb -x libsairedis_1.0.0_amd64.deb $LGTM_WORKSPACE
+      - dpkg-deb -x libsairedis-dev_1.0.0_amd64.deb $LGTM_WORKSPACE
+      - dpkg-deb -x libsaimetadata_1.0.0_amd64.deb $LGTM_WORKSPACE
+      - dpkg-deb -x libsaimetadata-dev_1.0.0_amd64.deb $LGTM_WORKSPACE
+      - dpkg-deb -x libsaivs_1.0.0_amd64.deb $LGTM_WORKSPACE
+      - dpkg-deb -x libsaivs-dev_1.0.0_amd64.deb $LGTM_WORKSPACE
+    configure:
+      command:
+      - ./autogen.sh
+      - ./configure --prefix=/usr --with-extra-inc=$LGTM_WORKSPACE/usr/include --with-extra-lib=$LGTM_WORKSPACE/usr/lib/x86_64-linux-gnu

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -215,7 +215,46 @@ bool OrchDaemon::init()
         CFG_PFC_WD_TABLE_NAME
     };
 
-    if ((platform == MLNX_PLATFORM_SUBSTRING) || (platform == INVM_PLATFORM_SUBSTRING) || (platform == BFN_PLATFORM_SUBSTRING))
+    if (platform == MLNX_PLATFORM_SUBSTRING)
+    {
+
+        static const vector<sai_port_stat_t> portStatIds =
+        {
+            SAI_PORT_STAT_PFC_0_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_1_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_2_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_5_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_6_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_7_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_0_RX_PKTS,
+            SAI_PORT_STAT_PFC_1_RX_PKTS,
+            SAI_PORT_STAT_PFC_2_RX_PKTS,
+            SAI_PORT_STAT_PFC_3_RX_PKTS,
+            SAI_PORT_STAT_PFC_4_RX_PKTS,
+            SAI_PORT_STAT_PFC_5_RX_PKTS,
+            SAI_PORT_STAT_PFC_6_RX_PKTS,
+            SAI_PORT_STAT_PFC_7_RX_PKTS,
+        };
+
+        static const vector<sai_queue_stat_t> queueStatIds =
+        {
+            SAI_QUEUE_STAT_PACKETS,
+            SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
+        };
+
+        static const vector<sai_queue_attr_t> queueAttrIds;
+
+        m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+                    m_configDb,
+                    pfc_wd_tables,
+                    portStatIds,
+                    queueStatIds,
+                    queueAttrIds,
+                    PFC_WD_POLL_MSECS));
+    }
+    else if ((platform == INVM_PLATFORM_SUBSTRING) || (platform == BFN_PLATFORM_SUBSTRING))
     {
 
         static const vector<sai_port_stat_t> portStatIds =
@@ -246,7 +285,7 @@ bool OrchDaemon::init()
 
         static const vector<sai_queue_attr_t> queueAttrIds;
 
-        if ((platform == MLNX_PLATFORM_SUBSTRING) || (platform == INVM_PLATFORM_SUBSTRING))
+        if (platform == INVM_PLATFORM_SUBSTRING)
         {
             m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                         m_configDb,


### PR DESCRIPTION
* Use "PFC duration" counters in micro seconds instead of quanta

Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updated PFCWD storm detection logic for Mellanox platforms in order to use "PFC duration" counters in micro seconds instead of quanta.

Depends on below PRs so they should be merged first.
- https://github.com/Azure/sonic-sairedis/pull/731
- https://github.com/Azure/sonic-buildimage/pull/6156

**Why I did it**
SONiC PFCWD logic requires "pfc duration" value in micro seconds but in SAI it was provided as quanta of time. So it required additional conversion which used speed value to do such conversion and it could cause PFCWD to detect storm on operationally down port in case of link flapping.

Now there are new SAI attributes that provide "pfc duration" in micro seconds so PCWD storm detection logic is updated in order to use this new "pfc duration" counters. Such algorithm change helps to avoid false PFC storm detection in case of link flapping because conversion is not needed anymore.

**How I verified it**
1. Ran all PFCWD tests from https://github.com/Azure/sonic-mgmt/tree/master/tests/pfcwd and verified all passed.
2. Manual test: manually start storm on fanout and manually put port down on fanout few times. Verified that no storm was detected when link was down

**Details if related**
N/A