### PR TITLE
[dvs] Fix issue where concurrent netns operations cause test setup to fail

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,9 +162,11 @@ class VirtualServer:
             ensure_system(f"ip netns add {self.nsname}")
 
             # create vpeer link
-            ensure_system(f"ip link add {self.nsname[0:12]} type veth peer name {self.pifname}")
-            ensure_system(f"ip link set {self.nsname[0:12]} netns {self.nsname}")
-            ensure_system(f"ip link set {self.pifname} netns {pid}")
+            ensure_system(
+                f"ip netns exec {self.nsname} ip link add {self.nsname[0:12]}"
+                f" type veth peer name {self.pifname}"
+            )
+            ensure_system(f"ip netns exec {self.nsname} ip link set {self.pifname} netns {pid}")
 
             # bring up link in the virtual server
             ensure_system(f"ip netns exec {self.nsname} ip link set dev {self.nsname[0:12]} name eth0")


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I moved some of the dynamic test setup steps to run inside the network namespace. This needs to be done b/c we may have multiple test runs ongoing at the same time on Jenkins, and if two tests re-use a name such as "eth9" before the link has been added to the namespace then it will cause the tests to crash and fail.

**Why I did it**
Fixes https://github.com/Azure/sonic-buildimage/issues/5205

**How I verified it**
Ran tests locally with `sudo pytest -sv` and they passed.

**Details if related**
