### PR TITLE
[Dynamic buffer calc] Bug fix: Remove PGs from an administratively down port.

### DIFF
--- a/cfgmgr/buffer_pool_mellanox.lua
+++ b/cfgmgr/buffer_pool_mellanox.lua
@@ -12,7 +12,7 @@ local lossypg_400g = 0
 local result = {}
 local profiles = {}
 
-local count_up_port = 0
+local total_port = 0
 
 local mgmt_pool_size = 256 * 1024
 local egress_mirror_headroom = 10 * 1024
@@ -30,40 +30,28 @@ end
 
 local function iterate_all_items(all_items)
     table.sort(all_items)
-    local prev_port = "None"
     local port
-    local is_up
     local fvpairs
-    local status
-    local admin_down_ports = 0
     for i = 1, #all_items, 1 do
-        -- Check whether the port on which pg or tc hosts is admin down
+        -- Count the number of priorities or queues in each BUFFER_PG or BUFFER_QUEUE item
+        -- For example, there are:
+        --     3 queues in 'BUFFER_QUEUE_TABLE:Ethernet0:0-2'
+        --     2 priorities in 'BUFFER_PG_TABLE:Ethernet0:3-4'
         port = string.match(all_items[i], "Ethernet%d+")
         if port ~= nil then
-            if prev_port ~= port then
-                status = redis.call('HGET', 'PORT_TABLE:'..port, 'admin_status')
-                prev_port = port
-                if status == "down" then
-                    is_up = false
-                else
-                    is_up = true
-                end
+            local range = string.match(all_items[i], "Ethernet%d+:([^%s]+)$")
+            local profile = redis.call('HGET', all_items[i], 'profile')
+            local index = find_profile(profile)
+            local size
+            if string.len(range) == 1 then
+                size = 1
+            else
+                size = 1 + tonumber(string.sub(range, -1)) - tonumber(string.sub(range, 1, 1))
             end
-            if is_up == true then
-                local range = string.match(all_items[i], "Ethernet%d+:([^%s]+)$")
-                local profile = redis.call('HGET', all_items[i], 'profile')
-                local index = find_profile(profile)
-                local size
-                if string.len(range) == 1 then
-                    size = 1
-                else
-                    size = 1 + tonumber(string.sub(range, -1)) - tonumber(string.sub(range, 1, 1))
-                end
-                profiles[index][2] = profiles[index][2] + size
-                local speed = redis.call('HGET', 'PORT_TABLE:'..port, 'speed')
-                if speed == '400000' and profile == '[BUFFER_PROFILE_TABLE:ingress_lossy_profile]' then
-                    lossypg_400g = lossypg_400g + size
-                end
+            profiles[index][2] = profiles[index][2] + size
+            local speed = redis.call('HGET', 'PORT_TABLE:'..port, 'speed')
+            if speed == '400000' and profile == '[BUFFER_PROFILE_TABLE:ingress_lossy_profile]' then
+                lossypg_400g = lossypg_400g + size
             end
         end
     end
@@ -74,12 +62,7 @@ redis.call('SELECT', config_db)
 
 local ports_table = redis.call('KEYS', 'PORT|*')
 
-for i = 1, #ports_table do
-    local status = redis.call('HGET', ports_table[i], 'admin_status')
-    if status == "up" then
-        count_up_port = count_up_port + 1
-    end
-end
+total_port = #ports_table
 
 local egress_lossless_pool_size = redis.call('HGET', 'BUFFER_POOL|egress_lossless_pool', 'size')
 
@@ -130,7 +113,7 @@ for i = 1, #profiles, 1 do
                 size = size + lossypg_reserved
             end
             if profiles[i][1] == "BUFFER_PROFILE_TABLE:egress_lossy_profile" then
-                profiles[i][2] = count_up_port
+                profiles[i][2] = total_port
             end
             if size ~= 0 then
                 if shp_enabled and shp_size == 0 then
@@ -152,7 +135,7 @@ local lossypg_extra_for_400g = (lossypg_reserved_400g - lossypg_reserved) * loss
 accumulative_occupied_buffer = accumulative_occupied_buffer + lossypg_extra_for_400g
 
 -- Accumulate sizes for egress mirror and management pool
-local accumulative_egress_mirror_overhead = count_up_port * egress_mirror_headroom
+local accumulative_egress_mirror_overhead = total_port * egress_mirror_headroom
 accumulative_occupied_buffer = accumulative_occupied_buffer + accumulative_egress_mirror_overhead + mgmt_pool_size
 
 -- Fetch mmu_size
@@ -240,5 +223,6 @@ table.insert(result, "debug:egress_mirror:" .. accumulative_egress_mirror_overhe
 table.insert(result, "debug:shp_enabled:" .. tostring(shp_enabled))
 table.insert(result, "debug:shp_size:" .. shp_size)
 table.insert(result, "debug:accumulative xoff:" .. accumulative_xoff)
+table.insert(result, "debug:total port:" .. total_port)
 
 return result

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1472,8 +1472,8 @@ task_process_status BufferMgrDynamic::handleBufferProfileTable(KeyOpFieldsValues
         }
         for (auto i = kfvFieldsValues(tuple).begin(); i != kfvFieldsValues(tuple).end(); i++)
         {
-            string &field = fvField(*i);
-            string &value = fvValue(*i);
+            const string &field = fvField(*i);
+            string value = fvValue(*i);
 
             SWSS_LOG_DEBUG("field:%s, value:%s", field.c_str(), value.c_str());
             if (field == buffer_pool_field_name)

--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -1794,6 +1794,13 @@ task_process_status BufferMgrDynamic::handleOneBufferPgEntry(const string &key, 
                 bufferPg.static_configured = true;
                 bufferPg.configured_profile_name = profileName;
             }
+
+            if (field != buffer_profile_field_name)
+            {
+                SWSS_LOG_ERROR("BUFFER_PG: Invalid field %s", field.c_str());
+                return task_process_status::task_invalid_entry;
+            }
+
             fvVector.emplace_back(field, value);
             SWSS_LOG_INFO("Inserting BUFFER_PG table field %s value %s", field.c_str(), value.c_str());
         }

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -236,8 +236,8 @@ private:
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
 
     // Main flows
-    task_process_status removeAllPGsFromPort(const std::string &port);
-    task_process_status refreshPriorityGroupsForPort(const std::string &port, const std::string &speed, const std::string &cable_length, const std::string &mtu, const std::string &exactly_matched_key);
+    task_process_status removeAllPgsFromPort(const std::string &port);
+    task_process_status refreshPgsForPort(const std::string &port, const std::string &speed, const std::string &cable_length, const std::string &mtu, const std::string &exactly_matched_key);
     task_process_status doUpdatePgTask(const std::string &pg_key, const std::string &port);
     task_process_status doRemovePgTask(const std::string &pg_key, const std::string &port);
     task_process_status doAdminStatusTask(const std::string port, const std::string adminStatus);

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -82,7 +82,9 @@ typedef enum {
     // Port is under initializing, which means its info hasn't been comprehensive for calculating headroom
     PORT_INITIALIZING,
     // All necessary information for calculating headroom is ready
-    PORT_READY
+    PORT_READY,
+    // Port is admin down. All PGs programmed to APPL_DB should be removed from the port
+    PORT_ADMIN_DOWN
 } port_state_t;
 
 typedef struct {
@@ -234,6 +236,7 @@ private:
     void refreshSharedHeadroomPool(bool enable_state_updated_by_ratio, bool enable_state_updated_by_size);
 
     // Main flows
+    task_process_status removeAllPGsFromPort(const std::string &port);
     task_process_status refreshPriorityGroupsForPort(const std::string &port, const std::string &speed, const std::string &cable_length, const std::string &mtu, const std::string &exactly_matched_key);
     task_process_status doUpdatePgTask(const std::string &pg_key, const std::string &port);
     task_process_status doRemovePgTask(const std::string &pg_key, const std::string &port);

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -102,10 +102,17 @@ class TestBufferMgrDyn(object):
                     self.ingress_lossless_pool_oid = key
 
     def check_new_profile_in_asic_db(self, dvs, profile):
-        diff = set(self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE")) - self.initProfileSet
-        if len(diff) == 1:
-            self.newProfileInAsicDb = diff.pop()
-        assert self.newProfileInAsicDb, "Can't get SAI OID for newly created profile {}".format(profile)
+        retry_count = 0
+        self.newProfileInAsicDb = None
+        while retry_count < 5:
+            retry_count += 1
+            diff = set(self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE")) - self.initProfileSet
+            if len(diff) == 1:
+                self.newProfileInAsicDb = diff.pop()
+                break
+            else:
+                time.sleep(1)
+        assert self.newProfileInAsicDb, "Can't get SAI OID for newly created profile {} after retry {} times".format(profile, retry_count)
 
         # in case diff is empty, we just treat the newProfileInAsicDb cached the latest one
         fvs = self.app_db.get_entry("BUFFER_PROFILE_TABLE", profile)

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -141,7 +141,10 @@ class TestBufferMgrDyn(object):
     def test_changeSpeed(self, dvs, testlog):
         self.setup_db(dvs)
 
-        # configure lossless PG 3-4 on interface
+        # Startup interface
+        dvs.runcmd('config interface startup Ethernet0')
+
+        # Configure lossless PG 3-4 on interface
         self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'NULL'})
 
         # Change speed to speed1 and verify whether the profile has been updated
@@ -179,14 +182,20 @@ class TestBufferMgrDyn(object):
         self.check_new_profile_in_asic_db(dvs, expectedProfile)
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
 
-        # remove lossless PG 3-4 on interface
+        # Remove lossless PG 3-4 on interface
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
         self.app_db.wait_for_deleted_entry("BUFFER_PG_TABLE", "Ethernet0:3-4")
+
+        # Shutdown interface
+        dvs.runcmd('config interface shutdown Ethernet0')
 
     def test_changeCableLen(self, dvs, testlog):
         self.setup_db(dvs)
 
-        # configure lossless PG 3-4 on interface
+        # Startup interface
+        dvs.runcmd('config interface startup Ethernet0')
+
+        # Configure lossless PG 3-4 on interface
         self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'NULL'})
 
         # Change to new cable length
@@ -224,13 +233,19 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_entry("BUFFER_PROFILE_TABLE", expectedProfile)
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
 
-        # remove lossless PG 3-4 on interface
+        # Remove lossless PG 3-4 on interface
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
+
+        # Shutdown interface
+        dvs.runcmd('config interface shutdown Ethernet0')
 
     def test_MultipleLosslessPg(self, dvs, testlog):
         self.setup_db(dvs)
 
-        # configure lossless PG 3-4 on interface
+        # Startup interface
+        dvs.runcmd('config interface startup Ethernet0')
+
+        # Configure lossless PG 3-4 on interface
         self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'NULL'})
 
         # Add another lossless PG
@@ -238,14 +253,14 @@ class TestBufferMgrDyn(object):
         expectedProfile = self.make_lossless_profile_name(self.originalSpeed, self.originalCableLen)
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
 
-        # change speed and check
+        # Change speed and check
         dvs.runcmd("config interface speed Ethernet0 " + self.speedToTest1)
         expectedProfile = self.make_lossless_profile_name(self.speedToTest1, self.originalCableLen)
         self.app_db.wait_for_entry("BUFFER_PROFILE_TABLE", expectedProfile)
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
 
-        # change cable length and check
+        # Change cable length and check
         self.change_cable_length(self.cableLenTest1)
         self.app_db.wait_for_deleted_entry("BUFFER_PROFILE_TABLE", expectedProfile)
         expectedProfile = self.make_lossless_profile_name(self.speedToTest1, self.cableLenTest1)
@@ -254,7 +269,7 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
 
-        # revert the speed and cable length and check
+        # Revert the speed and cable length and check
         self.change_cable_length(self.originalCableLen)
         dvs.runcmd("config interface speed Ethernet0 " + self.originalSpeed)
         self.app_db.wait_for_deleted_entry("BUFFER_PROFILE_TABLE", expectedProfile)
@@ -264,12 +279,18 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
 
-        # remove lossless PG 3-4 and 6 on interface
+        # Remove lossless PG 3-4 and 6 on interface
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|6')
 
+        # Shutdown interface
+        dvs.runcmd('config interface shutdown Ethernet0')
+
     def test_headroomOverride(self, dvs, testlog):
         self.setup_db(dvs)
+
+        # Startup interface
+        dvs.runcmd('config interface startup Ethernet0')
 
         # Configure static profile
         self.config_db.update_entry('BUFFER_PROFILE', 'test',
@@ -345,8 +366,14 @@ class TestBufferMgrDyn(object):
         # remove lossless PG 3-4 on interface
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
 
+        # Shutdown interface
+        dvs.runcmd('config interface shutdown Ethernet0')
+
     def test_mtuUpdate(self, dvs, testlog):
         self.setup_db(dvs)
+
+        # Startup interface
+        dvs.runcmd('config interface startup Ethernet0')
 
         test_mtu = '1500'
         default_mtu = '9100'
@@ -373,8 +400,14 @@ class TestBufferMgrDyn(object):
         # clear configuration
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
 
+        # Shutdown interface
+        dvs.runcmd('config interface shutdown Ethernet0')
+
     def test_nonDefaultAlpha(self, dvs, testlog):
         self.setup_db(dvs)
+
+        # Startup interface
+        dvs.runcmd('config interface startup Ethernet0')
 
         test_dynamic_th_1 = '1'
         expectedProfile_th1 = self.make_lossless_profile_name(self.originalSpeed, self.originalCableLen, dynamic_th = test_dynamic_th_1)
@@ -409,12 +442,17 @@ class TestBufferMgrDyn(object):
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
         self.config_db.delete_entry('BUFFER_PROFILE', 'non-default-dynamic')
 
+        # Shutdown interface
+        dvs.runcmd('config interface shutdown Ethernet0')
+
     def test_sharedHeadroomPool(self, dvs, testlog):
         self.setup_db(dvs)
 
+        # Startup interface
+        dvs.runcmd('config interface startup Ethernet0')
+
         # configure lossless PG 3-4 on interface and start up the interface
         self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'NULL'})
-        dvs.runcmd('config interface startup Ethernet0')
 
         expectedProfile = self.make_lossless_profile_name(self.originalSpeed, self.originalCableLen)
         self.app_db.wait_for_entry("BUFFER_PROFILE_TABLE", expectedProfile)
@@ -500,3 +538,37 @@ class TestBufferMgrDyn(object):
         # remove lossless PG 3-4 on interface
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
         dvs.runcmd('config interface shutdown Ethernet0')
+
+        # Shutdown interface
+        dvs.runcmd('config interface shutdown Ethernet0')
+
+    def test_shutdownPort(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        # Startup interface
+        dvs.runcmd('config interface startup Ethernet0')
+
+        # Configure lossless PG 3-4 on interface
+        self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'NULL'})
+        expectedProfile = self.make_lossless_profile_name(self.originalSpeed, self.originalCableLen)
+        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
+
+        # Shutdown port and check whether all the PGs have been removed
+        dvs.runcmd("config interface shutdown Ethernet0")
+        self.app_db.wait_for_deleted_entry("BUFFER_PG_TABLE", "Ethernet0:3-4")
+        self.app_db.wait_for_deleted_entry("BUFFER_PROFILE", expectedProfile)
+
+        # Add another PG when port is administratively down
+        self.config_db.update_entry('BUFFER_PG', 'Ethernet0|6', {'profile': 'NULL'})
+
+        # Startup port and check whether all the PGs haved been added
+        dvs.runcmd("config interface startup Ethernet0")
+        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
+        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
+
+        # Remove lossless PG 3-4 on interface
+        self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')
+        self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|6')
+
+        # Shutdown interface
+        dvs.runcmd("config interface shutdown Ethernet0")

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -349,7 +349,7 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_deleted_entry("BUFFER_PG_TABLE", "Ethernet0:6")
 
         # readd lossless PG with dynamic profile
-        self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profie': 'NULL'})
+        self.config_db.update_entry('BUFFER_PG', 'Ethernet0|3-4', {'profile': 'NULL'})
         self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:" + expectedProfile + "]"})
 
         # remove the headroom override profile


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Bug fixes: Remove PGs from an administratively down port.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
To fix bugs

**How I verified it**
Run regression and vs test

**Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012

**Details if related**
- Remove PGs from an administratively down port.
  - Introduce a new state: `PORT_ADMIN_DOWN` which represents the port is administratively down.
  - Remove all PGs when the port is shut down and re-add all configured PGs when port is started up
  - Only record the new value but don't touch `BUFFER_PG_TABLE` if the following events come when a port is administratively down
    - a port's MTU, speed, or cable length is updated
    - a new PG is added to a port or an existing PG is removed from a port
  - Optimize the port event handling flow since `refreshPriorityGroupsForPort` should be called only once in case more than one fields are updated
  - Optimize the Lua plugin which calculates the buffer pool size accordingly
