### PR TITLE
[CRM] Typecast to unit64_t to avoid divide by 0 during overflow

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -541,7 +541,7 @@ void CrmOrch::checkCrmThresholds()
 
             if (cnt.usedCounter != 0)
             {
-                percentageUtil = (cnt.usedCounter * 100) / (cnt.usedCounter + cnt.availableCounter);
+                percentageUtil = (uint32_t)((cnt.usedCounter * 100) / (uint64_t)(cnt.usedCounter + cnt.availableCounter));
             }
 
             switch (res.thresholdType)


### PR DESCRIPTION
**What I did**
Static cast to uint64_t

**Why I did it**
Fix orchagent crash in case of overflow resulting in divide by 0

**How I verified it**
Wrote a test program to simulate

**Details if related**
