### PR TITLE
[ci] Purge installed swss before installing one

### DIFF
--- a/.azure-pipelines/docker-sonic-vs/Dockerfile
+++ b/.azure-pipelines/docker-sonic-vs/Dockerfile
@@ -13,4 +13,5 @@ RUN dpkg -i /debs/libsairedis_1.0.0_amd64.deb
 RUN dpkg -i /debs/libsaivs_1.0.0_amd64.deb
 RUN dpkg -i /debs/syncd-vs_1.0.0_amd64.deb
 
+RUN dpkg --purge swss
 RUN dpkg -i /debs/swss_1.0.0_amd64.deb


### PR DESCRIPTION
Signed-off-by: Wenda Ni <wonda.ni@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**
Observe persistent failure of newly added vs test on testing code change in intfmgrd after migrating to azure pipeline. https://github.com/Azure/sonic-swss/pull/1521 passed in legacy Jenkins pipeline.


What we found is that the code change in the swss compiled with PR change is not properly installed in vs docker for a direct installation using `dpkg -i`. This is confirmed by verifying pipeline artifacts that md5sum value of `/user/bin/intfmgrd` changes if we install swss deb aritfact into the docker vs artifact, while that of `/usr/bin/orchangent` stays unchanged.  

md5sum before swss install in vs docker
```
# md5sum /usr/bin/orchagent
28307a7805ea6f3bc5057c0257bf46e6  /usr/bin/orchagent
 
# md5sum /usr/bin/intfmgrd  
fa2b06e20be683286adb47c55635a86d  /usr/bin/intfmgrd
```

md5sum after swss install
```
# dpkg -i swss_1.0.0_amd64.deb 
(Reading database ... 19180 files and directories currently installed.)
Preparing to unpack swss_1.0.0_amd64.deb ...
Unpacking swss (1.0.0) over (1.0.0) ...
Setting up swss (1.0.0) ...
# md5sum /usr/bin/orchagent
28307a7805ea6f3bc5057c0257bf46e6  /usr/bin/orchagent

# md5sum /usr/bin/intfmgrd 
e959340709e7aedd7489e69dfd19768f  /usr/bin/intfmgrd
```

**How I verified it**
pipeline vs test https://github.com/Azure/sonic-swss/pull/1521

**Details if related**

Acknowledgement to Danny, Guohan, Qi for advice.