### PR TITLE
[intfsorch] Create subport with the entry contains necessary attributes

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -588,8 +588,8 @@ void IntfsOrch::doTask(Consumer &consumer)
         string vrf_name = "", vnet_name = "", nat_zone = "";
         MacAddress mac;
 
-        uint32_t mtu;
-        bool adminUp;
+        uint32_t mtu = 0;
+        bool adminUp = false;
         uint32_t nat_zone_id = 0;
         string proxy_arp = "";
         string inband_type = "";
@@ -742,7 +742,7 @@ void IntfsOrch::doTask(Consumer &consumer)
             Port port;
             if (!gPortsOrch->getPort(alias, port))
             {
-                if (isSubIntf)
+                if (!ip_prefix_in_key && isSubIntf)
                 {
                     if (!gPortsOrch->addSubPort(port, alias, adminUp, mtu))
                     {


### PR DESCRIPTION
redis APPL_DB has two entries for subport
8) "INTF_TABLE:Ethernet4.20"
9) "INTF_TABLE:Ethernet4.20:192.169.1.1/24"

sometimes, if the entry with ip key are execute first,
the syslog is like
Feb 23 02:20:43.650184 as7726-32x-3 NOTICE swss#orchagent: :- addRouterIntfs: Create router interface Ethernet4.20 MTU 32761
Feb 23 02:20:43.651383 as7726-32x-3 ERR syncd#syncd:[none] brcm_sai_create_router_interface:284 Invalid MTU size

the mtu value is not init and is too large. sai will return SAI_STATUS_INVALID_PARAMETER

Thus, mtu should be initialized to 0

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
initialize mtu to 0
**Why I did it**
sometimes gPortsOrch->addSubPort(port, alias, adminUp, mtu) is called and 
the mtu value is not init and is too large. sai will return SAI_STATUS_INVALID_PARAMETER

Thus, mtu should be initialized to 0

**How I verified it**
create/remove subport interface many times

**Details if related**
