### PR TITLE
[vog/systemlag] Voq lagid allocator

### DIFF
--- a/orchagent/lagid.cpp
+++ b/orchagent/lagid.cpp
@@ -21,11 +21,8 @@ int32_t LagIdAllocator::lagIdAdd(
 {
     SWSS_LOG_ENTER();
 
+    // No keys
     vector<string> keys;
-    keys.push_back(CHASSIS_APP_LAG_ID_START_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_END_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_TABLE_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_SET_NAME);
 
     vector<string> args;
     args.push_back("add");
@@ -51,11 +48,8 @@ int32_t LagIdAllocator::lagIdDel(
 {
     SWSS_LOG_ENTER();
 
+    // No keys
     vector<string> keys;
-    keys.push_back(CHASSIS_APP_LAG_ID_START_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_END_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_TABLE_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_SET_NAME);
 
     vector<string> args;
     args.push_back("del");
@@ -80,11 +74,8 @@ int32_t LagIdAllocator::lagIdGet(
 {
     SWSS_LOG_ENTER();
 
+    // No keys
     vector<string> keys;
-    keys.push_back(CHASSIS_APP_LAG_ID_START_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_END_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_TABLE_NAME);
-    keys.push_back(CHASSIS_APP_LAG_ID_SET_NAME);
 
     vector<string> args;
     args.push_back("get");

--- a/orchagent/lagid.cpp
+++ b/orchagent/lagid.cpp
@@ -1,0 +1,105 @@
+#include "lagid.h"
+
+LagIdAllocator::LagIdAllocator(
+        _In_ DBConnector* chassis_app_db)
+{
+    SWSS_LOG_ENTER();
+
+    m_dbConnector = chassis_app_db;
+
+    // Load lua script to allocate system lag id. This lua script ensures allocation
+    // of unique system lag id from global chassis app db in atomic fashion when allocation
+    // is requested by different asic instances simultaneously
+
+    string luaScript = loadLuaScript("lagids.lua");
+    m_shaLagId = loadRedisScript(m_dbConnector, luaScript);
+}
+
+int32_t LagIdAllocator::lagIdAdd(
+        _In_ const string &pcname,
+        _In_ int32_t lag_id)
+{
+    SWSS_LOG_ENTER();
+
+    vector<string> keys;
+    keys.push_back(CHASSIS_APP_LAG_ID_START_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_END_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_TABLE_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_SET_NAME);
+
+    vector<string> args;
+    args.push_back("add");
+    args.push_back(pcname);
+    args.push_back(to_string(lag_id));
+
+    set<string> ret = runRedisScript(*m_dbConnector, m_shaLagId, keys, args);
+
+    if (!ret.empty())
+    {
+        // We expect only one value in the set returned
+
+        auto rv_lag_id = ret.begin();
+
+        return (stoi(*rv_lag_id));
+    }
+
+    return LAG_ID_ALLOCATOR_ERROR_DB_ERROR;
+}
+
+int32_t LagIdAllocator::lagIdDel(
+        _In_ const string &pcname)
+{
+    SWSS_LOG_ENTER();
+
+    vector<string> keys;
+    keys.push_back(CHASSIS_APP_LAG_ID_START_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_END_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_TABLE_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_SET_NAME);
+
+    vector<string> args;
+    args.push_back("del");
+    args.push_back(pcname);
+
+    set<string> ret = runRedisScript(*m_dbConnector, m_shaLagId, keys, args);
+
+    if (!ret.empty())
+    {
+        // We expect only one value in the set returned
+
+        auto rv_lag_id = ret.begin();
+
+        return (stoi(*rv_lag_id));
+    }
+
+    return LAG_ID_ALLOCATOR_ERROR_DB_ERROR;
+}
+
+int32_t LagIdAllocator::lagIdGet(
+        _In_ const string &pcname)
+{
+    SWSS_LOG_ENTER();
+
+    vector<string> keys;
+    keys.push_back(CHASSIS_APP_LAG_ID_START_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_END_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_TABLE_NAME);
+    keys.push_back(CHASSIS_APP_LAG_ID_SET_NAME);
+
+    vector<string> args;
+    args.push_back("get");
+    args.push_back(pcname);
+
+    set<string> ret = runRedisScript(*m_dbConnector, m_shaLagId, keys, args);
+
+    if (!ret.empty())
+    {
+        // We expect only one value in the set returned
+
+        auto rv_lag_id = ret.begin();
+
+        return (stoi(*rv_lag_id));
+    }
+
+    return LAG_ID_ALLOCATOR_ERROR_DB_ERROR;
+}

--- a/orchagent/lagid.h
+++ b/orchagent/lagid.h
@@ -1,0 +1,44 @@
+#ifndef SWSS_LAGID_H
+#define SWSS_LAGID_H
+
+#include "dbconnector.h"
+#include "sal.h"
+#include "schema.h"
+#include "redisapi.h"
+
+using namespace swss;
+using namespace std;
+
+#define LAG_ID_ALLOCATOR_ERROR_DELETE_ENTRY_NOT_FOUND  0
+#define LAG_ID_ALLOCATOR_ERROR_TABLE_FULL             -1
+#define LAG_ID_ALLOCATOR_ERROR_GET_ENTRY_NOT_FOUND    -2
+#define LAG_ID_ALLOCATOR_ERROR_INVALID_OP             -3
+#define LAG_ID_ALLOCATOR_ERROR_DB_ERROR               -4
+
+class LagIdAllocator
+{
+public:
+
+    LagIdAllocator(
+            _In_ DBConnector* chassis_app_db);
+
+public:
+
+    int32_t lagIdAdd(
+            _In_ const string &pcname,
+            _In_ int32_t lag_id);
+
+    int32_t lagIdDel(
+            _In_ const string &pcname);
+
+    int32_t lagIdGet(
+            _In_ const string &pcname);
+
+private:
+
+    DBConnector* m_dbConnector;
+
+    string m_shaLagId;
+};
+
+#endif // SWSS_LAGID_H

--- a/orchagent/lagids.lua
+++ b/orchagent/lagids.lua
@@ -4,9 +4,9 @@
 -- ARGV[3] - current lag id (for "add" operation only)
 
 -- return lagid if success for "add"/"del"
--- return 0 if lag not exists for "del"
+-- return 0 if lag does not exist for "del"
 -- return -1 if lag table full for "add"
--- return -2 if log does exist for "get"
+-- return -2 if lag does not exist for "get"
 -- return -3 if invalid operation
 
 local op = ARGV[1]
@@ -24,8 +24,7 @@ if op == "add" then
     if dblagid then
         dblagid = tonumber(dblagid)
         if plagid == 0 then
-            -- no lagid propsed. Return the existing lagid
-            redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(dblagid))
+            -- no lagid proposed. Return the existing lagid
             return dblagid
         end
     end
@@ -34,7 +33,6 @@ if op == "add" then
     if plagid >= lagid_start and plagid <= lagid_end then
         if plagid == dblagid then
             -- proposed lagid is same as the lagid in database
-            redis.call("sadd", "SYSTEM_LAG_ID_SET", tostring(plagid))
             return plagid
         end
         -- proposed lag id is different than that in database OR

--- a/orchagent/lagids.lua
+++ b/orchagent/lagids.lua
@@ -1,0 +1,90 @@
+-- KEYS - lagid_start, lagid_end, lagids, lagid_set
+-- ARGV[1] - operation (add/del/get)
+-- ARGV[2] - lag name
+-- ARGV[3] - current lag id (for "add" operation only)
+
+-- return lagid if success for "add"/"del"
+-- return 0 if lag not exists for "del"
+-- return -1 if lag table full for "add"
+-- return -2 if log does exist for "get"
+-- return -3 if invalid operation
+
+local op = ARGV[1]
+local pcname = ARGV[2]
+
+local lagid_start = tonumber(redis.call("get", KEYS[1]))
+local lagid_end = tonumber(redis.call("get", KEYS[2]))
+
+if op == "add" then
+
+    local plagid = tonumber(ARGV[3])
+
+    local dblagid = redis.call("hget", KEYS[3], pcname)
+
+    if dblagid then
+        dblagid = tonumber(dblagid)
+        if plagid == 0 then
+            -- no lagid propsed. Return the existing lagid
+            redis.call("sadd", KEYS[4], tostring(dblagid))
+            return dblagid
+        end
+    end
+
+    -- lagid allocation request with a lagid proposal
+    if plagid >= lagid_start and plagid <= lagid_end then
+        if plagid == dblagid then
+            -- proposed lagid is same as the lagid in database
+            redis.call("sadd", KEYS[4], tostring(plagid))
+            return plagid
+        end
+        -- proposed lag id is different than that in database OR
+        -- the portchannel does not exist in the database
+        -- If proposed lagid is available, return the same proposed lag id
+        if redis.call("sismember", KEYS[4], tostring(plagid)) == 0 then
+            redis.call("sadd", KEYS[4], tostring(plagid))
+            redis.call("srem", KEYS[4], tostring(dblagid))
+            redis.call("hset", KEYS[3], pcname, tostring(plagid))
+            return plagid
+        end
+    end
+
+    local lagid = lagid_start
+    while lagid <= lagid_end do
+        if redis.call("sismember", KEYS[4], tostring(lagid)) == 0 then
+            redis.call("sadd", KEYS[4], tostring(lagid))
+            redis.call("srem", KEYS[4], tostring(dblagid))
+            redis.call("hset", KEYS[3], pcname, tostring(lagid))
+            return lagid
+        end
+        lagid = lagid + 1
+    end
+
+    return -1
+
+end
+
+if op == "del" then
+
+    if redis.call("hexists", KEYS[3], pcname) == 1 then
+        local lagid = redis.call("hget", KEYS[3], pcname)
+        redis.call("srem", KEYS[4], lagid)
+        redis.call("hdel", KEYS[3], pcname)
+        return tonumber(lagid)
+    end
+
+    return 0
+
+end
+
+if op == "get" then
+
+    if redis.call("hexists", KEYS[3], pcname) == 1 then
+        local lagid = redis.call("hget", KEYS[3], pcname)
+        return tonumber(lagid)
+    end
+
+    return -2
+
+end
+
+return -3


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Defined class for lag id allocator and added lua script for allocating/freeing lag id in atomic fashion

**Why I did it**

For portchannels in VOQ based chassis systems we need unique lag id across
the system. The lag id (aka system port aggreggator id) is allocated during portchannel
creation. The changes are for a class for lag id allocation in atomic fashion. The LAG ID is allocated
from central chassis app db. A lua script loaded in the redis at the
time of lag id allocator instantiation ensures allocating unique lag id when
multiple clients requests for lag id simultaneously. 

Ref: VOQ LAG HLD PR: https://github.com/Azure/SONiC/pull/697

**How I verified it**

- In VOQ based chassis systems, make sure chassis app db is initialized with lag id start and lag id end data in supervisor card.
- Configure port channel in one asic instance.
- Check the ASIC DB for system port aggregator id (spa) attribute programmed and verify that this spa value is not duplicated in portchannels from different ASICs.

**Details if related**

Note: This PR is dependent on sonic-swss-common PR https://github.com/Azure/sonic-swss-common/pull/447