### PR TITLE
fixed unsupported resource issue

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -439,6 +439,10 @@ void CrmOrch::getResAvailableCounters()
         sai_attribute_t attr;
         attr.id = crmResSaiAvailAttrMap.at(res.first);
 
+        // ignore unsupported resources
+        if (res.second.resStatus != CrmResourceStatus::CRM_RES_SUPPORTED)
+            continue;
+
         switch (attr.id)
         {
             case SAI_SWITCH_ATTR_AVAILABLE_IPV4_ROUTE_ENTRY:
@@ -462,8 +466,8 @@ void CrmOrch::getResAvailableCounters()
                        SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) ||
                        SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status))
                     {
-                        // remove unsupported resources from map
-                        m_resourcesMap.erase(res.first);
+                        // mark unsupported resources
+                        res.second.resStatus = CrmResourceStatus::CRM_RES_NOT_SUPPORTED;
                         SWSS_LOG_NOTICE("Switch attribute %u not supported", attr.id);
                         break;
                     }

--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -436,12 +436,14 @@ void CrmOrch::getResAvailableCounters()
 
     for (auto &res : m_resourcesMap)
     {
-        sai_attribute_t attr;
-        attr.id = crmResSaiAvailAttrMap.at(res.first);
-
         // ignore unsupported resources
         if (res.second.resStatus != CrmResourceStatus::CRM_RES_SUPPORTED)
+        {
             continue;
+        }
+
+        sai_attribute_t attr;
+        attr.id = crmResSaiAvailAttrMap.at(res.first);
 
         switch (attr.id)
         {

--- a/orchagent/crmorch.h
+++ b/orchagent/crmorch.h
@@ -37,6 +37,12 @@ enum class CrmThresholdType
     CRM_FREE,
 };
 
+enum class CrmResourceStatus
+{
+    CRM_RES_SUPPORTED,
+    CRM_RES_NOT_SUPPORTED,
+};
+
 class CrmOrch : public Orch
 {
 public:
@@ -77,6 +83,7 @@ private:
         std::map<std::string, CrmResourceCounter> countersMap;
 
         uint32_t exceededLogCounter = 0;
+        CrmResourceStatus resStatus = CrmResourceStatus::CRM_RES_SUPPORTED;
     };
 
     std::chrono::seconds m_pollingInterval;


### PR DESCRIPTION
Signed-off-by: Prabhu Sreenivasan <prabhu.sreenivasan@broadcom.com>

Fix Azure/sonic-buildimage#6563

**What I did**
Instead of erasing unsupported resource from m_resourcesMap, mark it as unsupported.

**Why I did it**
Erasing an entry while iterating using range based iterator makes the iterator invalid.
Also removing a resource from the m_resourcesMap impacts cross access while iterating other maps (eg crmUsedCntsTableMap).

**How I verified it**
Added a new unsupported resource for testing and verified the logs.

**Details if related**
