### PR TITLE
[201911] Flushing FDB entries per VLAN when deleting VLAN

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -231,21 +231,6 @@ void FdbOrch::update(sai_fdb_event_t type, const sai_fdb_entry_t* entry, sai_obj
                 itr = next_item;
             }
         }
-        else if (bridge_port_id == SAI_NULL_OBJECT_ID)
-        {
-            /* FLUSH based on VLAN - unsupported */
-            SWSS_LOG_ERROR("Unsupported FDB Flush: [ %s , %s ] = { port: - }",
-                           update.entry.mac.to_string().c_str(),
-                           vlanName.c_str());
-
-        }
-        else
-        {
-            /* FLUSH based on port and VLAN - unsupported */
-            SWSS_LOG_ERROR("Unsupported FDB Flush: [ %s , %s ] = { port: %s }",
-                           update.entry.mac.to_string().c_str(),
-                           vlanName.c_str(), update.port.m_alias.c_str());
-        }
         break;
     }
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3230,6 +3230,10 @@ bool PortsOrch::removeVlanMember(Port &vlan, Port &port)
     sai_tagging_mode = vlan_member->second.vlan_mode;
     vlan_member_id = vlan_member->second.vlan_member_id;
 
+    /* Flush FDB entries pointing to this bridge port for the VLAN */
+    gFdbOrch->flushFDBEntries(port.m_bridge_port_id, vlan.m_vlan_info.vlan_oid);
+    SWSS_LOG_INFO("Flush FDB entries for port %s vlan %s", port.m_alias.c_str(), vlan.m_alias.c_str());
+
     sai_status_t status = sai_vlan_api->remove_vlan_member(vlan_member_id);
     if (status != SAI_STATUS_SUCCESS)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Flushed FDB entries for specific VLAN when trying to delete the VLAN

**Why I did it**
As flushing the FDB entries was not done, the VLAN had references in ASIC-DB and could not be removed.

**How I verified it**
Verified it by creating a VLAN, injecting traffic on the VLAN port and trying to remove the VLAN member port and then removed the VLAN. VLAN removal was successful.

**Details if related**
Changes were in FDB orchagent and PORTS orchagent of SONIC-SWSS.