### PR TITLE
[fdb]fix the process logical of 'SAI_FDB_EVENT_MOVE', not just delete…

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -166,17 +166,38 @@ void FdbOrch::update(sai_fdb_event_t        type,
         break;
 
     case SAI_FDB_EVENT_AGED:
-    case SAI_FDB_EVENT_MOVE:
         update.add = false;
         storeFdbEntryState(update);
 
-        SWSS_LOG_INFO("Notifying observers of FDB entry removal on AGED/MOVED");
+        SWSS_LOG_INFO("Notifying observers of FDB entry removal on AGED");
         for (auto observer: m_observers)
         {
             observer->update(SUBJECT_TYPE_FDB_CHANGE, &update);
         }
 
         break;
+
+    case SAI_FDB_EVENT_MOVE:
+	/* remove the old fdb entry */
+        update.add = false;
+        storeFdbEntryState(update);
+
+        SWSS_LOG_INFO("Notifying observers of FDB entry removal on MOVED");
+        for (auto observer: m_observers)
+        {
+            observer->update(SUBJECT_TYPE_FDB_CHANGE, &update);
+        }
+	/* add the new fdb entry */
+        update.add = true;
+        update.entry.port_name = update.port.m_alias;
+        storeFdbEntryState(update);
+
+        SWSS_LOG_INFO("Notifying observers of FDB entry LEARN");
+        for (auto observer: m_observers)
+        {
+            observer->update(SUBJECT_TYPE_FDB_CHANGE, &update);
+        }
+	break;
 
     case SAI_FDB_EVENT_FLUSHED:
 


### PR DESCRIPTION
… the entry in orchagent.

Signed-off-by: wangshengjun <wangshengjun@asterfusion.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When dealing with the fdb event of SAI_FDB_EVENT_MOVE, fdb orch should remove the old entry firstly and add the new entry.

**Why I did it**
For the event of SAI_FDB_EVENT_MOVE, the mac entry still in the meta data structural. If we just delete the entry in orch, the mac entry will erase in the list of 'm_entries'. And if we want to add the mac entry on sonic again, the fdb orch will encounter error and in a dead loop.
Jan  7 04:50:14.397539 spine-209 ERR swss#orchagent: :- addFdbEntry: Failed to create dynamic FDB b4:56:b9:f0:00:bf on Ethernet1-4, rv:-6
Jan  7 04:50:14.521695 spine-209 ERR swss#orchagent: :- meta_sai_validate_fdb_entry: object key SAI_OBJECT_TYPE_FDB_ENTRY:{"bvid":"oid:0x2600000000049b","mac":"B4:56:B9:F0:00:BF","switch_id":"oid:0x21000000000000"} already exists

**How I verified it**
1. trigger the 'SAI_FDB_EVENT_MOVE' event for a specific mac entry.
2. check the mac entry in state db to make sure the mac entry already delete by fdborch
3. add a new mac entry with the same key in swss docker.The reference json format as below:
{
"FDB_TABLE:Vlan400:B4:56:B9:F0:00:BF": {
"port": "Ethernet1-4",
"type":"dynamic"
},
"OP": "SET"
}
]
4. check the syslog
 

**Details if related**
