### PR TITLE
fix config qos clear and key only update

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1073,6 +1073,12 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
     vector<string> port_names;
 
     ref_resolve_status  resolve_result;
+
+    if((op != SET_COMMAND) && (op != DEL_COMMAND))
+    {
+        SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+        return task_process_status::task_invalid_entry;
+    }
     // sample "QUEUE: {Ethernet4|0-1}"
     tokens = tokenize(key, config_db_key_delimiter);
     if (tokens.size() != 2)
@@ -1109,22 +1115,17 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
                 {
                     result = applySchedulerToQueueSchedulerGroup(port, queue_ind, sai_scheduler_profile);
                 }
-                else if (op == DEL_COMMAND)
+                else
                 {
                     // NOTE: The map is un-bound from the port. But the map itself still exists.
                     result = applySchedulerToQueueSchedulerGroup(port, queue_ind, SAI_NULL_OBJECT_ID);
-                }
-                else
-                {
-                    SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
-                    return task_process_status::task_invalid_entry;
                 }
                 if (!result)
                 {
                     SWSS_LOG_ERROR("Failed setting field:%s to port:%s, queue:%zd, line:%d", scheduler_field_name.c_str(), port.m_alias.c_str(), queue_ind, __LINE__);
                     return task_process_status::task_failed;
                 }
-                SWSS_LOG_DEBUG("Applied scheduler to port:%s", port_name.c_str());
+                SWSS_LOG_DEBUG("Applied scheduler to port:%s queue:%zd", port_name.c_str(), queue_ind);
             }
             else if (resolve_result != ref_resolve_status::field_not_found)
             {
@@ -1136,6 +1137,18 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
                 SWSS_LOG_ERROR("Resolving scheduler reference failed");
                 return task_process_status::task_failed;
             }
+            else
+            {
+                /* config qos clear or SET/DEL with NULL:NULL or only key*/
+                result = applySchedulerToQueueSchedulerGroup(port, queue_ind, SAI_NULL_OBJECT_ID);
+                if (!result)
+                {
+                    SWSS_LOG_ERROR("Failed unbinding field:%s to port:%s, queue:%zd, line:%d",
+                    scheduler_field_name.c_str(), port.m_alias.c_str(), queue_ind, __LINE__);
+                    return task_process_status::task_failed;
+                }
+                SWSS_LOG_DEBUG("Removed scheduler to port:%s queue:%zd", port_name.c_str(), queue_ind);
+            }
 
             sai_object_id_t sai_wred_profile;
             string wred_profile_name;
@@ -1146,15 +1159,10 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer)
                 {
                     result = applyWredProfileToQueue(port, queue_ind, sai_wred_profile);
                 }
-                else if (op == DEL_COMMAND)
+                else
                 {
                     // NOTE: The map is un-bound from the port. But the map itself still exists.
                     result = applyWredProfileToQueue(port, queue_ind, SAI_NULL_OBJECT_ID);
-                }
-                else
-                {
-                    SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
-                    return task_process_status::task_invalid_entry;
                 }
                 if (!result)
                 {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix config qos clear command.

**Why I did it**
Queue table update without scheduler profile.

**How I verified it**
swssloglevel -l DEBUG -c orchagent
show log handleQueueTable
Dec 21 17:56:57.275101 sonic DEBUG swss#orchagent: :> handleQueueTable: enter
Dec 21 17:56:57.275305 sonic DEBUG swss#orchagent: :- handleQueueTable: processing port:Ethernet8
Dec 21 17:56:57.275305 sonic DEBUG swss#orchagent: :- handleQueueTable: processing range:1-1
Dec 21 17:56:57.275305 sonic DEBUG swss#orchagent: :- handleQueueTable: processing queue:1
Dec 21 17:56:57.424246 sonic DEBUG swss#orchagent: :- handleQueueTable: Applied scheduler to port:Ethernet8 queue:1
Dec 21 17:56:57.424246 sonic DEBUG swss#orchagent: :- handleQueueTable: finished
Dec 21 17:56:57.424246 sonic DEBUG swss#orchagent: :< handleQueueTable: exit
Dec 21 17:56:57.424246 sonic DEBUG swss#orchagent: :> handleQueueTable: enter
Dec 21 17:56:57.424449 sonic DEBUG swss#orchagent: :- handleQueueTable: processing port:Ethernet8
Dec 21 17:56:57.424488 sonic DEBUG swss#orchagent: :- handleQueueTable: processing range:2-2
Dec 21 17:56:57.424609 sonic DEBUG swss#orchagent: :- handleQueueTable: processing queue:2
Dec 21 17:56:57.447642 sonic DEBUG swss#orchagent: :- handleQueueTable: Applied scheduler to port:Ethernet8 queue:2
Dec 21 17:56:57.447773 sonic DEBUG swss#orchagent: :- handleQueueTable: finished
Dec 21 17:56:57.447803 sonic DEBUG swss#orchagent: :< handleQueueTable: exit
Dec 21 17:57:09.835991 sonic DEBUG swss#orchagent: :> handleQueueTable: enter
Dec 21 17:57:09.836647 sonic DEBUG swss#orchagent: :- handleQueueTable: processing port:Ethernet8
Dec 21 17:57:09.837054 sonic DEBUG swss#orchagent: :- handleQueueTable: processing range:1-1
Dec 21 17:57:09.837188 sonic DEBUG swss#orchagent: :- handleQueueTable: processing queue:1
Dec 21 17:57:09.862697 sonic DEBUG swss#orchagent: :- handleQueueTable: Removed scheduler to port:Ethernet8 queue:1
Dec 21 17:57:09.862697 sonic DEBUG swss#orchagent: :- handleQueueTable: finished
Dec 21 17:57:09.862697 sonic DEBUG swss#orchagent: :< handleQueueTable: exit
Dec 21 17:57:09.862697 sonic DEBUG swss#orchagent: :> handleQueueTable: enter
Dec 21 17:57:09.862775 sonic DEBUG swss#orchagent: :- handleQueueTable: processing port:Ethernet8
Dec 21 17:57:09.862964 sonic DEBUG swss#orchagent: :- handleQueueTable: processing range:2-2
Dec 21 17:57:09.862964 sonic DEBUG swss#orchagent: :- handleQueueTable: processing queue:2
Dec 21 17:57:09.867682 sonic DEBUG swss#orchagent: :- handleQueueTable: Removed scheduler to port:Ethernet8 queue:2
Dec 21 17:57:09.867682 sonic DEBUG swss#orchagent: :- handleQueueTable: finished
Dec 21 17:57:09.867682 sonic DEBUG swss#orchagent: :< handleQueueTable: exit
**Details if related**
config load qos.json
config qos clear
qos.json
{
"QUEUE": {
     "Ethernet8|1": {
         "scheduler": "[SCHEDULER|port_qos_shaper@1]"
     }, 
     "Ethernet8|2": {
         "scheduler": "[SCHEDULER|port_qos_shaper@2]"
     }
},
      "SCHEDULER": {
          "port_qos_shaper@1": {
              "pir": "10000", 
              "meter_type": "bytes"
          }, 
          "port_qos_shaper@2": {
             "pir": "2500", 
             "meter_type": "bytes"
         }
     }
}