### PR TITLE
add retry logic, fix schedule profile del,detach order

### DIFF
--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -60,7 +60,7 @@ public:
     virtual void freeAttribResources(vector<sai_attribute_t> &attributes);
     virtual bool modifyQosItem(sai_object_id_t, vector<sai_attribute_t> &attributes);
     virtual sai_object_id_t addQosItem(const vector<sai_attribute_t> &attributes) = 0;//different for sub-classes
-    virtual bool removeQosItem(sai_object_id_t sai_object);
+    virtual task_process_status  removeQosItem(sai_object_id_t sai_object);
 };
 
 class DscpToTcMapHandler : public QosMapHandler
@@ -91,7 +91,7 @@ public:
     void freeAttribResources(vector<sai_attribute_t> &attributes);
     sai_object_id_t addQosItem(const vector<sai_attribute_t> &attributes);
     bool modifyQosItem(sai_object_id_t sai_object, vector<sai_attribute_t> &attribs);
-    bool removeQosItem(sai_object_id_t sai_object);
+    task_process_status removeQosItem(sai_object_id_t sai_object);
 protected:
     bool convertEcnMode(string str, sai_ecn_mark_mode_t &ecn_val);
     bool convertBool(string str, bool &val);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added retry logic if reference count not zero

**Why I did it**
The order of deletion 'config qos clear' may not guarantee the order.

**How I verified it**
config load qos.jon
config qos clear

**Details if related**
qos.json
{
"QUEUE": {
     "Ethernet8|1": {
         "scheduler": "[SCHEDULER|port_qos_shaper@1]"
     }, 
     "Ethernet8|2": {
         "scheduler": "[SCHEDULER|port_qos_shaper@2]"
     }
},
      "SCHEDULER": {
          "port_qos_shaper@1": {
              "pir": "10000", 
              "meter_type": "bytes"
          }, 
          "port_qos_shaper@2": {
             "pir": "2500", 
             "meter_type": "bytes"
         }
     }
}