### PR TITLE
Support shared headroom pool on top of dynamic buffer calculation

### DIFF
--- a/cfgmgr/buffer_headroom_mellanox.lua
+++ b/cfgmgr/buffer_headroom_mellanox.lua
@@ -87,9 +87,6 @@ else
     shp_enabled = false
 end
 
--- Fetch DEFAULT_LOSSLESS_BUFFER_PARAMETER from CONFIG_DB
-local lossless_traffic_keys = redis.call('KEYS', 'DEFAULT_LOSSLESS_BUFFER_PARAMETER*')
-
 -- Calculate the headroom information
 local speed_of_light = 198000000
 local minimal_packet_size = 64
@@ -136,11 +133,10 @@ xon_value = math.ceil(xon_value / 1024) * 1024
 
 if shp_enabled then
     headroom_size = xon_value + speed_overhead
-    headroom_size = math.ceil(headroom_size / 1024) * 1024
 else
     headroom_size = xoff_value + xon_value + speed_overhead
-    headroom_size = math.ceil(headroom_size / 1024) * 1024
 end
+headroom_size = math.ceil(headroom_size / 1024) * 1024
 
 table.insert(ret, "xon" .. ":" .. math.ceil(xon_value))
 table.insert(ret, "xoff" .. ":" .. math.ceil(xoff_value))

--- a/cfgmgr/buffer_headroom_mellanox.lua
+++ b/cfgmgr/buffer_headroom_mellanox.lua
@@ -132,7 +132,7 @@ xon_value = pipeline_latency
 xon_value = math.ceil(xon_value / 1024) * 1024
 
 if shp_enabled then
-    headroom_size = xon_value + speed_overhead
+    headroom_size = xon_value
 else
     headroom_size = xoff_value + xon_value + speed_overhead
 end

--- a/cfgmgr/buffer_headroom_mellanox.lua
+++ b/cfgmgr/buffer_headroom_mellanox.lua
@@ -16,6 +16,7 @@
 
 local lossless_mtu
 local small_packet_percentage
+local over_subscribe_ratio = 0
 local cell_size
 local pipeline_latency
 local mac_phy_delay
@@ -72,6 +73,20 @@ for i = 1, #lossless_traffic_table_content, 2 do
     end
 end
 
+-- Fetch over subscribe ratio
+local default_lossless_param_keys = redis.call('KEYS', 'DEFAULT_LOSSLESS_BUFFER_PARAMETER*')
+local over_subscribe_ratio = tonumber(redis.call('HGET', default_lossless_param_keys[1], 'over_subscribe_ratio'))
+
+-- Fetch the shared headroom pool size
+local shp_size = tonumber(redis.call('HGET', 'BUFFER_POOL|ingress_lossless_pool', 'xoff'))
+
+local shp_enabled
+if shp_size ~= nil and shp_size ~= 0 or over_subscribe_ratio ~= nil and over_subscribe_ratio ~= 0 then
+    shp_enabled = true
+else
+    shp_enabled = false
+end
+
 -- Fetch DEFAULT_LOSSLESS_BUFFER_PARAMETER from CONFIG_DB
 local lossless_traffic_keys = redis.call('KEYS', 'DEFAULT_LOSSLESS_BUFFER_PARAMETER*')
 
@@ -119,8 +134,13 @@ xoff_value = math.ceil(xoff_value / 1024) * 1024
 xon_value = pipeline_latency
 xon_value = math.ceil(xon_value / 1024) * 1024
 
-headroom_size = xoff_value + xon_value + speed_overhead
-headroom_size = math.ceil(headroom_size / 1024) * 1024
+if shp_enabled then
+    headroom_size = xon_value + speed_overhead
+    headroom_size = math.ceil(headroom_size / 1024) * 1024
+else
+    headroom_size = xoff_value + xon_value + speed_overhead
+    headroom_size = math.ceil(headroom_size / 1024) * 1024
+end
 
 table.insert(ret, "xon" .. ":" .. math.ceil(xon_value))
 table.insert(ret, "xoff" .. ":" .. math.ceil(xoff_value))

--- a/cfgmgr/buffer_pool_mellanox.lua
+++ b/cfgmgr/buffer_pool_mellanox.lua
@@ -83,6 +83,24 @@ end
 
 local egress_lossless_pool_size = redis.call('HGET', 'BUFFER_POOL|egress_lossless_pool', 'size')
 
+-- Whether shared headroom pool is enabled?
+local default_lossless_param_keys = redis.call('KEYS', 'DEFAULT_LOSSLESS_BUFFER_PARAMETER*')
+local over_subscribe_ratio = tonumber(redis.call('HGET', default_lossless_param_keys[1], 'over_subscribe_ratio'))
+
+-- Fetch the shared headroom pool size
+local shp_size = tonumber(redis.call('HGET', 'BUFFER_POOL|ingress_lossless_pool', 'xoff'))
+
+local shp_enabled = false
+if over_subscribe_ratio ~= nil and over_subscribe_ratio ~= 0 then
+    shp_enabled = true
+end
+
+if shp_size ~= nil and shp_size ~= 0 then
+    shp_enabled = true
+else
+    shp_size = 0
+end
+
 -- Switch to APPL_DB
 redis.call('SELECT', appl_db)
 
@@ -103,6 +121,7 @@ local statistics = {}
 
 -- Fetch sizes of all of the profiles, accumulate them
 local accumulative_occupied_buffer = 0
+local accumulative_xoff = 0
 for i = 1, #profiles, 1 do
     if profiles[i][1] ~= "BUFFER_PROFILE_TABLE_KEY_SET" and profiles[i][1] ~= "BUFFER_PROFILE_TABLE_DEL_SET" then
         local size = tonumber(redis.call('HGET', profiles[i][1], 'size'))
@@ -114,6 +133,13 @@ for i = 1, #profiles, 1 do
                 profiles[i][2] = count_up_port
             end
             if size ~= 0 then
+                if shp_enabled and shp_size == 0 then
+                    local xon = tonumber(redis.call('HGET', profiles[i][1], 'xon'))
+                    local xoff = tonumber(redis.call('HGET', profiles[i][1], 'xoff'))
+                    if xon ~= nil and xoff ~= nil then
+                        accumulative_xoff = accumulative_xoff + (xon + xoff - size) * profiles[i][2]
+                    end
+                end
                 accumulative_occupied_buffer = accumulative_occupied_buffer + size * profiles[i][2]
             end
             table.insert(statistics, {profiles[i][1], size, profiles[i][2]})
@@ -138,7 +164,7 @@ end
 local asic_keys = redis.call('KEYS', 'ASIC_TABLE*')
 local cell_size = tonumber(redis.call('HGET', asic_keys[1], 'cell_size'))
 
--- Align mmu_size at cell size boundary, otherwith the sdk will complain and the syncd will faill
+-- Align mmu_size at cell size boundary, otherwise the sdk will complain and the syncd will fail
 local number_of_cells = math.floor(mmu_size / cell_size)
 local ceiling_mmu_size = number_of_cells * cell_size
 
@@ -149,11 +175,16 @@ redis.call('SELECT', config_db)
 local pools_need_update = {}
 local ipools = redis.call('KEYS', 'BUFFER_POOL|ingress*')
 local ingress_pool_count = 0
+local ingress_lossless_pool_size = nil
 for i = 1, #ipools, 1 do
     local size = tonumber(redis.call('HGET', ipools[i], 'size'))
     if not size then
         table.insert(pools_need_update, ipools[i])
         ingress_pool_count = ingress_pool_count + 1
+    else
+        if ipools[i] == 'BUFFER_POOL|ingress_lossless_pool' and shp_enabled and shp_size == 0 then
+            ingress_lossless_pool_size = size
+        end
     end
 end
 
@@ -165,7 +196,14 @@ for i = 1, #epools, 1 do
     end
 end
 
+if shp_enabled and shp_size == 0 then
+    shp_size = math.ceil(accumulative_xoff / over_subscribe_ratio)
+end
+
 local pool_size
+if shp_size then
+    accumulative_occupied_buffer = accumulative_occupied_buffer + shp_size
+end
 if ingress_pool_count == 1 then
     pool_size = mmu_size - accumulative_occupied_buffer
 else
@@ -176,18 +214,31 @@ if pool_size > ceiling_mmu_size then
     pool_size = ceiling_mmu_size
 end
 
+local shp_deployed = false
 for i = 1, #pools_need_update, 1 do
     local pool_name = string.match(pools_need_update[i], "BUFFER_POOL|([^%s]+)$")
-    table.insert(result, pool_name .. ":" .. math.ceil(pool_size))
+    if shp_size ~= 0 and pool_name == "ingress_lossless_pool" then
+        table.insert(result, pool_name .. ":" .. math.ceil(pool_size) .. ":" .. math.ceil(shp_size))
+        shp_deployed = true
+    else
+        table.insert(result, pool_name .. ":" .. math.ceil(pool_size))
+    end
+end
+
+if not shp_deployed and shp_size ~= 0 and ingress_lossless_pool_size ~= nil then
+    table.insert(result, "ingress_lossless_pool:" .. math.ceil(ingress_lossless_pool_size) .. ":" .. math.ceil(shp_size))
 end
 
 table.insert(result, "debug:mmu_size:" .. mmu_size)
-table.insert(result, "debug:accumulative:" .. accumulative_occupied_buffer)
+table.insert(result, "debug:accumulative size:" .. accumulative_occupied_buffer)
 for i = 1, #statistics do
     table.insert(result, "debug:" .. statistics[i][1] .. ":" .. statistics[i][2] .. ":" .. statistics[i][3])
 end
 table.insert(result, "debug:extra_400g:" .. (lossypg_reserved_400g - lossypg_reserved) .. ":" .. lossypg_400g)
 table.insert(result, "debug:mgmt_pool:" .. mgmt_pool_size)
 table.insert(result, "debug:egress_mirror:" .. accumulative_egress_mirror_overhead)
+table.insert(result, "debug:shp_enabled:" .. tostring(shp_enabled))
+table.insert(result, "debug:shp_size:" .. shp_size)
+table.insert(result, "debug:accumulative xoff:" .. accumulative_xoff)
 
 return result

--- a/cfgmgr/buffer_pool_mellanox.lua
+++ b/cfgmgr/buffer_pool_mellanox.lua
@@ -136,7 +136,7 @@ for i = 1, #profiles, 1 do
                 if shp_enabled and shp_size == 0 then
                     local xon = tonumber(redis.call('HGET', profiles[i][1], 'xon'))
                     local xoff = tonumber(redis.call('HGET', profiles[i][1], 'xoff'))
-                    if xon ~= nil and xoff ~= nil then
+                    if xon ~= nil and xoff ~= nil and xon + xoff > size then
                         accumulative_xoff = accumulative_xoff + (xon + xoff - size) * profiles[i][2]
                     end
                 end

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -47,6 +47,14 @@ typedef struct {
     bool static_configured;
     bool ingress;
     bool lossless;
+
+    // fields representing parameters by which the headroom is calculated
+    std::string speed;
+    std::string cable_length;
+    std::string port_mtu;
+    std::string gearbox_model;
+
+    // APPL_DB.BUFFER_PROFILE fields
     std::string name;
     std::string size;
     std::string xon;
@@ -124,6 +132,9 @@ private:
     bool m_portInitDone;
     bool m_firstTimeCalculateBufferPool;
 
+    bool m_isSharedHeadroomPoolSizeConfigured;
+    std::string m_configuredSharedHeadroomPoolSize;
+
     std::shared_ptr<DBConnector> m_applDb = nullptr;
     SelectableTimer *m_buffermgrPeriodtimer = nullptr;
 
@@ -191,6 +202,8 @@ private:
     unsigned long m_mmuSizeNumber;
     std::string m_defaultThreshold;
 
+    std::string m_overSubscribeRatio;
+
     // Initializers
     void initTableHandlerMap();
     void parseGearboxInfo(std::shared_ptr<std::vector<KeyOpFieldsValuesTuple>> gearboxInfo);
@@ -202,6 +215,10 @@ private:
     std::string parseObjectNameFromKey(const std::string &key, size_t pos/* = 1*/);
     std::string parseObjectNameFromReference(const std::string &reference);
     std::string getDynamicProfileName(const std::string &speed, const std::string &cable, const std::string &mtu, const std::string &threshold, const std::string &gearbox_model);
+    inline bool isNonZero(const std::string &value) const
+    {
+        return !value.empty() && value != "0";
+    }
 
     // APPL_DB table operations
     void updateBufferPoolToDb(const std::string &name, const buffer_pool_t &pool);
@@ -209,12 +226,13 @@ private:
     void updateBufferPgToDb(const std::string &key, const std::string &profile, bool add);
 
     // Meta flows
-    void calculateHeadroomSize(const std::string &speed, const std::string &cable, const std::string &port_mtu, const std::string &gearbox_model, buffer_profile_t &headroom);
+    void calculateHeadroomSize(buffer_profile_t &headroom);
     void checkSharedBufferPoolSize();
     void recalculateSharedBufferPool();
     task_process_status allocateProfile(const std::string &speed, const std::string &cable, const std::string &mtu, const std::string &threshold, const std::string &gearbox_model, std::string &profile_name);
     void releaseProfile(const std::string &profile_name);
     bool isHeadroomResourceValid(const std::string &port, const buffer_profile_t &profile, const std::string &new_pg);
+    void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
 
     // Main flows
     task_process_status refreshPriorityGroupsForPort(const std::string &port, const std::string &speed, const std::string &cable_length, const std::string &mtu, const std::string &exactly_matched_key);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -132,7 +132,6 @@ private:
     bool m_portInitDone;
     bool m_firstTimeCalculateBufferPool;
 
-    bool m_isSharedHeadroomPoolSizeConfigured;
     std::string m_configuredSharedHeadroomPoolSize;
 
     std::shared_ptr<DBConnector> m_applDb = nullptr;

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -239,7 +239,8 @@ private:
     task_process_status doUpdatePgTask(const std::string &pg_key, const std::string &port);
     task_process_status doRemovePgTask(const std::string &pg_key, const std::string &port);
     task_process_status doAdminStatusTask(const std::string port, const std::string adminStatus);
-    task_process_status doUpdateStaticProfileTask(buffer_profile_t &profile);
+    task_process_status doUpdateBufferProfileForDynamicTh(buffer_profile_t &profile);
+    task_process_status doUpdateBufferProfileForSize(buffer_profile_t &profile, bool update_pool_size);
 
     // Table update handlers
     task_process_status handleBufferMaxParam(KeyOpFieldsValuesTuple &t);

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -454,6 +454,10 @@ class TestBufferMgrDyn(object):
         ingress_lossless_pool_in_configdb = self.config_db.get_entry('BUFFER_POOL', 'ingress_lossless_pool')
         ingress_lossless_pool_in_configdb['xoff'] = shp_size
         self.config_db.update_entry('BUFFER_POOL', 'ingress_lossless_pool', ingress_lossless_pool_in_configdb)
+        # make sure the size is still equal to xon in the profile
+        self.app_db.wait_for_field_match('BUFFER_PROFILE_TABLE', expectedProfile, profileInApplDb)
+        self.check_new_profile_in_asic_db(dvs, expectedProfile)
+
         # config over subscribe ratio to 4
         default_lossless_buffer_parameter['over_subscribe_ratio'] = '4'
         self.config_db.update_entry('DEFAULT_LOSSLESS_BUFFER_PARAMETER', 'AZURE', default_lossless_buffer_parameter)
@@ -462,6 +466,9 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_field_match('BUFFER_POOL_TABLE', 'ingress_lossless_pool', ingress_lossless_pool_in_appldb)
         ingress_lossless_pool_in_asicdb['SAI_BUFFER_POOL_ATTR_XOFF_SIZE'] = shp_size
         self.asic_db.wait_for_field_match('ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL', self.ingress_lossless_pool_oid, ingress_lossless_pool_in_asicdb)
+        # make sure the size is still equal to xon in the profile
+        self.app_db.wait_for_field_match('BUFFER_PROFILE_TABLE', expectedProfile, profileInApplDb)
+        self.check_new_profile_in_asic_db(dvs, expectedProfile)
 
         # remove size configuration, new over subscribe ratio takes effect
         ingress_lossless_pool_in_configdb['xoff'] = '0'
@@ -473,6 +480,9 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_field_match('BUFFER_POOL_TABLE', 'ingress_lossless_pool', ingress_lossless_pool_in_appldb)
         ingress_lossless_pool_in_asicdb['SAI_BUFFER_POOL_ATTR_XOFF_SIZE'] = shp_size
         self.asic_db.wait_for_field_match('ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL', self.ingress_lossless_pool_oid, ingress_lossless_pool_in_asicdb)
+        # make sure the size is still equal to xon in the profile
+        self.app_db.wait_for_field_match('BUFFER_PROFILE_TABLE', expectedProfile, profileInApplDb)
+        self.check_new_profile_in_asic_db(dvs, expectedProfile)
 
         # remove over subscribe ratio configuration
         default_lossless_buffer_parameter['over_subscribe_ratio'] = '0'
@@ -482,6 +492,10 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_field_match('BUFFER_POOL_TABLE', 'ingress_lossless_pool', ingress_lossless_pool_in_appldb)
         ingress_lossless_pool_in_asicdb['SAI_BUFFER_POOL_ATTR_XOFF_SIZE'] = '0'
         self.asic_db.wait_for_field_match('ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL', self.ingress_lossless_pool_oid, ingress_lossless_pool_in_asicdb)
+        # make sure the size is equal to xon + xoff in the profile
+        profileInApplDb['size'] = str(int(profileInApplDb['xon']) + int(profileInApplDb['xoff']))
+        self.app_db.wait_for_field_match('BUFFER_PROFILE_TABLE', expectedProfile, profileInApplDb)
+        self.check_new_profile_in_asic_db(dvs, expectedProfile)
 
         # remove lossless PG 3-4 on interface
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -408,3 +408,81 @@ class TestBufferMgrDyn(object):
         # clear configuration
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
         self.config_db.delete_entry('BUFFER_PROFILE', 'non-default-dynamic')
+
+    def test_sharedHeadroomPool(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        # configure lossless PG 3-4 on interface and start up the interface
+        self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'NULL'})
+        dvs.runcmd('config interface startup Ethernet0')
+
+        expectedProfile = self.make_lossless_profile_name(self.originalSpeed, self.originalCableLen)
+        self.app_db.wait_for_entry("BUFFER_PROFILE_TABLE", expectedProfile)
+        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
+        self.check_new_profile_in_asic_db(dvs, expectedProfile)
+        profileInApplDb = self.app_db.get_entry('BUFFER_PROFILE_TABLE', expectedProfile)
+
+        # enable shared headroom pool by configuring over subscribe ratio
+        default_lossless_buffer_parameter = self.config_db.get_entry('DEFAULT_LOSSLESS_BUFFER_PARAMETER', 'AZURE')
+        over_subscribe_ratio = default_lossless_buffer_parameter.get('over_subscribe_ratio')
+        assert not over_subscribe_ratio or over_subscribe_ratio == '0', "Over subscribe ratio isn't 0"
+
+        # config over subscribe ratio to 2
+        default_lossless_buffer_parameter['over_subscribe_ratio'] = '2'
+        self.config_db.update_entry('DEFAULT_LOSSLESS_BUFFER_PARAMETER', 'AZURE', default_lossless_buffer_parameter)
+
+        # check buffer profile: xoff should be removed from size
+        profileInApplDb['size'] = profileInApplDb['xon']
+        self.app_db.wait_for_field_match('BUFFER_PROFILE_TABLE', expectedProfile, profileInApplDb)
+        self.check_new_profile_in_asic_db(dvs, expectedProfile)
+
+        # check ingress_lossless_pool between appldb and asicdb
+        # there are only two lossless PGs configured on one port.
+        # hence the shared headroom pool size should be pg xoff * 2 / over subscribe ratio (2) = xoff.
+        ingress_lossless_pool_in_appldb = self.app_db.get_entry('BUFFER_POOL_TABLE', 'ingress_lossless_pool')
+        shp_size = profileInApplDb['xoff']
+        ingress_lossless_pool_in_appldb['xoff'] = shp_size
+        # toggle shared headroom pool, it requires some time to update pools
+        time.sleep(20)
+        self.app_db.wait_for_field_match('BUFFER_POOL_TABLE', 'ingress_lossless_pool', ingress_lossless_pool_in_appldb)
+        ingress_lossless_pool_in_asicdb = self.asic_db.get_entry('ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE', self.ingress_lossless_pool_oid)
+        ingress_lossless_pool_in_asicdb['SAI_BUFFER_POOL_ATTR_XOFF_SIZE'] = shp_size
+        self.asic_db.wait_for_field_match('ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL', self.ingress_lossless_pool_oid, ingress_lossless_pool_in_asicdb)
+
+        # config shared headroom pool size
+        shp_size = '204800'
+        ingress_lossless_pool_in_configdb = self.config_db.get_entry('BUFFER_POOL', 'ingress_lossless_pool')
+        ingress_lossless_pool_in_configdb['xoff'] = shp_size
+        self.config_db.update_entry('BUFFER_POOL', 'ingress_lossless_pool', ingress_lossless_pool_in_configdb)
+        # config over subscribe ratio to 4
+        default_lossless_buffer_parameter['over_subscribe_ratio'] = '4'
+        self.config_db.update_entry('DEFAULT_LOSSLESS_BUFFER_PARAMETER', 'AZURE', default_lossless_buffer_parameter)
+        # shp size wins in case both size and over subscribe ratio is configured
+        ingress_lossless_pool_in_appldb['xoff'] = shp_size
+        self.app_db.wait_for_field_match('BUFFER_POOL_TABLE', 'ingress_lossless_pool', ingress_lossless_pool_in_appldb)
+        ingress_lossless_pool_in_asicdb['SAI_BUFFER_POOL_ATTR_XOFF_SIZE'] = shp_size
+        self.asic_db.wait_for_field_match('ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL', self.ingress_lossless_pool_oid, ingress_lossless_pool_in_asicdb)
+
+        # remove size configuration, new over subscribe ratio takes effect
+        ingress_lossless_pool_in_configdb['xoff'] = '0'
+        self.config_db.update_entry('BUFFER_POOL', 'ingress_lossless_pool', ingress_lossless_pool_in_configdb)
+        # shp size: pg xoff * 2 / over subscribe ratio (4) = pg xoff / 2
+        shp_size = str(int(int(profileInApplDb['xoff']) / 2))
+        time.sleep(30)
+        ingress_lossless_pool_in_appldb['xoff'] = shp_size
+        self.app_db.wait_for_field_match('BUFFER_POOL_TABLE', 'ingress_lossless_pool', ingress_lossless_pool_in_appldb)
+        ingress_lossless_pool_in_asicdb['SAI_BUFFER_POOL_ATTR_XOFF_SIZE'] = shp_size
+        self.asic_db.wait_for_field_match('ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL', self.ingress_lossless_pool_oid, ingress_lossless_pool_in_asicdb)
+
+        # remove over subscribe ratio configuration
+        default_lossless_buffer_parameter['over_subscribe_ratio'] = '0'
+        self.config_db.update_entry('DEFAULT_LOSSLESS_BUFFER_PARAMETER', 'AZURE', default_lossless_buffer_parameter)
+        # check whether shp size has been removed from both asic db and appl db
+        ingress_lossless_pool_in_appldb['xoff'] = '0'
+        self.app_db.wait_for_field_match('BUFFER_POOL_TABLE', 'ingress_lossless_pool', ingress_lossless_pool_in_appldb)
+        ingress_lossless_pool_in_asicdb['SAI_BUFFER_POOL_ATTR_XOFF_SIZE'] = '0'
+        self.asic_db.wait_for_field_match('ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL', self.ingress_lossless_pool_oid, ingress_lossless_pool_in_asicdb)
+
+        # remove lossless PG 3-4 on interface
+        self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
+        dvs.runcmd('config interface shutdown Ethernet0')


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Support shared headroom pool on top of dynamic buffer calculation.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

Support shared headroom pool on top of dynamic buffer calculation:
 - Feature is enabled/disabled on-the-fly by configuring over-subscribe-ration and shared headroom pool size.
   If both are configured, the shared headroom pool size will take effect.
   When turn on/off the feature, all the lossless profiles and buffer pool size will be recalculated.
 - Support calculating shared headroom pool while ingress lossless pool is statically configured.

**How I verified it**
Run vs test and regression test.
**Details if related**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012