### PR TITLE
Log level change from ERR to INFO for fetch systemports issue

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4848,7 +4848,7 @@ bool PortsOrch::getSystemPorts()
     status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
-        SWSS_LOG_ERROR("Failed to get number of system ports, rv:%d", status);
+        SWSS_LOG_INFO("Failed to get number of system ports, rv:%d", status);
         return false;
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix: https://github.com/Azure/sonic-buildimage/issues/6727

**Why I did it**
SAI attribute `SAI_SWITCH_ATTR_NUMBER_OF_SYSTEM_PORTS` is not supported on many platforms, and the call to `getSystemPorts()` throws error.
This error is not harmful at this state, and therefore the log level is changed from `ERROR` to `INFO`.

**How I verified it**

**Details if related**
