### PR TITLE
[201911] [pfcwd] Update PFC storm detection logic for Mellanox platforms

### DIFF
--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -286,10 +286,48 @@ bool OrchDaemon::init()
         CFG_PFC_WD_TABLE_NAME
     };
 
-    if ((platform == MLNX_PLATFORM_SUBSTRING)
-        || (platform == INVM_PLATFORM_SUBSTRING)
-        || (platform == BFN_PLATFORM_SUBSTRING)
-        || (platform == NPS_PLATFORM_SUBSTRING))
+    if (platform == MLNX_PLATFORM_SUBSTRING)
+    {
+
+        static const vector<sai_port_stat_t> portStatIds =
+        {
+            SAI_PORT_STAT_PFC_0_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_1_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_2_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_3_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_4_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_5_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_6_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_7_RX_PAUSE_DURATION_US,
+            SAI_PORT_STAT_PFC_0_RX_PKTS,
+            SAI_PORT_STAT_PFC_1_RX_PKTS,
+            SAI_PORT_STAT_PFC_2_RX_PKTS,
+            SAI_PORT_STAT_PFC_3_RX_PKTS,
+            SAI_PORT_STAT_PFC_4_RX_PKTS,
+            SAI_PORT_STAT_PFC_5_RX_PKTS,
+            SAI_PORT_STAT_PFC_6_RX_PKTS,
+            SAI_PORT_STAT_PFC_7_RX_PKTS,
+        };
+
+        static const vector<sai_queue_stat_t> queueStatIds =
+        {
+            SAI_QUEUE_STAT_PACKETS,
+            SAI_QUEUE_STAT_CURR_OCCUPANCY_BYTES,
+        };
+
+        static const vector<sai_queue_attr_t> queueAttrIds;
+
+        m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
+                    m_configDb,
+                    pfc_wd_tables,
+                    portStatIds,
+                    queueStatIds,
+                    queueAttrIds,
+                    PFC_WD_POLL_MSECS));
+    }
+    else if ((platform == INVM_PLATFORM_SUBSTRING)
+             || (platform == BFN_PLATFORM_SUBSTRING)
+             || (platform == NPS_PLATFORM_SUBSTRING))
     {
 
         static const vector<sai_port_stat_t> portStatIds =
@@ -320,9 +358,7 @@ bool OrchDaemon::init()
 
         static const vector<sai_queue_attr_t> queueAttrIds;
 
-        if ((platform == MLNX_PLATFORM_SUBSTRING)
-            || (platform == INVM_PLATFORM_SUBSTRING)
-            || (platform == NPS_PLATFORM_SUBSTRING))
+        if ((platform == INVM_PLATFORM_SUBSTRING) || (platform == NPS_PLATFORM_SUBSTRING))
         {
             m_orchList.push_back(new PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>(
                         m_configDb,


### PR DESCRIPTION
* Use "PFC duration" counters in micro seconds instead of quanta

Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Updated PFCWD storm detection logic for Mellanox platforms in order to use "PFC duration" counters in micro seconds instead of quanta.

**Why I did it**
SONiC PFCWD logic requires "pfc duration" value in micro seconds but in SAI it was provided as quanta of time. So it required additional conversion which used speed value to do such conversion and it could cause PFCWD to detect storm on operationally down port in case of link flapping.

Now there are new SAI attributes that provide "pfc duration" in micro seconds so PCWD storm detection logic is updated in order to use this new "pfc duration" counters. Such algorithm change helps to avoid false PFC storm detection in case of link flapping because conversion is not needed anymore.

**How I verified it**
1. Ran all PFCWD tests from https://github.com/Azure/sonic-mgmt/tree/master/tests/pfcwd and verified all passed.
2. Manual test: manually start storm on fanout and manually put port down on fanout few times. Verified that no storm was detected when link was down

**Details if related**
N/A