### PR TITLE
[acl] Move ACL table constants to acltable.h

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3073,11 +3073,11 @@ void AclOrch::doAclTableTask(Consumer &consumer)
 
                 SWSS_LOG_DEBUG("TABLE ATTRIBUTE: %s : %s", attr_name.c_str(), attr_value.c_str());
 
-                if (attr_name == TABLE_DESCRIPTION)
+                if (attr_name == ACL_TABLE_DESCRIPTION)
                 {
                     newTable.description = attr_value;
                 }
-                else if (attr_name == TABLE_TYPE)
+                else if (attr_name == ACL_TABLE_TYPE)
                 {
                     if (!processAclTableType(attr_value, newTable.type))
                     {
@@ -3087,7 +3087,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                         break;
                     }
                 }
-                else if (attr_name == TABLE_PORTS)
+                else if (attr_name == ACL_TABLE_PORTS)
                 {
                     if (!processAclTablePorts(attr_value, newTable))
                     {
@@ -3097,7 +3097,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                         break;
                     }
                 }
-                else if (attr_name == TABLE_STAGE)
+                else if (attr_name == ACL_TABLE_STAGE)
                 {
                    if (!processAclTableStage(attr_value, newTable.stage))
                    {
@@ -3107,7 +3107,7 @@ void AclOrch::doAclTableTask(Consumer &consumer)
                        break;
                    }
                 }
-                else if (attr_name == TABLE_SERVICES)
+                else if (attr_name == ACL_TABLE_SERVICES)
                 {
                     // TODO: validate control plane ACL table has this attribute
                     continue;

--- a/orchagent/aclorch.h
+++ b/orchagent/aclorch.h
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <map>
 #include <condition_variable>
+
 #include "orch.h"
 #include "switchorch.h"
 #include "portsorch.h"
@@ -15,28 +16,12 @@
 #include "dtelorch.h"
 #include "observer.h"
 
+#include "acltable.h"
+
 // ACL counters update interval in the DB
 // Value is in seconds. Should not be less than 5 seconds
 // (in worst case update of 1265 counters takes almost 5 sec)
 #define COUNTERS_READ_INTERVAL 10
-
-#define TABLE_DESCRIPTION "POLICY_DESC"
-#define TABLE_TYPE        "TYPE"
-#define TABLE_PORTS       "PORTS"
-#define TABLE_SERVICES    "SERVICES"
-
-#define TABLE_TYPE_L3                   "L3"
-#define TABLE_TYPE_L3V6                 "L3V6"
-#define TABLE_TYPE_MIRROR               "MIRROR"
-#define TABLE_TYPE_MIRRORV6             "MIRRORV6"
-#define TABLE_TYPE_MIRROR_DSCP          "MIRROR_DSCP"
-#define TABLE_TYPE_PFCWD                "PFCWD"
-#define TABLE_TYPE_CTRLPLANE            "CTRLPLANE"
-#define TABLE_TYPE_DTEL_FLOW_WATCHLIST  "DTEL_FLOW_WATCHLIST"
-#define TABLE_TYPE_DTEL_DROP_WATCHLIST  "DTEL_DROP_WATCHLIST"
-#define TABLE_TYPE_MCLAG                "MCLAG"
-#define TABLE_TYPE_MUX                  "MUX"
-#define TABLE_TYPE_DROP                 "DROP"
 
 #define RULE_PRIORITY           "PRIORITY"
 #define MATCH_IN_PORTS          "IN_PORTS"
@@ -109,24 +94,6 @@
 #define RULE_OPER_ADD           0
 #define RULE_OPER_DELETE        1
 
-typedef enum
-{
-    ACL_TABLE_UNKNOWN,
-    ACL_TABLE_L3,
-    ACL_TABLE_L3V6,
-    ACL_TABLE_MIRROR,
-    ACL_TABLE_MIRRORV6,
-    ACL_TABLE_MIRROR_DSCP,
-    ACL_TABLE_PFCWD,
-    ACL_TABLE_CTRLPLANE,
-    ACL_TABLE_DTEL_FLOW_WATCHLIST,
-    ACL_TABLE_DTEL_DROP_WATCHLIST,
-    ACL_TABLE_MCLAG,
-    ACL_TABLE_MUX,
-    ACL_TABLE_DROP
-} acl_table_type_t;
-
-typedef map<string, acl_table_type_t> acl_table_type_lookup_t;
 typedef map<string, sai_acl_entry_attr_t> acl_rule_attr_lookup_t;
 typedef map<string, sai_acl_ip_type_t> acl_ip_type_lookup_t;
 typedef map<string, sai_acl_dtel_flow_op_t> acl_dtel_flow_op_type_lookup_t;

--- a/orchagent/acltable.h
+++ b/orchagent/acltable.h
@@ -1,24 +1,35 @@
-#ifndef SWSS_ACLTABLE_H
-#define SWSS_ACLTABLE_H
+#pragma once
 
 extern "C" {
 #include "sai.h"
 }
 
-#include <set>
 #include <string>
-#include <vector>
-#include <map>
+#include <unordered_map>
 
-using namespace std;
+// TODO: Move the rest of AclTable implementation out of AclOrch
 
-/* TODO: move all acltable and aclrule implementation out of aclorch */
+#define ACL_TABLE_DESCRIPTION  "POLICY_DESC"
+#define ACL_TABLE_STAGE        "STAGE"
+#define ACL_TABLE_TYPE         "TYPE"
+#define ACL_TABLE_PORTS        "PORTS"
+#define ACL_TABLE_SERVICES     "SERVICES"
 
-#define STAGE_INGRESS     "INGRESS"
-#define STAGE_EGRESS      "EGRESS"
-#define TABLE_INGRESS     STAGE_INGRESS
-#define TABLE_EGRESS      STAGE_EGRESS
-#define TABLE_STAGE       "STAGE"
+#define STAGE_INGRESS  "INGRESS"
+#define STAGE_EGRESS   "EGRESS"
+
+#define TABLE_TYPE_L3                   "L3"
+#define TABLE_TYPE_L3V6                 "L3V6"
+#define TABLE_TYPE_MIRROR               "MIRROR"
+#define TABLE_TYPE_MIRRORV6             "MIRRORV6"
+#define TABLE_TYPE_MIRROR_DSCP          "MIRROR_DSCP"
+#define TABLE_TYPE_PFCWD                "PFCWD"
+#define TABLE_TYPE_CTRLPLANE            "CTRLPLANE"
+#define TABLE_TYPE_DTEL_FLOW_WATCHLIST  "DTEL_FLOW_WATCHLIST"
+#define TABLE_TYPE_DTEL_DROP_WATCHLIST  "DTEL_DROP_WATCHLIST"
+#define TABLE_TYPE_MCLAG                "MCLAG"
+#define TABLE_TYPE_MUX                  "MUX"
+#define TABLE_TYPE_DROP                 "DROP"
 
 typedef enum
 {
@@ -27,6 +38,23 @@ typedef enum
     ACL_STAGE_EGRESS
 } acl_stage_type_t;
 
-typedef map<string, acl_stage_type_t> acl_stage_type_lookup_t;
+typedef std::unordered_map<std::string, acl_stage_type_t> acl_stage_type_lookup_t;
 
-#endif /* SWSS_ACLTABLE_H */
+typedef enum
+{
+    ACL_TABLE_UNKNOWN,
+    ACL_TABLE_L3,
+    ACL_TABLE_L3V6,
+    ACL_TABLE_MIRROR,
+    ACL_TABLE_MIRRORV6,
+    ACL_TABLE_MIRROR_DSCP,
+    ACL_TABLE_PFCWD,
+    ACL_TABLE_CTRLPLANE,
+    ACL_TABLE_DTEL_FLOW_WATCHLIST,
+    ACL_TABLE_DTEL_DROP_WATCHLIST,
+    ACL_TABLE_MCLAG,
+    ACL_TABLE_MUX,
+    ACL_TABLE_DROP
+} acl_table_type_t;
+
+typedef std::unordered_map<std::string, acl_table_type_t> acl_table_type_lookup_t;

--- a/tests/mock_tests/aclorch_ut.cpp
+++ b/tests/mock_tests/aclorch_ut.cpp
@@ -748,10 +748,7 @@ namespace aclorch_test
         {
             for (const auto &fv : values)
             {
-                if (fv.first == TABLE_DESCRIPTION)
-                {
-                }
-                else if (fv.first == TABLE_TYPE)
+                if (fv.first == ACL_TABLE_TYPE)
                 {
                     if (fv.second == TABLE_TYPE_L3)
                     {
@@ -772,16 +769,16 @@ namespace aclorch_test
                         return false;
                     }
                 }
-                else if (fv.first == TABLE_STAGE)
+                else if (fv.first == ACL_TABLE_STAGE)
                 {
-                    if (fv.second == TABLE_INGRESS)
+                    if (fv.second == STAGE_INGRESS)
                     {
                         if (acl_table.stage != ACL_STAGE_INGRESS)
                         {
                             return false;
                         }
                     }
-                    else if (fv.second == TABLE_EGRESS)
+                    else if (fv.second == STAGE_EGRESS)
                     {
                         if (acl_table.stage != ACL_STAGE_EGRESS)
                         {
@@ -792,9 +789,6 @@ namespace aclorch_test
                     {
                         return false;
                     }
-                }
-                else if (fv.first == TABLE_PORTS)
-                {
                 }
             }
 
@@ -951,17 +945,17 @@ namespace aclorch_test
 
         for (const auto &acl_table_type : { TABLE_TYPE_L3, TABLE_TYPE_L3V6 })
         {
-            for (const auto &acl_table_stage : { TABLE_INGRESS, TABLE_EGRESS })
+            for (const auto &acl_table_stage : { STAGE_INGRESS, STAGE_EGRESS })
             {
                 string acl_table_id = "acl_table_1";
 
                 auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
                     { { acl_table_id,
                         SET_COMMAND,
-                        { { TABLE_DESCRIPTION, "filter source IP" },
-                          { TABLE_TYPE, acl_table_type },
-                          { TABLE_STAGE, acl_table_stage },
-                          { TABLE_PORTS, "1,2" } } } });
+                        { { ACL_TABLE_DESCRIPTION, "filter source IP" },
+                          { ACL_TABLE_TYPE, acl_table_type },
+                          { ACL_TABLE_STAGE, acl_table_stage },
+                          { ACL_TABLE_PORTS, "1,2" } } } });
                 // FIXME:                  ^^^^^^^^^^^^^ fixed port
 
                 orch->doAclTableTask(kvfAclTable);
@@ -1012,12 +1006,12 @@ namespace aclorch_test
         auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
             { { acl_table_id,
                 SET_COMMAND,
-                { { TABLE_DESCRIPTION, "filter source IP" },
-                  { TABLE_TYPE, TABLE_TYPE_L3 },
+                { { ACL_TABLE_DESCRIPTION, "filter source IP" },
+                  { ACL_TABLE_TYPE, TABLE_TYPE_L3 },
                   //            ^^^^^^^^^^^^^ L3 ACL
-                  { TABLE_STAGE, TABLE_INGRESS },
+                  { ACL_TABLE_STAGE, STAGE_INGRESS },
                   // FIXME:      ^^^^^^^^^^^^^ only support / test for ingress ?
-                  { TABLE_PORTS, "1,2" } } } });
+                  { ACL_TABLE_PORTS, "1,2" } } } });
         // FIXME:                  ^^^^^^^^^^^^^ fixed port
 
         orch->doAclTableTask(kvfAclTable);
@@ -1102,12 +1096,12 @@ namespace aclorch_test
         auto kvfAclTable = deque<KeyOpFieldsValuesTuple>(
             { { acl_table_id,
                 SET_COMMAND,
-                { { TABLE_DESCRIPTION, "filter source IP" },
-                  { TABLE_TYPE, TABLE_TYPE_L3V6 },
+                { { ACL_TABLE_DESCRIPTION, "filter source IP" },
+                  { ACL_TABLE_TYPE, TABLE_TYPE_L3V6 },
                   //            ^^^^^^^^^^^^^ L3V6 ACL
-                  { TABLE_STAGE, TABLE_INGRESS },
+                  { ACL_TABLE_STAGE, STAGE_INGRESS },
                   // FIXME:      ^^^^^^^^^^^^^ only support / test for ingress ?
-                  { TABLE_PORTS, "1,2" } } } });
+                  { ACL_TABLE_PORTS, "1,2" } } } });
         // FIXME:                  ^^^^^^^^^^^^^ fixed port
 
         orch->doAclTableTask(kvfAclTable);


### PR DESCRIPTION
Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I moved all of the ACL table related constants over to acltable.h.

**Why I did it**
aclorch.h and aclorch.cpp are both huge files that have become hard to maintain/update to support new features. This is part of a bigger effort to try to refactor it to be more manageable.

**How I verified it**
Confirmed that the compiler doesn't throw any new errors, unit tests still work the same as before, and I ran `test_acl` and `test_everflow` from sonic-mgmt to confirm there is no traffic impact.

**Details if related**
