### PR TITLE
[Muxorch] Handle StateDB state for error, update APP_DB for state changes

### DIFF
--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -87,6 +87,7 @@ public:
     void setState(string state);
     string getState();
     bool isStateChangeInProgress() { return st_chg_in_progress_; }
+    bool isStateChangeFailed() { return st_chg_failed_; }
 
     bool isIpInSubnet(IpAddress ip);
     void updateNeighbor(NextHopKey nh, bool add);
@@ -107,6 +108,7 @@ private:
 
     MuxState state_ = MuxState::MUX_STATE_INIT;
     bool st_chg_in_progress_ = false;
+    bool st_chg_failed_ = false;
 
     IpPrefix srv_ip4_, srv_ip6_;
     IpAddress peer_ip4_;


### PR DESCRIPTION
**What I did**
If orchagent fails in state change, update StateDB with "error" state
Update APP_DB for every state change request from Linkmgr irrespective of internal handling in orchagent

**Why I did it**
As part of https://github.com/Azure/sonic-buildimage/issues/6761

**How I verified it**

**Details if related**
