### PR TITLE
Keep attribute order in bulk mode

### DIFF
--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -31,6 +31,7 @@ tests_SOURCES = aclorch_ut.cpp \
                 mock_table.cpp \
                 mock_hiredis.cpp \
                 mock_redisreply.cpp \
+                bulker_ut.cpp \
                 $(top_srcdir)/lib/gearboxutils.cpp \
                 $(top_srcdir)/orchagent/orchdaemon.cpp \
                 $(top_srcdir)/orchagent/orch.cpp \

--- a/tests/mock_tests/bulker_ut.cpp
+++ b/tests/mock_tests/bulker_ut.cpp
@@ -1,0 +1,106 @@
+#include "ut_helper.h"
+#include "bulker.h"
+
+extern sai_route_api_t *sai_route_api;
+
+namespace bulker_test
+{
+    using namespace std;
+
+    struct BulkerTest : public ::testing::Test
+    {
+        BulkerTest()
+        {
+        }
+
+        void SetUp() override
+        {
+            ASSERT_EQ(sai_route_api, nullptr);
+            sai_route_api = new sai_route_api_t();
+        }
+
+        void TearDown() override
+        {
+            delete sai_route_api;
+            sai_route_api = nullptr;
+        }
+    };
+
+    TEST_F(BulkerTest, BulkerAttrOrder)
+    {
+        // Create bulker
+        EntityBulker<sai_route_api_t> gRouteBulker(sai_route_api);
+        deque<sai_status_t> object_statuses;
+
+        // Create a dummy route entry
+        sai_route_entry_t route_entry;
+        route_entry.destination.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+        route_entry.destination.addr.ip4 = htonl(0x0a00000f);
+        route_entry.destination.mask.ip4 = htonl(0xffffff00);
+        route_entry.vr_id = 0x0;
+        route_entry.switch_id = 0x0;
+
+        // Set packet action for route first
+        sai_attribute_t route_attr;
+        route_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+        route_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+        object_statuses.emplace_back();
+        gRouteBulker.set_entry_attribute(&object_statuses.back(), &route_entry, &route_attr);
+
+        // Set next hop for route
+        route_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+        route_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+        object_statuses.emplace_back();
+        gRouteBulker.set_entry_attribute(&object_statuses.back(), &route_entry, &route_attr);
+
+        // Check number of routes in bulk
+        ASSERT_EQ(gRouteBulker.setting_entries_count(), 1);
+
+        // Confirm the order of attributes in bulk is the same as being set
+        auto const& attrs = gRouteBulker.setting_entries[route_entry];
+        ASSERT_EQ(attrs.size(), 2);
+        auto ia = attrs.begin();
+        ASSERT_EQ(ia->first.id, SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION);
+        ASSERT_EQ(ia->first.value.s32, SAI_PACKET_ACTION_FORWARD);
+        ia++;
+        ASSERT_EQ(ia->first.id, SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID);
+        ASSERT_EQ(ia->first.value.oid, SAI_NULL_OBJECT_ID);
+
+        // Clear the bulk
+        gRouteBulker.clear();
+        object_statuses.clear();
+
+        // Check the bulker has been cleared
+        ASSERT_EQ(gRouteBulker.setting_entries_count(), 0);
+
+        // Test the inverse order
+        // Set next hop for route first
+        route_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+        route_attr.value.oid = SAI_NULL_OBJECT_ID;
+
+        object_statuses.emplace_back();
+        gRouteBulker.set_entry_attribute(&object_statuses.back(), &route_entry, &route_attr);
+
+        // Set packet action for route
+        route_attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
+        route_attr.value.s32 = SAI_PACKET_ACTION_FORWARD;
+
+        object_statuses.emplace_back();
+        gRouteBulker.set_entry_attribute(&object_statuses.back(), &route_entry, &route_attr);
+
+        // Check number of routes in bulk
+        ASSERT_EQ(gRouteBulker.setting_entries_count(), 1);
+
+        // Confirm the order of attributes in bulk is the same as being set
+        auto const& attrs_reverse = gRouteBulker.setting_entries[route_entry];
+        ASSERT_EQ(attrs_reverse.size(), 2);
+        ia = attrs_reverse.begin();
+        ASSERT_EQ(ia->first.id, SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID);
+        ASSERT_EQ(ia->first.value.oid, SAI_NULL_OBJECT_ID);
+        ia++;
+        ASSERT_EQ(ia->first.id, SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION);
+        ASSERT_EQ(ia->first.value.s32, SAI_PACKET_ACTION_FORWARD);
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Keep attributes for the same entry in the order that the attributes are set in bulk mode.

Fix https://github.com/Azure/sonic-buildimage/issues/6881

**Why I did it**
Some attributes have a dependency on others in SAI operations (e.g., setting nexthop requires packet action to be forward in route set operation). Without keeping the order of the attributes, the configuration may not be successfully applied to hardware. Therefore, it is necessary to keep the order of attributes in bulk mode.

**How I verified it**
Verify that sairedis applys `SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION` before `SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID` when setting default routes.

```
2021-03-03.06:01:12.003330|S|SAI_OBJECT_TYPE_ROUTE_ENTRY||{"dest":"::/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000022"}|SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_FORWARD||{"dest":"::/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000022"}|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x5000000000687
2021-03-03.06:01:12.945653|S|SAI_OBJECT_TYPE_ROUTE_ENTRY||{"dest":"0.0.0.0/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000022"}|SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION=SAI_PACKET_ACTION_FORWARD||{"dest":"0.0.0.0/0","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000022"}|SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID=oid:0x5000000000683
```

**Details if related**
