### PR TITLE
Deactivate mirror session only when status is true in updateLagMember

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1342,7 +1342,10 @@ void MirrorOrch::updateLagMember(const LagMemberUpdate& update)
             // If LAG is empty, deactivate session
             if (update.lag.m_members.empty())
             {
-                deactivateSession(name, session);
+                if (session.status)
+                {
+                    deactivateSession(name, session);
+                }
                 session.neighborInfo.portId = SAI_OBJECT_TYPE_NULL;
             }
             // Switch to a new member of the LAG


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Deactivate mirror session only when status is true in updateLagMember

**Why I did it**
Fix the issue when mirrororch tries to deactivate a session when it is not activated
```
Mar  7 18:22:03.125662 e07265d2546e NOTICE #orchagent: :- removeLagMember: Remove member Ethernet88 from LAG PortChannel008 lid:20000000005ff lmid:1b000000000600
Mar  7 18:22:03.125691 e07265d2546e ERR #orchagent: :- meta_sai_validate_oid: object key SAI_OBJECT_TYPE_MIRROR_SESSION:oid:0xe000000000603 doesn't exist
Mar  7 18:22:03.125695 e07265d2546e ERR #orchagent: :- deactivateSession: Failed to deactivate mirroring session TEST_SESSION
Mar  7 18:22:04.126757 e07265d2546e NOTICE #orchagent: :- removeLag: Remove LAG PortChannel008 lid:20000000005ff
```

**How I verified it**
Verified that the above error message does not show up in dvs test

**Details if related**
