### PR TITLE
[pfc] Introduce pfc config bitmask to track user-configured pfc enabled TCs on physical port

### DIFF
--- a/orchagent/countercheckorch.cpp
+++ b/orchagent/countercheckorch.cpp
@@ -79,15 +79,15 @@ void CounterCheckOrch::mcCounterCheck()
             if (newMcCounters[prio] == numeric_limits<uint64_t>::max())
             {
                 SWSS_LOG_WARN("Could not retreive MC counters on queue %zu port %s",
-                              prio,
-                              port.m_alias.c_str());
+                        prio,
+                        port.m_alias.c_str());
             }
             else if (!isLossy && mcCounters[prio] < newMcCounters[prio])
             {
                 SWSS_LOG_WARN("Got Multicast %" PRIu64 " frame(s) on lossless queue %zu port %s",
-                              newMcCounters[prio] - mcCounters[prio],
-                              prio,
-                              port.m_alias.c_str());
+                        newMcCounters[prio] - mcCounters[prio],
+                        prio,
+                        port.m_alias.c_str());
             }
         }
 
@@ -125,15 +125,15 @@ void CounterCheckOrch::pfcFrameCounterCheck()
             if (newCounters[prio] == numeric_limits<uint64_t>::max())
             {
                 SWSS_LOG_WARN("Could not retreive PFC frame count on queue %zu port %s",
-                              prio,
-                              port.m_alias.c_str());
+                        prio,
+                        port.m_alias.c_str());
             }
             else if (isLossy && counters[prio] < newCounters[prio])
             {
                 SWSS_LOG_WARN("Got PFC %" PRIu64 " frame(s) on lossy queue %zu port %s",
-                              newCounters[prio] - counters[prio],
-                              prio,
-                              port.m_alias.c_str());
+                        newCounters[prio] - counters[prio],
+                        prio,
+                        port.m_alias.c_str());
             }
         }
 

--- a/orchagent/countercheckorch.cpp
+++ b/orchagent/countercheckorch.cpp
@@ -56,7 +56,7 @@ void CounterCheckOrch::mcCounterCheck()
     {
         auto oid = i.first;
         auto mcCounters = i.second;
-        uint8_t pfcMask = 0;
+        uint8_t pfcMaskCfg = 0;
 
         Port port;
         if (!gPortsOrch->getPort(oid, port))
@@ -67,7 +67,7 @@ void CounterCheckOrch::mcCounterCheck()
 
         auto newMcCounters = getQueueMcCounters(port);
 
-        if (!gPortsOrch->getPortPfc(port.m_port_id, &pfcMask))
+        if (!gPortsOrch->getPortPfc(port.m_port_id, nullptr, &pfcMaskCfg))
         {
             SWSS_LOG_ERROR("Failed to get PFC mask on port %s", port.m_alias.c_str());
             continue;
@@ -75,19 +75,19 @@ void CounterCheckOrch::mcCounterCheck()
 
         for (size_t prio = 0; prio != mcCounters.size(); prio++)
         {
-            bool isLossy = ((1 << prio) & pfcMask) == 0;
+            bool isLossy = ((1 << prio) & pfcMaskCfg) == 0;
             if (newMcCounters[prio] == numeric_limits<uint64_t>::max())
             {
                 SWSS_LOG_WARN("Could not retreive MC counters on queue %zu port %s",
-                        prio,
-                        port.m_alias.c_str());
+                              prio,
+                              port.m_alias.c_str());
             }
             else if (!isLossy && mcCounters[prio] < newMcCounters[prio])
             {
                 SWSS_LOG_WARN("Got Multicast %" PRIu64 " frame(s) on lossless queue %zu port %s",
-                        newMcCounters[prio] - mcCounters[prio],
-                        prio,
-                        port.m_alias.c_str());
+                              newMcCounters[prio] - mcCounters[prio],
+                              prio,
+                              port.m_alias.c_str());
             }
         }
 
@@ -104,7 +104,7 @@ void CounterCheckOrch::pfcFrameCounterCheck()
         auto oid = i.first;
         auto counters = i.second;
         auto newCounters = getPfcFrameCounters(oid);
-        uint8_t pfcMask = 0;
+        uint8_t pfcMaskCfg = 0;
 
         Port port;
         if (!gPortsOrch->getPort(oid, port))
@@ -113,7 +113,7 @@ void CounterCheckOrch::pfcFrameCounterCheck()
             continue;
         }
 
-        if (!gPortsOrch->getPortPfc(port.m_port_id, &pfcMask))
+        if (!gPortsOrch->getPortPfc(port.m_port_id, nullptr, &pfcMaskCfg))
         {
             SWSS_LOG_ERROR("Failed to get PFC mask on port %s", port.m_alias.c_str());
             continue;
@@ -121,19 +121,19 @@ void CounterCheckOrch::pfcFrameCounterCheck()
 
         for (size_t prio = 0; prio != counters.size(); prio++)
         {
-            bool isLossy = ((1 << prio) & pfcMask) == 0;
+            bool isLossy = ((1 << prio) & pfcMaskCfg) == 0;
             if (newCounters[prio] == numeric_limits<uint64_t>::max())
             {
                 SWSS_LOG_WARN("Could not retreive PFC frame count on queue %zu port %s",
-                        prio,
-                        port.m_alias.c_str());
+                              prio,
+                              port.m_alias.c_str());
             }
             else if (isLossy && counters[prio] < newCounters[prio])
             {
                 SWSS_LOG_WARN("Got PFC %" PRIu64 " frame(s) on lossy queue %zu port %s",
-                        newCounters[prio] - counters[prio],
-                        prio,
-                        port.m_alias.c_str());
+                              newCounters[prio] - counters[prio],
+                              prio,
+                              port.m_alias.c_str());
             }
         }
 

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -332,16 +332,16 @@ PfcWdLossyHandler::PfcWdLossyHandler(sai_object_id_t port, sai_object_id_t queue
 {
     SWSS_LOG_ENTER();
 
-    uint8_t pfcMask = 0;
+    uint8_t pfcMaskStatus = 0;
 
-    if (!gPortsOrch->getPortPfc(port, &pfcMask))
+    if (!gPortsOrch->getPortPfc(port, &pfcMaskStatus))
     {
         SWSS_LOG_ERROR("Failed to get PFC mask on port 0x%" PRIx64, port);
     }
 
-    pfcMask = static_cast<uint8_t>(pfcMask & ~(1 << queueId));
+    pfcMaskStatus = static_cast<uint8_t>(pfcMaskStatus & ~(1 << queueId));
 
-    if (!gPortsOrch->setPortPfc(port, pfcMask))
+    if (!gPortsOrch->setPortPfcStatus(port, pfcMaskStatus))
     {
         SWSS_LOG_ERROR("Failed to set PFC mask on port 0x%" PRIx64, port);
     }
@@ -351,16 +351,16 @@ PfcWdLossyHandler::~PfcWdLossyHandler(void)
 {
     SWSS_LOG_ENTER();
 
-    uint8_t pfcMask = 0;
+    uint8_t pfcMaskStatus = 0;
 
-    if (!gPortsOrch->getPortPfc(getPort(), &pfcMask))
+    if (!gPortsOrch->getPortPfc(getPort(), &pfcMaskStatus))
     {
         SWSS_LOG_ERROR("Failed to get PFC mask on port 0x%" PRIx64, getPort());
     }
 
-    pfcMask = static_cast<uint8_t>(pfcMask | (1 << getQueueId()));
+    pfcMaskStatus = static_cast<uint8_t>(pfcMaskStatus | (1 << getQueueId()));
 
-    if (!gPortsOrch->setPortPfc(getPort(), pfcMask))
+    if (!gPortsOrch->setPortPfcStatus(getPort(), pfcMaskStatus))
     {
         SWSS_LOG_ERROR("Failed to set PFC mask on port 0x%" PRIx64, getPort());
     }

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -352,13 +352,15 @@ PfcWdLossyHandler::~PfcWdLossyHandler(void)
     SWSS_LOG_ENTER();
 
     uint8_t pfcMaskStatus = 0;
+    uint8_t pfcMaskCfg = 0;
 
-    if (!gPortsOrch->getPortPfc(getPort(), &pfcMaskStatus))
+    if (!gPortsOrch->getPortPfc(getPort(), &pfcMaskStatus, &pfcMaskCfg))
     {
         SWSS_LOG_ERROR("Failed to get PFC mask on port 0x%" PRIx64, getPort());
     }
 
-    pfcMaskStatus = static_cast<uint8_t>(pfcMaskStatus | (1 << getQueueId()));
+    // Set pfc enable bit to asic only if the corresponding bit in config is set
+    pfcMaskStatus = static_cast<uint8_t>(pfcMaskStatus | ((1 << getQueueId()) & pfcMaskCfg));
 
     if (!gPortsOrch->setPortPfcStatus(getPort(), pfcMaskStatus))
     {

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -238,6 +238,7 @@ PfcWdAclHandler::PfcWdAclHandler(sai_object_id_t port, sai_object_id_t queue,
     {
         // First time of handling PFC for this queue, create ACL table, and bind
         createPfcAclTable(port, m_strIngressTable, true);
+        // Create acl rule in bound acl table
         shared_ptr<AclRulePfcwd> newRule = make_shared<AclRulePfcwd>(gAclOrch, m_strRule, m_strIngressTable, table_type);
         createPfcAclRule(newRule, queueId, m_strIngressTable);
     }

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -359,7 +359,7 @@ PfcWdLossyHandler::~PfcWdLossyHandler(void)
         SWSS_LOG_ERROR("Failed to get PFC mask on port 0x%" PRIx64, getPort());
     }
 
-    // Set pfc enable bit to asic only if the corresponding bit in config is set
+    // Set PFC enable bit to asic only if the corresponding bit in config is set
     pfcMaskStatus = static_cast<uint8_t>(pfcMaskStatus | ((1 << getQueueId()) & pfcMaskCfg));
 
     if (!gPortsOrch->setPortPfcStatus(getPort(), pfcMaskStatus))

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -446,7 +446,7 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
         }
         // By removing action handler, we expect pfc bit mask status in asic to
         // be the same as that in config
-        assert(pfcMaskStatus == cfgMaskCfg);
+        assert(pfcMaskStatus == pfcMaskCfg);
 
         for (uint8_t i = 0; i < PFC_WD_TC_MAX; i++)
         {

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -399,8 +399,8 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
         for (uint8_t i = 0; i < PFC_WD_TC_MAX; i++)
         {
             sai_object_id_t queueId = port.m_queue_ids[i];
-            // Pfc enable bit not set can be the case that the corresponding tc
-            // is lossless, and is currently in pfc storm, with pfc action in act.
+            // PFC enable bit not set can be the case that the corresponding TC
+            // is lossless, and is currently in PFC storm, with PFC action in act.
             // We pick up such a case to enable big red switch mode by checking if a corresponding
             // entry exists in m_entryMap
             if ((pfcMaskStatus & (1 << i)) == 0 && m_entryMap.find(queueId) == m_entryMap.end())
@@ -444,7 +444,7 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::enableBigRedSwitchMode()
             SWSS_LOG_ERROR("Failed to get PFC mask on port %s", port.m_alias.c_str());
             return;
         }
-        // By removing action handler, we expect pfc bit mask status in asic to
+        // By removing action handler, we expect PFC bit mask status in asic to
         // be the same as that in config
         assert(pfcMaskStatus == pfcMaskCfg);
 

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -258,7 +258,7 @@ task_process_status PfcWdOrch<DropHandler, ForwardHandler>::createEntry(const st
 
     if (!startWdOnPort(port, detectionTime, restorationTime, action))
     {
-        SWSS_LOG_ERROR("Failed to start PFC Watchdog on port %s", port.m_alias.c_str());
+        SWSS_LOG_INFO("Failed to start PFC Watchdog on port %s", port.m_alias.c_str());
         return task_process_status::task_need_retry;
     }
 
@@ -494,11 +494,12 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::registerInWdDb(const Port& port,
             continue;
         }
 
+        SWSS_LOG_NOTICE("Lossless TC %u found on port %s", i, port.m_alias.c_str());
         losslessTc.insert(i);
     }
     if (losslessTc.empty())
     {
-        SWSS_LOG_NOTICE("No lossless TC found on port %s", port.m_alias.c_str());
+        SWSS_LOG_INFO("No lossless TC found on port %s", port.m_alias.c_str());
         return false;
     }
 
@@ -890,7 +891,6 @@ void PfcWdSwOrch<DropHandler, ForwardHandler>::doTask(SelectableTimer &timer)
             handlerPair.second.handler->commitCounters(true);
         }
     }
-
 }
 
 template <typename DropHandler, typename ForwardHandler>

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -119,7 +119,8 @@ public:
     std::vector<sai_object_id_t> m_queue_ids;
     std::vector<sai_object_id_t> m_priority_group_ids;
     sai_port_priority_flow_control_mode_t m_pfc_asym = SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED;
-    uint8_t   m_pfc_bitmask = 0;
+    uint8_t   m_pfc_bitmask_cfg = 0;    // bitmask from config
+    uint8_t   m_pfc_bitmask_status = 0; // bitmask status in asic
     uint32_t  m_nat_zone_id = 0;
     uint32_t  m_vnid = VNID_NONE;
     uint32_t  m_fdb_count = 0;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -966,7 +966,7 @@ bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask_cfg)
     // Pfc enable bit is temporarily cleared if the corresponding tc is in pfc storm.
     // This causes pfc bit mask status in asic to be different from that in config.
     // We leave such different bits as they are to be further handled by the corresponding
-    // observer (i.e., pfcwd) while update the rest bits to asic according to config.
+    // orch (i.e., pfcwd) while update the rest bits to asic according to config.
     uint8_t bitmask = p.m_pfc_bitmask_cfg ^ p.m_pfc_bitmask_status;
     uint8_t pfc_bitmask_status = static_cast<uint8_t>((bitmask & p.m_pfc_bitmask_status) | (~bitmask & pfc_bitmask_cfg));
     if (!setPortPfcStatus(p, pfc_bitmask_status))

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -963,8 +963,8 @@ bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask_cfg)
         return false;
     }
 
-    // Pfc enable bit is temporarily cleared if the corresponding tc is in pfc storm.
-    // This causes pfc bit mask status in asic to be different from that in config.
+    // PFC enable bit is temporarily cleared if the corresponding TC is in PFC storm.
+    // This causes PFC bit mask status in asic to be different from that in config.
     // We leave such different bits as they are to be further handled by the corresponding
     // orch (i.e., pfcwd) while update the rest bits to asic according to config.
     uint8_t bitmask = p.m_pfc_bitmask_cfg ^ p.m_pfc_bitmask_status;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -867,7 +867,7 @@ bool PortsOrch::setPortFec(Port &port, sai_port_fec_mode_t mode)
     return true;
 }
 
-bool PortsOrch::getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask)
+bool PortsOrch::getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask_status, uint8_t *pfc_bitmask_cfg)
 {
     SWSS_LOG_ENTER();
 
@@ -879,7 +879,15 @@ bool PortsOrch::getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask)
         return false;
     }
 
-    *pfc_bitmask = p.m_pfc_bitmask;
+    if (pfc_bitmask_status != nullptr)
+    {
+        *pfc_bitmask_status = p.m_pfc_bitmask_status;
+    }
+
+    if (pfc_bitmask_cfg != nullptr)
+    {
+        *pfc_bitmask_cfg = p.m_pfc_bitmask_cfg;
+    }
 
     return true;
 }
@@ -928,7 +936,7 @@ bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask_cfg)
         return false;
     }
 
-    // Pfc enabled bit is temporarily cleared if the corresponding tc is in pfc storm.
+    // Pfc enable bit is temporarily cleared if the corresponding tc is in pfc storm.
     // This causes pfc bit mask status in asic to be different from that in config.
     // We leave such different bits as they are to be further handled by the corresponding
     // observer (i.e., pfcwd) while update the rest bits to asic according to config.
@@ -956,9 +964,9 @@ bool PortsOrch::setPortPfcAsym(Port &port, string pfc_asym)
     SWSS_LOG_ENTER();
 
     sai_attribute_t attr;
-    uint8_t pfc = 0;
+    uint8_t pfc_status = 0;
 
-    if (!getPortPfc(port.m_port_id, &pfc))
+    if (!getPortPfc(port.m_port_id, &pfc_status))
     {
         return false;
     }
@@ -990,7 +998,7 @@ bool PortsOrch::setPortPfcAsym(Port &port, string pfc_asym)
         return false;
     }
 
-    if (!setPortPfc(port.m_port_id, pfc))
+    if (!setPortPfcStatus(port.m_port_id, pfc_status))
     {
         return false;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -924,6 +924,33 @@ bool PortsOrch::setPortPfcStatus(const Port &p, uint8_t pfc_bitmask_status)
     return true;
 }
 
+bool PortsOrch::setPortPfcStatus(sai_object_id_t portId, uint8_t pfc_bitmask_status)
+{
+    SWSS_LOG_ENTER();
+
+    Port p;
+
+    if (!getPort(portId, p))
+    {
+        SWSS_LOG_ERROR("Failed to get port object for port id 0x%" PRIx64, portId);
+        return false;
+    }
+
+    if (!setPortPfcStatus(p, pfc_bitmask_status))
+    {
+        SWSS_LOG_ERROR("Failed to set PFC status 0x%x to port id 0x%" PRIx64, pfc_bitmask_status, portId);
+        return false;
+    }
+
+    if (p.m_pfc_bitmask_status != pfc_bitmask_status)
+    {
+        p.m_pfc_bitmask_status = pfc_bitmask_status;
+        m_portList[p.m_alias] = p;
+    }
+
+    return true;
+}
+
 bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask_cfg)
 {
     SWSS_LOG_ENTER();

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -967,8 +967,8 @@ bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask_cfg)
     // This causes pfc bit mask status in asic to be different from that in config.
     // We leave such different bits as they are to be further handled by the corresponding
     // observer (i.e., pfcwd) while update the rest bits to asic according to config.
-    uint8_t bitmask = p.pfc_bitmask_cfg ^ p.pfc_bitmask_status;
-    uint8_t pfc_bitmask_status = (bitmask & p.pfc_bitmask_status) | (~bitmask & p.pfc_bitmask_cfg);
+    uint8_t bitmask = p.m_pfc_bitmask_cfg ^ p.m_pfc_bitmask_status;
+    uint8_t pfc_bitmask_status = static_cast<uint8_t>((bitmask & p.m_pfc_bitmask_status) | (~bitmask & p.m_pfc_bitmask_cfg));
     if (!setPortPfcStatus(p, pfc_bitmask_status))
     {
         SWSS_LOG_ERROR("Failed to set PFC status 0x%x to port id 0x%" PRIx64, pfc_bitmask_status, portId);

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -968,7 +968,7 @@ bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask_cfg)
     // We leave such different bits as they are to be further handled by the corresponding
     // observer (i.e., pfcwd) while update the rest bits to asic according to config.
     uint8_t bitmask = p.m_pfc_bitmask_cfg ^ p.m_pfc_bitmask_status;
-    uint8_t pfc_bitmask_status = static_cast<uint8_t>((bitmask & p.m_pfc_bitmask_status) | (~bitmask & p.m_pfc_bitmask_cfg));
+    uint8_t pfc_bitmask_status = static_cast<uint8_t>((bitmask & p.m_pfc_bitmask_status) | (~bitmask & pfc_bitmask_cfg));
     if (!setPortPfcStatus(p, pfc_bitmask_status))
     {
         SWSS_LOG_ERROR("Failed to set PFC status 0x%x to port id 0x%" PRIx64, pfc_bitmask_status, portId);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -256,6 +256,7 @@ private:
     bool setPortFec(Port &port, sai_port_fec_mode_t mode);
     bool setPortPfcAsym(Port &port, string pfc_asym);
     bool getDestPortId(sai_object_id_t src_port_id, dest_port_type_t port_type, sai_object_id_t &des_port_id);
+    bool setPortPfcStatus(const Port &p, uint8_t pfc_bitmask_status);
 
     bool setBridgePortAdminStatus(sai_object_id_t id, bool up);
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -116,8 +116,8 @@ public:
     bool bindUnbindAclTableGroup(Port &port,
                                  bool ingress,
                                  bool bind);
-    bool getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask);
-    bool setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask);
+    bool getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask_status, uint8_t *pfc_bitmask_cfg = nullptr);
+    bool setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask_cfg);
 
     void generateQueueMap();
     void generatePriorityGroupMap();

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -118,6 +118,7 @@ public:
                                  bool bind);
     bool getPortPfc(sai_object_id_t portId, uint8_t *pfc_bitmask_status, uint8_t *pfc_bitmask_cfg = nullptr);
     bool setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask_cfg);
+    bool setPortPfcStatus(sai_object_id_t portId, uint8_t pfc_bitmask_status);
 
     void generateQueueMap();
     void generatePriorityGroupMap();

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1331,7 +1331,7 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
             SWSS_LOG_INFO("Applied %s to port %s", it->second.first.c_str(), port_name.c_str());
         }
 
-        if (port.m_pfc_bitmask != pfc_enable)
+        if (port.m_pfc_bitmask_cfg != pfc_enable)
         {
             if (!gPortsOrch->setPortPfc(port.m_port_id, pfc_enable))
             {

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1331,7 +1331,7 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
             SWSS_LOG_INFO("Applied %s to port %s", it->second.first.c_str(), port_name.c_str());
         }
 
-        if (pfc_enable)
+        if (port.m_pfc_bitmask != pfc_enable)
         {
             if (!gPortsOrch->setPortPfc(port.m_port_id, pfc_enable))
             {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Introduce PFC config bitmask to track user-configured PFC enabled TCs on physical port

This allows separate tracking of user-configured PFC bitmask (`pfc_enable` field in `CONFIG_DB`) from PFC bitmask status in ASIC. As when pfc wd is enabled and PFC storm occurs on a lossless TC, PFC bit on that TC is cleared in ASIC during the storm by `PfcWdLossyHandler`, making PFC bitmask status in ASIC to be different from that configured by user.

Such a difference causes the following misleading log message in syslog when a lossless TC is in PFC storm and pfc wd drop action is in place:
```
Aug 20 10:28:43.590517 sonic WARNING swss#orchagent: :- pfcFrameCounterCheck: Got PFC 933416836 frame(s) on lossy queue 3 port Ethernet0
```

**Why I did it**
Fix https://github.com/Azure/sonic-buildimage/issues/5910

**How I verified it**
On brcm

**Details if related**

When user wants to change PFC enable bits on TCs, if pfc wd is enabled, user still needs to toggle pfc wd stop and start to ensure pfc wd state machine is stopped on a PFC-disabled TC and is running on a PFC-enabled TC. However, before this change, command sequence matters: pfcwd must be stopped before PFC bits change on TCs, followed by `pfcwd start`. With this change, restriction on command sequence is no longer needed, i.e., PFC bits change on TC can be issued either before or after `pfcwd stop`, followed by `pfcwd start`.

Removing manual intervention described above (pfc wd stop and start toggle in changing PFC bits on TCs) is out of the scope of this PR, and will be in follow-up ones.

Covers fix to allow disabling last lossless TC in pending PR https://github.com/Azure/sonic-swss/pull/1055