### PR TITLE
[fpmsyncd] Skip routes to eth0 or docker0

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -679,7 +679,7 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
     {
         /*
          * An FRR behavior change from 7.2 to 7.5 makes FRR update default route to eth0 in interface
-         * up/down events. Skipping routes to eth0 or docker0 to aviod such behavior
+         * up/down events. Skipping routes to eth0 or docker0 to avoid such behavior
          */
         if (alias == "eth0" || alias == "docker0")
         {

--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -674,6 +674,21 @@ void RouteSync::onRouteMsg(int nlmsg_type, struct nl_object *obj, char *vrf)
     string nexthops = getNextHopGw(route_obj);
     string ifnames = getNextHopIf(route_obj);
 
+    vector<string> alsv = tokenize(ifnames, ',');
+    for (auto alias : alsv)
+    {
+        /*
+         * An FRR behavior change from 7.2 to 7.5 makes FRR update default route to eth0 in interface
+         * up/down events. Skipping routes to eth0 or docker0 to aviod such behavior
+         */
+        if (alias == "eth0" || alias == "docker0")
+        {
+            SWSS_LOG_NOTICE("Skip routes to eth0 or docker0: %s %s %s",
+                    destipprefix, nexthops.c_str(), ifnames.c_str());
+            return;
+        }
+    }
+
     vector<FieldValueTuple> fvVector;
     FieldValueTuple nh("nexthop", nexthops);
     FieldValueTuple idx("ifname", ifnames);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Skip routes to eth0 or docker0 in fpmsyncd.

Fix https://github.com/Azure/sonic-buildimage/issues/6483

**Why I did it**
An FRR behavior change from 7.2 to 7.5 makes FRR update the default route to eth0 in interface up/down events. Skipping routes to eth0 or docker0 to avoid such behavior.

**How I verified it**
Tested locally that the default route does not change in interface up/down events.

**Details if related**
