### PR TITLE
[synchronous mode] Add failure notification for SAI failures in synchronous mode

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -85,4 +85,4 @@ tunnelmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 macsecmgrd_SOURCES = macsecmgrd.cpp macsecmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 macsecmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 macsecmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-macsecmgrd_LDADD = -lswsscommon
+macsecmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)

--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -24,62 +24,62 @@ endif
 vlanmgrd_SOURCES = vlanmgrd.cpp vlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vlanmgrd_LDADD = -lswsscommon
+vlanmgrd_LDADD = -lswsscommon -lsaimetadata
 
 teammgrd_SOURCES = teammgrd.cpp teammgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-teammgrd_LDADD = -lswsscommon
+teammgrd_LDADD = -lswsscommon -lsaimetadata
 
 portmgrd_SOURCES = portmgrd.cpp portmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 portmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 portmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-portmgrd_LDADD = -lswsscommon
+portmgrd_LDADD = -lswsscommon -lsaimetadata
 
 intfmgrd_SOURCES = intfmgrd.cpp intfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-intfmgrd_LDADD = -lswsscommon
+intfmgrd_LDADD = -lswsscommon -lsaimetadata
 
 buffermgrd_SOURCES = buffermgrd.cpp buffermgr.cpp buffermgrdyn.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 buffermgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 buffermgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-buffermgrd_LDADD = -lswsscommon
+buffermgrd_LDADD = -lswsscommon -lsaimetadata
 
 vrfmgrd_SOURCES = vrfmgrd.cpp vrfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vrfmgrd_LDADD = -lswsscommon
+vrfmgrd_LDADD = -lswsscommon -lsaimetadata
 
 nbrmgrd_SOURCES = nbrmgrd.cpp nbrmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CFLAGS)
 nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CPPFLAGS)
-nbrmgrd_LDADD = -lswsscommon $(LIBNL_LIBS)
+nbrmgrd_LDADD = -lswsscommon -lsaimetadata $(LIBNL_LIBS)
 
 vxlanmgrd_SOURCES = vxlanmgrd.cpp vxlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vxlanmgrd_LDADD = -lswsscommon
+vxlanmgrd_LDADD = -lswsscommon -lsaimetadata
 
 sflowmgrd_SOURCES = sflowmgrd.cpp sflowmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 sflowmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 sflowmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-sflowmgrd_LDADD = -lswsscommon
+sflowmgrd_LDADD = -lswsscommon -lsaimetadata
 
 natmgrd_SOURCES = natmgrd.cpp natmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 natmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 natmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-natmgrd_LDADD = -lswsscommon
+natmgrd_LDADD = -lswsscommon -lsaimetadata
 
 coppmgrd_SOURCES = coppmgrd.cpp coppmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 coppmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 coppmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-coppmgrd_LDADD = -lswsscommon
+coppmgrd_LDADD = -lswsscommon -lsaimetadata
 
 tunnelmgrd_SOURCES = tunnelmgrd.cpp tunnelmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 tunnelmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 tunnelmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-tunnelmgrd_LDADD = -lswsscommon
+tunnelmgrd_LDADD = -lswsscommon -lsaimetadata
 
 macsecmgrd_SOURCES = macsecmgrd.cpp macsecmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 macsecmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)

--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -2,6 +2,7 @@ INCLUDES = -I$(top_srcdir)/lib -I $(top_srcdir) -I $(top_srcdir)/orchagent -I $(
 CFLAGS_SAI = -I /usr/include/sai
 LIBNL_CFLAGS = -I/usr/include/libnl3
 LIBNL_LIBS = -lnl-genl-3 -lnl-route-3 -lnl-3
+SAIMETA_LIBS = -lsaimeta -lsaimetadata
 
 bin_PROGRAMS = vlanmgrd teammgrd portmgrd intfmgrd buffermgrd vrfmgrd nbrmgrd vxlanmgrd sflowmgrd natmgrd coppmgrd tunnelmgrd macsecmgrd
 
@@ -24,62 +25,62 @@ endif
 vlanmgrd_SOURCES = vlanmgrd.cpp vlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vlanmgrd_LDADD = -lswsscommon -lsaimetadata
+vlanmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 teammgrd_SOURCES = teammgrd.cpp teammgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-teammgrd_LDADD = -lswsscommon -lsaimetadata
+teammgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 portmgrd_SOURCES = portmgrd.cpp portmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 portmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 portmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-portmgrd_LDADD = -lswsscommon -lsaimetadata
+portmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 intfmgrd_SOURCES = intfmgrd.cpp intfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-intfmgrd_LDADD = -lswsscommon -lsaimetadata
+intfmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 buffermgrd_SOURCES = buffermgrd.cpp buffermgr.cpp buffermgrdyn.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 buffermgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 buffermgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-buffermgrd_LDADD = -lswsscommon -lsaimetadata
+buffermgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 vrfmgrd_SOURCES = vrfmgrd.cpp vrfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vrfmgrd_LDADD = -lswsscommon -lsaimetadata
+vrfmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 nbrmgrd_SOURCES = nbrmgrd.cpp nbrmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CFLAGS)
 nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CPPFLAGS)
-nbrmgrd_LDADD = -lswsscommon -lsaimetadata $(LIBNL_LIBS)
+nbrmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS) $(LIBNL_LIBS)
 
 vxlanmgrd_SOURCES = vxlanmgrd.cpp vxlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vxlanmgrd_LDADD = -lswsscommon -lsaimetadata
+vxlanmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 sflowmgrd_SOURCES = sflowmgrd.cpp sflowmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 sflowmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 sflowmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-sflowmgrd_LDADD = -lswsscommon -lsaimetadata
+sflowmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 natmgrd_SOURCES = natmgrd.cpp natmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 natmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 natmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-natmgrd_LDADD = -lswsscommon -lsaimetadata
+natmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 coppmgrd_SOURCES = coppmgrd.cpp coppmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 coppmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 coppmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-coppmgrd_LDADD = -lswsscommon -lsaimetadata
+coppmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 tunnelmgrd_SOURCES = tunnelmgrd.cpp tunnelmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 tunnelmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 tunnelmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-tunnelmgrd_LDADD = -lswsscommon -lsaimetadata
+tunnelmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 macsecmgrd_SOURCES = macsecmgrd.cpp macsecmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 macsecmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -204,7 +204,7 @@ bool NeighOrch::addNextHop(const IpAddress &ipAddress, const string &alias)
     {
         SWSS_LOG_ERROR("Failed to create next hop %s on %s, rv:%d",
                        ipAddress.to_string().c_str(), alias.c_str(), status);
-        return handleSaiCreateFailure(status);
+        return handleSaiCreateFailure(SAI_API_NEXT_HOP, status);
     }
 
     SWSS_LOG_NOTICE("Created next hop %s on %s",
@@ -678,7 +678,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-                return handleSaiCreateFailure(status);
+                return handleSaiCreateFailure(SAI_API_NEIGHBOR, status);
             }
         }
         SWSS_LOG_NOTICE("Created neighbor ip %s, %s on %s", ip_address.to_string().c_str(),
@@ -701,7 +701,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                                macAddress.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveFailure(status);
+                return handleSaiRemoveFailure(SAI_API_NEIGHBOR, status);
             }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
 
@@ -725,7 +725,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
         {
             SWSS_LOG_ERROR("Failed to update neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-            return handleSaiSetFailure(status);
+            return handleSaiSetFailure(SAI_API_NEIGHBOR, status);
         }
         SWSS_LOG_NOTICE("Updated neighbor %s on %s", macAddress.to_string().c_str(), alias.c_str());
     }
@@ -798,7 +798,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
                                ip_address.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveFailure(status);
+                return handleSaiRemoveFailure(SAI_API_NEXT_HOP, status);
             }
         }
 
@@ -830,7 +830,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                         m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveFailure(status);
+                return handleSaiRemoveFailure(SAI_API_NEIGHBOR, status);
             }
         }
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -204,7 +204,7 @@ bool NeighOrch::addNextHop(const IpAddress &ipAddress, const string &alias)
     {
         SWSS_LOG_ERROR("Failed to create next hop %s on %s, rv:%d",
                        ipAddress.to_string().c_str(), alias.c_str(), status);
-        return false;
+        return handleSaiCreateFailure(status);
     }
 
     SWSS_LOG_NOTICE("Created next hop %s on %s",
@@ -678,7 +678,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-                return false;
+                return handleSaiCreateFailure(status);
             }
         }
         SWSS_LOG_NOTICE("Created neighbor ip %s, %s on %s", ip_address.to_string().c_str(),
@@ -701,7 +701,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                                macAddress.to_string().c_str(), alias.c_str(), status);
-                return false;
+                return handleSaiRemoveFailure(status);
             }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
 
@@ -725,7 +725,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
         {
             SWSS_LOG_ERROR("Failed to update neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-            return false;
+            return handleSaiSetFailure(status);
         }
         SWSS_LOG_NOTICE("Updated neighbor %s on %s", macAddress.to_string().c_str(), alias.c_str());
     }
@@ -798,7 +798,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
                                ip_address.to_string().c_str(), alias.c_str(), status);
-                return false;
+                return handleSaiRemoveFailure(status);
             }
         }
 
@@ -830,7 +830,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                         m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str(), status);
-                return false;
+                return handleSaiRemoveFailure(status);
             }
         }
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -204,7 +204,7 @@ bool NeighOrch::addNextHop(const IpAddress &ipAddress, const string &alias)
     {
         SWSS_LOG_ERROR("Failed to create next hop %s on %s, rv:%d",
                        ipAddress.to_string().c_str(), alias.c_str(), status);
-        return handleSaiCreateFailure(SAI_API_NEXT_HOP, status);
+        return handleSaiCreateStatus(SAI_API_NEXT_HOP, status);
     }
 
     SWSS_LOG_NOTICE("Created next hop %s on %s",
@@ -678,7 +678,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-                return handleSaiCreateFailure(SAI_API_NEIGHBOR, status);
+                return handleSaiCreateStatus(SAI_API_NEIGHBOR, status);
             }
         }
         SWSS_LOG_NOTICE("Created neighbor ip %s, %s on %s", ip_address.to_string().c_str(),
@@ -701,7 +701,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                                macAddress.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveFailure(SAI_API_NEIGHBOR, status);
+                return handleSaiRemoveStatus(SAI_API_NEIGHBOR, status);
             }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
 
@@ -725,7 +725,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
         {
             SWSS_LOG_ERROR("Failed to update neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-            return handleSaiSetFailure(SAI_API_NEIGHBOR, status);
+            return handleSaiSetStatus(SAI_API_NEIGHBOR, status);
         }
         SWSS_LOG_NOTICE("Updated neighbor %s on %s", macAddress.to_string().c_str(), alias.c_str());
     }
@@ -798,7 +798,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
                                ip_address.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveFailure(SAI_API_NEXT_HOP, status);
+                return handleSaiRemoveStatus(SAI_API_NEXT_HOP, status);
             }
         }
 
@@ -830,7 +830,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                         m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveFailure(SAI_API_NEIGHBOR, status);
+                return handleSaiRemoveStatus(SAI_API_NEIGHBOR, status);
             }
         }
 

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -685,7 +685,7 @@ Executor *Orch::getExecutor(string executorName)
     return NULL;
 }
 
-bool Orch::handleSaiCreateFailure(sai_api_t api, sai_status_t status)
+bool Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t status)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis create
@@ -699,7 +699,7 @@ bool Orch::handleSaiCreateFailure(sai_api_t api, sai_status_t status)
     return false;
 }
 
-bool Orch::handleSaiSetFailure(sai_api_t api, sai_status_t status)
+bool Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis set
@@ -713,7 +713,7 @@ bool Orch::handleSaiSetFailure(sai_api_t api, sai_status_t status)
     return false;
 }
 
-bool Orch::handleSaiRemoveFailure(sai_api_t api, sai_status_t status)
+bool Orch::handleSaiRemoveStatus(sai_api_t api, sai_status_t status)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis remove

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -685,6 +685,46 @@ Executor *Orch::getExecutor(string executorName)
     return NULL;
 }
 
+bool Orch::handleSaiCreateFailure(sai_status_t status)
+{
+    /*
+     * This function aims to provide coarse handling of failures in sairedis create
+     * operation (i.e., notify users by throwing excepions when failures happen).
+     * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_ITEM_ALREADY_EXISTS)
+     *       2. Develop fine-grain failure handling mechanisms specific and replace
+     *          this coarse handling in each orch.
+     */
+    SWSS_LOG_THROW("Encountered failure in Create operation, status: %d", status);
+    return false;
+}
+
+bool Orch::handleSaiSetFailure(sai_status_t status)
+{
+    /*
+     * This function aims to provide coarse handling of failures in sairedis set
+     * operation (i.e., notify users by throwing excepions when failures happen).
+     * TODO: 1. Add general handling logic for specific statuses
+     *       2. Develop fine-grain failure handling mechanisms specific and replace
+     *          this coarse handling in each orch.
+     */
+    SWSS_LOG_THROW("Encountered failure in set operation, status: %d", status); // need to update message, comment, and status 
+    return false;
+}
+
+bool Orch::handleSaiRemoveFailure(sai_status_t status)
+{
+    /*
+     * This function aims to provide coarse handling of failures in sairedis remove
+     * operation (i.e., notify users by throwing excepions when failures happen).
+     * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_OBJECT_IN_USE,
+     *          SAI_STATUS_ITEM_NOT_FOUND)
+     *       2. Develop fine-grain failure handling mechanisms specific and replace
+     *          this coarse handling in each orch.
+     */
+    SWSS_LOG_THROW("Encountered failure in DEL operation, status: %d", status); // need to update message, comment, and status 
+    return false;
+}
+
 void Orch2::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -709,7 +709,7 @@ bool Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status)
      *          this coarse handling in each orch.
      *       3. Take the type of sai api into consideration.
      */
-    SWSS_LOG_THROW("Encountered failure in set operation, status: %d", status); // need to update message, comment, and status 
+    SWSS_LOG_THROW("Encountered failure in set operation, status: %d", status);
     return false;
 }
 
@@ -724,7 +724,7 @@ bool Orch::handleSaiRemoveStatus(sai_api_t api, sai_status_t status)
      *          this coarse handling in each orch.
      *       3. Take the type of sai api into consideration.
      */
-    SWSS_LOG_THROW("Encountered failure in del operation, status: %d", status); // need to update message, comment, and status 
+    SWSS_LOG_THROW("Encountered failure in remove operation, status: %d", status);
     return false;
 }
 

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -685,7 +685,7 @@ Executor *Orch::getExecutor(string executorName)
     return NULL;
 }
 
-bool Orch::handleSaiCreateFailure(sai_status_t status)
+bool Orch::handleSaiCreateFailure(sai_api_t api, sai_status_t status)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis create
@@ -693,12 +693,13 @@ bool Orch::handleSaiCreateFailure(sai_status_t status)
      * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_ITEM_ALREADY_EXISTS)
      *       2. Develop fine-grain failure handling mechanisms specific and replace
      *          this coarse handling in each orch.
+     *       3. Take the type of sai api into consideration.
      */
-    SWSS_LOG_THROW("Encountered failure in Create operation, status: %d", status);
+    SWSS_LOG_THROW("Encountered failure in create operation, status: %d", status);
     return false;
 }
 
-bool Orch::handleSaiSetFailure(sai_status_t status)
+bool Orch::handleSaiSetFailure(sai_api_t api, sai_status_t status)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis set
@@ -706,12 +707,13 @@ bool Orch::handleSaiSetFailure(sai_status_t status)
      * TODO: 1. Add general handling logic for specific statuses
      *       2. Develop fine-grain failure handling mechanisms specific and replace
      *          this coarse handling in each orch.
+     *       3. Take the type of sai api into consideration.
      */
     SWSS_LOG_THROW("Encountered failure in set operation, status: %d", status); // need to update message, comment, and status 
     return false;
 }
 
-bool Orch::handleSaiRemoveFailure(sai_status_t status)
+bool Orch::handleSaiRemoveFailure(sai_api_t api, sai_status_t status)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis remove
@@ -720,8 +722,9 @@ bool Orch::handleSaiRemoveFailure(sai_status_t status)
      *          SAI_STATUS_ITEM_NOT_FOUND)
      *       2. Develop fine-grain failure handling mechanisms specific and replace
      *          this coarse handling in each orch.
+     *       3. Take the type of sai api into consideration.
      */
-    SWSS_LOG_THROW("Encountered failure in DEL operation, status: %d", status); // need to update message, comment, and status 
+    SWSS_LOG_THROW("Encountered failure in del operation, status: %d", status); // need to update message, comment, and status 
     return false;
 }
 

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -10,6 +10,7 @@
 #include "tokenize.h"
 #include "logger.h"
 #include "consumerstatetable.h"
+#include "sai_serialize.h"
 
 using namespace swss;
 
@@ -690,12 +691,23 @@ bool Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t status)
     /*
      * This function aims to provide coarse handling of failures in sairedis create
      * operation (i.e., notify users by throwing excepions when failures happen).
+     * Return value: true - Handled the status successfully. No need to retry this SAI operation.
+     *               false - Cannot handle the status. Need to retry the SAI operation.
      * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_ITEM_ALREADY_EXISTS)
      *       2. Develop fine-grain failure handling mechanisms specific and replace
      *          this coarse handling in each orch.
      *       3. Take the type of sai api into consideration.
      */
-    SWSS_LOG_THROW("Encountered failure in create operation, status: %d", status);
+    switch (status)
+    {
+        case SAI_STATUS_SUCCESS:
+            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
+            return true;
+        default:
+            SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
+                        sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+            exit(EXIT_FAILURE);
+    }
     return false;
 }
 
@@ -704,12 +716,23 @@ bool Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status)
     /*
      * This function aims to provide coarse handling of failures in sairedis set
      * operation (i.e., notify users by throwing excepions when failures happen).
+     * Return value: true - Handled the status successfully. No need to retry this SAI operation.
+     *               false - Cannot handle the status. Need to retry the SAI operation.
      * TODO: 1. Add general handling logic for specific statuses
      *       2. Develop fine-grain failure handling mechanisms specific and replace
      *          this coarse handling in each orch.
      *       3. Take the type of sai api into consideration.
      */
-    SWSS_LOG_THROW("Encountered failure in set operation, status: %d", status);
+    switch (status)
+    {
+        case SAI_STATUS_SUCCESS:
+            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiSetStatus");
+            return true;
+        default:
+            SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
+                        sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+            exit(EXIT_FAILURE);
+    }
     return false;
 }
 
@@ -718,13 +741,24 @@ bool Orch::handleSaiRemoveStatus(sai_api_t api, sai_status_t status)
     /*
      * This function aims to provide coarse handling of failures in sairedis remove
      * operation (i.e., notify users by throwing excepions when failures happen).
+     * Return value: true - Handled the status successfully. No need to retry this SAI operation.
+     *               false - Cannot handle the status. Need to retry the SAI operation.
      * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_OBJECT_IN_USE,
      *          SAI_STATUS_ITEM_NOT_FOUND)
      *       2. Develop fine-grain failure handling mechanisms specific and replace
      *          this coarse handling in each orch.
      *       3. Take the type of sai api into consideration.
      */
-    SWSS_LOG_THROW("Encountered failure in remove operation, status: %d", status);
+    switch (status)
+    {
+        case SAI_STATUS_SUCCESS:
+            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiRemoveStatus");
+            return true;
+        default:
+            SWSS_LOG_ERROR("Encountered failure in remove operation, exiting orchagent, SAI API: %s, status: %s",
+                        sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+            exit(EXIT_FAILURE);
+    }
     return false;
 }
 

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -686,7 +686,7 @@ Executor *Orch::getExecutor(string executorName)
     return NULL;
 }
 
-bool Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t status)
+bool Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis create
@@ -694,8 +694,8 @@ bool Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t status)
      * Return value: true - Handled the status successfully. No need to retry this SAI operation.
      *               false - Cannot handle the status. Need to retry the SAI operation.
      * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_ITEM_ALREADY_EXISTS)
-     *       2. Develop fine-grain failure handling mechanisms specific and replace
-     *          this coarse handling in each orch.
+     *       2. Develop fine-grain failure handling mechanisms and replace this coarse handling
+     *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
     switch (status)
@@ -711,7 +711,7 @@ bool Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t status)
     return false;
 }
 
-bool Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status)
+bool Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status, void *context)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis set
@@ -719,8 +719,8 @@ bool Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status)
      * Return value: true - Handled the status successfully. No need to retry this SAI operation.
      *               false - Cannot handle the status. Need to retry the SAI operation.
      * TODO: 1. Add general handling logic for specific statuses
-     *       2. Develop fine-grain failure handling mechanisms specific and replace
-     *          this coarse handling in each orch.
+     *       2. Develop fine-grain failure handling mechanisms and replace this coarse handling
+     *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
     switch (status)
@@ -736,7 +736,7 @@ bool Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status)
     return false;
 }
 
-bool Orch::handleSaiRemoveStatus(sai_api_t api, sai_status_t status)
+bool Orch::handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context)
 {
     /*
      * This function aims to provide coarse handling of failures in sairedis remove
@@ -745,8 +745,8 @@ bool Orch::handleSaiRemoveStatus(sai_api_t api, sai_status_t status)
      *               false - Cannot handle the status. Need to retry the SAI operation.
      * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_OBJECT_IN_USE,
      *          SAI_STATUS_ITEM_NOT_FOUND)
-     *       2. Develop fine-grain failure handling mechanisms specific and replace
-     *          this coarse handling in each orch.
+     *       2. Develop fine-grain failure handling mechanisms and replace this coarse handling
+     *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
     switch (status)

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -218,6 +218,11 @@ public:
     static void recordTuple(Consumer &consumer, const swss::KeyOpFieldsValuesTuple &tuple);
 
     void dumpPendingTasks(std::vector<std::string> &ts);
+
+    /* Failure handling */
+    bool handleSaiCreateFailure(sai_status_t status);
+    bool handleSaiSetFailure(sai_status_t status);
+    bool handleSaiRemoveFailure(sai_status_t status);
 protected:
     ConsumerMap m_consumerMap;
 

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -236,10 +236,10 @@ protected:
     void addExecutor(Executor* executor);
     Executor *getExecutor(std::string executorName);
 
-    /* Failure handling */
-    virtual bool handleSaiCreateFailure(sai_api_t api, sai_status_t status);
-    virtual bool handleSaiSetFailure(sai_api_t api, sai_status_t status);
-    virtual bool handleSaiRemoveFailure(sai_api_t api, sai_status_t status);
+    /* Handling SAI status*/
+    virtual bool handleSaiCreateStatus(sai_api_t api, sai_status_t status);
+    virtual bool handleSaiSetStatus(sai_api_t api, sai_status_t status);
+    virtual bool handleSaiRemoveStatus(sai_api_t api, sai_status_t status);
 private:
     void removeMeFromObjsReferencedByMe(type_map &type_maps, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);
     void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -218,11 +218,6 @@ public:
     static void recordTuple(Consumer &consumer, const swss::KeyOpFieldsValuesTuple &tuple);
 
     void dumpPendingTasks(std::vector<std::string> &ts);
-
-    /* Failure handling */
-    bool handleSaiCreateFailure(sai_status_t status);
-    bool handleSaiSetFailure(sai_status_t status);
-    bool handleSaiRemoveFailure(sai_status_t status);
 protected:
     ConsumerMap m_consumerMap;
 
@@ -240,6 +235,11 @@ protected:
     /* Note: consumer will be owned by this class */
     void addExecutor(Executor* executor);
     Executor *getExecutor(std::string executorName);
+
+    /* Failure handling */
+    virtual bool handleSaiCreateFailure(sai_api_t api, sai_status_t status);
+    virtual bool handleSaiSetFailure(sai_api_t api, sai_status_t status);
+    virtual bool handleSaiRemoveFailure(sai_api_t api, sai_status_t status);
 private:
     void removeMeFromObjsReferencedByMe(type_map &type_maps, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);
     void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -237,9 +237,9 @@ protected:
     Executor *getExecutor(std::string executorName);
 
     /* Handling SAI status*/
-    virtual bool handleSaiCreateStatus(sai_api_t api, sai_status_t status);
-    virtual bool handleSaiSetStatus(sai_api_t api, sai_status_t status);
-    virtual bool handleSaiRemoveStatus(sai_api_t api, sai_status_t status);
+    virtual bool handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    virtual bool handleSaiSetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    virtual bool handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 private:
     void removeMeFromObjsReferencedByMe(type_map &type_maps, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);
     void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -331,7 +331,7 @@ bool RouteOrch::validnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t& 
         {
             SWSS_LOG_ERROR("Failed to add next hop member to group %" PRIx64 ": %d\n",
                            nhopgroup->second.next_hop_group_id, status);
-            return handleSaiCreateFailure(SAI_API_NEXT_HOP_GROUP, status);
+            return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
         }
 
         ++count;
@@ -371,7 +371,7 @@ bool RouteOrch::invalidnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t
         {
             SWSS_LOG_ERROR("Failed to remove next hop member %" PRIx64 " from group %" PRIx64 ": %d\n",
                            nexthop_id, nhopgroup->second.next_hop_group_id, status);
-            return handleSaiRemoveFailure(SAI_API_NEXT_HOP_GROUP, status);
+            return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
         }
 
         ++count;
@@ -950,7 +950,7 @@ bool RouteOrch::createFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create next hop group rv:%d", status);
-        return handleSaiCreateFailure(SAI_API_NEXT_HOP_GROUP, status);
+        return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -968,7 +968,7 @@ bool RouteOrch::removeFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d",
                 next_hop_group_id, status);
-        return handleSaiRemoveFailure(SAI_API_NEXT_HOP_GROUP, status);
+        return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -1033,7 +1033,7 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
     {
         SWSS_LOG_ERROR("Failed to create next hop group %s, rv:%d",
                        nexthops.to_string().c_str(), status);
-        return handleSaiCreateFailure(SAI_API_NEXT_HOP_GROUP, status);
+        return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     m_nextHopGroupCount ++;
@@ -1150,7 +1150,7 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
         {
             SWSS_LOG_ERROR("Failed to remove next hop group member[%zu] %" PRIx64 ", rv:%d",
                            i, next_hop_ids[i], statuses[i]);
-            return handleSaiRemoveFailure(SAI_API_NEXT_HOP_GROUP, statuses[i]);
+            return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, statuses[i]);
         }
 
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
@@ -1160,7 +1160,7 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d", next_hop_group_id, status);
-        return handleSaiRemoveFailure(SAI_API_NEXT_HOP_GROUP, status);
+        return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     m_nextHopGroupCount --;
@@ -1636,7 +1636,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 removeNextHopGroup(nextHops);
             }
-            return handleSaiCreateFailure(SAI_API_ROUTE, status);
+            return handleSaiCreateStatus(SAI_API_ROUTE, status);
         }
 
         if (ipPrefix.isV4())
@@ -1666,7 +1666,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 SWSS_LOG_ERROR("Failed to set route %s with packet action forward, %d",
                                ipPrefix.to_string().c_str(), status);
-                return handleSaiSetFailure(SAI_API_ROUTE, status);
+                return handleSaiSetStatus(SAI_API_ROUTE, status);
             }
         }
 
@@ -1675,7 +1675,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         {
             SWSS_LOG_ERROR("Failed to set route %s with next hop(s) %s",
                     ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
-            return handleSaiSetFailure(SAI_API_ROUTE, status);
+            return handleSaiSetStatus(SAI_API_ROUTE, status);
         }
 
         /* Increase the ref_count for the next hop (group) entry */
@@ -1793,7 +1793,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s packet action to drop, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return handleSaiSetFailure(SAI_API_ROUTE, status);
+            return handleSaiSetStatus(SAI_API_ROUTE, status);
         }
 
         SWSS_LOG_INFO("Set route %s packet action to drop", ipPrefix.to_string().c_str());
@@ -1803,7 +1803,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s next hop ID to NULL, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return handleSaiSetFailure(SAI_API_ROUTE, status);
+            return handleSaiSetStatus(SAI_API_ROUTE, status);
         }
 
         SWSS_LOG_INFO("Set route %s next hop ID to NULL", ipPrefix.to_string().c_str());
@@ -1814,7 +1814,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to remove route prefix:%s\n", ipPrefix.to_string().c_str());
-            return handleSaiRemoveFailure(SAI_API_ROUTE, status);
+            return handleSaiRemoveStatus(SAI_API_ROUTE, status);
         }
 
         if (ipPrefix.isV4())

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -331,7 +331,7 @@ bool RouteOrch::validnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t& 
         {
             SWSS_LOG_ERROR("Failed to add next hop member to group %" PRIx64 ": %d\n",
                            nhopgroup->second.next_hop_group_id, status);
-            return handleSaiCreateFailure(status);
+            return handleSaiCreateFailure(SAI_API_NEXT_HOP_GROUP, status);
         }
 
         ++count;
@@ -371,7 +371,7 @@ bool RouteOrch::invalidnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t
         {
             SWSS_LOG_ERROR("Failed to remove next hop member %" PRIx64 " from group %" PRIx64 ": %d\n",
                            nexthop_id, nhopgroup->second.next_hop_group_id, status);
-            return handleSaiRemoveFailure(status);
+            return handleSaiRemoveFailure(SAI_API_NEXT_HOP_GROUP, status);
         }
 
         ++count;
@@ -950,7 +950,7 @@ bool RouteOrch::createFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create next hop group rv:%d", status);
-        return handleSaiCreateFailure(status);
+        return handleSaiCreateFailure(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -968,7 +968,7 @@ bool RouteOrch::removeFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d",
                 next_hop_group_id, status);
-        return handleSaiRemoveFailure(status);
+        return handleSaiRemoveFailure(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -1033,7 +1033,7 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
     {
         SWSS_LOG_ERROR("Failed to create next hop group %s, rv:%d",
                        nexthops.to_string().c_str(), status);
-        return handleSaiCreateFailure(status);
+        return handleSaiCreateFailure(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     m_nextHopGroupCount ++;
@@ -1150,7 +1150,7 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
         {
             SWSS_LOG_ERROR("Failed to remove next hop group member[%zu] %" PRIx64 ", rv:%d",
                            i, next_hop_ids[i], statuses[i]);
-            return handleSaiRemoveFailure(statuses[i]);
+            return handleSaiRemoveFailure(SAI_API_NEXT_HOP_GROUP, statuses[i]);
         }
 
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
@@ -1160,7 +1160,7 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d", next_hop_group_id, status);
-        return handleSaiRemoveFailure(status);
+        return handleSaiRemoveFailure(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     m_nextHopGroupCount --;
@@ -1636,7 +1636,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 removeNextHopGroup(nextHops);
             }
-            return handleSaiCreateFailure(status);
+            return handleSaiCreateFailure(SAI_API_ROUTE, status);
         }
 
         if (ipPrefix.isV4())
@@ -1666,7 +1666,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 SWSS_LOG_ERROR("Failed to set route %s with packet action forward, %d",
                                ipPrefix.to_string().c_str(), status);
-                return handleSaiSetFailure(status);
+                return handleSaiSetFailure(SAI_API_ROUTE, status);
             }
         }
 
@@ -1675,7 +1675,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         {
             SWSS_LOG_ERROR("Failed to set route %s with next hop(s) %s",
                     ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
-            return handleSaiSetFailure(status);
+            return handleSaiSetFailure(SAI_API_ROUTE, status);
         }
 
         /* Increase the ref_count for the next hop (group) entry */
@@ -1793,7 +1793,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s packet action to drop, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return handleSaiSetFailure(status);
+            return handleSaiSetFailure(SAI_API_ROUTE, status);
         }
 
         SWSS_LOG_INFO("Set route %s packet action to drop", ipPrefix.to_string().c_str());
@@ -1803,7 +1803,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s next hop ID to NULL, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return handleSaiSetFailure(status);
+            return handleSaiSetFailure(SAI_API_ROUTE, status);
         }
 
         SWSS_LOG_INFO("Set route %s next hop ID to NULL", ipPrefix.to_string().c_str());
@@ -1814,7 +1814,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to remove route prefix:%s\n", ipPrefix.to_string().c_str());
-            return handleSaiRemoveFailure(status);
+            return handleSaiRemoveFailure(SAI_API_ROUTE, status);
         }
 
         if (ipPrefix.isV4())

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -331,7 +331,7 @@ bool RouteOrch::validnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t& 
         {
             SWSS_LOG_ERROR("Failed to add next hop member to group %" PRIx64 ": %d\n",
                            nhopgroup->second.next_hop_group_id, status);
-            return false;
+            return handleSaiCreateFailure(status);
         }
 
         ++count;
@@ -371,7 +371,7 @@ bool RouteOrch::invalidnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t
         {
             SWSS_LOG_ERROR("Failed to remove next hop member %" PRIx64 " from group %" PRIx64 ": %d\n",
                            nexthop_id, nhopgroup->second.next_hop_group_id, status);
-            return false;
+            return handleSaiRemoveFailure(status);
         }
 
         ++count;
@@ -950,7 +950,7 @@ bool RouteOrch::createFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create next hop group rv:%d", status);
-        return false;
+        return handleSaiCreateFailure(status);
     }
 
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -968,7 +968,7 @@ bool RouteOrch::removeFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d",
                 next_hop_group_id, status);
-        return false;
+        return handleSaiRemoveFailure(status);
     }
 
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -1033,7 +1033,7 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
     {
         SWSS_LOG_ERROR("Failed to create next hop group %s, rv:%d",
                        nexthops.to_string().c_str(), status);
-        return false;
+        return handleSaiCreateFailure(status);
     }
 
     m_nextHopGroupCount ++;
@@ -1150,7 +1150,7 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
         {
             SWSS_LOG_ERROR("Failed to remove next hop group member[%zu] %" PRIx64 ", rv:%d",
                            i, next_hop_ids[i], statuses[i]);
-            return false;
+            return handleSaiRemoveFailure(statuses[i]);
         }
 
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
@@ -1160,7 +1160,7 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d", next_hop_group_id, status);
-        return false;
+        return handleSaiRemoveFailure(status);
     }
 
     m_nextHopGroupCount --;
@@ -1626,7 +1626,8 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
     }
     else if (it_route == m_syncdRoutes.at(vrf_id).end())
     {
-        if (*it_status++ != SAI_STATUS_SUCCESS)
+        sai_status_t status = *it_status++;
+        if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create route %s with next hop(s) %s",
                     ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
@@ -1635,7 +1636,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 removeNextHopGroup(nextHops);
             }
-            return false;
+            return handleSaiCreateFailure(status);
         }
 
         if (ipPrefix.isV4())
@@ -1665,7 +1666,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 SWSS_LOG_ERROR("Failed to set route %s with packet action forward, %d",
                                ipPrefix.to_string().c_str(), status);
-                return false;
+                return handleSaiSetFailure(status);
             }
         }
 
@@ -1674,7 +1675,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         {
             SWSS_LOG_ERROR("Failed to set route %s with next hop(s) %s",
                     ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
-            return false;
+            return handleSaiSetFailure(status);
         }
 
         /* Increase the ref_count for the next hop (group) entry */
@@ -1792,7 +1793,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s packet action to drop, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return false;
+            return handleSaiSetFailure(status);
         }
 
         SWSS_LOG_INFO("Set route %s packet action to drop", ipPrefix.to_string().c_str());
@@ -1802,7 +1803,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s next hop ID to NULL, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return false;
+            return handleSaiSetFailure(status);
         }
 
         SWSS_LOG_INFO("Set route %s next hop ID to NULL", ipPrefix.to_string().c_str());
@@ -1813,7 +1814,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to remove route prefix:%s\n", ipPrefix.to_string().c_str());
-            return false;
+            return handleSaiRemoveFailure(status);
         }
 
         if (ipPrefix.isV4())


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add function to notify users in the presence of SAI failures by throwing exceptions and trigger swss restart in synchronous mode. And include this function in routeorch and neighorch. 

This is a part of the first step in the SAI failure handling in orchagent with synchronous mode:
1. Failure notification mechanism to ensure enough notifications in the presence of SAI failures and avoid running switches with unhandled failures. 
2. Add general failure handling logic by status.
3. Develop fine-grain failure handling mechanism for each orch to properly handle different SAI failures.

**Why I did it**
This function aims to ensure enough notifications in the presence of SAI failures and avoid running switches with unhandled failures (on-par with asynchronous mode). 

**How I verified it**
Generate SAI failure in vs SAI. Verify that the function gets the error status and throws an exception.
```
vlab-01 ERR syncd#syncd: :- create: create status: SAI_STATUS_FAILURE
vlab-01 ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_BULK_CREATE failed in syncd mode: SAI_STATUS_FAILURE
vlab-01 ERR swss#orchagent: :- addRoutePost: Failed to create route 201.0.0.128/25 with next hop(s) 10.0.0.57@PortChannel0001,10.0.0.59@PortChannel0002,10.0.0.61@PortChannel0003,10.0.0.63@PortChannel0004
Jan 29 02:09:48.865390 vlab-01 ERR swss#orchagent: :- handleSaiCreateStatus: Encountered failure in create operation, SAI API: SAI_API_ROUTE, status: SAI_STATUS_FAILURE
vlab-01 NOTICE swss#orchagent: :- uninitialize: begin
vlab-01 NOTICE swss#orchagent: :- uninitialize: begin
```

**Details if related**
From the orchagent’s perspective, failures in sairedis may caused by three types of failure: a) SAI failure; b) communication failure; c) metadata failure. The function in this PR is on par with asynchronous mode in the first two failure scenarios. For metadata failures, triggering swss restart might be more extreme than asynchronous mode. However, probability of such a scenario is low and the presence of such failure is likely to indicate bugs in orchagent, we treat it the same as the first two scenarios.