### PR TITLE
Revert "[buffermgr] Support maximum port headroom checking"

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -124,7 +124,6 @@ public:
     uint32_t  m_vnid = VNID_NONE;
     uint32_t  m_fdb_count = 0;
     uint32_t  m_up_member_count = 0;
-    uint32_t  m_maximum_headroom = 0;
 
     /*
      * Following two bit vectors are used to lock

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -263,9 +263,6 @@ PortsOrch::PortsOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames)
     m_flexCounterTable = unique_ptr<ProducerTable>(new ProducerTable(m_flex_db.get(), FLEX_COUNTER_TABLE));
     m_flexCounterGroupTable = unique_ptr<ProducerTable>(new ProducerTable(m_flex_db.get(), FLEX_COUNTER_GROUP_TABLE));
 
-    m_state_db = shared_ptr<DBConnector>(new DBConnector("STATE_DB", 0));
-    m_stateBufferMaximumValueTable = unique_ptr<Table>(new Table(m_state_db.get(), STATE_BUFFER_MAXIMUM_VALUE_TABLE));
-
     initGearbox();
 
     string queueWmSha, pgWmSha;
@@ -3325,25 +3322,6 @@ void PortsOrch::initializePriorityGroups(Port &port)
     SWSS_LOG_INFO("Get priority groups for port %s", port.m_alias.c_str());
 }
 
-void PortsOrch::initializePortMaximumHeadroom(Port &port)
-{
-    sai_attribute_t attr;
-
-    attr.id = SAI_PORT_ATTR_QOS_MAXIMUM_HEADROOM_SIZE;
-
-    sai_status_t status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_NOTICE("Unable to get the maximum headroom for port %s rv:%d, ignored", port.m_alias.c_str(), status);
-        return;
-    }
-
-    vector<FieldValueTuple> fvVector;
-    port.m_maximum_headroom = attr.value.u32;
-    fvVector.emplace_back("max_headroom_size", to_string(port.m_maximum_headroom));
-    m_stateBufferMaximumValueTable->set(port.m_alias, fvVector);
-}
-
 bool PortsOrch::initializePort(Port &port)
 {
     SWSS_LOG_ENTER();
@@ -3352,7 +3330,6 @@ bool PortsOrch::initializePort(Port &port)
 
     initializePriorityGroups(port);
     initializeQueues(port);
-    initializePortMaximumHeadroom(port);
 
     /* Create host interface */
     if (!addHostIntfs(port, port.m_alias, port.m_hif_id))

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -155,7 +155,6 @@ private:
     unique_ptr<Table> m_pgTable;
     unique_ptr<Table> m_pgPortTable;
     unique_ptr<Table> m_pgIndexTable;
-    unique_ptr<Table> m_stateBufferMaximumValueTable;
     unique_ptr<ProducerTable> m_flexCounterTable;
     unique_ptr<ProducerTable> m_flexCounterGroupTable;
 
@@ -166,7 +165,6 @@ private:
 
     shared_ptr<DBConnector> m_counter_db;
     shared_ptr<DBConnector> m_flex_db;
-    shared_ptr<DBConnector> m_state_db;
 
     FlexCounterManager port_stat_manager;
     FlexCounterManager port_buffer_drop_stat_manager;
@@ -229,7 +227,6 @@ private:
 
     bool initializePort(Port &port);
     void initializePriorityGroups(Port &port);
-    void initializePortMaximumHeadroom(Port &port);
     void initializeQueues(Port &port);
 
     bool addHostIntfs(Port &port, string alias, sai_object_id_t &host_intfs_id);


### PR DESCRIPTION
Reverts Azure/sonic-swss#1607

Suspecting this for a test failure. Reverting to verify. 

Refer: https://github.com/Azure/sonic-buildimage/pull/6989. Failing when the PR is updated to this comment. 