### PR TITLE
[gearbox] Add support for "hwinfo" field

### DIFF
--- a/gearsyncd/gearboxparser.cpp
+++ b/gearsyncd/gearboxparser.cpp
@@ -143,6 +143,14 @@ bool GearboxParser::parse()
             val = phy["bus_id"];
             attr = std::make_pair("bus_id", std::to_string(val.get<int>()));
             attrs.push_back(attr);
+            if (phy.find("hwinfo") == phy.end())
+            {
+                SWSS_LOG_ERROR("missing 'hwinfo' field in 'phys' item %d in gearbox configuration", iter);
+                return false;
+            }
+            val = phy["hwinfo"];
+            attr = std::make_pair("hwinfo", std::string(val.get<std::string>()));
+            attrs.push_back(attr);
             std::string key;
             key = "phy:" + std::to_string(phyId);
             if (getWriteToDb() == true) 

--- a/gearsyncd/tests/configs/negative/gearbox_config_empty_ethernet_line_lanes.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_empty_ethernet_line_lanes.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_empty_ethernet_system_lanes.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_empty_ethernet_system_lanes.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_invalid_array.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_invalid_array.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_invalid_json.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_invalid_json.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_invalid_phy_config_file.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_invalid_phy_config_file.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy_config_does_not_exist.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_index.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_index.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_line_lane_speed.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_line_lane_speed.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_line_lanes.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_line_lanes.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_phy_id.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_phy_id.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_system_lane_speed.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_system_lane_speed.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/3"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_system_lanes.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_ethernet_system_lanes.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_interfaces.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_interfaces.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ]
 }

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_address.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_address.json
@@ -7,7 +7,8 @@
       "firmware_path": "/tmp/phy-example1.bin",
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "phy_access": "MDIO(NPU)",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -17,7 +18,8 @@
       "firmware_path": "/tmp/phy-example2.bin",
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "phy_access": "I2C",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_bus_id.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_bus_id.json
@@ -7,7 +7,8 @@
       "lib_name": "libsai_phy_example1.so",
       "firmware_path": "/tmp/phy-example1.bin",
       "config_file": "tests/configs/positive/phy1_config_1.json",
-      "phy_access": "MDIO(NPU)"
+      "phy_access": "MDIO(NPU)",
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -17,7 +18,8 @@
       "firmware_path": "/tmp/phy-example2.bin",
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "phy_access": "I2C",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_config_file.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_config_file.json
@@ -7,7 +7,8 @@
       "lib_name": "libsai_phy_example1.so",
       "firmware_path": "/tmp/phy-example1.bin",
       "phy_access": "MDIO(NPU)",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -17,7 +18,8 @@
       "firmware_path": "/tmp/phy-example2.bin",
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "phy_access": "I2C",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_firmware_path.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_firmware_path.json
@@ -7,7 +7,8 @@
       "lib_name": "libsai_phy_example1.so",
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "phy_access": "MDIO(NPU)",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -17,7 +18,8 @@
       "firmware_path": "/tmp/phy-example2.bin",
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "phy_access": "I2C",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_hwinfo.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_hwinfo.json
@@ -8,8 +8,7 @@
       "firmware_path": "/tmp/phy-example1.bin",
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "phy_access": "mdio",
-      "bus_id": 0,
-      "hwinfo": "mdio0/0"
+      "bus_id": 0
     },
     {
       "phy_id": 1,
@@ -18,7 +17,7 @@
       "lib_name": "libsai_phy_example2.so",
       "firmware_path": "/tmp/phy-example2.bin",
       "config_file": "tests/configs/positive/phy2_config_1.json",
-      "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
+      "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",
       "phy_access": "i2c",
       "bus_id": 1,
       "hwinfo": ""

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_id.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_id.json
@@ -8,7 +8,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -19,7 +20,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_lib_name.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_lib_name.json
@@ -7,7 +7,8 @@
       "firmware_path": "/tmp/phy-example1.bin",
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "phy_access": "MDIO(NPU)",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -17,7 +18,8 @@
       "firmware_path": "/tmp/phy-example2.bin",
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "phy_access": "I2C",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_name.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_name.json
@@ -7,7 +7,8 @@
       "firmware_path": "/tmp/phy-example1.bin",
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "phy_access": "MDIO(NPU)",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -17,7 +18,8 @@
       "firmware_path": "/tmp/phy-example2.bin",
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "phy_access": "I2C",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_phy_access.json
+++ b/gearsyncd/tests/configs/negative/gearbox_config_missing_phy_phy_access.json
@@ -7,7 +7,8 @@
       "lib_name": "libsai_phy_example1.so",
       "firmware_path": "/tmp/phy-example1.bin",
       "config_file": "tests/configs/positive/phy1_config_1.json",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/0"
     },
     {
       "phy_id": 1,
@@ -17,7 +18,8 @@
       "firmware_path": "/tmp/phy-example2.bin",
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "phy_access": "I2C",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/configs/positive/gearbox_config_1.json
+++ b/gearsyncd/tests/configs/positive/gearbox_config_1.json
@@ -9,7 +9,8 @@
       "config_file": "tests/configs/positive/phy1_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-1.bcm",     
       "phy_access": "mdio",
-      "bus_id": 0
+      "bus_id": 0,
+      "hwinfo": "mdio0/1"
     },
     {
       "phy_id": 1,
@@ -20,7 +21,8 @@
       "config_file": "tests/configs/positive/phy2_config_1.json",
       "sai_init_config_file": "/usr/share/sonic/hwsku/example-2.bcm",     
       "phy_access": "i2c",
-      "bus_id": 1
+      "bus_id": 1,
+      "hwinfo": ""
     }
   ],
   "interfaces": [

--- a/gearsyncd/tests/testgearparser.cpp
+++ b/gearsyncd/tests/testgearparser.cpp
@@ -63,6 +63,8 @@ void negativeConfigTest()
     CU_ASSERT_EQUAL(ret, false);
     ret = handleGearboxConfigFile("tests/configs/negative/gearbox_config_missing_phy_bus_id.json", false);
     CU_ASSERT_EQUAL(ret, false);
+    ret = handleGearboxConfigFile("tests/configs/negative/gearbox_config_missing_phy_hwinfo.json", false);
+    CU_ASSERT_EQUAL(ret, false);
     ret = handleGearboxConfigFile("tests/configs/negative/gearbox_config_invalid_phy_config_file.json", false);
     CU_ASSERT_EQUAL(ret, false);
 

--- a/lib/gearboxutils.cpp
+++ b/lib/gearboxutils.cpp
@@ -173,6 +173,10 @@ std::map<int, gearbox_phy_t> GearboxUtils::loadPhyMap(Table *gearboxTable)
                 {
                     phy.access = val.second;
                 }
+                else if (val.first == "hwinfo")
+                {
+                    phy.hwinfo = val.second;
+                }
                 else if (val.first == "address")
                 {
                     phy.address = std::stoi(val.second);

--- a/lib/gearboxutils.h
+++ b/lib/gearboxutils.h
@@ -41,6 +41,7 @@ typedef struct
     std::string sai_init_config_file;
     std::string config_file;
     std::string access;
+    std::string hwinfo;
     uint32_t address;
     uint32_t bus_id;
 } gearbox_phy_t;


### PR DESCRIPTION
**What I did**

This PR adds support for a new "hwinfo" attribute in gearbox_config.json. The field is propagated by syncd to the SAI by setting SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO.

**Why I did it**

This is necessary to propagate the MDIO interface & phy_id that should be used by the SAI driver for a particular gearbox.

**How I verified it**

Verified on an internal Arista build that the field from the configuration was propagated all the way to the SAI.
