### PR TITLE
Fix format string for size_t

### DIFF
--- a/orchagent/fgnhgorch.cpp
+++ b/orchagent/fgnhgorch.cpp
@@ -114,7 +114,7 @@ bool FgNhgOrch::bake()
     vector<string> keys;
     m_stateWarmRestartRouteTable.getKeys(keys);
 
-    SWSS_LOG_NOTICE("Warm reboot: recovering entry %lu from state", keys.size());
+    SWSS_LOG_NOTICE("Warm reboot: recovering entry %zu from state", keys.size());
 
     for (const auto &key : keys)
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix format string for size_t

**Why I did it**
We met below error message in armhf build (32-bit)
```
g++ -DHAVE_CONFIG_H -I. -I.. -I ../lib -I .. -I ../warmrestart -I flex_counter -I debug_counter -g -DNDEBUG  -std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/libnl3 -I/usr/include/swss -Werror -Wno-reorder -Wcast-align -Wcast-qual -Wconversion -Wdisabled-optimization -Wextra -Wfloat-equal -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k -Wimport -Winit-self -Winvalid-pch -Wlong-long -Wmissing-field-initializers -Wmissing-format-attribute -Wno-aggregate-return -Wno-padded -Wno-switch-enum -Wno-unused-parameter -Wpacked -Wpointer-arith -Wredundant-decls -Wstack-protector -Wstrict-aliasing=3 -Wswitch -Wswitch-default -Wunreachable-code -Wunused -Wvariadic-macros -Wno-switch-default -Wno-long-long -Wno-redundant-decls -I /usr/include/sai -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -fdebug-prefix-map=/__w/1/s=. -fstack-protector-strong -Wformat -Werror=format-security -c -o orchagent-copporch.o `test -f 'copporch.cpp' || echo './'`copporch.cpp
In file included from /usr/include/swss/redistran.h:7,
                 from /usr/include/swss/table.h:17,
                 from orch.h:17,
                 from fgnhgorch.h:4,
                 from fgnhgorch.cpp:3:
fgnhgorch.cpp: In member function 'virtual bool FgNhgOrch::bake()':
/usr/include/swss/logger.h:17:101: error: format '%lu' expects argument of type 'long unsigned int', but argument 5 has type 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'unsigned int'} [-Werror=format=]
 #define SWSS_LOG_NOTICE(MSG, ...)      swss::Logger::getInstance().write(swss::Logger::SWSS_NOTICE, ":- %s: " MSG, __FUNCTION__, ##__VA_ARGS__)
fgnhgorch.cpp:117:5: note: in expansion of macro 'SWSS_LOG_NOTICE'
     SWSS_LOG_NOTICE("Warm reboot: recovering entry %lu from state", keys.size());
     ^~~~~~~~~~~~~~~
In file included from /usr/include/c++/8/vector:69,
                 from acltable.h:10,
                 from portsorch.h:6,
                 from portsorch.cpp:1:
```
**How I verified it**

**Details if related**
