### PR TITLE
[cfgmgr]: Integrate MACsecMGR with sonic-buildimage

### DIFF
--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -63,7 +63,7 @@ static bool get_value(
     auto value_opt = swss::fvsGetValue(ta, field, true);
     if (!value_opt)
     {
-        SWSS_LOG_WARN("Cannot find field : %s", field.c_str());
+        SWSS_LOG_DEBUG("Cannot find field : %s", field.c_str());
         return false;
     }
 

--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -24,11 +24,10 @@
 using namespace std;
 using namespace swss;
 
-#define WPA_SUPPLICANT_CMD "./wpa_supplicant"
-#define WPA_CLI_CMD        "./wpa_cli"
-#define WPA_CONF           "./wpa.conf"
-// #define SOCK_DIR           "/var/run/macsec/"
-#define SOCK_DIR           "./"
+#define WPA_SUPPLICANT_CMD "/sbin/wpa_supplicant"
+#define WPA_CLI_CMD        "/sbin/wpa_cli"
+#define WPA_CONF           "/etc/wpa_supplicant.conf"
+#define SOCK_DIR           "/var/run/"
 
 constexpr std::uint64_t RETRY_TIME = 30;
 
@@ -68,9 +67,17 @@ static bool get_value(
         return false;
     }
 
-    lexical_convert(*value_opt, value);
+    try
+    {
+        lexical_convert(*value_opt, value);
+    }
+    catch(const boost::bad_lexical_cast &e)
+    {
+        SWSS_LOG_ERROR("Cannot convert value(%s) in field(%s)", value_opt->c_str(), field.c_str());
+        return false;
+    }
 
-    return false;
+    return true;
 }
 
 static void wpa_cli_commands(std::ostringstream & ostream)

--- a/cfgmgr/macsecmgr.h
+++ b/cfgmgr/macsecmgr.h
@@ -27,7 +27,7 @@ public:
     using TaskArgs = std::vector<FieldValueTuple>;
     struct MACsecProfile
     {
-        std::uint8_t        priority;
+        std::uint32_t       priority;
         std::string         cipher_suite;
         std::string         primary_cak;
         std::string         primary_ckn;

--- a/cfgmgr/macsecmgrd.cpp
+++ b/cfgmgr/macsecmgrd.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
 
     try
     {
-        // Logger::linkToDbNative("macsecmgrd");
+        Logger::linkToDbNative("macsecmgrd");
         SWSS_LOG_NOTICE("--- Starting macsecmgrd ---");
 
         swss::DBConnector cfgDb("CONFIG_DB", 0);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Fix bug about the return value of `get_value`, it should return `true` if it's OK
2. Fix bug about the type of `MACsecProfile::priority`, the original `uint8_t` will cause a `lexical_convert` failure when the priority is a integer.
3. Polish log in `get_value`.
4. Change the predefined paths for sonic-buildimage integration

**Why I did it**
I want that the MACsecMgrd can automatically start, so these configuration should be changed to adapt the configuration in sonic-buildimage

**How I verified it**
Change the `/etc/sonic/config_db.json` as follow
```
{
    "PORT": {
        "Ethernet0": {
            ...
            "macsec": "test"
         }
    }
    ...
    "MACSEC_PROFILE": {
        "test": {
            "priority": 64,
            "cipher_suite": "GCM-AES-128",
            "primary_cak": "0123456789ABCDEF0123456789ABCDEF",
            "primary_ckn": "6162636465666768696A6B6C6D6E6F707172737475767778797A303132333435",
            "policy": "security"
        }
    }
}
```
To execute `sudo config reload -y`, We should find the following new items were inserted in app_db of redis
```
127.0.0.1:6379> keys *MAC*
1) "MACSEC_EGRESS_SC_TABLE:Ethernet0:72152375678227538"
2) "MACSEC_PORT_TABLE:Ethernet0"
127.0.0.1:6379> hgetall "MACSEC_EGRESS_SC_TABLE:Ethernet0:72152375678227538"
1) "ssci"
2) ""
3) "encoding_an"
4) "0"
127.0.0.1:6379> hgetall "MACSEC_PORT_TABLE:Ethernet0"
 1) "enable"
 2) "false"
 3) "cipher_suite"
 4) "GCM-AES-128"
 5) "enable_protect"
 6) "true"
 7) "enable_encrypt"
 8) "true"
 9) "enable_replay_protect"
10) "false"
11) "replay_window"
12) "0"

```
**Details if related**
