### PR TITLE
Change gAsicInstance to type string with max length limit

### DIFF
--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -498,7 +498,7 @@ namespace aclorch_test
                     switch (meta->attrvaluetype)
                     {
                         case SAI_ATTR_VALUE_TYPE_INT32_LIST:
-                            new_attr.value.s32list.list = (int32_t *)malloc(sizeof(int32_t) * attr.value.s32list.count);
+                            new_attr.value.s32list.list = (int32_t *)calloc(attr.value.s32list.count, sizeof(int32_t));
                             new_attr.value.s32list.count = attr.value.s32list.count;
                             m_s32list_pool.emplace_back(new_attr.value.s32list.list);
                             break;
@@ -555,7 +555,7 @@ namespace aclorch_test
                     switch (meta->attrvaluetype)
                     {
                         case SAI_ATTR_VALUE_TYPE_INT32_LIST:
-                            new_attr.value.s32list.list = (int32_t *)malloc(sizeof(int32_t) * attr.value.s32list.count);
+                            new_attr.value.s32list.list = (int32_t *)calloc(attr.value.s32list.count, sizeof(int32_t));
                             new_attr.value.s32list.count = attr.value.s32list.count;
                             m_s32list_pool.emplace_back(new_attr.value.s32list.list);
                             break;


### PR DESCRIPTION
**What I did**
1. Change gAsicInstance to type string with max length limit
2. Replace malloc with calloc to prevent risk of integer overflow, in test code

**Why I did it**
1. Remove `calloc` manual memory management.
2. Graceful release memory before exiting. 
3. Save memory if input is very long

**How I verified it**
Ad-hoc test with different input arguments.

**Details if related**
