### PR TITLE
[FPMSYNCD] Change done to support FRR7.5

### DIFF
--- a/fpmsyncd/fpmlink.cpp
+++ b/fpmsyncd/fpmlink.cpp
@@ -18,6 +18,18 @@ void netlink_parse_rtattr(struct rtattr **tb, int max, struct rtattr *rta,
         {
             tb[rta->rta_type] = rta;
         }
+        else
+        {
+            /* FRR 7.5 is sending RTA_ENCAP with NLA_F_NESTED bit set*/
+            if (rta->rta_type & NLA_F_NESTED)
+            {
+                int rta_type = rta->rta_type & ~NLA_F_NESTED;
+                if (rta_type <= max)
+                {
+                   tb[rta_type] = rta;
+                }
+            }
+        }
         rta = RTA_NEXT(rta, len);
     }
 }

--- a/fpmsyncd/routesync.h
+++ b/fpmsyncd/routesync.h
@@ -41,7 +41,7 @@ private:
     /* Handle regular route (include VRF route) */
     void onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf);
 
-    void parseEncap(struct rtattr *tb, uint32_t &encap_value, string &rmac, uint32_t &vlan);
+    void parseEncap(struct rtattr *tb, uint32_t &encap_value, string &rmac);
 
     void parseRtAttrNested(struct rtattr **tb, int max,
                  struct rtattr *rta);
@@ -64,7 +64,7 @@ private:
     void getEvpnNextHopGwIf(char *gwaddr, int vni_value,
                           string& nexthops, string& vni_list,
                           string& mac_list, string& intf_list,
-                          string rmac, unsigned int vid);
+                          string rmac, string vlan_id);
 
     bool getEvpnNextHop(struct nlmsghdr *h, int received_bytes, struct rtattr *tb[],
                         string& nexthops, string& vni_list, string& mac_list,


### PR DESCRIPTION
What I did
1) While extracting the RT Attribute from netlink message, If the message is NESTED msg remove the NESTED flag and extract the msg.
2) Get nexthop ifindex from Netlink msg RTA_OIF attribute and use the name based on the ifindex program in the APP_DB.

Why I did it
1) With FRR7.5 upgrade Netlink Msg from FRR has NLA_F_NESTED flag set in
RTA_TYPE while sending VNI and RMAC.
2) In the new patch to keep it in line with FRR upstreaming, we are not
sending the VLAN ID from FRR as it can be extracted from ifindex inside
the nexthop information.

How I verified it
Verified using vsonic

Signed-off-by: Kishore Kunal kishore.kunal@broadcom.com