### PR TITLE
Increase tunnel nexthop reference count when nh_tunnels create new entry

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -574,6 +574,7 @@ void VxlanTunnel::updateNextHop(IpAddress& ipAddr, MacAddress macAddress,
     if (it == nh_tunnels_.end())
     {
         nh_tunnels_[key] = {nh_id, 1};
+        nh_tunnels_[key].ref_count++;
         return;
     } 
     else 


### PR DESCRIPTION
**What I did**
I found  nh_tunnels ref_count without increasing when entry create, 
the nh_tunnels ref_count may decrease to negative number when remove nexthop entry.

Increase tunnel nexthop reference count when nh_tunnels create new entry.

**Why I did it**
the nh_tunnels ref_count may decrease to negative number when remove nexthop entry.

**How I verified it**
test on broadcom dut.


