### PR TITLE
[portsorch] Configure hostif tagging for subports

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -753,11 +753,11 @@ bool PortsOrch::removeSubPort(const string &alias)
     // Restore hostif vlan tag for the parent port when the last subport is removed
     if (parentPort.m_child_ports.empty())
     {
-        if (!parentPort.m_bridge_port_id)
+        if (parentPort.m_bridge_port_id == SAI_NULL_OBJECT_ID)
         {
             if (!setHostIntfsStripTag(parentPort, SAI_HOSTIF_VLAN_TAG_STRIP))
             {
-                SWSS_LOG_WARN("Failed to set %s for hostif of port %s",
+                SWSS_LOG_ERROR("Failed to set %s for hostif of port %s",
                         hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], parentPort.m_alias.c_str());
                 return false;
             }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -702,6 +702,17 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
     }
     p.m_vlan_info.vlan_id = vlan_id;
 
+    // Change hostif vlan tag for the parent port only when a first subport is created
+    if (parentPort.m_child_ports.empty())
+    {
+        if (!setHostIntfsStripTag(parentPort, SAI_HOSTIF_VLAN_TAG_KEEP))
+        {
+            SWSS_LOG_ERROR("Failed to set %s for hostif of port %s",
+                    hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_KEEP], parentPort.m_alias.c_str());
+            return false;
+        }
+    }
+
     parentPort.m_child_ports.insert(p.m_alias);
 
     m_portList[alias] = p;
@@ -738,6 +749,21 @@ bool PortsOrch::removeSubPort(const string &alias)
     m_portList[parentPort.m_alias] = parentPort;
 
     m_portList.erase(it);
+
+    // Restore hostif vlan tag for the parent port when the last subport is removed
+    if (parentPort.m_child_ports.empty())
+    {
+        if (!parentPort.m_bridge_port_id)
+        {
+            if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+            {
+                SWSS_LOG_WARN("Failed to set %s for hostif of port %s",
+                        hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], parentPort.m_alias.c_str());
+                return false;
+            }
+        }
+    }
+
     return true;
 }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -755,7 +755,7 @@ bool PortsOrch::removeSubPort(const string &alias)
     {
         if (!parentPort.m_bridge_port_id)
         {
-            if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+            if (!setHostIntfsStripTag(parentPort, SAI_HOSTIF_VLAN_TAG_STRIP))
             {
                 SWSS_LOG_WARN("Failed to set %s for hostif of port %s",
                         hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], parentPort.m_alias.c_str());


### PR DESCRIPTION
Signed-off-by: Vitaliy Senchyshyn <vsenchyshyn@barefootnetworks.com>

**What I did**
Configure SAI_HOSTIF_VLAN_TAG_KEEP for the parent port hostif when a first subport is added and restore it to SAI_HOSTIF_VLAN_TAG_STRIP when the last subport is removed.

**Why I did it**
As the parent port hostif tagging is not modified during subports creation the packets destined to the subport interfaces are forwarded as untagged by the packet driver and therefore never reaching the subport netdevs.

**How I verified it**

Created two subports using the config below and pinged their IPs with vlan 10 and 20 tagged packets respectively. The ping was successful.

```
{
    "VLAN_SUB_INTERFACE": {
        "Ethernet1.10": {
            "admin_status" : "up"
        },
        "Ethernet1.10|11.0.10.1/24": {},

        "Ethernet1.20": {
            "admin_status" : "up"
        },
        "Ethernet1.20|11.0.20.1/24": {}
    }
}
``` 

**Details if related**
