### PR TITLE
[acl] Add VLAN bindings to dataplane ACL tables

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1332,7 +1332,7 @@ bool AclTable::create()
     }
     else
     {
-        bpoint_list = { SAI_ACL_BIND_POINT_TYPE_PORT, SAI_ACL_BIND_POINT_TYPE_LAG };
+        bpoint_list = { SAI_ACL_BIND_POINT_TYPE_PORT, SAI_ACL_BIND_POINT_TYPE_LAG, SAI_ACL_BIND_POINT_TYPE_VLAN };
     }
 
     attr.id = SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -104,7 +104,7 @@ namespace aclorch_test
         ASSERT_TRUE(res->ret_val);
 
         auto v = vector<swss::FieldValueTuple>(
-            { { "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST", "2:SAI_ACL_BIND_POINT_TYPE_PORT,SAI_ACL_BIND_POINT_TYPE_LAG" },
+            { { "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST", "3:SAI_ACL_BIND_POINT_TYPE_PORT,SAI_ACL_BIND_POINT_TYPE_LAG,SAI_ACL_BIND_POINT_TYPE_VLAN" },
               { "SAI_ACL_TABLE_ATTR_FIELD_ETHER_TYPE", "true" },
               { "SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE", "true" },
               { "SAI_ACL_TABLE_ATTR_FIELD_IP_PROTOCOL", "true" },
@@ -419,9 +419,8 @@ namespace aclorch_test
         {
             vector<swss::FieldValueTuple> fields;
 
-            fields.push_back({ "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST", "2:SAI_ACL_BIND_POINT_TYPE_PORT,SAI_ACL_BIND_POINT_TYPE_LAG" });
+            fields.push_back({ "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST", "3:SAI_ACL_BIND_POINT_TYPE_PORT,SAI_ACL_BIND_POINT_TYPE_LAG,SAI_ACL_BIND_POINT_TYPE_VLAN" });
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_ACL_IP_TYPE", "true" });
-
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_L4_SRC_PORT", "true" });
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_L4_DST_PORT", "true" });
             fields.push_back({ "SAI_ACL_TABLE_ATTR_FIELD_TCP_FLAGS", "true" });

--- a/tests/test_mirror_ipv6_combined.py
+++ b/tests/test_mirror_ipv6_combined.py
@@ -198,7 +198,7 @@ class TestMirror(object):
                 if key == "SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE":
                     assert set(list_attrs) == set(["SAI_ACL_RANGE_TYPE_L4_DST_PORT_RANGE", "SAI_ACL_RANGE_TYPE_L4_SRC_PORT_RANGE"])
                 elif key == "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST":
-                    assert set(list_attrs) == set(["SAI_ACL_BIND_POINT_TYPE_PORT", "SAI_ACL_BIND_POINT_TYPE_LAG"])
+                    assert set(list_attrs) == set(["SAI_ACL_BIND_POINT_TYPE_PORT", "SAI_ACL_BIND_POINT_TYPE_LAG", "SAI_ACL_BIND_POINT_TYPE_VLAN"])
                 else:
                     print("Encountered unexpected range attribute on mirror table: {}".format(key))
                     assert False

--- a/tests/test_mirror_ipv6_separate.py
+++ b/tests/test_mirror_ipv6_separate.py
@@ -191,7 +191,7 @@ class TestMirror(object):
                 if key == "SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE":
                     assert set(list_attrs) == set(["SAI_ACL_RANGE_TYPE_L4_DST_PORT_RANGE", "SAI_ACL_RANGE_TYPE_L4_SRC_PORT_RANGE"])
                 elif key == "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST":
-                    assert set(list_attrs) == set(["SAI_ACL_BIND_POINT_TYPE_PORT", "SAI_ACL_BIND_POINT_TYPE_LAG"])
+                    assert set(list_attrs) == set(["SAI_ACL_BIND_POINT_TYPE_PORT", "SAI_ACL_BIND_POINT_TYPE_LAG", "SAI_ACL_BIND_POINT_TYPE_VLAN"])
                 else:
                     print("Encountered unexpected range attribute on mirror table: {}".format(key))
                     assert False
@@ -256,7 +256,7 @@ class TestMirror(object):
                 if key == "SAI_ACL_TABLE_ATTR_FIELD_ACL_RANGE_TYPE":
                     assert set(list_attrs) == set(["SAI_ACL_RANGE_TYPE_L4_DST_PORT_RANGE", "SAI_ACL_RANGE_TYPE_L4_SRC_PORT_RANGE"])
                 elif key == "SAI_ACL_TABLE_ATTR_ACL_BIND_POINT_TYPE_LIST":
-                    assert set(list_attrs) == set(["SAI_ACL_BIND_POINT_TYPE_PORT", "SAI_ACL_BIND_POINT_TYPE_LAG"])
+                    assert set(list_attrs) == set(["SAI_ACL_BIND_POINT_TYPE_PORT", "SAI_ACL_BIND_POINT_TYPE_LAG", "SAI_ACL_BIND_POINT_TYPE_VLAN"])
                 else:
                     print("Encountered unexpected range attribute on mirror table: {}".format(key))
                     assert False


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I added the VLAN bind option to ACL tables.

**Why I did it**
So that ACLs can be bound to VLAN ports.

**How I verified it**
Updated tests. Also validating locally.

**Details if related**
