### PR TITLE
[vxlanmgr] Fix build error when compiling for armhf (32-bit)

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -915,13 +915,13 @@ void VxlanMgr::createAppDBTunnelMapTable(const KeyOpFieldsValuesTuple & t)
         if (it != m_appVxlanTunnelMapKeysRecon.end())
         {
             m_appVxlanTunnelMapKeysRecon.erase(it);
-            SWSS_LOG_INFO("Reconcile App Tunnel Map Table create %s reconciled. Pending %lu",
+            SWSS_LOG_INFO("Reconcile App Tunnel Map Table create %s reconciled. Pending %zu",
                             vxlanTunnelMapName.c_str(), m_appVxlanTunnelMapKeysRecon.size());
             return;
         }
         else
         {
-            SWSS_LOG_INFO("Reconcile App Tunnel Map Table create %s doesnt not exist. Pending %lu",
+            SWSS_LOG_INFO("Reconcile App Tunnel Map Table create %s doesnt not exist. Pending %zu",
                             vxlanTunnelMapName.c_str(), m_appVxlanTunnelMapKeysRecon.size());
         }
     }
@@ -965,13 +965,13 @@ int VxlanMgr::createVxlanNetdevice(std::string vxlanTunnelName, std::string vni_
         if (it != m_vxlanNetDevices.end())
         {
             m_vxlanNetDevices.erase(it);
-            SWSS_LOG_INFO("Reconcile VxlanNetDevice %s reconciled. Pending %lu",
+            SWSS_LOG_INFO("Reconcile VxlanNetDevice %s reconciled. Pending %zu",
                             vxlan_dev_name.c_str(), m_vxlanNetDevices.size());
             return 0;
         }
         else
         {
-            SWSS_LOG_INFO("Reconcile VxlanNetDevice %s does not exist. Pending %lu",
+            SWSS_LOG_INFO("Reconcile VxlanNetDevice %s does not exist. Pending %zu",
                             vxlan_dev_name.c_str(), m_vxlanNetDevices.size());
         }
     }
@@ -1184,7 +1184,7 @@ void VxlanMgr::beginReconcile(bool warm)
     {
         SWSS_LOG_INFO("App Tunnel Map Key: %s", k.c_str());
     }
-    SWSS_LOG_INFO("Pending %lu entries for the Tunnel Map Table", m_appVxlanTunnelMapKeysRecon.size());
+    SWSS_LOG_INFO("Pending %zu entries for the Tunnel Map Table", m_appVxlanTunnelMapKeysRecon.size());
     return;
 }
 


### PR DESCRIPTION
Changed format specifiers from %lu to %zu for size_t to avoid compilation
errors in arm 32-bit

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This commit modifies various SWSS_LOG calls to use the correct format specifier (%zu) for size_t

**Why I did it**
This fixes a build break when compiling for ARM 32-bit (armhf)

**How I verified it**
Successfully built the  sonic-marvell-armhf.bin image

**Details if related**
