### PR TITLE
Arp Refresh changes

### DIFF
--- a/neighsyncd/Makefile.am
+++ b/neighsyncd/Makefile.am
@@ -1,4 +1,8 @@
-INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/warmrestart
+INCLUDES = -I $(top_srcdir) -I $(top_srcdir)/warmrestart -I
+
+LIBNL_CFLAGS = -I/usr/include/libnl3
+LIBNL_LIBS = -lnl-genl-3 -lnl-route-3 -lnl-3 
+
 
 bin_PROGRAMS = neighsyncd
 
@@ -12,5 +16,5 @@ neighsyncd_SOURCES = neighsyncd.cpp neighsync.cpp $(top_srcdir)/warmrestart/warm
 
 neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
 neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-neighsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+neighsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon -lpthread $(LIBNL_LIBS)
 

--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -1,22 +1,34 @@
 #include <string>
+#include <net/if.h>
+#include <errno.h>
 #include <netinet/in.h>
+#include <netinet/ip6.h>
+#include <netinet/icmp6.h>
 #include <netlink/route/link.h>
 #include <netlink/route/neighbour.h>
-
+#include <net/ethernet.h>
+#include <netpacket/packet.h>
 #include "logger.h"
 #include "dbconnector.h"
 #include "producerstatetable.h"
+#include "subscriberstatetable.h"
 #include "ipaddress.h"
 #include "netmsg.h"
 #include "linkcache.h"
 #include "macaddress.h"
-
+#include "ipaddress.h"
+#include "ipprefix.h"
+#include "tokenize.h"
 #include "neighsync.h"
 #include "warm_restart.h"
 
 using namespace std;
 using namespace swss;
 
+extern class NeighSync *g_neighsync;
+
+const char config_db_key_delimiter = '|';
+NeighSync* gDbgNeighSyncd;
 NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb) :
     m_neighTable(pipelineAppDB, APP_NEIGH_TABLE_NAME),
     m_stateNeighRestoreTable(stateDb, STATE_NEIGH_RESTORE_TABLE_NAME)
@@ -26,6 +38,14 @@ NeighSync::NeighSync(RedisPipeline *pipelineAppDB, DBConnector *stateDb) :
     {
         m_AppRestartAssist->registerAppTable(APP_NEIGH_TABLE_NAME, &m_neighTable);
     }
+    neighRefreshInit();
+    m_ref_timeout_v4        = REFERENCE_AGEOUT;
+    m_ref_timeout_v6        = REFERENCE_AGEOUT;
+    m_fdb_aging_time        = DEFAULT_FDB_AGEOUT;
+    m_ipv4_arp_timeout      = DEFAULT_ARP_AGEOUT;
+    m_ipv6_nd_cache_expiry  = DEFAULT_NS_AGEOUT;
+
+
 }
 
 NeighSync::~NeighSync()
@@ -57,10 +77,13 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     struct rtnl_neigh *neigh = (struct rtnl_neigh *)obj;
     string key;
     string family;
+    string ifName, ifNameRcvd;
 
     if ((nlmsg_type != RTM_NEWNEIGH) && (nlmsg_type != RTM_GETNEIGH) &&
         (nlmsg_type != RTM_DELNEIGH))
         return;
+
+    ifNameRcvd = ifName = LinkCache::getInstance().ifindexToName(rtnl_neigh_get_ifindex(neigh));
 
     if (rtnl_neigh_get_family(neigh) == AF_INET)
         family = IPV4_NAME;
@@ -88,6 +111,7 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     }
 
     bool delete_key = false;
+    int flags = rtnl_neigh_get_flags(neigh);
     if ((nlmsg_type == RTM_DELNEIGH) || (state == NUD_INCOMPLETE) ||
         (state == NUD_FAILED))
     {
@@ -95,6 +119,12 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     }
 
     nl_addr2str(rtnl_neigh_get_lladdr(neigh), macStr, MAX_ADDR_SIZE);
+    if (!delete_key && !strcmp(macStr,"none"))
+    {
+        SWSS_LOG_NOTICE("No MAC address received for neighbor %s", ipStr);
+        return;
+    }
+ 
 
     /* Ignore neighbor entries with Broadcast Mac - Trigger for directed broadcast */
     if (!delete_key && (MacAddress(macStr) == MacAddress("ff:ff:ff:ff:ff:ff")))
@@ -119,8 +149,919 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
         if (delete_key == true)
         {
             m_neighTable.del(key);
-            return;
         }
-        m_neighTable.set(key, fvVector);
+        else
+        {
+            m_neighTable.set(key, fvVector);
+        }
+    }
+
+    //Add Neigh entries to cache irrespective of warm reboot status
+    addNeighToQueue(nlmsg_type, IpAddress(ipStr), ifNameRcvd.c_str(), macStr, state, flags);
+}
+
+bool NeighSync::neighRefreshInit()
+{
+    int ttl = 255, val = 1;
+
+    //Socket to send ARP request packet
+    m_sock_fd[0] = socket(PF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if(m_sock_fd[0] < 0)
+    {
+        SWSS_LOG_ERROR("NeighSynCache: Arp Refresh socket create failed %d, err(%d):%s ",m_sock_fd[0], errno, strerror(errno));
+        return false;
+    }
+
+    //Socket to send ICMPv6 NS packet
+    m_sock_fd[1] = socket (AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
+    if(m_sock_fd[1] < 0)
+    {
+        SWSS_LOG_ERROR("NeighSynCache: IPv6 Neigh Refresh socket create failed %d, err(%d):%s ",m_sock_fd[1], errno, strerror(errno));
+        return false;
+    }
+
+    // set socket options
+    setsockopt (m_sock_fd[1], IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &ttl, sizeof(ttl));
+
+    //Socket to send ICMPv6 Echo Request packet
+    m_sock_fd[2] = socket (AF_INET6, SOCK_RAW, IPPROTO_IPV6);
+    if(m_sock_fd[2] < 0)
+    {
+        SWSS_LOG_ERROR("NeighSynCache: IPv6 Neigh Refresh socket create failed %d, err(%d):%s ",m_sock_fd[2], errno, strerror(errno));
+        return false;
+    }
+
+    // set socket options to include ipv6hdr from application
+    setsockopt (m_sock_fd[2], IPPROTO_IPV6, IPV6_HDRINCL, &val, sizeof(val));
+
+    return true;
+}
+
+int NeighSync::buildArpPkt(unsigned char* pkt, IpAddress tgt_ip, MacAddress tgt_mac, IpAddress src_ip, MacAddress src_mac)
+{
+    struct ethhdr eth_hdr;
+    struct arphdr arp_hdr;
+    uint32_t ipaddr = 0;
+    //uint8_t broadcast_mac[6] = {0xff,0xff,0xff,0xff,0xff,0xff };
+    uint8_t *pkt_buff = pkt;
+
+    memset(&eth_hdr, 0x0, sizeof(eth_hdr));
+    memcpy(&eth_hdr.src, src_mac.getMac(), 6);
+    //memcpy(&eth_hdr.dst, &broadcast_mac, 6);
+    memcpy(&eth_hdr.dst, tgt_mac.getMac(), 6);
+    eth_hdr.type = htons(0x806);
+    memcpy (pkt_buff, &eth_hdr, sizeof(eth_hdr));
+
+    pkt_buff = pkt_buff + sizeof(eth_hdr);
+    memset(&arp_hdr, 0x0, sizeof(arp_hdr));
+    arp_hdr.ar_hdr = htons(0x1);
+    arp_hdr.ar_pro = htons(0x800);
+    arp_hdr.ar_hln = 6;
+    arp_hdr.ar_pln = 4;
+    arp_hdr.ar_op  = htons(0x1);
+
+    memcpy( &arp_hdr.ar_sha, src_mac.getMac(), 6);
+    ipaddr = src_ip.getV4Addr();
+    memcpy( &arp_hdr.ar_sip, (uint8_t*)(&ipaddr), 4);
+    ipaddr = tgt_ip.getV4Addr();
+    memcpy( &arp_hdr.ar_tip, (uint8_t*)(&ipaddr), 4);
+
+    memcpy(pkt_buff, &arp_hdr, sizeof(arp_hdr));
+
+    return (sizeof(eth_hdr) +sizeof(arp_hdr));
+}
+
+int NeighSync::buildNSPkt(unsigned char* pkt, IpAddress ip, MacAddress mac)
+{
+    struct nd_neighbor_solicit ns_hdr;
+    struct nd_opt_hdr opt_hdr = {0,0};
+    uint8_t mac_addr[6];
+    uint8_t *pkt_buff = pkt;
+
+    memset(&ns_hdr, 0x0, sizeof(ns_hdr));
+
+    ns_hdr.nd_ns_type       = ND_NEIGHBOR_SOLICIT;
+    ns_hdr.nd_ns_code       = 0;
+    ns_hdr.nd_ns_cksum      = 0;
+    ns_hdr.nd_ns_reserved   = 0;
+    memcpy (&ns_hdr.nd_ns_target, (ip.getIp().ip_addr.ipv6_addr), 16);
+    memcpy (pkt_buff, &ns_hdr, sizeof(ns_hdr));
+
+    pkt_buff = pkt_buff + sizeof(ns_hdr);
+    opt_hdr.nd_opt_type = ND_OPT_SOURCE_LINKADDR;
+    opt_hdr.nd_opt_len  = 1;
+    memcpy (pkt_buff, &opt_hdr, sizeof(opt_hdr));
+
+    pkt_buff = pkt_buff + sizeof(opt_hdr);
+    mac.getMac(mac_addr);
+    memcpy (pkt_buff, mac_addr, sizeof(mac_addr));
+
+    return (sizeof(ns_hdr) + sizeof(opt_hdr) + sizeof(mac_addr));
+}
+
+int NeighSync::buildIcmp6EchoReqPkt(unsigned char* pkt, IpAddress sip, IpAddress dip)
+{
+    uint8_t *pkt_buff = pkt;
+    struct ip6_hdr ip6hdr;
+    struct icmp6_hdr icmp6hdr;
+
+    memset(&ip6hdr, 0x0, sizeof(ip6hdr));
+    memset(&icmp6hdr, 0x0, sizeof(icmp6hdr));
+
+    ip6hdr.ip6_nxt        = 58;
+    ip6hdr.ip6_hlim       = 255;
+    ip6hdr.ip6_plen       = htons(sizeof(icmp6hdr));
+    ip6hdr.ip6_vfc        = 0x6 << 4;
+    memcpy (&ip6hdr.ip6_src, (sip.getIp().ip_addr.ipv6_addr), 16);
+    memcpy (&ip6hdr.ip6_dst, (dip.getIp().ip_addr.ipv6_addr), 16);
+    memcpy (pkt_buff, &ip6hdr, sizeof(ip6hdr));
+
+    pkt_buff = pkt_buff + sizeof(ip6hdr);
+
+    icmp6hdr.icmp6_type   = ICMP6_ECHO_REQUEST;
+    memcpy( &icmp6hdr.icmp6_data8, "\x0a\xbb\xcc\xdd", 4);
+    memcpy (pkt_buff, &icmp6hdr, sizeof(icmp6hdr));
+
+    return (sizeof(ip6hdr) + sizeof(icmp6hdr));
+}
+
+unsigned int NeighSync::ifNameToIndex(const char *name)
+{
+  unsigned idx;
+  int saved_errno = 0;
+
+  if (name == NULL)
+  {
+    SWSS_LOG_ERROR("Interface name passed NULL\n");
+    return false;
+  }
+
+  idx = if_nametoindex(name);
+
+  if (idx == 0)
+  {
+    saved_errno = errno;
+    sscanf(name, "if%u", &idx);
+  }
+
+  SWSS_LOG_DEBUG("Interface name %s has index %u ernno %d\n", name, idx, saved_errno);
+
+  return idx;
+}
+
+
+bool NeighSync::sendRefresh(IpAddress ip, string ifname, MacAddress dstMac)
+{
+    MacAddress src_mac;
+    IpAddress src_ip;
+    uint8_t pkt[256];
+    int pkt_len = 0;
+    long int ret = 0;
+
+    uint32_t ifidx = 0;
+    struct rtnl_link *link = NULL;
+    char addrStr[MAX_ADDR_SIZE+1] = {0};
+
+    // Get Source Interface MAC from Outgoing interface
+    link = LinkCache::getInstance().getLinkByName(ifname.c_str());
+    if (!link)
+    {
+        SWSS_LOG_ERROR("NeighSynCache: IFname to MacAddr failed %s", ifname.c_str());
+        return false;
+    }
+    nl_addr2str(rtnl_link_get_addr(link), addrStr, MAX_ADDR_SIZE);
+    src_mac = MacAddress(addrStr);
+
+    ifidx = ifNameToIndex(ifname.c_str());
+    
+    if(!ifidx)
+    {
+        SWSS_LOG_ERROR("NeighSynCache: IFname to ifidx failed %s", ifname.c_str());
+        return false;
+    }
+
+    if((!ip.isV4()) && (ip.getAddrScope() == IpAddress::LINK_SCOPE))
+    {
+        //create linklocal address
+        src_ip = getV6LLIpaddr(src_mac);
+    }
+    else
+    {
+        src_ip = getIntfIpAddress(ifname, ip);
+        if(src_ip == IpAddress("0.0.0.0"))
+        {
+            SWSS_LOG_ERROR("NeighSynCache: Src IP Not Found: Ifindex - %s (%d) Src-mac - %s, Tgt-ip - %s, Tgt-mac - %s ",
+                    ifname.c_str(),ifidx, src_mac.to_string().c_str(), ip.to_string().c_str(), dstMac.to_string().c_str());
+
+            return false;
+        }
+    }
+
+    SWSS_LOG_INFO("NeighSynCache: Ifindex - %s (%d) Src-ip - %s, Src-mac - %s, Tgt-ip - %s, Tgt-mac - %s ",
+    ifname.c_str(),ifidx, src_ip.to_string().c_str(), src_mac.to_string().c_str(), ip.to_string().c_str(), dstMac.to_string().c_str());
+
+    if(ip.getIp().family == AF_INET)
+    {
+        struct sockaddr_ll dst;
+
+        //build the ARP packet
+        pkt_len =  buildArpPkt(pkt, ip, dstMac, src_ip, src_mac);
+
+        //Send the packet
+        memset (&dst, 0x0, sizeof(dst));
+        dst.sll_family      = AF_PACKET;
+        dst.sll_ifindex     = ifidx;
+        dst.sll_protocol    = htons(ETH_P_ALL);
+        dst.sll_halen       = ETH_ALEN;
+        //set dst mac
+        dstMac.getMac(dst.sll_addr);
+        //memcpy (&dst.sll_addr, "\xff\xff\xff\xff\xff\xff", 6);
+
+        ret = sendto(m_sock_fd[0], pkt, pkt_len, 0, (struct sockaddr *)&dst, sizeof(dst));
+        if(ret < 0)
+            SWSS_LOG_ERROR("NeighSynCache: Arp Send failed for IP %s intf %s, err:%s", ip.to_string().c_str(), ifname.c_str(), strerror(errno));
+        else
+            SWSS_LOG_DEBUG("NeighSynCache: Arp Sent for IP %s intf %s, ret %ld ", ip.to_string().c_str(), ifname.c_str(), ret);
+
+    }
+    else if (ip.getIp().family == AF_INET6)
+    {
+        struct sockaddr_in6 dst;
+
+        memset (&dst, 0x0, sizeof(dst));
+        dst.sin6_scope_id           = ifidx;
+        dst.sin6_family             = AF_INET6;
+
+        if(!(dstMac ==  MacAddress("FF:FF:FF:FF:FF:FF")))
+        {
+            //build the NS packet
+            pkt_len = buildNSPkt(pkt, ip, src_mac);
+
+            struct ip_addr_t ipaddr = ip.getIp();
+            memcpy (&dst.sin6_addr.s6_addr, "\xff\x02\x00\x00\x00\x00\x00\x00"
+                    "\x00\x00\x00\x01\xff", 13);
+            dst.sin6_addr.s6_addr[13]   = ipaddr.ip_addr.ipv6_addr[13];
+            dst.sin6_addr.s6_addr[14]   = ipaddr.ip_addr.ipv6_addr[14];
+            dst.sin6_addr.s6_addr[15]   = ipaddr.ip_addr.ipv6_addr[15];
+
+            //Send the NS packet
+            ret = sendto (m_sock_fd[1], &pkt, pkt_len, MSG_DONTROUTE,
+                    (const struct sockaddr *)&dst, sizeof (dst));
+            if(ret < 0)
+                SWSS_LOG_ERROR("NeighSynCache: NS Send failed for IP %s intf %s, err:%s", ip.to_string().c_str(), ifname.c_str(), strerror(errno));
+            else
+                SWSS_LOG_DEBUG("NeighSynCache: NS Sent for IP %s intf %s, ret %ld ", ip.to_string().c_str(), ifname.c_str(), ret);
+        }
+        else
+        {
+            //For entries in failed state trigger NS/NA frm kernel, tx over vrf interface needs BINDTODEVICE option
+            ret = setsockopt(m_sock_fd[2], SOL_SOCKET, SO_BINDTODEVICE, ifname.c_str(), (unsigned int)strlen(ifname.c_str())+1);
+            if(ret < 0)
+                SWSS_LOG_ERROR("NeighSynCache: setsockopt for IP %s intf %s, err:%s", ip.to_string().c_str(), ifname.c_str(), strerror(errno)); 
+
+            //build the icmp6 echo request packet
+            pkt_len = buildIcmp6EchoReqPkt(pkt, src_ip, ip);
+
+            memcpy (&dst.sin6_addr.s6_addr, (ip.getIp().ip_addr.ipv6_addr), 16);
+
+            //Send the NS packet
+            ret = sendto (m_sock_fd[2], &pkt, pkt_len, 0,
+                    (const struct sockaddr *)&dst, sizeof (dst));
+            if(ret < 0)
+                SWSS_LOG_ERROR("NeighSynCache: Icmp6 EchoReq Send failed for IP %s intf %s, err:%s", ip.to_string().c_str(), ifname.c_str(), strerror(errno));
+            else
+                SWSS_LOG_DEBUG("NeighSynCache: Icmp6 EchoReq Sent for IP %s intf %s, ret %ld ", ip.to_string().c_str(), ifname.c_str(), ret);
+        }
+    }
+    else
+    {
+        SWSS_LOG_ERROR("NeighSynCache: Invalid IP %s", ip.to_string().c_str());
+        return false;
+    }
+
+    return true;
+}
+
+/*bool NeighSync::hasNeigh(NeighCacheKey neigh)
+ * {
+ *     return m_neighCache.find(neigh) != m_neighCache.end();
+ * }
+ */
+
+
+void NeighSync::addNeighToQueue(int type, IpAddress ip, string ifname, string mac, int state, int flags)
+{
+    NeighCacheVal c_entry;
+    c_entry.type            = type;
+    c_entry.ip_address      = ip;
+    c_entry.alias           = ifname;
+    c_entry.mac_address     = mac;
+    c_entry.state           = state;
+    c_entry.flags           = flags;
+
+    if(!isRefreshRequired(type, ip, ifname, mac, state, flags))
+        return;
+
+    pthread_mutex_lock(&mutex);
+    m_neighQueue.push_back(c_entry);
+    pthread_mutex_unlock(&mutex);
+}
+
+void NeighSync::getNeighFrmQueue(NeighCacheVal *neigh)
+{
+    pthread_mutex_lock(&g_neighsync->mutex);
+    *neigh = m_neighQueue.front();
+    m_neighQueue.pop_front();
+    pthread_mutex_unlock(&g_neighsync->mutex);
+}
+
+long unsigned int NeighSync::getNeighQueueSize(void)
+{
+    long unsigned int qsize = 0;
+    pthread_mutex_lock(&g_neighsync->mutex);
+    qsize = m_neighQueue.size();
+    pthread_mutex_unlock(&g_neighsync->mutex);
+    return qsize;
+}
+
+bool NeighSync::isNeighQueueEmpty(void)
+{
+    bool is_empty = false;
+    pthread_mutex_lock(&g_neighsync->mutex);
+    is_empty = m_neighQueue.empty();
+    pthread_mutex_unlock(&g_neighsync->mutex);
+    return is_empty;
+}
+
+void NeighSync::processNeighfrmQueue(void)
+{
+    if(!isNeighQueueEmpty())
+    {
+        long unsigned int cnt = getNeighQueueSize();
+
+        while(cnt--)
+        {
+            NeighCacheVal neigh;
+
+            getNeighFrmQueue(&neigh);
+
+            updateNeighCache(neigh.type, neigh.ip_address, neigh.alias, neigh.mac_address, neigh.state, neigh.flags);
+        }
+    }
+
+    return;
+}
+
+bool NeighSync::isRefreshRequired(int type, IpAddress ip, string ifname, string mac, int state, int flags)
+{
+    /* Ignore neighbors received from eth0 interfaces */
+    if ((ifname.compare(0, strlen("eth"), "eth") == 0 ) ||
+       (ifname.compare(0, strlen("lo"), "lo") == 0 )) 
+    {
+        SWSS_LOG_INFO("NeighSynCache: Ignore neighbor(%s) interface(%s)",ip.to_string().c_str(), ifname.c_str());
+        return false;
+    }
+
+    //Skip IPv4 LL entries created for BGP unnumbered, correponding ipv6ll will be refreshed
+    if(ip.getAddrScope() == IpAddress::LINK_SCOPE)
+    {
+        if(ip.isV4())
+        {
+            SWSS_LOG_INFO("NeighSynCache: Ignore Ipv4LL neighbor(%s) interface(%s)",ip.to_string().c_str(), ifname.c_str());
+            return false; 
+        }
+    }
+
+    if(state == NUD_NOARP)
+    {
+        delNeighFrmCache(ip, ifname);
+        SWSS_LOG_INFO("NeighSynCache: Ignore NUD_NOARP neighbor(%s) interface(%s)",ip.to_string().c_str(), ifname.c_str());
+        return false;
+    }
+
+    return true;
+}
+
+bool NeighSync::updateNeighCache(int type, IpAddress ip, string ifname, string mac, int state, int flags)
+{
+    bool del = false;
+
+    SWSS_LOG_INFO("NeighSynCache: Update neighbor(%s) intf(%s) mac(%s), state(%d), flags(%d), type(%d)",
+                    ip.to_string().c_str(), ifname.c_str(), mac.c_str(), state, flags, type);
+
+    if (type == RTM_DELNEIGH) /*|| (state == NUD_INCOMPLETE) ||
+        (state == NUD_FAILED))*/
+    {
+        del = true;
+    }
+
+    if (state == NUD_PERMANENT && flags & NTF_EXT_LEARNED)
+    {
+        SWSS_LOG_NOTICE("NeighSynCache: neighbor(%s) intf(%s) learned from remote nodes ",ip.to_string().c_str(), ifname.c_str());
+        del = true;
+    }
+
+    if (!del)
+    {
+        //In case of Failed entries MAC may not be present, but we want to store them and refresh them
+        if(!strcmp(mac.c_str(),"none")) 
+        {
+            if(!(state == NUD_FAILED) || (state == NUD_INCOMPLETE))
+            {
+                SWSS_LOG_NOTICE("NeighSynCache: Ignore this update as no MAC address received for neighbor %s", ip.to_string().c_str());
+                return true;
+            }
+        }
+        else //MAC is not none
+        {
+            /* Ignore neighbor entries with Broadcast Mac - Trigger for directed broadcast */
+            if(MacAddress(mac) == MacAddress("ff:ff:ff:ff:ff:ff"))
+            {
+                SWSS_LOG_NOTICE("NeighSynCache: Broadcast Mac recieved, deleting %s", ip.to_string().c_str());
+                del = true;
+            }
+        }
+    }
+
+    if (del)
+    {
+        delNeighFrmCache(ip, ifname);
+    }
+    else
+    {
+        addNeighToCache(ip, ifname, mac, state);
+    }
+
+    return true;
+}
+
+bool NeighSync::addNeighToCache(IpAddress ipAddress, string alias, string mac, int state)
+{
+    NeighCacheKey neigh = { ipAddress, alias };
+
+    NeighCacheEntry neigh_cache_entry;
+    if((state == NUD_FAILED) || (state == NUD_INCOMPLETE))
+        neigh_cache_entry.mac_address       = MacAddress("ff:ff:ff:ff:ff:ff");
+    else
+        neigh_cache_entry.mac_address       = MacAddress(mac);
+
+    neigh_cache_entry.state             = state;
+    neigh_cache_entry.curr_time         = get_currtime_ms();
+    neigh_cache_entry.refresh_timeout   = get_refresh_timeout(ipAddress.isV4());
+    neigh_cache_entry.lst_updated       = getTimestamp();
+    neigh_cache_entry.num_refresh_sent  = 0;
+    m_neighCache[neigh] = neigh_cache_entry;
+
+    SWSS_LOG_NOTICE("NeighSynCache: Add neighbor %s interface %s MAC:%s state:(%d) curr_time(%lld), timeout(%lld)", 
+                    ipAddress.to_string().c_str(), alias.c_str(), mac.c_str(), state, neigh_cache_entry.curr_time,
+                    neigh_cache_entry.refresh_timeout);
+
+    return true;
+}
+
+bool NeighSync::delNeighFrmCache(IpAddress ipAddress, string alias)
+{
+    NeighCacheKey neigh = { ipAddress, alias };
+
+    if(m_neighCache.find(neigh) == m_neighCache.end())
+    {
+        SWSS_LOG_NOTICE("NeighSynCache: EntryNotFound - neighbor %s interface %s ", ipAddress.to_string().c_str(), alias.c_str() );
+        return false;
+    }
+
+    SWSS_LOG_NOTICE("NeighSynCache: Del neighbor %s interface %s ", ipAddress.to_string().c_str(), alias.c_str());
+
+    m_neighCache.erase(neigh);
+
+    return true;
+}
+
+void NeighSync::refreshTimer()
+{
+    int num_refresh = 0;
+    static int timer = 0;
+
+    timer++;
+
+    processNeighfrmQueue();
+
+    if(!(timer % NEIGH_REFRESH_INTERVAL))
+    {
+        SWSS_LOG_INFO("NeighSynCache: Neighbor Refresh Timeout - Start");
+
+        auto it = m_neighCache.begin();
+        while (it != m_neighCache.end())
+        {
+            if(is_time_elapsed_ms(it->second.curr_time, it->second.refresh_timeout))
+            {
+                sendRefresh(it->first.ip_address , it->first.alias, it->second.mac_address);
+                it->second.curr_time = get_currtime_ms();
+                it->second.refresh_timeout = get_refresh_timeout(it->first.ip_address.isV4());
+                it->second.lst_refresh_sent = getTimestamp();
+                it->second.num_refresh_sent++;
+                num_refresh++;
+            }
+            it++;
+        }
+        timer = 0;
+        SWSS_LOG_INFO("NeighSynCache: Neighbor Refresh Timeout - End, total sent - %d", num_refresh);
+    }
+    return;
+}
+
+unsigned long long NeighSync::get_currtime_ms(void)
+{
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
+    {
+        return ((((unsigned long long)ts.tv_sec) * 1000) + (((unsigned long long)ts.tv_nsec)/1000000));
+    }
+    else
+    {
+        SWSS_LOG_NOTICE("NeighSynCache: GetTime Failed");
+    }
+
+    return 0;
+}
+
+unsigned long long NeighSync::get_refresh_timeout(bool isV4)
+{
+    if(isV4)
+    {
+        return (((1 + rand ()) % (((TIMEOUT_MAX_PERCENT - TIMEOUT_MIN_PERCENT) * m_ref_timeout_v4 )/100)) +  ((TIMEOUT_MIN_PERCENT * m_ref_timeout_v4)/100));
+    }
+    else
+    {
+        return (((1 + rand ()) % (((TIMEOUT_MAX_PERCENT - TIMEOUT_MIN_PERCENT) * m_ref_timeout_v6 )/100)) +  ((TIMEOUT_MIN_PERCENT * m_ref_timeout_v6)/100));
     }
 }
+
+void NeighSync::setall_refresh_timeout(void)
+{
+    SWSS_LOG_NOTICE("NeighSynCache: ChangeAllNeighRefreshTimeout- Start");
+
+    auto it = m_neighCache.begin();
+    while (it != m_neighCache.end())
+    {
+        it->second.curr_time = get_currtime_ms();
+        it->second.refresh_timeout = get_refresh_timeout(it->first.ip_address.isV4());
+        it++;
+    }
+
+    SWSS_LOG_NOTICE("NeighSynCache: ChangeAllNeighRefreshTimeout- End");
+}
+
+void NeighSync::updateReferenceAgeout(void)
+{
+    // fdb/v4/v6 ageout are in sec, convert to ms
+    if(m_fdb_aging_time)
+    {
+        m_ref_timeout_v4 = ((m_fdb_aging_time <= m_ipv4_arp_timeout) ? (m_fdb_aging_time*1000) : (m_ipv4_arp_timeout*1000));
+        m_ref_timeout_v6 = ((m_fdb_aging_time <= m_ipv6_nd_cache_expiry) ? (m_fdb_aging_time*1000) : (m_ipv6_nd_cache_expiry*1000));
+    }
+    else
+    {
+        //If fdb_aging_time is 0 then use only arp/nd_timeout
+        m_ref_timeout_v4 = (m_ipv4_arp_timeout*1000);
+        m_ref_timeout_v6 = (m_ipv6_nd_cache_expiry*1000);
+    }
+
+    SWSS_LOG_NOTICE("NeighSynCache: FdbAge(%ds), v4Age(%ds), v6Age(%ds), v4RefAge(%lldms), v6RefAge(%lldms)",
+                    m_fdb_aging_time, m_ipv4_arp_timeout, m_ipv6_nd_cache_expiry, m_ref_timeout_v4, m_ref_timeout_v6);
+
+    //Update refresh timeout in existing neighbor cache
+    setall_refresh_timeout();
+}
+
+bool NeighSync::is_time_elapsed_ms(unsigned long long time_to_chk, unsigned long long elaspe_time)
+{
+    unsigned long long curr_time_ms = 0;
+
+    curr_time_ms = get_currtime_ms();
+    if(curr_time_ms)
+    {
+        if((curr_time_ms - time_to_chk) > elaspe_time)
+            return true;
+    }
+
+    return false;
+}
+
+
+//Interface Cache Management
+bool NeighSync::isIpValid(const string& ipStr, const bool ipv4)
+{
+    if (ipv4 == true)
+    {
+        if (ipStr.find(':') != std::string::npos)
+        {
+            return false;
+        }
+        else
+        {
+            return true;
+        }
+    }
+    else
+    {
+        if (ipStr.find(':') != std::string::npos)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+}
+
+void NeighSync::processIpInterfaceTask(std::deque<KeyOpFieldsValuesTuple> &entries)
+{
+    if (entries.empty())
+    {
+        return;
+    }
+
+    for (auto entry: entries)
+    {
+        vector<string> keys = tokenize(kfvKey(entry), config_db_key_delimiter);
+        string op = kfvOp(entry);
+        string key = kfvKey(entry);
+
+        if (keys.size() == 2)
+        {
+            string alias(keys[0]);
+            IpPrefix ip_prefix(keys[1]);
+
+            if (op == SET_COMMAND)
+            {
+                SWSS_LOG_NOTICE(" SET commands received with interace %s IP address %s", alias.c_str(), ip_prefix.to_string().c_str());
+                if (m_IntfsTable.find(alias) == m_IntfsTable.end())
+                {
+                    IntfsEntry intfs_entry;
+                    m_IntfsTable[alias] = intfs_entry;
+                }
+                m_IntfsTable[alias].ip_addresses.insert(ip_prefix);
+                m_IntfsTable[alias].source_mac = m_system_mac;
+            }
+            else if (op == DEL_COMMAND)
+            {
+                SWSS_LOG_NOTICE(" DEL commands received with interace %s IP address %s", alias.c_str(), ip_prefix.to_string().c_str());
+                if (m_IntfsTable.find(alias) != m_IntfsTable.end())
+                {
+                    if(m_IntfsTable[alias].ip_addresses.find(ip_prefix) != (m_IntfsTable[alias].ip_addresses.end()))
+                    {
+                        m_IntfsTable[alias].ip_addresses.erase(ip_prefix);
+                        if(m_IntfsTable[alias].ip_addresses.size() == 0 && !(m_IntfsTable[alias].ipv6_enable_config))
+                        {
+                           m_IntfsTable.erase(alias);
+                        }
+                    }
+                }
+            }
+        }
+        else if (keys.size() == 1)
+        {
+            string alias(keys[0]);
+            const vector<FieldValueTuple>& data = kfvFieldsValues(entry);
+            string ipv6_link_local_mode = "";
+            string donar_intf = "";
+            bool is_ip_unnm = false;
+            for (auto idx : data)
+            {
+                const auto &field = fvField(idx);
+                const auto &value = fvValue(idx);
+                if (field == "ipv6_use_link_local_only")
+                {
+                    ipv6_link_local_mode = value;
+                    break;
+                }
+                if (field == "unnumbered")
+                {
+                    is_ip_unnm = true;
+                    donar_intf = value;
+                    break;
+                }
+            }
+            if (op == SET_COMMAND)
+            {
+                if((ipv6_link_local_mode == "enable") || is_ip_unnm)
+                {
+                    if (m_IntfsTable.find(alias) == m_IntfsTable.end())
+                    {
+                        IntfsEntry intfs_entry;
+                        m_IntfsTable[alias] = intfs_entry;
+                    }
+
+                    if (ipv6_link_local_mode == "enable")
+                        m_IntfsTable[alias].ipv6_enable_config = true;
+
+                    if(is_ip_unnm)
+                        m_IntfsTable[alias].donar_intf = donar_intf;
+                        
+                    m_IntfsTable[alias].is_ip_unnm = is_ip_unnm;
+                    m_IntfsTable[alias].source_mac = m_system_mac;
+                }
+            }
+            if (op == DEL_COMMAND || ipv6_link_local_mode == "disable")
+            {
+                if (m_IntfsTable.find(alias) != m_IntfsTable.end())
+                {
+                    if(m_IntfsTable[alias].ip_addresses.size() == 0)
+                    {
+                        m_IntfsTable.erase(alias);
+                    }
+                    else
+                    {
+                        m_IntfsTable[alias].ipv6_enable_config = false;
+                    }
+                }
+            }
+        }
+    }
+    return;
+}
+
+void NeighSync::doSystemMacTask(std::deque<KeyOpFieldsValuesTuple> &entries)
+{
+    if (entries.empty())
+    {
+        return;
+    }
+
+    SWSS_LOG_ENTER();
+    for (auto entry: entries)
+    {
+        vector<string> keys = tokenize(kfvKey(entry), config_db_key_delimiter);
+        string op = kfvOp(entry);
+        string key = kfvKey(entry);
+
+        if (op == SET_COMMAND)
+        {
+            for (auto i : kfvFieldsValues(entry))
+            {
+                SWSS_LOG_INFO("Field: %s Val %s", fvField(i).c_str(), fvValue(i).c_str());
+                if (fvField(i) == "mac") {
+                    m_system_mac = MacAddress(fvValue(i));
+                    SWSS_LOG_NOTICE("System MAC %s", m_system_mac.to_string().c_str());
+
+                    auto itr = m_IntfsTable.begin();
+                    while (itr != m_IntfsTable.end())
+                    {
+                        itr++;
+                    }
+
+                    break;
+                }
+            }
+        }
+        else if (op == DEL_COMMAND)
+        {
+            m_system_mac = MacAddress();
+        }
+    }
+}
+
+MacAddress NeighSync::getSystemMac(void)
+{
+    return m_system_mac;
+}
+
+IpAddress NeighSync::getV6LLIpaddr(MacAddress mac)
+{
+    const uint8_t *mac_addr = mac.getMac();
+    uint8_t        eui64_id[8];
+    char           ipv6_addr[INET6_ADDRSTRLEN] = {0};
+
+    eui64_id[0] = mac_addr[0] ^ 0x02;
+    eui64_id[1] = mac_addr[1];
+    eui64_id[2] = mac_addr[2];
+    eui64_id[3] = 0xff;
+    eui64_id[4] = 0xfe;
+    eui64_id[5] = mac_addr[3];
+    eui64_id[6] = mac_addr[4];
+    eui64_id[7] = mac_addr[5];
+
+    snprintf(ipv6_addr, INET6_ADDRSTRLEN, "fe80::%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+             eui64_id[0], eui64_id[1], eui64_id[2], eui64_id[3], eui64_id[4], eui64_id[5],
+             eui64_id[6], eui64_id[7]);
+
+    return IpAddress(string(ipv6_addr));
+}
+
+IpAddress NeighSync::getIntfIpAddress(string ifname, IpAddress dst_ip)
+{
+    //Get Interface from Interface Cache
+    auto it =  m_IntfsTable.find(ifname);
+
+    if(it != m_IntfsTable.end())
+    {
+        struct IntfsEntry intfs = it->second;
+        if (intfs.is_ip_unnm)
+        {
+            auto it_unnm  =  m_IntfsTable.find(intfs.donar_intf);
+            if(it_unnm !=  m_IntfsTable.end())
+            {
+                for (auto &prefixIt: m_IntfsTable[intfs.donar_intf].ip_addresses)
+                {
+                    return prefixIt.getIp();
+                }
+            }
+        }
+        else
+        {
+            for (auto &prefixIt: m_IntfsTable[ifname].ip_addresses)
+            {
+                if (prefixIt.isAddressInSubnet(dst_ip))
+                {
+                    return prefixIt.getIp();
+                }
+            }
+        }
+    }
+    return IpAddress("0.0.0.0");
+}
+
+void NeighSync::doNeighGlobalTask(std::deque<KeyOpFieldsValuesTuple> &entries)
+{
+    int ipv4_arp_timeout = DEFAULT_ARP_AGEOUT;
+    int ipv6_nd_cache_expiry = DEFAULT_NS_AGEOUT;
+    if (entries.empty())
+    {
+        return;
+    }
+    for (auto entry: entries)
+    {
+        vector<string> keys = tokenize(kfvKey(entry), config_db_key_delimiter);
+        string op = kfvOp(entry);
+        string key = kfvKey(entry);
+        for (auto i : kfvFieldsValues(entry))
+        {
+            if (fvField(i) == "ipv4_arp_timeout")
+            {
+                ipv4_arp_timeout = stoi(fvValue(i).c_str());
+            }
+            else if (fvField(i) == "ipv6_nd_cache_expiry")
+            {
+                ipv6_nd_cache_expiry = stoi(fvValue(i).c_str());
+            }
+        }
+    }
+    m_ipv4_arp_timeout = ipv4_arp_timeout;
+    m_ipv6_nd_cache_expiry = ipv6_nd_cache_expiry;
+    SWSS_LOG_NOTICE(" ipv4_arp_timeout %d ipv6_nd_cache_expiry %d", ipv4_arp_timeout, ipv6_nd_cache_expiry);
+
+    updateReferenceAgeout();
+    return;
+}
+
+void NeighSync::doSwitchTask(std::deque<KeyOpFieldsValuesTuple> &entries)
+{
+    int FdbAgingTime = DEFAULT_FDB_AGEOUT;
+    if (entries.empty())
+    {
+        return;
+    }
+
+    for (auto entry: entries)
+    {
+        //vector<string> keys = tokenize(kfvKey(entry), config_db_key_delimiter);
+        string op = kfvOp(entry);
+        string key = kfvKey(entry);
+
+        for (auto i : kfvFieldsValues(entry))
+        {
+            if (fvField(i) == "fdb_aging_time")
+            {
+                if (op == SET_COMMAND)
+                {
+                    FdbAgingTime = atoi(fvValue(i).c_str());
+                    if(FdbAgingTime < 0)
+                    {
+                        SWSS_LOG_ERROR("Invalid fdb_aging_time %s", fvValue(i).c_str());
+                        break;
+                    }
+                }
+                else if (op == DEL_COMMAND)
+                {
+                    SWSS_LOG_DEBUG("operation:del");
+                    FdbAgingTime = 600;
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+                    break;
+                }
+            }
+        }
+    }
+    m_fdb_aging_time = FdbAgingTime;
+    SWSS_LOG_NOTICE("Received fdb aging time %d", FdbAgingTime);
+
+    //Update reference ageout
+    updateReferenceAgeout();
+    return;
+}
+
+
+

--- a/neighsyncd/neighsync.h
+++ b/neighsyncd/neighsync.h
@@ -1,10 +1,19 @@
 #ifndef __NEIGHSYNC__
 #define __NEIGHSYNC__
 
+#include "ipaddress.h"
+#include "macaddress.h"
+
 #include "dbconnector.h"
 #include "producerstatetable.h"
 #include "netmsg.h"
 #include "warmRestartAssist.h"
+#include "ipprefix.h"
+#include <string>
+#include <time.h>
+#include "timestamp.h"
+
+using namespace std;
 
 // The timeout value (in seconds) for neighsyncd reconcilation logic
 #define DEFAULT_NEIGHSYNC_WARMSTART_TIMER 5
@@ -14,9 +23,95 @@
  * service to finish, should be longer than the restore_neighbors timeout value (110)
  * This should not happen, if happens, system is in a unknown state, we should exit.
  */
-#define RESTORE_NEIGH_WAIT_TIME_OUT 120
+#define RESTORE_NEIGH_WAIT_TIME_OUT 600
+#define TIMEOUT_MIN_PERCENT         30
+#define TIMEOUT_MAX_PERCENT         70
+#define REFERENCE_AGEOUT            600000      //10mins In MilliSeconds
+#define DEFAULT_FDB_AGEOUT          600         //10mins In Seconds
+#define DEFAULT_ARP_AGEOUT          1800        //30mins In Seconds
+#define DEFAULT_NS_AGEOUT           1800        //30mins In seconds
+
+
+#define NEIGH_REFRESH_TIMER_TICK 1
+#define NEIGH_REFRESH_INTERVAL  (30/NEIGH_REFRESH_TIMER_TICK)
 
 namespace swss {
+
+struct arphdr
+{
+    uint16_t ar_hdr;        // Hardware address Format = ETH
+    uint16_t ar_pro;        // Protocol address Type = 0x800 for IP
+    uint8_t  ar_hln;        // Size of Hardware address = 6 [MAC]
+    uint8_t  ar_pln;        // Size of Protcol address = 4 [IP]
+    uint16_t ar_op;         // ARP Opcode = ARP_REQUEST / ARP_REPLY
+
+    uint8_t ar_sha[6];      // Sender Hardware Address
+    uint8_t ar_sip[4];      // Sender IP address
+    uint8_t ar_tha[6];      // Target Hardware Address
+    uint8_t ar_tip[4];      // Target IP address
+};
+
+struct ethhdr
+{
+    uint8_t     dst[6];
+    uint8_t     src[6];
+    uint16_t    type;
+};
+
+struct NeighCacheVal
+{
+    string          mac_address;
+    IpAddress       ip_address;     //neighbor IP address
+    string          alias;          //Interface name
+    int             state;          //state of entry in kernel
+    int             flags;          //flags while receiving entry from Netlink
+    int             type;           //Type of Netlink msg
+};
+
+struct NeighCacheEntry
+{
+    MacAddress          mac_address;
+    int                 state;
+    unsigned long long  curr_time;
+    unsigned long long  refresh_timeout;
+    string              lst_updated;
+    string              lst_refresh_sent;
+    int                 num_refresh_sent;
+};
+
+struct NeighCacheKey
+{
+    IpAddress       ip_address;     // neighbor IP address
+    string          alias;          // Interface name
+
+    bool operator<(const NeighCacheKey &o) const
+    {
+        return tie(ip_address, alias) < tie(o.ip_address, o.alias);
+    }
+
+    bool operator==(const NeighCacheKey &o) const
+    {
+        return ((ip_address == o.ip_address) && (alias == o.alias));
+    }
+
+    bool operator!=(const NeighCacheKey &o) const
+    {
+        return !(*this == o);
+    }
+};
+
+struct IntfsEntry
+{
+    bool ipv6_enable_config = false;
+    bool is_ip_unnm = false;
+    MacAddress source_mac;
+    std::set<IpPrefix>  ip_addresses;
+    string donar_intf;
+};
+
+typedef map<string, IntfsEntry> IntfsTable;
+
+typedef map<NeighCacheKey, NeighCacheEntry> NeighCacheTable;
 
 class NeighSync : public NetMsg
 {
@@ -35,10 +130,55 @@ public:
         return m_AppRestartAssist;
     }
 
+    void refreshTimer();
+    bool neighRefreshInit(); // create sockets used to tx arp/ns
+    bool sendRefresh(IpAddress ip, string ifname, MacAddress dst_mac);
+    int buildArpPkt(unsigned char* pkt, IpAddress tgt_ip, MacAddress tgt_mac, IpAddress src_ip, MacAddress src_mac);
+    int buildNSPkt(unsigned char* pkt, IpAddress ip, MacAddress mac);
+    int buildIcmp6EchoReqPkt(unsigned char* pkt, IpAddress sip, IpAddress dip);
+    bool updateNeighCache(int type, IpAddress ip, string ifname, string mac, int state, int flags);
+    bool addNeighToCache(IpAddress ip, string ifname, string mac, int state);
+    bool delNeighFrmCache(IpAddress ip, string ifname);
+    bool isRefreshRequired(int type, IpAddress ip, string ifname, string mac, int state, int flags);
+    bool hasNeigh(NeighCacheKey);
+    MacAddress getSystemMac(void);
+    bool isIpValid(const string& ipStr, const bool ipv4);
+    void processIpInterfaceTask(std::deque<KeyOpFieldsValuesTuple> &entries);
+    void doSystemMacTask(std::deque<KeyOpFieldsValuesTuple> &entries);
+    void doSwitchTask(std::deque<KeyOpFieldsValuesTuple> &entries);
+    void doNeighGlobalTask(std::deque<KeyOpFieldsValuesTuple> &entries);
+    IpAddress getIntfIpAddress(string ifname, IpAddress dst_ip);
+    IpAddress getV6LLIpaddr(MacAddress mac);
+    unsigned long long get_currtime_ms(void);
+    unsigned long long get_refresh_timeout(bool isV4);
+    void setall_refresh_timeout(void);
+    void updateReferenceAgeout(void);
+    bool is_time_elapsed_ms(unsigned long long time_to_chk, unsigned long long elaspe_time);
+    void startArpRefreshThread();
+    static void* arpRefreshThread(void *arg);
+    void processNeighfrmQueue(void);
+    bool isNeighQueueEmpty(void);
+    long unsigned int getNeighQueueSize(void);
+    unsigned int ifNameToIndex(const char *name);
+    void getNeighFrmQueue(NeighCacheVal *neigh);
+    void addNeighToQueue(int type, IpAddress ip, string ifname, string mac, int state, int flags);
+    pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+
+
 private:
     Table m_stateNeighRestoreTable;
     ProducerStateTable m_neighTable;
     AppRestartAssist  *m_AppRestartAssist;
+    int m_sock_fd[5];
+    IntfsTable m_IntfsTable;
+    MacAddress m_system_mac;
+    NeighCacheTable m_neighCache;
+    std::deque<NeighCacheVal> m_neighQueue;
+    unsigned long long m_ref_timeout_v4;
+    unsigned long long m_ref_timeout_v6;
+    int m_ipv4_arp_timeout;
+    int m_ipv6_nd_cache_expiry;
+    int m_fdb_aging_time;
 };
 
 }


### PR DESCRIPTION


**What I did**
This is the change to arp refresh , details are provided in below sections .
**Why I did it**
SONiC depends upon the Linux kernel to manage the ARP/ND tables. SONiC then listens to ARP/ND events from the kernel and synchronizes the hardware as required. However, there are a number of problems with this: -

The kernel does not "see" the routed (in HW) through-traffic, and so cannot update its "hit bits" accordingly. Therefore the kernel may age out an entry that is still in use.
The kernel also does not "see" the HW MAC aging process, and so does not know that a MAC address associated with an ARP/ND entry has been aged out, and so does not refresh it. This can result in traffic black holes for a "quiet" neighbor (i.e. one that does not transmit much).
There is a further problem in MCLAG/ICCP setups whereby the response to an ARP/ND initiated by the kernel on one peer can go to the other peer. This eventually makes its way back across the ICCP control plane, but by then the kernel may have already aged out the entry.
 The current ARP Refresh process is implemented as a bash script, and cannot run fast enough to be effective at scale, requiring the network operator to set much higher aging timers than would otherwise be used. It's also a very inefficient use of system resources. So, the proposal here is to design and implement a much faster and more efficient instance of the ARP Refresh process.

**How I verified it**
1. Verifications are done by adding arp entries dynamically and tcpdump verifications was done to check if arp request/reply are observed in accordance with the proposed design . Here are the details test logs .
a. For arp (3 updates for 12.12.12.2 are shown in logs below , other arps/ more logs are not updated  here)
admin@sonic:~$ show arp
Address      MacAddress         Iface      Vlan
-----------  -----------------  ---------  ------
10.59.128.1  00:00:0c:9f:f4:68  eth0       -
12.12.12.2   00:10:94:00:00:05  Ethernet0  -
12.12.12.3   00:10:94:00:00:06  Ethernet0  -
12.12.12.4   00:10:94:00:00:07  Ethernet0  -
12.12.12.5   00:10:94:00:00:08  Ethernet0  -
Total number of entries 5

admin@sonic:~$ sudo tcpdump -ei Ethernet0
19:27:40.364309 3c:2c:99:2d:84:35 (oui Unknown) > 00:10:94:00:00:05 (oui Unknown), ethertype ARP (0x0806), length 42: Request who-has 12.12.12.2 tell 12.12.12.1, length 28
19:27:40.364666 00:10:94:00:00:05 (oui Unknown) > 3c:2c:99:2d:84:35 (oui Unknown), ethertype ARP (0x0806), length 60: Reply 12.12.12.2 is-at 00:10:94:00:00:05 (oui Unknown), length 46

19:32:40.397044 3c:2c:99:2d:84:35 (oui Unknown) > 00:10:94:00:00:05 (oui Unknown), ethertype ARP (0x0806), length 42: Request who-has 12.12.12.2 tell 12.12.12.1, length 28
19:32:40.397380 00:10:94:00:00:05 (oui Unknown) > 3c:2c:99:2d:84:35 (oui Unknown), ethertype ARP (0x0806), length 60: Reply 12.12.12.2 is-at 00:10:94:00:00:05 (oui Unknown), length 46

19:37:40.428211 3c:2c:99:2d:84:35 (oui Unknown) > 00:10:94:00:00:05 (oui Unknown), ethertype ARP (0x0806), length 42: Request who-has 12.12.12.2 tell 12.12.12.1, length 28
19:37:40.428622 00:10:94:00:00:05 (oui Unknown) > 3c:2c:99:2d:84:35 (oui Unknown), ethertype ARP (0x0806), length 60: Reply 12.12.12.2 is-at 00:10:94:00:00:05 (oui Unknown), length 46


admin@sonic:~$ sudo tcpdump -ei Ethernet0


b. For ndp 
(3 updates for 2100::2 are shown in logs below , other ndps/ more logs are not updated  here)
admin@sonic:~$ show ndp | head
Address                    MacAddress         Iface      Vlan    Status
-------------------------  -----------------  ---------  ------  ---------
2100::2                    00:10:94:00:00:09  Ethernet0  -       REACHABLE
2100::3                    00:10:94:00:00:0a  Ethernet0  -       REACHABLE
2100::4                    00:10:94:00:00:0b  Ethernet0  -       REACHABLE
2100::5                    00:10:94:00:00:0c  Ethernet0  -       REACHABLE
fe80::1a5a:58ff:fe17:c2e0  18:5a:58:17:c2:e0  eth0       -       STALE
fe80::1a5a:58ff:fe18:f720  18:5a:58:18:f7:20  eth0       -       STALE
fe80::1a5a:58ff:fe19:620   18:5a:58:19:06:20  eth0       -       STALE
fe80::3e2c:99ff:fe2d:8735  3c:2c:99:2d:87:35  eth0       -       STALE

11:55:46.283420 3c:2c:99:2d:84:35 (oui Unknown) > 33:33:ff:00:00:02 (oui Unknown), ethertype IPv6 (0x86dd), length 86: fe80::3e2c:99ff:fe2d:8435 > ff02::1:ff00:2: ICMP6, neighbor solicitation, who has 2100::2, length 32
11:55:46.283763 00:10:94:00:00:09 (oui Unknown) > 3c:2c:99:2d:84:35 (oui Unknown), ethertype IPv6 (0x86dd), length 86: 2100::2 > fe80::3e2c:99ff:fe2d:8435: ICMP6, neighbor advertisement, tgt is 2100::2, length 32

12:00:46.314416 3c:2c:99:2d:84:35 (oui Unknown) > 33:33:ff:00:00:02 (oui Unknown), ethertype IPv6 (0x86dd), length 86: fe80::3e2c:99ff:fe2d:8435 > ff02::1:ff00:2: ICMP6, neighbor solicitation, who has 2100::2, length 32
12:00:46.314820 00:10:94:00:00:09 (oui Unknown) > 3c:2c:99:2d:84:35 (oui Unknown), ethertype IPv6 (0x86dd), length 86: 2100::2 > fe80::3e2c:99ff:fe2d:8435: ICMP6, neighbor advertisement, tgt is 2100::2, length 32

12:06:46.350847 3c:2c:99:2d:84:35 (oui Unknown) > 33:33:ff:00:00:02 (oui Unknown), ethertype IPv6 (0x86dd), length 86: fe80::3e2c:99ff:fe2d:8435 > ff02::1:ff00:2: ICMP6, neighbor solicitation, who has 2100::2, length 32
12:06:46.351333 00:10:94:00:00:09 (oui Unknown) > 3c:2c:99:2d:84:35 (oui Unknown), ethertype IPv6 (0x86dd), length 86: 2100::2 > fe80::3e2c:99ff:fe2d:8435: ICMP6, neighbor advertisement, tgt is 2100::2, length 32


2. More compliant test results will be updated
**Details if related**

ARP Refresh Thread:

ARP refresh functionality is added to neighsyncd process. 

Neighsyncd is responsible for syncing the kernel ARP table to the hardware via the APP_DB and OrchAgents. Neighsyncd listens on netlink events (RTM_NEWNEIGH, RTM_DELNEIGH) and creates/deletes NEIGH_TABLE entries in APP_DB.

Existing functionality of neighsyncd is retained as it is. In addition to managing NEIGH_TABLE entries in APP_DB, neighsyncd will also add the details of the neighbor into a queue towards the new ARP Refresh thread described below.

A new ARP refresh thread is created in neighsyncd: -
to dequeue the neighbor events and populate a neighbor cache. 
to periodically refresh ARP/ND by sending ARP request pkt / NS pkt
to subscribe to redis-db to gather the data required to send the ARP refresh packets.

Following are the different modules in the ARP refresh thread.

Neighbor Cache Management
Add neighbor entries to cache when the entry is learned from the kernel
All Dynamically learned neighbor entries [ARP, ND (Global, LinkLocal)]
All Static neighbor entries (MAC can be dynamic)
Below entries will not be added to the neighbor cache
Neighbors learned from “eth0” interface
Neighbors learned from BGP/EVPN MAC/IP type-2 route 
MYIPaddress entries /// FF:FF:FF:FF:FF:FF Permanent entries
Remove entries from cache when the entry is deleted from Kernel
v4/v6 Neighbors Cache [map] contents are: -
Key = IP Address + InterfaceName [Phy/PortChannel/Vlan/Sag]
Value 
MAC Address 
State  (Reachable/Failed)    
Timestamp (Entry creation/last refresh)

Interface Cache Management
Required for framing the ARP packets we send 
Interface Cache [Map]
Key = Interface name
Value = IP, MAC, Ifname to Index
Subscribe to redis-db tables
IP address 
            - CONFIG_DB: INTERFACE, VLAN_INTERFACE, SAG_INTERFACE
MAC 
            - CONFIG_DB: DEVICE_METADATA ==> System MAC
            - CONFIG_DB: SAG_GLOBAL
Ifname to Index (required for socket send)

Packet Builder
Based on Neighbor Cache 
Build ARP packet
Build NS packet
For Resolved ARP Dst MAC, the ARP request is unicast
For Unresolved ARP, Dst MAC the ARP request is broadcast
IPv6 NS uses multicast


Send Refresh 
Send ARP/NS packets using raw socket 
Separate sockets for ARP and ICMPv6 NS
Send Unicast packet 
VLAN tagging & FDB lookup happens in kernel based on outgoing interface

Refresh Timer
Traverse the neighbor Cache entries periodically (every 30 secs)
Check refresh timeout has elapsed for every neighbors
If elapsed then send ARP/NS packet


Refresh timeout Calculation:

To avoid sending all ARP/NS packets simultaneously, each neighbor entry will be configured with different refresh timeout value. This refresh timeout value will be based on MAC/ARP/NS aging time.

ARP Reference Timeout (ARP_RT) = Lesser of [MAC age, ARP age]
ND Reference Timeout (ND_RT)     = Lesser of [MAC age, ND age]

Refresh Timeout = 30% to 70% of [ARP/ND Reference Timeout] 

For example:

MAC Age is less than ARP age
ARP ageout = 60 mins 
MAC ageout = 30 mins
Reference Timeout = 30 mins.
Refresh timeout will be between 30% to 70% of reference timeout (9 to 21) mins.

ARP Age is less than MAC age
ARP ageout = 60 mins 
MAC ageout = 90 mins
Reference Timeout = 60 mins
Refresh timeout will be between 30% to 70% of reference timeout (18 to 42) mins.


Refresh timeout will be set whenever the neighbor entry is added/updated in cache, it will also be recomputed after sending the ARP/NS refresh packet.


Recommended Configurations:

ARP scale | MAC aging timer (min) | ARP Aging timer (min)
-- | -- | --
2000 | 10 (default) | 30 ( default)
4000 | 10 | 30 (default)
6000 | 20 | 60
24K | 40 | 60
32K | 60 | 90



