### PR TITLE
[buffermgmt] more build error fixes when compiling for armhf (32-bit)

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -229,7 +229,7 @@ string BufferMgrDynamic::parseObjectNameFromKey(const string &key, size_t pos = 
     auto keys = tokenize(key, delimiter);
     if (pos >= keys.size())
     {
-        SWSS_LOG_ERROR("Failed to fetch %lu-th sector of key %s", pos, key.c_str());
+        SWSS_LOG_ERROR("Failed to fetch %zu-th sector of key %s", pos, key.c_str());
         return string();
     }
     return keys[pos];

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -124,7 +124,7 @@ void BufferOrch::initBufferConstants()
     vector<FieldValueTuple> fvVector;
     fvVector.emplace_back(make_pair("mmu_size", to_string(attr.value.u64 * 1024)));
     m_stateBufferMaximumValueTable.set("global", fvVector);
-    SWSS_LOG_NOTICE("Got maximum memory size %lu, exposing to %s|global",
+    SWSS_LOG_NOTICE("Got maximum memory size %" PRIx64 ", exposing to %s|global",
                     attr.value.u64, STATE_BUFFER_MAXIMUM_VALUE_TABLE);
 }
 


### PR DESCRIPTION
Changed format specifiers to avoid compilation errors in arm 32-bit

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This commit modifies various SWSS_LOG calls to use the correct format specifier

**Why I did it**
This fixes a build break when compiling for ARM 32-bit (armhf)

**How I verified it**
Successfully built the sonic-marvell-armhf.bin image

**Details if related**
