### PR TITLE
[sub intf] Update vs tests to validate physical port host interface vlan tag attribute

### DIFF
--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -95,10 +95,11 @@ class TestSubPortIntf(object):
         self.config_db.create_entry(CFG_VLAN_SUB_INTF_TABLE_NAME, sub_port_intf_name, fvs)
 
     def add_lag_members(self, lag, members):
-        fvs = {"NULL", "NULL"}
+        fvs = {"NULL": "NULL"}
 
         for member in members:
-            self.config_db.create_entry(CFG_LAG_MEMBER_TABLE_NAME, lag + "|" + member, fvs)
+            key = "{}|{}".format(lag, member)
+            self.config_db.create_entry(CFG_LAG_MEMBER_TABLE_NAME, key, fvs)
 
     def add_sub_port_intf_ip_addr(self, sub_port_intf_name, ip_addr):
         fvs = {"NULL": "NULL"}
@@ -113,7 +114,8 @@ class TestSubPortIntf(object):
 
     def remove_lag_members(self, lag, members):
         for member in members:
-            self.config_db.delete_entry(CFG_LAG_MEMBER_TABLE_NAME, lag + "|" + member)
+            key = "{}|{}".format(lag, member)
+            self.config_db.delete_entry(CFG_LAG_MEMBER_TABLE_NAME, key)
 
     def remove_sub_port_intf_profile(self, sub_port_intf_name):
         self.config_db.delete_entry(CFG_VLAN_SUB_INTF_TABLE_NAME, sub_port_intf_name)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -100,6 +100,7 @@ class TestSubPortIntf(object):
         for member in members:
             key = "{}|{}".format(lag, member)
             self.config_db.create_entry(CFG_LAG_MEMBER_TABLE_NAME, key, fvs)
+        time.sleep(1)
 
     def add_sub_port_intf_ip_addr(self, sub_port_intf_name, ip_addr):
         fvs = {"NULL": "NULL"}
@@ -116,6 +117,7 @@ class TestSubPortIntf(object):
         for member in members:
             key = "{}|{}".format(lag, member)
             self.config_db.delete_entry(CFG_LAG_MEMBER_TABLE_NAME, key)
+        time.sleep(1)
 
     def remove_sub_port_intf_profile(self, sub_port_intf_name):
         self.config_db.delete_entry(CFG_VLAN_SUB_INTF_TABLE_NAME, sub_port_intf_name)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -24,6 +24,7 @@ ASIC_ROUTE_ENTRY_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"
 ASIC_NEXT_HOP_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP"
 ASIC_NEXT_HOP_GROUP_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP"
 ASIC_NEXT_HOP_GROUP_MEMBER_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER"
+ASIC_HOSTIF_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF"
 
 ADMIN_STATUS = "admin_status"
 
@@ -217,6 +218,13 @@ class TestSubPortIntf(object):
         }
         rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
         self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Verify physical port host interface vlan tag attribute
+        fv_dict = {
+            "SAI_HOSTIF_ATTR_VLAN_TAG": "SAI_HOSTIF_VLAN_TAG_KEEP",
+        }
+        hostif_oid = dvs.asicdb.hostifnamemap[parent_port]
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_HOSTIF_TABLE, hostif_oid, fv_dict)
 
         # Remove a sub port interface
         self.remove_sub_port_intf_profile(sub_port_intf_name)
@@ -470,6 +478,13 @@ class TestSubPortIntf(object):
 
         # Verify that sub port router interface entry is removed from ASIC_DB
         self.check_sub_port_intf_key_removal(self.asic_db, ASIC_RIF_TABLE, rif_oid)
+
+        # Verify physical port host interface vlan tag attribute
+        fv_dict = {
+            "SAI_HOSTIF_ATTR_VLAN_TAG": "SAI_HOSTIF_VLAN_TAG_STRIP",
+        }
+        hostif_oid = dvs.asicdb.hostifnamemap[parent_port]
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_HOSTIF_TABLE, hostif_oid, fv_dict)
 
     def test_sub_port_intf_removal(self, dvs):
         self.connect_dbs(dvs)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -25,6 +25,7 @@ ASIC_ROUTE_ENTRY_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"
 ASIC_NEXT_HOP_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP"
 ASIC_NEXT_HOP_GROUP_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP"
 ASIC_NEXT_HOP_GROUP_MEMBER_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER"
+ASIC_LAG_MEMBER_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER"
 ASIC_HOSTIF_TABLE = "ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF"
 
 ADMIN_STATUS = "admin_status"
@@ -100,7 +101,6 @@ class TestSubPortIntf(object):
         for member in members:
             key = "{}|{}".format(lag, member)
             self.config_db.create_entry(CFG_LAG_MEMBER_TABLE_NAME, key, fvs)
-        time.sleep(1)
 
     def add_sub_port_intf_ip_addr(self, sub_port_intf_name, ip_addr):
         fvs = {"NULL": "NULL"}
@@ -117,7 +117,6 @@ class TestSubPortIntf(object):
         for member in members:
             key = "{}|{}".format(lag, member)
             self.config_db.delete_entry(CFG_LAG_MEMBER_TABLE_NAME, key)
-        time.sleep(1)
 
     def remove_sub_port_intf_profile(self, sub_port_intf_name):
         self.config_db.delete_entry(CFG_VLAN_SUB_INTF_TABLE_NAME, sub_port_intf_name)
@@ -215,6 +214,7 @@ class TestSubPortIntf(object):
         # Add lag members to test physical port host interface vlan tag attribute
         if parent_port.startswith(LAG_PREFIX):
             self.add_lag_members(parent_port, self.LAG_MEMBERS_UNDER_TEST)
+            self.asic_db.wait_for_n_keys(ASIC_LAG_MEMBER_TABLE, len(self.LAG_MEMBERS_UNDER_TEST))
         self.create_sub_port_intf_profile(sub_port_intf_name)
 
         # Verify that sub port interface state ok is pushed to STATE_DB by Intfmgrd
@@ -255,6 +255,7 @@ class TestSubPortIntf(object):
         # Remove lag members from lag parent port
         if parent_port.startswith(LAG_PREFIX):
             self.remove_lag_members(parent_port, self.LAG_MEMBERS_UNDER_TEST)
+            self.asic_db.wait_for_n_keys(ASIC_LAG_MEMBER_TABLE, 0)
 
     def test_sub_port_intf_creation(self, dvs):
         self.connect_dbs(dvs)
@@ -473,6 +474,7 @@ class TestSubPortIntf(object):
         # Add lag members to test physical port host interface vlan tag attribute
         if parent_port.startswith(LAG_PREFIX):
             self.add_lag_members(parent_port, self.LAG_MEMBERS_UNDER_TEST)
+            self.asic_db.wait_for_n_keys(ASIC_LAG_MEMBER_TABLE, len(self.LAG_MEMBERS_UNDER_TEST))
         self.create_sub_port_intf_profile(sub_port_intf_name)
 
         self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
@@ -521,6 +523,7 @@ class TestSubPortIntf(object):
         # Remove lag members from lag parent port
         if parent_port.startswith(LAG_PREFIX):
             self.remove_lag_members(parent_port, self.LAG_MEMBERS_UNDER_TEST)
+            self.asic_db.wait_for_n_keys(ASIC_LAG_MEMBER_TABLE, 0)
 
     def test_sub_port_intf_removal(self, dvs):
         self.connect_dbs(dvs)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**
vs test update to cover changes in https://github.com/Azure/sonic-swss/pull/1573

**How I verified it**
vs test:

Without https://github.com/Azure/sonic-swss/pull/1573, vs tests on sub interface creation and removal fail
#### Physical parent port:
##### sub interface creation
```
====================================================================== test session starts ======================================================================
platform linux -- Python 3.6.9, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /var/wendani/src/sonic-buildimage/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 1 item                                                                                                                                                

test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_creation remove extra link PortChannel1
remove extra link dummy
FAILED

=========================================================================== FAILURES ============================================================================
__________________________________________________________ TestSubPortIntf.test_sub_port_intf_creation __________________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7f4e5d63cb00>, dvs = <conftest.DockerVirtualSwitch object at 0x7f4e5d5670f0>

    def test_sub_port_intf_creation(self, dvs):
        self.connect_dbs(dvs)
    
>       self._test_sub_port_intf_creation(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)

test_sub_port_intf.py:258: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_sub_port_intf.py:245: in _test_sub_port_intf_creation
    self.check_sub_port_intf_fvs(self.asic_db, ASIC_HOSTIF_TABLE, hostif_oid, fv_dict)
test_sub_port_intf.py:167: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dvslib.dvs_database.DVSDatabase object at 0x7f4e5d640198>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF', key = 'oid:0xd00000000059e'
expected_fields = {'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_KEEP'}, polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True)
failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_KEEP'}, received={'SAI_HOSTIF_ATTR_TYPE': 'SAI_HOSTIF_TYPE_NETDEV', 'SAI_HOSTIF_ATTR_OBJ_ID': 'oid:0x1000000000012', 'SAI_HOSTIF_ATTR_NAME': 'Ethernet64', 'SAI_HOSTIF_ATTR_OPER_STATUS': 'true'}, key="oid:0xd00000000059e", table="ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF"

dvslib/dvs_database.py:203: AssertionError
==================================================================== short test summary info ====================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_creation - AssertionError: Expected field/value pairs not found: expected={'SAI_HOSTIF_ATTR_...
================================================================= 1 failed in 62.62s (0:01:02) ==================================================================
```

##### sub interface removal
```
====================================================================== test session starts ======================================================================
platform linux -- Python 3.6.9, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /var/wendani/src/sonic-buildimage/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 1 item                                                                                                                                                

test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_removal remove extra link dummy
FAILED

=========================================================================== FAILURES ============================================================================
__________________________________________________________ TestSubPortIntf.test_sub_port_intf_removal ___________________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7f11468beeb8>, dvs = <conftest.DockerVirtualSwitch object at 0x7f11468c80f0>

    def test_sub_port_intf_removal(self, dvs):
        self.connect_dbs(dvs)
    
>       self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)

test_sub_port_intf.py:524: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_sub_port_intf.py:515: in _test_sub_port_intf_removal
    self.check_sub_port_intf_fvs(self.asic_db, ASIC_HOSTIF_TABLE, hostif_oid, fv_dict)
test_sub_port_intf.py:167: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dvslib.dvs_database.DVSDatabase object at 0x7f11468484e0>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF', key = 'oid:0xd00000000059e'
expected_fields = {'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_STRIP'}, polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True)
failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_STRIP'}, received={'SAI_HOSTIF_ATTR_TYPE': 'SAI_HOSTIF_TYPE_NETDEV', 'SAI_HOSTIF_ATTR_OBJ_ID': 'oid:0x1000000000012', 'SAI_HOSTIF_ATTR_NAME': 'Ethernet64', 'SAI_HOSTIF_ATTR_OPER_STATUS': 'true'}, key="oid:0xd00000000059e", table="ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF"

dvslib/dvs_database.py:203: AssertionError
==================================================================== short test summary info ====================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_removal - AssertionError: Expected field/value pairs not found: expected={'SAI_HOSTIF_ATTR_V...
================================================================= 1 failed in 62.89s (0:01:02) ==================================================================
```

#### Lag parent port
##### sub interface creation
```
====================================================================== test session starts ======================================================================
platform linux -- Python 3.6.9, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /var/wendani/src/sonic-buildimage/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 1 item                                                                                                                                                

test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_creation remove extra link PortChannel1
remove extra link dummy
FAILED

=========================================================================== FAILURES ============================================================================
__________________________________________________________ TestSubPortIntf.test_sub_port_intf_creation __________________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7f00297710b8>, dvs = <conftest.DockerVirtualSwitch object at 0x7f00297714a8>

    def test_sub_port_intf_creation(self, dvs):
        self.connect_dbs(dvs)
    
        #self._test_sub_port_intf_creation(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
>       self._test_sub_port_intf_creation(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)

test_sub_port_intf.py:261: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_sub_port_intf.py:247: in _test_sub_port_intf_creation
    self.check_sub_port_intf_fvs(self.asic_db, ASIC_HOSTIF_TABLE, hostif_oid, fv_dict)
test_sub_port_intf.py:169: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dvslib.dvs_database.DVSDatabase object at 0x7f0029858f28>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF', key = 'oid:0xd00000000059d'
expected_fields = {'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_KEEP'}, polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True)
failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_KEEP'}, received={'SAI_HOSTIF_ATTR_TYPE': 'SAI_HOSTIF_TYPE_NETDEV', 'SAI_HOSTIF_ATTR_OBJ_ID': 'oid:0x1000000000013', 'SAI_HOSTIF_ATTR_NAME': 'Ethernet68', 'SAI_HOSTIF_ATTR_OPER_STATUS': 'false'}, key="oid:0xd00000000059d", table="ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF"

dvslib/dvs_database.py:203: AssertionError
==================================================================== short test summary info ====================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_creation - AssertionError: Expected field/value pairs not found: expected={'SAI_HOSTIF_ATTR_...
================================================================= 1 failed in 62.00s (0:01:02) ==================================================================
```

##### sub interface removal
```
====================================================================== test session starts ======================================================================
platform linux -- Python 3.6.9, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /var/wendani/src/sonic-buildimage/src/sonic-swss/tests
plugins: flaky-3.7.0
collected 1 item                                                                                                                                                

test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_removal remove extra link PortChannel1
remove extra link PortChannel1.20@PortChannel1
remove extra link dummy
FAILED

=========================================================================== FAILURES ============================================================================
__________________________________________________________ TestSubPortIntf.test_sub_port_intf_removal ___________________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7f13746c2eb8>, dvs = <conftest.DockerVirtualSwitch object at 0x7f13746b26d8>

    def test_sub_port_intf_removal(self, dvs):
        self.connect_dbs(dvs)
    
        #self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
>       self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)

test_sub_port_intf.py:527: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_sub_port_intf.py:517: in _test_sub_port_intf_removal
    self.check_sub_port_intf_fvs(self.asic_db, ASIC_HOSTIF_TABLE, hostif_oid, fv_dict)
test_sub_port_intf.py:169: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dvslib.dvs_database.DVSDatabase object at 0x7f13745ee6a0>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF', key = 'oid:0xd00000000059d'
expected_fields = {'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_STRIP'}, polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True)
failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'SAI_HOSTIF_ATTR_VLAN_TAG': 'SAI_HOSTIF_VLAN_TAG_STRIP'}, received={'SAI_HOSTIF_ATTR_TYPE': 'SAI_HOSTIF_TYPE_NETDEV', 'SAI_HOSTIF_ATTR_OBJ_ID': 'oid:0x1000000000013', 'SAI_HOSTIF_ATTR_NAME': 'Ethernet68', 'SAI_HOSTIF_ATTR_OPER_STATUS': 'false'}, key="oid:0xd00000000059d", table="ASIC_STATE:SAI_OBJECT_TYPE_HOSTIF"

dvslib/dvs_database.py:203: AssertionError
==================================================================== short test summary info ====================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_removal - AssertionError: Expected field/value pairs not found: expected={'SAI_HOSTIF_ATTR_V...
================================================================= 1 failed in 62.04s (0:01:02) ==================================================================
```

**Details if related**
