### PR TITLE
[bufferorch] Handle NOT IMPLEMENTED status returned during set attr operation

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -372,7 +372,7 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
                     SWSS_LOG_NOTICE("Buffer pool SET for name:%s, sai object:%" PRIx64 ", not implemented. status:%d. Ignoring it", object_name.c_str(), sai_object, sai_status);
                     return task_process_status::task_ignore;
                 }
-		        else if (SAI_STATUS_SUCCESS != sai_status)
+                else if (SAI_STATUS_SUCCESS != sai_status)
                 {
                     SWSS_LOG_ERROR("Failed to modify buffer pool, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
                     return task_process_status::task_failed;

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -367,7 +367,12 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
             for (auto &attribute : attribs)
             {
                 sai_status = sai_buffer_api->set_buffer_pool_attribute(sai_object, &attribute);
-                if (SAI_STATUS_SUCCESS != sai_status)
+                if (SAI_STATUS_ATTR_NOT_IMPLEMENTED_0 == sai_status)
+                {
+                    SWSS_LOG_NOTICE("Buffer pool SET for name:%s, sai object:%" PRIx64 ", not implemented. status:%d. Ignoring it", object_name.c_str(), sai_object, sai_status);
+                    return task_process_status::task_ignore;
+                }
+		        else if (SAI_STATUS_SUCCESS != sai_status)
                 {
                     SWSS_LOG_ERROR("Failed to modify buffer pool, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
                     return task_process_status::task_failed;
@@ -553,7 +558,12 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
             for (auto &attribute : attribs)
             {
                 sai_status = sai_buffer_api->set_buffer_profile_attribute(sai_object, &attribute);
-                if (SAI_STATUS_SUCCESS != sai_status)
+                if (SAI_STATUS_ATTR_NOT_IMPLEMENTED_0 == sai_status)
+                {
+                    SWSS_LOG_NOTICE("Buffer profile SET for name:%s, sai object:%" PRIx64 ", not implemented. status:%d. Ignoring it", object_name.c_str(), sai_object, sai_status);
+                    return task_process_status::task_ignore;
+                }
+                else if (SAI_STATUS_SUCCESS != sai_status)
                 {
                     SWSS_LOG_ERROR("Failed to modify buffer profile, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
                     return task_process_status::task_failed;
@@ -1011,6 +1021,7 @@ void BufferOrch::doTask(Consumer &consumer)
         switch(task_status)
         {
             case task_process_status::task_success :
+            case task_process_status::task_ignore :
                 it = consumer.m_toSync.erase(it);
                 break;
             case task_process_status::task_invalid_entry:


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Set operations for some attributes of buffer pool and buffer profile may not be implemented by some vendors and they return SAI_STATUS_ATTR_NOT_IMPLEMENTED_0. Handle that status in the code and ignore that task

**Why I did it**
Reduce the noise in the logs due to these operations

**How I verified it**
With the code changes in place triggered a warm reboot where these were logged as errors and see them logged as NOTICE
