### PR TITLE
prevent default fallback route lookup from user-defined VRF table to local table(default vrf).

### DIFF
--- a/cfgmgr/vrfmgr.cpp
+++ b/cfgmgr/vrfmgr.cpp
@@ -11,7 +11,9 @@
 
 #define VRF_TABLE_START 1001
 #define VRF_TABLE_END 2000
-#define TABLE_LOCAL_PREF 1001 // after l3mdev-table
+#define L3MDEV_UNICAST_PREF 1000
+#define VRF_FALLBACK_DISABLE_PREF 1001
+#define TABLE_LOCAL_PREF 1002 // after l3mdev-table
 
 using namespace swss;
 
@@ -98,7 +100,9 @@ VrfMgr::VrfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, con
         cmd.str("");
         cmd.clear();
         cmd << IP_CMD << " rule add pref " << TABLE_LOCAL_PREF << " table local && " << IP_CMD << " rule del pref 0 && "
-            << IP_CMD << " -6 rule add pref " << TABLE_LOCAL_PREF << " table local && " << IP_CMD << " -6 rule del pref 0";
+            << IP_CMD << " -6 rule add pref " << TABLE_LOCAL_PREF << " table local && " << IP_CMD << " -6 rule del pref 0 && "
+                << IP_CMD << " rule add pref " << VRF_FALLBACK_DISABLE_PREF << " l3mdev unreachable && "
+                << IP_CMD << " -6 rule add pref " << VRF_FALLBACK_DISABLE_PREF << " l3mdev unreachable";
         EXEC_WITH_ERROR_THROW(cmd.str(), res);
     }
 }


### PR DESCRIPTION

**What I did**
By default fallback to local table if l3mdev table lookup fails is
enabled in kernel.
This enables packet to move to default-vrf if route lookup in
non-default-vrf fails.
To disable this fallback feature below IPv4 & IPv6 rules are added to
FIB Routing Policy Data Base.

ip ru add pref 1001 l3mdev unreachable
ip -6 ru add pref 1001 l3mdev unreachable

**Why I did it**
This fix is needed as it prevents default fallback route lookup from user-defined VRF table to local table(default vrf).

**How I verified it**
Please refer to below output after fix : 
admin@sonic:~$ ip -4 rule ls
1000:   from all lookup [l3mdev-table]
1003:   from 10.59.133.11 lookup mgmt
1004:   from all to 10.0.0.0/8 lookup mgmt
32765:  from all lookup local
32766:  from all lookup main
32767:  from all lookup default
admin@sonic:~$

admin@sonic:~$ ip -6 rule ls
1000:   from all lookup [l3mdev-table]
1003:   from 2100::2 lookup mgmt
32765:  from all lookup local
32766:  from all lookup main
admin@sonic:~$

