### PR TITLE
[vxlanorch] Use PRI instead of %l to avoid warnings in 32-bit arch

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -279,7 +279,7 @@ create_tunnel(
       if (ids->tunnel_decap_id[i] != SAI_NULL_OBJECT_ID)
       {
           map_list[num_map] = ids->tunnel_decap_id[i];
-          SWSS_LOG_INFO("create_tunnel:maplist[%d]=0x%lx",num_map,map_list[num_map]);
+          SWSS_LOG_INFO("create_tunnel:maplist[%d]=0x%" PRIx64 "",num_map,map_list[num_map]);
           num_map++;
       }
     }
@@ -297,7 +297,7 @@ create_tunnel(
         if (ids->tunnel_encap_id[i] != SAI_NULL_OBJECT_ID)
         {
             emap_list[num_emap] = ids->tunnel_encap_id[i];
-            SWSS_LOG_NOTICE("create_tunnel:encapmaplist[%d]=0x%lx",num_emap,emap_list[num_emap]);
+            SWSS_LOG_NOTICE("create_tunnel:encapmaplist[%d]=0x%" PRIx64 "",num_emap,emap_list[num_emap]);
             num_emap++;
         }
     }
@@ -1821,7 +1821,7 @@ bool VxlanTunnelMapOrch::delOperation(const Request& request)
     }
 
     vector<string> map_entries = tokenize(tunnel_map_entry_name, '_');
-    SWSS_LOG_INFO("Vxlan tunnel map '%s' size %ld", tunnel_map_entry_name.c_str(), 
+    SWSS_LOG_INFO("Vxlan tunnel map '%s' size %zu", tunnel_map_entry_name.c_str(), 
                                                     map_entries.size());
     if (map_entries.size() == 3)
     {
@@ -1953,7 +1953,7 @@ bool VxlanVrfMapOrch::delOperation(const Request& request)
          */
         entry = vxlan_vrf_table_[full_map_entry_name];
 
-        SWSS_LOG_NOTICE("VxlanVrfMapOrch Vxlan tunnel VRF encap entry '%lx' decap entry '0x%lx'",
+        SWSS_LOG_NOTICE("VxlanVrfMapOrch Vxlan tunnel VRF encap entry '%" PRIx64 "' decap entry '0x%" PRIx64 "'",
                 entry.encap_id, entry.decap_id);
 
         remove_tunnel_map_entry(entry.encap_id);


### PR DESCRIPTION
Signed-off-by: Sabareesh Kumar Anandan <sanandan@marvell.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
