### PR TITLE
NAT : Update the CRM used counters for SNAT and DNAT entries

### DIFF
--- a/orchagent/natorch.cpp
+++ b/orchagent/natorch.cpp
@@ -26,7 +26,9 @@
 #include "natorch.h"
 #include "notifier.h"
 #include "sai_serialize.h"
+#include "crmorch.h"
 
+extern CrmOrch            *gCrmOrch;
 extern PortsOrch          *gPortsOrch;
 extern sai_object_id_t     gSwitchId;
 extern sai_switch_api_t   *sai_switch_api;
@@ -786,6 +788,7 @@ bool NatOrch::addHwDnatEntry(const IpAddress &ip_address)
 
     updateNatCounters(ip_address, 0, 0);
     m_natEntries[ip_address].addedToHw = true; 
+    gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_DNAT_ENTRY);
 
     if (entry.entry_type == "static")
     {
@@ -868,6 +871,7 @@ bool NatOrch::addHwDnaptEntry(const NaptEntryKey &key)
 
     m_naptEntries[key].addedToHw = true;
     updateNaptCounters(key.prototype.c_str(), key.ip_address, key.l4_port, 0, 0);
+    gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_DNAT_ENTRY);
 
     if (entry.entry_type == "static")
     {
@@ -935,6 +939,7 @@ bool NatOrch::removeHwDnatEntry(const IpAddress &dstIp)
                     entry.entry_type.c_str(), dstIp.to_string().c_str(), entry.translated_ip.to_string().c_str());
   
     deleteNatCounters(dstIp);
+    gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_DNAT_ENTRY);
 
     if (entry.entry_type == "static")
     {
@@ -1118,6 +1123,7 @@ bool NatOrch::removeHwDnaptEntry(const NaptEntryKey &key)
                     entry.translated_ip.to_string().c_str(), entry.translated_l4_port);
 
     deleteNaptCounters(key.prototype.c_str(), key.ip_address, key.l4_port);
+    gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_DNAT_ENTRY);
 
     if (entry.entry_type == "static")
     {
@@ -1308,6 +1314,7 @@ bool NatOrch::addHwSnatEntry(const IpAddress &ip_address)
     updateNatCounters(ip_address, 0, 0);
     m_natEntries[ip_address].addedToHw = true;
     m_natEntries[ip_address].activeTime = time_now.tv_sec;
+    gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_SNAT_ENTRY);
 
     if (entry.entry_type == "static")
     {
@@ -1478,6 +1485,7 @@ bool NatOrch::addHwSnaptEntry(const NaptEntryKey &keyEntry)
      m_naptEntries[keyEntry].activeTime = time_now.tv_sec;
 
      updateNaptCounters(keyEntry.prototype.c_str(), keyEntry.ip_address, keyEntry.l4_port, 0, 0);
+     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_SNAT_ENTRY);
 
      if (entry.entry_type == "static")
      {
@@ -1630,6 +1638,7 @@ bool NatOrch::removeHwSnatEntry(const IpAddress &ip_address)
     }
     deleteNatCounters(ip_address);
     m_natEntries.erase(ip_address);
+    gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_SNAT_ENTRY);
 
     if (entry.entry_type == "static")
     {
@@ -1720,6 +1729,7 @@ bool NatOrch::removeHwSnaptEntry(const NaptEntryKey &keyEntry)
     }
     deleteNaptCounters(keyEntry.prototype.c_str(), keyEntry.ip_address, keyEntry.l4_port);
     m_naptEntries.erase(keyEntry);
+    gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_SNAT_ENTRY);
 
     if (entry.entry_type == "static")
     {

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -12,7 +12,6 @@ class TestNat(object):
         self.app_db = dvs.get_app_db()
         self.asic_db = dvs.get_asic_db()
         self.config_db = dvs.get_config_db()
-        self.counters_db = dvs.get_counters_db()
 
     def set_interfaces(self, dvs):
         fvs = {"NULL": "NULL"}
@@ -42,16 +41,6 @@ class TestNat(object):
         dvs.servers[1].runcmd("ifconfig eth0 0.0.0.0")
 
         time.sleep(1)
-
-    def getCrmCounterValue(self, dvs, counter):
-
-        crmStatsTable = self.counters_db.get_entry("CRM", "STATS")
-
-        if counter in crmStatsTable.keys():
-            value = crmStatsTable[counter]
-            return int(value)
-
-        return 0
 
     def test_NatGlobalTable(self, dvs, testlog):
         # initialize
@@ -377,12 +366,12 @@ class TestNat(object):
         time.sleep(2)
 
         # get snat counters
-        used_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_used')
-        avail_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_available')
+        used_snat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_snat_entry_used')
+        avail_snat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_snat_entry_available')
 
         # get dnat counters
-        used_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_used')
-        avail_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_available')
+        used_dnat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_dnat_entry_used')
+        avail_dnat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_dnat_entry_available')
 
         # add a static nat entry
         dvs.runcmd("config nat add static basic 67.66.65.1 18.18.18.2")
@@ -401,17 +390,17 @@ class TestNat(object):
         time.sleep(2)
 
         # get snat counters
-        new_used_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_used')
-        new_avail_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_available')
+        new_used_snat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_snat_entry_used')
+        new_avail_snat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_snat_entry_available')
 
         # get dnat counters
-        new_used_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_used')
-        new_avail_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_available')
+        new_used_dnat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_dnat_entry_used')
+        new_avail_dnat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_dnat_entry_available')
 
         assert new_used_snat_counter - used_snat_counter == 1
-        assert new_avail_snat_counter - avail_snat_counter == 1
+        assert avail_snat_counter - new_avail_snat_counter == 1
         assert new_used_dnat_counter - used_dnat_counter == 1
-        assert new_avail_dnat_counter - avail_dnat_counter == 1
+        assert avail_dnat_counter - new_avail_dnat_counter == 1
 
         # delete a static nat entry
         dvs.runcmd("config nat remove static basic 67.66.65.1 18.18.18.2")
@@ -422,12 +411,12 @@ class TestNat(object):
         time.sleep(2)
 
         # get snat counters
-        new_used_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_used')
-        new_avail_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_available')
+        new_used_snat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_snat_entry_used')
+        new_avail_snat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_snat_entry_available')
 
         # get dnat counters
-        new_used_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_used')
-        new_avail_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_available')
+        new_used_dnat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_dnat_entry_used')
+        new_avail_dnat_counter = dvs.getCrmCounterValue('STATS', 'crm_stats_dnat_entry_available')
 
         assert new_used_snat_counter == used_snat_counter
         assert new_avail_snat_counter == avail_snat_counter

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -7,24 +7,12 @@ L3_TABLE_NAME = "L3_TEST"
 L3_BIND_PORTS = ["Ethernet0"]
 L3_RULE_NAME = "L3_TEST_RULE"
 
-from swsscommon import swsscommon
-
-def getCrmCounterValue(dvs, key, counter):
-
-    counters_db = swsscommon.DBConnector(swsscommon.COUNTERS_DB, dvs.redis_sock, 0)
-    crm_stats_table = swsscommon.Table(counters_db, 'CRM')
-
-    for k in crm_stats_table.get(key)[1]:
-        if k[0] == counter:
-            return int(k[1])
-
-    return 0
-
 class TestNat(object):
     def setup_db(self, dvs):
         self.app_db = dvs.get_app_db()
         self.asic_db = dvs.get_asic_db()
         self.config_db = dvs.get_config_db()
+        self.counters_db = dvs.get_counters_db()
 
     def set_interfaces(self, dvs):
         fvs = {"NULL": "NULL"}
@@ -54,6 +42,16 @@ class TestNat(object):
         dvs.servers[1].runcmd("ifconfig eth0 0.0.0.0")
 
         time.sleep(1)
+
+    def getCrmCounterValue(self, dvs, counter):
+
+        crmStatsTable = self.counters_db.get_entry("CRM", "STATS")
+
+        if counter in crmStatsTable.keys():
+            value = crmStatsTable[counter]
+            return int(value)
+
+        return 0
 
     def test_NatGlobalTable(self, dvs, testlog):
         # initialize
@@ -379,12 +377,12 @@ class TestNat(object):
         time.sleep(2)
 
         # get snat counters
-        used_snat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_snat_entry_used')
-        avail_snat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_snat_entry_available')
+        used_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_used')
+        avail_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_available')
 
         # get dnat counters
-        used_dnat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_dnat_entry_used')
-        avail_dnat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_dnat_entry_available')
+        used_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_used')
+        avail_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_available')
 
         # add a static nat entry
         dvs.runcmd("config nat add static basic 67.66.65.1 18.18.18.2")
@@ -403,12 +401,12 @@ class TestNat(object):
         time.sleep(2)
 
         # get snat counters
-        new_used_snat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_snat_entry_used')
-        new_avail_snat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_snat_entry_available')
+        new_used_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_used')
+        new_avail_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_available')
 
         # get dnat counters
-        new_used_dnat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_dnat_entry_used')
-        new_avail_dnat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_dnat_entry_available')
+        new_used_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_used')
+        new_avail_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_available')
 
         assert new_used_snat_counter - used_snat_counter == 1
         assert new_avail_snat_counter - avail_snat_counter == 1
@@ -424,12 +422,12 @@ class TestNat(object):
         time.sleep(2)
 
         # get snat counters
-        new_used_snat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_snat_entry_used')
-        new_avail_snat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_snat_entry_available')
+        new_used_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_used')
+        new_avail_snat_counter = getCrmCounterValue(dvs, 'crm_stats_snat_entry_available')
 
         # get dnat counters
-        new_used_dnat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_dnat_entry_used')
-        new_avail_dnat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_dnat_entry_available')
+        new_used_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_used')
+        new_avail_dnat_counter = getCrmCounterValue(dvs, 'crm_stats_dnat_entry_available')
 
         assert new_used_snat_counter == used_snat_counter
         assert new_avail_snat_counter == avail_snat_counter

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -300,9 +300,6 @@ class TestNat(object):
         #check the entry is not there in asic db
         self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 0)
 
-        # clear interfaces
-        self.clear_interfaces(dvs)
-
     def test_VerifyConntrackTimeoutForNatEntry(self, dvs, testlog):
         # get neighbor and arp entry
         dvs.servers[0].runcmd("ping -c 1 18.18.18.2")
@@ -438,6 +435,9 @@ class TestNat(object):
         assert new_avail_snat_counter == avail_snat_counter
         assert new_used_dnat_counter == used_dnat_counter
         assert new_avail_dnat_counter == avail_dnat_counter
+
+        # clear interfaces
+        self.clear_interfaces(dvs)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -373,6 +373,14 @@ class TestNat(object):
         # get neighbor and arp entry
         dvs.servers[0].runcmd("ping -c 1 18.18.18.2")
 
+        # set pooling interval to 1
+        dvs.runcmd("crm config polling interval 1")
+
+        dvs.setReadOnlyAttr('SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY', '1000')
+        dvs.setReadOnlyAttr('SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY', '1000')
+
+        time.sleep(2)
+
         # get snat counters
         used_snat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_snat_entry_used')
         avail_snat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_snat_entry_available')
@@ -380,9 +388,6 @@ class TestNat(object):
         # get dnat counters
         used_dnat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_dnat_entry_used')
         avail_dnat_counter = getCrmCounterValue(dvs, 'STATS', 'crm_stats_dnat_entry_available')
-
-        # set pooling interval to 1
-        dvs.runcmd("crm config polling interval 1")
 
         # add a static nat entry
         dvs.runcmd("config nat add static basic 67.66.65.1 18.18.18.2")
@@ -394,6 +399,9 @@ class TestNat(object):
                 assert True
             else:
                 assert False
+
+        dvs.setReadOnlyAttr('SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY', '999')
+        dvs.setReadOnlyAttr('SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY', '999')
 
         time.sleep(2)
 
@@ -412,6 +420,9 @@ class TestNat(object):
 
         # delete a static nat entry
         dvs.runcmd("config nat remove static basic 67.66.65.1 18.18.18.2")
+
+        dvs.setReadOnlyAttr('SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY', '1000')
+        dvs.setReadOnlyAttr('SAI_OBJECT_TYPE_SWITCH', 'SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY', '1000')
 
         time.sleep(2)
 


### PR DESCRIPTION
Issue : CRM used counters are not getting updated for SNAT and DNAT entries

Steps to recreate:
Add a static NAT entry and verify the CRM counters
```
root@sonic:/home/admin# config nat feature enable
root@sonic:/home/admin# config interface ip add Ethernet9 12.12.0.1/24
root@sonic:/home/admin# config interface ip add Ethernet11 125.56.90.12/24
root@sonic:/home/admin# config nat add interface Ethernet11 -nat_zone 1
root@sonic:/home/admin# 
root@sonic:/home/admin# config nat add static basic 125.56.90.8 12.12.0.2
root@sonic:/home/admin# show nat translations 

Static NAT Entries         ..................... 2
Static NAPT Entries        ..................... 0
Dynamic NAT Entries        ..................... 0
Dynamic NAPT Entries       ..................... 0
Static Twice NAT Entries   ..................... 0
Static Twice NAPT Entries  ..................... 0
Dynamic Twice NAT Entries  ..................... 0
Dynamic Twice NAPT Entries ..................... 0
Total SNAT/SNAPT Entries   ..................... 1
Total DNAT/DNAPT Entries   ..................... 1
Total Entries              ..................... 2

Protocol    Source     Destination    Translated Source    Translated Destination
----------  ---------  -------------  -------------------  ------------------------
all         12.12.0.2  ---            125.56.90.8          ---
all         ---        125.56.90.8    ---                  12.12.0.2

root@sonic:/home/admin#

=============After polling interval of 300 seconds ========

root@sonic:/home/admin# crm show resources snat

Resource Name    Used Count   Available Count
--------------- ------------ -----------------
snat_entry                0             1024

root@sonic:/home/admin#

root@sonic:/home/admin# crm show resources dnat

Resource Name    Used Count    Available Count
--------------- ------------ -----------------
dnat_entry                0             1024

root@sonic:/home/admin#
```
Fix: Increment/Decrement the crm used counters for snat/dnat entries when entry is created/deleted.

Repeated the same steps to add static nat entry like above and verified the crm counters.
```
root@sonic:/home/admin# crm show resources dnat

Resource Name     Used Count   Available Count
--------------- ------------ -----------------
dnat_entry                1             1023

root@sonic:/home/admin# crm show resources snat

Resource Name     Used Count   Available Count
--------------- ------------ -----------------
snat_entry                1             1023

root@sonic:/home/admin#
```
Signed-off-by: Akhilesh Samineni <akhilesh.samineni@broadcom.com>
