### PR TITLE
[linksync] Netdev oper status determination using IFF_RUNNING

### DIFF
--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -174,7 +174,7 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
 
     unsigned int flags = rtnl_link_get_flags(link);
     bool admin = flags & IFF_UP;
-    bool oper = flags & IFF_LOWER_UP;
+    bool oper = flags & IFF_RUNNING;
 
     char addrStr[MAX_ADDR_SIZE+1] = {0};
     nl_addr2str(rtnl_link_get_addr(link), addrStr, MAX_ADDR_SIZE);


### PR DESCRIPTION
Signed-off-by: vedganes <vedavinayagam.ganesan@nokia.com>

Changes in linksync to use IFF_RUNNING to determine netdev operational
status instead of using IFF_LOWER_UP.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Changed linksync.cpp to use IFF_RUNNING to determine the netdev operational status instead of using IFF_LOWER_UP.

**Why I did it**

The objective of this change is to make orchagent/linksync align with FRR/Zebra in handling interface states. Zebra uses IFF_RUNNING flag to determine interfaces' oper state while linksync uses IFF_LOWER_UP. Zebra rightly depends on IFF_RUNNING flag. As a routing daemon, zebra wants to know whether the interface is capable of passing packets or not. The flag IFF_RUNNING indicates exactly that (based on comment in if.h, this flag reflects the interface oper up state as defined in RFC2863). Since orchagent uses IFF_LOWER_UP, which comes earlier than IFF_RUNNING, there is interface state mismatch between zebra and orchagent for a window of time. Since with voq implementation we write static neigh/routes when the netdev (inband port) becomes oper up and bgp depends on these kernel entries, there is a need for this change to have the interface state timing same in both orchagent and zebra.  

Refer issue https://github.com/Azure/sonic-buildimage/issues/6295 for detailed information.

**How I verified it**

- Currently the operational state of netdev of front panel ports are not used. It is used only for the management port. All vs tests passed.

**Details if related**

- The operational state will be used for voq based chassis systems with inband interface type port  (Ref: https://github.com/Azure/SONiC/blob/master/doc/voq/voq_hld.md, https://github.com/Azure/SONiC/blob/master/doc/voq/architecture.md). With inband interface implementation, there will be an additional attribute called "netdev_oper_status" in the **PORT_TABLE** of STATE_DB. This "netdev_oper_status" will be set based on IFF_RUNNING.