### PR TITLE
[dvs] Clean-up dvs_database and dvs_common

### DIFF
--- a/tests/dvslib/dvs_vlan.py
+++ b/tests/dvslib/dvs_vlan.py
@@ -1,4 +1,4 @@
-from .dvs_database import DVSDatabase
+from .dvs_common import PollingConfig
 
 class DVSVlan(object):
     def __init__(self, adb, cdb, sdb, cntrdb, appdb):
@@ -49,7 +49,7 @@ class DVSVlan(object):
 
     def get_and_verify_vlan_ids(self,
                                 expected_num,
-                                polling_config=DVSDatabase.DEFAULT_POLLING_CONFIG):
+                                polling_config=PollingConfig()):
         vlan_entries = self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_VLAN",
                                                     expected_num + 1,
                                                     polling_config)

--- a/tests/test_fgnhg.py
+++ b/tests/test_fgnhg.py
@@ -5,7 +5,6 @@ import json
 import pytest
 
 from dvslib.dvs_common import wait_for_result
-from dvslib.dvs_database import DVSDatabase
 from swsscommon import swsscommon
 
 IF_TB = 'INTERFACE'
@@ -98,10 +97,7 @@ def validate_asic_nhg_regular_ecmp(asic_db, ipprefix):
         if nhg_type != "SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP":
             return false_ret
         return (True, nhgid)
-    status, result = wait_for_result(_access_function, DVSDatabase.DEFAULT_POLLING_CONFIG)
-    if not status:
-        assert not polling_config.strict, \
-                f"SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP not found"
+    _, result = wait_for_result(_access_function, failure_message="SAI_NEXT_HOP_GROUP_TYPE_DYNAMIC_UNORDERED_ECMP not found")
     return result
 
 
@@ -159,10 +155,9 @@ def verify_programmed_fg_asic_db_entry(asic_db,nh_memb_exp_count,nh_oid_map,nhgi
             ret = ret and (idx == 1)
         return (ret, nh_memb_count)
 
-    status, result = wait_for_result(_access_function, DVSDatabase.DEFAULT_POLLING_CONFIG)
-    if not status:
-        assert not polling_config.strict, \
-                f"Exact match not found: expected={nh_memb_exp_count}, received={result}"
+    status, result = wait_for_result(_access_function)
+    assert status, f"Exact match not found: expected={nh_memb_exp_count}, received={result}"
+
     return result
 
 

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -1,7 +1,6 @@
 import time
 
 from dvslib.dvs_common import wait_for_result
-from dvslib.dvs_database import DVSDatabase
 
 
 class TestNat(object):
@@ -316,7 +315,7 @@ class TestNat(object):
 
             return (True, None)
 
-        wait_for_result(_check_conntrack_for_static_entry, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        wait_for_result(_check_conntrack_for_static_entry)
 
         # delete a static nat entry
         dvs.runcmd("config nat remove static basic 67.66.65.1 18.18.18.2")

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -6,7 +6,6 @@ import pytest
 
 from swsscommon import swsscommon
 from dvslib.dvs_common import wait_for_result
-from dvslib.dvs_database import DVSDatabase
 
 class TestRouteBase(object):
     def setup_db(self, dvs):
@@ -61,7 +60,7 @@ class TestRouteBase(object):
                                   for route_entry in route_entries]
             return (all(destination in route_destinations for destination in destinations), None)
 
-        wait_for_result(_access_function, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        wait_for_result(_access_function)
 
     def check_route_entries_with_vrf(self, destinations, vrf_oids):
         def _access_function():
@@ -71,7 +70,7 @@ class TestRouteBase(object):
             return (all((destination, vrf_oid) in route_destination_vrf
                         for destination, vrf_oid in zip(destinations, vrf_oids)), None)
 
-        wait_for_result(_access_function, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        wait_for_result(_access_function)
 
     def check_route_entries_nexthop(self, destinations, vrf_oids, nexthops):
         def _access_function_nexthop():
@@ -80,7 +79,7 @@ class TestRouteBase(object):
                                  for key in nexthop_entries])
             return (all(nexthop in nexthop_oids for nexthop in nexthops), nexthop_oids)
 
-        status, nexthop_oids = wait_for_result(_access_function_nexthop, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        status, nexthop_oids = wait_for_result(_access_function_nexthop)
 
         def _access_function_route_nexthop():
             route_entries = self.adb.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
@@ -90,7 +89,7 @@ class TestRouteBase(object):
             return (all(route_destination_nexthop.get((destination, vrf_oid)) == nexthop_oids.get(nexthop)
                         for destination, vrf_oid, nexthop in zip(destinations, vrf_oids, nexthops)), None)
 
-        wait_for_result(_access_function_route_nexthop, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        wait_for_result(_access_function_route_nexthop)
 
     def check_deleted_route_entries(self, destinations):
         def _access_function():
@@ -98,7 +97,7 @@ class TestRouteBase(object):
             route_destinations = [json.loads(route_entry)["dest"] for route_entry in route_entries]
             return (all(destination not in route_destinations for destination in destinations), None)
 
-        wait_for_result(_access_function, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        wait_for_result(_access_function)
 
     def clear_srv_config(self, dvs):
         dvs.servers[0].runcmd("ip address flush dev eth0")

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -2,7 +2,6 @@ import json
 import time
 
 from dvslib.dvs_common import wait_for_result
-from dvslib.dvs_database import DVSDatabase
 from swsscommon import swsscommon
 
 DEFAULT_MTU = "9100"
@@ -138,7 +137,7 @@ class TestSubPortIntf(object):
 
             return (route_entry_found, raw_route_entry_key)
 
-        (route_entry_found, raw_route_entry_key) = wait_for_result(_access_function, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        (route_entry_found, raw_route_entry_key) = wait_for_result(_access_function)
 
         fvs = self.asic_db.get_entry(ASIC_ROUTE_ENTRY_TABLE, raw_route_entry_key)
 
@@ -166,7 +165,7 @@ class TestSubPortIntf(object):
                                   for raw_route_entry in raw_route_entries]
             return (all(dest in route_destinations for dest in expected_destinations), None)
 
-        wait_for_result(_access_function, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        wait_for_result(_access_function)
 
     def check_sub_port_intf_key_removal(self, db, table_name, key):
         db.wait_for_deleted_keys(table_name, [key])
@@ -179,7 +178,7 @@ class TestSubPortIntf(object):
                          for raw_route_entry in raw_route_entries)
             return (status, None)
 
-        wait_for_result(_access_function, DVSDatabase.DEFAULT_POLLING_CONFIG)
+        wait_for_result(_access_function)
 
     def _test_sub_port_intf_creation(self, dvs, sub_port_intf_name):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)


### PR DESCRIPTION
- Fix formatting for default assert messages
- Add support for customized assert messages
- Use dataclass for PollingConfig

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Fixed formatting for default assert messages
- Added support for customized assert messages
- Used dataclass for PollingConfig instead of namedtuple

**Why I did it**
- Some logging messages look choppy when printed out b/c the line break was including all the extra whitespace as well. f-strings provide a clean way of avoiding this problem, so I moved all the log statements to use that.
- For some tests it may be more useful to say what _logically_ went wrong rather than just saying "the database looks wrong," so that support has been added.
- `dataclass`  is a new construct in python3 that fulfills the same purpose as namedtuple and is a little cleaner/easier to work with. This also deprecates the DEFAULT_POLLING_CONFIG that a lot of code was borrowing from dvs_database.

**How I verified it**
Ran the tests and verified there was no regression.

**Details if related**
