### PR TITLE
[201911] [bufferorch] Skip setting not implemented brcm attr in buffer profile

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -395,6 +395,8 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
     string map_type_name = consumer.getTableName();
     string object_name = kfvKey(tuple);
     string op = kfvOp(tuple);
+    auto platform_env_var = getenv("platform");
+    string platform = platform_env_var ? platform_env_var: "";
 
     SWSS_LOG_DEBUG("object name:%s", object_name.c_str());
     if (m_buffer_type_maps[map_type_name]->find(object_name) != m_buffer_type_maps[map_type_name]->end())
@@ -509,6 +511,11 @@ task_process_status BufferOrch::processBufferProfile(Consumer &consumer)
             SWSS_LOG_DEBUG("Modifying existing sai object:%" PRIx64, sai_object);
             for (auto &attribute : attribs)
             {
+                if ((platform == BRCM_PLATFORM_SUBSTRING) && (attribute.id != SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH))
+                {
+                    continue;
+                }
+
                 sai_status = sai_buffer_api->set_buffer_profile_attribute(sai_object, &attribute);
                 if (SAI_STATUS_SUCCESS != sai_status)
                 {


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Used the platform string to skip the SET operation for buffer profile attributes that are not implemented in Broadcom platform

**Why I did it**
SET operations for some of the buffer profile attributes are not implemented on Broadcom platforms which leads to an orchagent crash when those attributes are pushed down

**How I verified it**
Changed the dynamic threshold setting for one of the buffer profiles using "mmuconfig" command. Verified from the sairedis.rec, only dynamic threshold value was seen for Broadcom and all the buffer profile attributes were seen 
 for Mellanox

