### PR TITLE
[logfile]: Add option to specify swss rec file name

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -65,7 +65,7 @@ string gRecordFile;
 
 void usage()
 {
-    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s]" << endl;
+    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode]" << endl;
     cout << "    -h: display this message" << endl;
     cout << "    -r record_type: record orchagent logs with type (default 3)" << endl;
     cout << "                    0: do not record logs" << endl;
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
     string swss_rec_filename = "swss.rec";
     string sairedis_rec_filename = "sairedis.rec";
 
-    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hs")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz")) != -1)
     {
         switch (opt)
         {

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -65,7 +65,7 @@ string gRecordFile;
 
 void usage()
 {
-    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-b batch_size] [-m MAC] [-i INST_ID] [-s] [-z mode]" << endl;
+    cout << "usage: orchagent [-h] [-r record_type] [-d record_location] [-f swss_rec_filename] [-j sairedis_rec_filename] [-b batch_size] [-m MAC] [-i INST_ID] [-s]" << endl;
     cout << "    -h: display this message" << endl;
     cout << "    -r record_type: record orchagent logs with type (default 3)" << endl;
     cout << "                    0: do not record logs" << endl;
@@ -78,6 +78,8 @@ void usage()
     cout << "    -i INST_ID: set the ASIC instance_id in multi-asic platform" << endl;
     cout << "    -s: enable synchronous mode (depreacated, use -z)" << endl;
     cout << "    -z: redis communication mode (redis_async|redis_sync|zmq_sync), default: redis_async" << endl;
+    cout << "    -f swss_rec_filename: swss record log filename(default 'swss.rec')" << endl;
+    cout << "    -j sairedis_rec_filename:  sairedis record log filename(default sairedis.rec)" << endl;
 }
 
 void sighup_handler(int signo)
@@ -161,8 +163,10 @@ int main(int argc, char **argv)
     sai_status_t status;
 
     string record_location = ".";
+    string swss_rec_filename = "swss.rec";
+    string sairedis_rec_filename = "sairedis.rec";
 
-    while ((opt = getopt(argc, argv, "b:m:r:d:i:hsz:")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hs")) != -1)
     {
         switch (opt)
         {
@@ -218,7 +222,20 @@ int main(int argc, char **argv)
         case 'z':
             sai_deserialize_redis_communication_mode(optarg, gRedisCommunicationMode);
             break;
-
+        case 'f':
+            swss_rec_filename = optarg;
+            if (swss_rec_filename.empty())
+            {
+                swss_rec_filename=  "swss.rec";
+            }
+            break;
+        case 'j':
+            sairedis_rec_filename = optarg;
+            if (sairedis_rec_filename.empty())
+            {
+                sairedis_rec_filename=  "sairedis.rec";
+            }
+            break;
         default: /* '?' */
             exit(EXIT_FAILURE);
         }
@@ -227,7 +244,7 @@ int main(int argc, char **argv)
     SWSS_LOG_NOTICE("--- Starting Orchestration Agent ---");
 
     initSaiApi();
-    initSaiRedis(record_location);
+    initSaiRedis(record_location, sairedis_rec_filename);
 
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;
@@ -242,7 +259,7 @@ int main(int argc, char **argv)
     /* Disable/enable SwSS recording */
     if (gSwssRecord)
     {
-        gRecordFile = record_location + "/" + "swss.rec";
+        gRecordFile = record_location + "/" + swss_rec_filename;
         gRecordOfs.open(gRecordFile, std::ofstream::out | std::ofstream::app);
         if (!gRecordOfs.is_open())
         {

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -79,7 +79,7 @@ void usage()
     cout << "    -s: enable synchronous mode (depreacated, use -z)" << endl;
     cout << "    -z: redis communication mode (redis_async|redis_sync|zmq_sync), default: redis_async" << endl;
     cout << "    -f swss_rec_filename: swss record log filename(default 'swss.rec')" << endl;
-    cout << "    -j sairedis_rec_filename:  sairedis record log filename(default sairedis.rec)" << endl;
+    cout << "    -j sairedis_rec_filename: sairedis record log filename(default sairedis.rec)" << endl;
 }
 
 void sighup_handler(int signo)

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -232,17 +232,16 @@ int main(int argc, char **argv)
             sai_deserialize_redis_communication_mode(optarg, gRedisCommunicationMode);
             break;
         case 'f':
-            swss_rec_filename = optarg;
-            if (swss_rec_filename.empty())
+
+            if (optarg)
             {
-                swss_rec_filename=  "swss.rec";
+                swss_rec_filename = optarg;
             }
             break;
         case 'j':
-            sairedis_rec_filename = optarg;
-            if (sairedis_rec_filename.empty())
+            if (optarg)
             {
-                sairedis_rec_filename=  "sairedis.rec";
+                sairedis_rec_filename = optarg;
             }
             break;
         default: /* '?' */

--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
     string swss_rec_filename = "swss.rec";
     string sairedis_rec_filename = "sairedis.rec";
 
-    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz")) != -1)
+    while ((opt = getopt(argc, argv, "b:m:r:f:j:d:i:hsz:")) != -1)
     {
         switch (opt)
         {

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -199,7 +199,7 @@ void initSaiApi()
     sai_log_set((sai_api_t)SAI_API_NAT,         SAI_LOG_LEVEL_NOTICE);
 }
 
-void initSaiRedis(const string &record_location)
+void initSaiRedis(const string &record_location, const std::string &record_filename)
 {
     /**
      * NOTE: Notice that all Redis attributes here are using SAI_NULL_OBJECT_ID
@@ -225,6 +225,19 @@ void initSaiRedis(const string &record_location)
                 record_location.c_str(), status);
             exit(EXIT_FAILURE);
         }
+
+        attr.id = SAI_REDIS_SWITCH_ATTR_RECORDING_FILENAME;
+        attr.value.s8list.count = (uint32_t)record_filename.size();
+        attr.value.s8list.list = (int8_t*)const_cast<char *>(record_filename.c_str());
+
+        status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set SAI Redis recording logfile to %s, rv:%d",
+                record_filename.c_str(), status);
+            exit(EXIT_FAILURE);
+        }
+
     }
 
     /* Disable/enable SAI Redis recording */

--- a/orchagent/saihelper.h
+++ b/orchagent/saihelper.h
@@ -5,5 +5,5 @@
 #include <string>
 
 void initSaiApi();
-void initSaiRedis(const std::string &record_location);
+void initSaiRedis(const std::string &record_location, const std::string &record_filename);
 sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add new options to specify swss rec and sairedis rec file name.
Corresponding change in sairedis https://github.com/Azure/sonic-sairedis/pull/747

**Why I did it**
This option will be used in the multi asic system. The swss and sairedis record filename will be different for each asic and will be passed from the orchagent.sh 

**How I verified it**
- Check if swss.rec and sairedis.rec files are created when the new options are not used
```
admin@vlab-01:~$ ls /var/log/swss/
sairedis.rec  swss.rec
admin@vlab-01:~$ tail -10 /var/log/swss/sairedis.rec
2020-12-15.17:57:02.194381|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000059e|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.195879|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000059d|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.197539|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000059f|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.210632|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005a0|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.221479|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd000000000595|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.223484|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005a8|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.229325|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005a7|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.231627|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005a9|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.233420|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005aa|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.17:57:02.236314|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005ac|SAI_HOSTIF_ATTR_OPER_STATUS=true
admin@vlab-01:~$ tail -10 /var/log/swss/swss.rec
2020-12-15.17:57:01.728078|BUFFER_PG|Ethernet64|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728093|BUFFER_PG|Ethernet68|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728108|BUFFER_PG|Ethernet72|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728122|BUFFER_PG|Ethernet76|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728137|BUFFER_PG|Ethernet8|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728152|BUFFER_PG|Ethernet80|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728167|BUFFER_PG|Ethernet84|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728182|BUFFER_PG|Ethernet88|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728196|BUFFER_PG|Ethernet92|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
2020-12-15.17:57:01.728210|BUFFER_PG|Ethernet96|3-4|SET|profile:[BUFFER_PROFILE|pg_lossless_40000_5m_profile]
```

- Update the orchagent.sh to provide the swss.asic0.rec and sairedis.asic0.rec and verify the files are created
```
admin@vlab-01:~$ docker exec -it swss grep -i asic0 /usr/bin/orchagent.sh
ORCHAGENT_ARGS+=" -f swss.asic0.rec -j sairedis.asic0.rec"
admin@vlab-01:~$ sudo systemctl restart swss
admin@vlab-01:~$ ls /var/log/swss/
sairedis.asic0.rec  sairedis.rec  swss.asic0.rec  swss.rec
admin@vlab-01:~$ tail -10 /var/log/swss/swss.asic0.rec
2020-12-15.18:01:49.716184|ROUTE_TABLE:fc00::7c/126|SET|nexthop:::|ifname:PortChannel0004
2020-12-15.18:01:49.716194|ROUTE_TABLE:2064:100::1d|SET|nexthop:fc00::72|ifname:PortChannel0001
2020-12-15.18:01:49.716232|ROUTE_TABLE:2064:100::20|SET|nexthop:fc00::7e|ifname:PortChannel0004
2020-12-15.18:01:49.716410|ROUTE_TABLE:100.1.0.30|SET|nexthop:10.0.0.59|ifname:PortChannel0002
2020-12-15.18:01:49.716422|ROUTE_TABLE:10.0.0.58/31|SET|nexthop:0.0.0.0|ifname:PortChannel0002
2020-12-15.18:01:49.716434|ROUTE_TABLE:100.1.0.31|SET|nexthop:10.0.0.61|ifname:PortChannel0003
2020-12-15.18:01:49.716446|ROUTE_TABLE:fe80::/64|SET|nexthop:::|ifname:eth0
2020-12-15.18:01:49.718218|ROUTE_TABLE:2064:100::1e|SET|nexthop:fc00::76|ifname:PortChannel0002
2020-12-15.18:01:49.719083|ROUTE_TABLE:fc00::74/126|SET|nexthop:::|ifname:PortChannel0002
2020-12-15.18:01:49.719118|ROUTE_TABLE:10.0.0.56/31|SET|nexthop:0.0.0.0|ifname:PortChannel0001
admin@vlab-01:~$ tail -10 /var/log/swss/sairedis.asic0.rec
2020-12-15.18:01:49.863253|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000059e|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.864090|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000059d|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.865178|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd00000000059f|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.865863|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005a0|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.866615|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd000000000595|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.893033|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005a8|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.912529|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005a7|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.922334|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005a9|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.933690|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005aa|SAI_HOSTIF_ATTR_OPER_STATUS=true
2020-12-15.18:01:49.942162|s|SAI_OBJECT_TYPE_HOSTIF:oid:0xd0000000005ac|SAI_HOSTIF_ATTR_OPER_STATUS=true
```

**Details if related**
