### PR TITLE
Vlan remove comm bug 779

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1825,7 +1825,7 @@ sai_status_t PortsOrch::removePort(sai_object_id_t port_id)
 
     Port port;
 
-    /*
+    /* 
      * Make sure to bring down admin state.
      * SET would have replaced with DEL
      */
@@ -3600,12 +3600,7 @@ bool PortsOrch::removeVlan(Port vlan)
     /* Vlan removing is not allowed when the VLAN still has members */
     if (vlan.m_members.size() > 0)
     {
-        string vlan_members;
-        for (auto &name: vlan.m_members)
-        {
-            vlan_members += " " + name;
-        }
-        SWSS_LOG_INFO("VLAN %s still has members assigned: [%s ].", vlan.m_alias.c_str(), vlan_members.c_str());
+        SWSS_LOG_ERROR("Failed to remove non-empty VLAN %s", vlan.m_alias.c_str());
         return false;
     }
 
@@ -4944,7 +4939,7 @@ bool PortsOrch::setVoqInbandIntf(string &alias, string &type)
     // host if for the inband here
 
     // May do the processing for other inband type like type=vlan here
-
+    
     //Store the name of the local inband port
     m_inbandPortName = alias;
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1825,7 +1825,7 @@ sai_status_t PortsOrch::removePort(sai_object_id_t port_id)
 
     Port port;
 
-    /* 
+    /*
      * Make sure to bring down admin state.
      * SET would have replaced with DEL
      */
@@ -3600,7 +3600,12 @@ bool PortsOrch::removeVlan(Port vlan)
     /* Vlan removing is not allowed when the VLAN still has members */
     if (vlan.m_members.size() > 0)
     {
-        SWSS_LOG_ERROR("Failed to remove non-empty VLAN %s", vlan.m_alias.c_str());
+        string vlan_members;
+        for (auto &name: vlan.m_members)
+        {
+            vlan_members += " " + name;
+        }
+        SWSS_LOG_INFO("VLAN %s still has members assigned: [%s ].", vlan.m_alias.c_str(), vlan_members.c_str());
         return false;
     }
 
@@ -4939,7 +4944,7 @@ bool PortsOrch::setVoqInbandIntf(string &alias, string &type)
     // host if for the inband here
 
     // May do the processing for other inband type like type=vlan here
-    
+
     //Store the name of the local inband port
     m_inbandPortName = alias;
 


### PR DESCRIPTION
**What I did**
Changed severity level of log notification from ERR to INFO, in the case vlan is deleted and there are still members on this VLAN.

**Why I did it**
When we remove VLAN and there are members on this VLAN, the events which coming to portsorch.cpp doTask(...) are not according to the order that they are executed in vlan.py - file which activated this command.

Lets see the next flow: we have 3 members on the VLAN and user type "sudo config vlan del <>"
In vlan.py the flow is next:

Remove entries from VLAN_MEMBER_CFG_TABLE with the key of the VLAN user want to remove.

Remove entry from VLAN_CFG_TABLE with the key of the VLAN user want to remove.
However, the order of requests getting to VlanMgr.cpp file is different.

Request DEL entry from VLAN_MEMBER_CFG_TABLE, Request DEL entry from VLAN_CFG_TABLE, Request DEL entry from VLAN_MEMBER_CFG_TABLE, Request DEL entry from VLAN_MEMBER_CFG_TABLE
(3 members - 3 calls of delete entry from VLAN_MEMBER_CFG_TABLE, but between these calls we have call fromVLAN_CFG_TABLE )

As VlanMgr.cpp update APP_TABLEs, STATE_TABLEs of the same tables the request is coming from (VLAN_CFG_TABLE update VLAN_APP_TABLE, VLAN_STATE_TABLE , VLAN_MEMBER_CFG_TABLE update VLAN_MEMBER_APP_TABLE ...) PortsOrch.cpp receives the notification events in the same order.
It means that request to delete VLAN will come before all vlan members are deleted.

However, finally, when all members will be deleted - the VLAN will be deleted too, as doVlanTask function will try it again and again ... and finally it should be remove VLAN

This BUG was opened by community:
Azure/sonic-utilities#779
**How I verified it**
sudo config vlan add 200
sudo config vlan member add 200 Ethernet0
sudo config vlan member add 200 Ethernet8
sudo config vlan member add 200 Ethernet16
sudo config vlan del 200

The log had info messages :

removeVlan: VLAN Vlan200 still has members assigned: < Ethernet8 >...

**Details if related**