### PR TITLE
[PortsOrch] Add reference counting to ports for ACL bindings

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1249,9 +1249,9 @@ bool PortsOrch::unbindAclTable(sai_object_id_t  port_oid,
 
 
     Port port;
-    if (getPort(port_id, port))
+    if (getPort(port_oid, port))
     {
-        decreasePortRefCount(it->second);
+        decreasePortRefCount(port.m_alias);
     }
 
     if (!unbindRemoveAclTableGroup(port_oid, acl_table_oid, acl_stage)) {
@@ -1315,7 +1315,7 @@ bool PortsOrch::bindAclTable(sai_object_id_t  port_oid,
     }
 
     Port port;
-    if (getPort(port_id, port))
+    if (getPort(port_oid, port))
     {
         increasePortRefCount(port.m_alias);
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1247,6 +1247,13 @@ bool PortsOrch::unbindAclTable(sai_object_id_t  port_oid,
         return false;
     }
 
+
+    Port port;
+    if (getPort(port_id, port))
+    {
+        decreasePortRefCount(it->second);
+    }
+
     if (!unbindRemoveAclTableGroup(port_oid, acl_table_oid, acl_stage)) {
         return false;
     }
@@ -1305,6 +1312,12 @@ bool PortsOrch::bindAclTable(sai_object_id_t  port_oid,
         SWSS_LOG_ERROR("Failed to create member in ACL table group %" PRIx64 " for ACL table %" PRIx64 ", rv:%d",
                 group_oid, table_oid, status);
         return false;
+    }
+
+    Port port;
+    if (getPort(port_id, port))
+    {
+        increasePortRefCount(port.m_alias);
     }
 
     return true;


### PR DESCRIPTION
What I did:
Use reference count for protect interface, If interface bind to ACL the reference will increase and vice versa.

Why I did it:
If interface bind to ACL and remove interface causes the ACL rule become global rule to match all interfaces.

How I verified it:
Run the pytest check ACL and Port test case passed.