### PR TITLE
add remove queue port map function

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1915,12 +1915,47 @@ bool PortsOrch::initPort(const string &alias, const int index, const set<int> &l
     return true;
 }
 
+void PortsOrch::removeQueueMapPerPort(const Port& port)
+{
+    /* Delete the Queue map in the Counter DB
+     * FIXME : Remove flex_counter counter part of generateQueueMapPerPort
+     */
+    for (size_t queueIndex = 0; queueIndex < port.m_queue_ids.size(); ++queueIndex)
+    {
+        std::ostringstream name;
+        name << port.m_alias << ":" << queueIndex;
+
+        const auto id = sai_serialize_object_id(port.m_queue_ids[queueIndex]);
+
+        m_queueTable->hdel("", name.str(), id);
+        m_queuePortTable->hdel("", id, sai_serialize_object_id(port.m_port_id));
+
+        string queueType;
+        uint8_t queueRealIndex = 0;
+        if (getQueueTypeAndIndex(port.m_queue_ids[queueIndex], queueType, queueRealIndex))
+        {
+            m_queueTypeTable->hdel("", id, queueType);
+            m_queueIndexTable->hdel("", id, to_string(queueRealIndex)); 
+        }
+        SWSS_LOG_DEBUG("removeQueueMapPerPort: Port %s queueIndex %zu qid:%s", port.m_alias.c_str(), queueIndex, id.c_str());
+    }
+    CounterCheckOrch::getInstance().removePort(port);
+}
+
 void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
 {
     SWSS_LOG_ENTER();
 
-    Port p(alias, Port::PHY);
-    p.m_port_id = port_id;
+    Port p;
+
+    if(!getPort(alias, p))
+    {
+        SWSS_LOG_WARN("deInitPort: Port %s not found!", alias.c_str());
+        return;
+    }
+
+    /* remove queue port map associated to this port */
+    removeQueueMapPerPort(p);
 
     /* remove port from flex_counter_table for updating counters  */
     port_stat_manager.clearCounterIdList(p.m_port_id);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -265,6 +265,7 @@ private:
 
     bool m_isQueueMapGenerated = false;
     void generateQueueMapPerPort(const Port& port);
+    void removeQueueMapPerPort(const Port& port);
 
     bool m_isPriorityGroupMapGenerated = false;
     void generatePriorityGroupMapPerPort(const Port& port);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added removeQueueMapPerPort() counter part of  generateQueueMapPerPort()

**Why I did it**
Need this cleanup as part of port remove.

**How I verified it**
Verified the Queue counter map before and after port remove and create

**Details if related**
Used these command to verify the cleanup
redis-cli -n 2  hgetall COUNTERS_QUEUE_NAME_MAP > q_name_map.txt
redis-cli -n 2  hgetall COUNTERS_QUEUE_PORT_MAP > q_port_map.txt
redis-cli -n 2  hgetall COUNTERS_QUEUE_TYPE_MAP > q_type_map.txt
redis-cli -n 2  hgetall COUNTERS_QUEUE_INDEX_MAP > q_index_map.txt
