### PR TITLE
Support ACL Table type Mirrorv6 for Innovium

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -127,7 +127,7 @@ static const acl_capabilities_t defaultAclActionsSupported =
         }
     },
     {
-        ACL_STAGE_EGRESS, 
+        ACL_STAGE_EGRESS,
         {
             SAI_ACL_ACTION_TYPE_PACKET_ACTION
         }
@@ -2114,6 +2114,7 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     if (platform == BRCM_PLATFORM_SUBSTRING ||
             platform == MLNX_PLATFORM_SUBSTRING ||
             platform == BFN_PLATFORM_SUBSTRING  ||
+            platform == INVM_PLATFORM_SUBSTRING ||
             platform == NPS_PLATFORM_SUBSTRING)
     {
         m_mirrorTableCapabilities =
@@ -2140,7 +2141,8 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     // In Broadcom platform, V4 and V6 rules are stored in the same table
     if (platform == BRCM_PLATFORM_SUBSTRING ||
         platform == NPS_PLATFORM_SUBSTRING  ||
-        platform == BFN_PLATFORM_SUBSTRING) {
+        platform == BFN_PLATFORM_SUBSTRING  ||
+        platform == INVM_PLATFORM_SUBSTRING) {
         m_isCombinedMirrorV6Table = true;
     }
 


### PR DESCRIPTION
**What I did**
Enable v6 ACL rule based Mirroring for Innovium Platform

**Why I did it**
It was not previously enabled.

**How I verified it**
Verified on Innovium based SONiC platform

show version

SONiC Software Version: SONiC.SONiC201911_Innovium.0-dirty-20201106.003458
Distribution: Debian 9.13
Kernel: 4.9.0-11-2-amd64
Build commit: d72517d7
Build date: Fri Nov  6 10:37:45 UTC 2020


redis-cli -n 6 hgetall "SWITCH_CAPABILITY|switch"
 :
 :
 3) "MIRROR"
 4) "true"
 **5) "MIRRORV6"
 6) "true"**
:
:
root@sonic-dut:~#


