### PR TITLE
[portsorch] adjust port initialized event back to notice

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1874,7 +1874,7 @@ bool PortsOrch::initPort(const string &alias, const int index, const set<int> &l
 
                 m_portList[alias].m_init = true;
 
-                SWSS_LOG_ERROR("Initialized port %s", alias.c_str());
+                SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
             }
             else
             {


### PR DESCRIPTION
**What I did**
Adjust port initialized event back to notice.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>

**Why I did it**
This event was raised from notice to error unnecessarily in PR #1264. This event is causing test to fail with loganalyzer.
