### PR TITLE
Fix the compiling errors in gcc9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,7 @@ CFLAGS_COMMON+=" -Wvariadic-macros"
 CFLAGS_COMMON+=" -Wno-switch-default"
 CFLAGS_COMMON+=" -Wno-long-long"
 CFLAGS_COMMON+=" -Wno-redundant-decls"
+CFLAGS_COMMON+=" -Wno-stringop-overflow"
 
 AC_SUBST(CFLAGS_COMMON)
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,6 @@ CFLAGS_COMMON+=" -Wvariadic-macros"
 CFLAGS_COMMON+=" -Wno-switch-default"
 CFLAGS_COMMON+=" -Wno-long-long"
 CFLAGS_COMMON+=" -Wno-redundant-decls"
-CFLAGS_COMMON+=" -Wno-stringop-overflow"
 
 AC_SUBST(CFLAGS_COMMON)
 

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -606,7 +606,7 @@ ref_resolve_status Orch::resolveFieldRefArray(
                 SWSS_LOG_DEBUG("Resolved to sai_object:0x%" PRIx64 ", type:%s, name:%s", sai_obj, ref_type_name.c_str(), object_name.c_str());
                 sai_object_arr.push_back(sai_obj);
                 if (!object_name_list.empty())
-                    object_name_list += string(&list_item_delimiter, 1);
+                    object_name_list += list_item_delimiter;
                 object_name_list += ref_type_name + delimiter + object_name;
             }
             count++;

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -606,7 +606,7 @@ ref_resolve_status Orch::resolveFieldRefArray(
                 SWSS_LOG_DEBUG("Resolved to sai_object:0x%" PRIx64 ", type:%s, name:%s", sai_obj, ref_type_name.c_str(), object_name.c_str());
                 sai_object_arr.push_back(sai_obj);
                 if (!object_name_list.empty())
-                    object_name_list += string(&list_item_delimiter);
+                    object_name_list += string(&list_item_delimiter, 1);
                 object_name_list += ref_type_name + delimiter + object_name;
             }
             count++;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix the following error.
```
    orch.cpp: In member function 'ref_resolve_status Orch::resolveFieldRefArray(type_map&, const string&, swss::KeyOpFieldsValuesTuple&, std::vector<long unsigned int>&, std::string&)':
    orch.cpp:609:41: error: 'strlen' argument missing terminating nul [-Werror=stringop-overflow=]
      609 |                     object_name_list += string(&list_item_delimiter);
          |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from orch.cpp:6:
    orch.h:25:12: note: referenced argument declared here
       25 | const char list_item_delimiter = ',';
          |            ^~~~~~~~~~~~~~~~~~~
    cc1plus: all warnings being treated as errors
```

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**

**Details if related**

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012