### PR TITLE
[crm] Ignore unsupported switch attributes

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -458,8 +458,9 @@ void CrmOrch::getResAvailableCounters()
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     if((status == SAI_STATUS_NOT_SUPPORTED) ||
-                       (status == SAI_STATUS_ATTR_NOT_SUPPORTED_0) ||
-                       (status == SAI_STATUS_ATTR_NOT_IMPLEMENTED_0))
+                       (status == SAI_STATUS_NOT_IMPLEMENTED) ||
+                       SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) ||
+                       SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status))
                     {
                         // remove unsupported resources from map
                         m_resourcesMap.erase(res.first);

--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -457,10 +457,14 @@ void CrmOrch::getResAvailableCounters()
                 sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
                 if (status != SAI_STATUS_SUCCESS)
                 {
-                    if(status == SAI_STATUS_NOT_SUPPORTED)
+                    if((status == SAI_STATUS_NOT_SUPPORTED) ||
+                       (status == SAI_STATUS_ATTR_NOT_SUPPORTED_0) ||
+                       (status == SAI_STATUS_ATTR_NOT_IMPLEMENTED_0))
                     {
                         // remove unsupported resources from map
                         m_resourcesMap.erase(res.first);
+                        SWSS_LOG_NOTICE("Switch attribute %u not supported", attr.id);
+                        break;
                     }
                     SWSS_LOG_ERROR("Failed to get switch attribute %u , rv:%d", attr.id, status);
                     break;


### PR DESCRIPTION
Signed-off-by: Prabhu Sreenivasan <prabhu.sreenivasan@broadcom.com>

Fix https://github.com/Azure/sonic-buildimage/issues/6563

**What I did**
Added checks for SAI_STATUS_ATTR_NOT_SUPPORTED_0  and SAI_STATUS_ATTR_NOT_IMPLEMENTED_0 to ignore unsupported CRM attributes.

**Why I did it**
Switch attributes SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY, SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY and SAI_SWITCH_ATTR_AVAILABLE_IPMC_ENTRY are currently unsupported by some SAI implementations and below logs were appearing on those switches.

```
Jan 26 07:08:51.743298 mts-sonic-dut ERR swss#orchagent: :- getResAvailableCounters: Failed to get switch attribute 60 , rv:-327680
Jan 26 07:08:51.745972 mts-sonic-dut ERR swss#orchagent: :- getResAvailableCounters: Failed to get switch attribute 61 , rv:-196608
Jan 26 07:08:51.759107 mts-sonic-dut ERR swss#orchagent: :- getResAvailableCounters: Failed to get switch attribute 62 , rv:-196608
```

**How I verified it**
SWSS unit test

**Details if related**
