### PR TITLE
[portorch] parse on/off value from autoneg

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2228,7 +2228,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 /* Set autoneg and ignore the port speed setting */
                 else if (fvField(i) == "autoneg")
                 {
-                    an = (int)stoul(fvValue(i));
+                    an = (fvValue(i) == "on");
                 }
                 /* Set port serdes Pre-emphasis */
                 else if (fvField(i) == "preemphasis")

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -12,8 +12,8 @@ class TestPortAutoNeg(object):
 
         tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
 
-        # set autoneg = false and speed = 1000
-        fvs = swsscommon.FieldValuePairs([("autoneg","1"), ("speed", "1000")])
+        # set autoneg = true and speed = 1000
+        fvs = swsscommon.FieldValuePairs([("autoneg","on"), ("speed", "1000")])
 
         tbl.set("Ethernet0", fvs)
 
@@ -50,7 +50,7 @@ class TestPortAutoNeg(object):
                 assert fv[1] == "1:100"
 
         # change autoneg to false
-        fvs = swsscommon.FieldValuePairs([("autoneg","0")])
+        fvs = swsscommon.FieldValuePairs([("autoneg","off")])
 
         tbl.set("Ethernet0", fvs)
 
@@ -99,7 +99,7 @@ class TestPortAutoNeg(object):
         stbl = swsscommon.Table(sdb, "PORT_TABLE")
 
         # set autoneg = true and speed = 1000
-        fvs = swsscommon.FieldValuePairs([("autoneg","1"), ("speed", "1000")])
+        fvs = swsscommon.FieldValuePairs([("autoneg","on"), ("speed", "1000")])
         ctbl.set("Ethernet0", fvs)
 
         time.sleep(1)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
As part of PR in sonic-buildimage

**What I did**
Changed parsing `autoneg` from 1/0 to on/off
 
**Why I did it**

**How I verified it**

**Details if related**
