### PR TITLE
[loopback]: skip route pointing to loopback interface

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -38,7 +38,6 @@ const int intfsorch_pri = 35;
 #define RIF_FLEX_STAT_COUNTER_POLL_MSECS "1000"
 #define UPDATE_MAPS_SEC 1
 
-#define LOOPBACK_PREFIX     "Loopback"
 
 static const vector<sai_router_interface_stat_t> rifStatIds =
 {
@@ -57,7 +56,7 @@ IntfsOrch::IntfsOrch(DBConnector *db, string tableName, VRFOrch *vrf_orch) :
 {
     SWSS_LOG_ENTER();
 
-    /* Initialize DB connectors */ 
+    /* Initialize DB connectors */
     m_counter_db = shared_ptr<DBConnector>(new DBConnector("COUNTERS_DB", 0));
     m_flex_db = shared_ptr<DBConnector>(new DBConnector("FLEX_COUNTER_DB", 0));
     m_asic_db = shared_ptr<DBConnector>(new DBConnector("ASIC_DB", 0));
@@ -576,7 +575,7 @@ void IntfsOrch::doTask(Consumer &consumer)
                     SWSS_LOG_ERROR("Invalid mac argument %s to %s()", value.c_str(), e.what());
                     continue;
                 }
-            }  
+            }
             else if (field == "nat_zone")
             {
                 try

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -557,7 +557,13 @@ void RouteOrch::doTask(Consumer& consumer)
 
                 for (auto alias : alsv)
                 {
-                    if (alias == "eth0" || alias == "lo" || alias == "docker0")
+                    /* skip route to management, docker, loopback
+                     * TODO: for route to loopback interface, the proper
+                     * way is to create loopback interface and then create
+                     * route pointing to it, so that we can traps packets to
+                     * CPU */
+                    if (alias == "eth0" || alias == "docker0" ||
+                        alias == "lo" || !alias.compare(0, strlen(LOOPBACK_PREFIX), LOOPBACK_PREFIX))
                     {
                         excp_intfs_flag = true;
                         break;
@@ -1231,7 +1237,7 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
             && vrf_id == gVirtualRouterId)
     {
         /* Only support the default vrf for Fine Grained ECMP */
-        SWSS_LOG_INFO("Reroute %s:%s to fgNhgOrch", ipPrefix.to_string().c_str(), 
+        SWSS_LOG_INFO("Reroute %s:%s to fgNhgOrch", ipPrefix.to_string().c_str(),
                 nextHops.to_string().c_str());
         return m_fgNhgOrch->addRoute(vrf_id, ipPrefix, nextHops);
     }

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -21,6 +21,8 @@
 /* Length of the Interface Id value in EUI64 format */
 #define EUI64_INTF_ID_LEN 8
 
+#define LOOPBACK_PREFIX     "Loopback"
+
 typedef std::map<NextHopKey, sai_object_id_t> NextHopGroupMembers;
 
 struct NextHopGroupEntry


### PR DESCRIPTION
Signed-off-by: Guohan Lu <lguohan@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
skip route pointing to loopback interface

**Why I did it**
if we assign the loopback interface with non full-masked route, then we could 
receive a route from fpmsyncd. we need to skip it otherwise, it will be queued 
in orchagent. 

```
Dec 26 19:45:40.063448 vlab-01 INFO swss#orchagent: :- addRoute: Failed to get next hop ::@Loopback0 for fc00:1::/64
```

**How I verified it**

**Details if related**
