### PR TITLE
[Dynamic Buffer Calc] Stabilize the vs test

### DIFF
--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -102,10 +102,17 @@ class TestBufferMgrDyn(object):
                     self.ingress_lossless_pool_oid = key
 
     def check_new_profile_in_asic_db(self, dvs, profile):
-        diff = set(self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE")) - self.initProfileSet
-        if len(diff) == 1:
-            self.newProfileInAsicDb = diff.pop()
-        assert self.newProfileInAsicDb, "Can't get SAI OID for newly created profile {}".format(profile)
+        retry_count = 0
+        self.newProfileInAsicDb = None
+        while retry_count < 5:
+            retry_count += 1
+            diff = set(self.asic_db.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE")) - self.initProfileSet
+            if len(diff) == 1:
+                self.newProfileInAsicDb = diff.pop()
+                break
+            else:
+                time.sleep(1)
+        assert self.newProfileInAsicDb, "Can't get SAI OID for newly created profile {} after retry {} times".format(profile, retry_count)
 
         # in case diff is empty, we just treat the newProfileInAsicDb cached the latest one
         fvs = self.app_db.get_entry("BUFFER_PROFILE_TABLE", profile)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Stabilize the vs test.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
Stabilize the vs test.

**How I verified it**
Run the vs test.

**Details if related**
One logic in the vs test is to check consistency between APPL_DB and ASIC_DB for buffer profiles. However, the mapping between are stored in the orchagent and can't be accessed from outside. The way we fetch that mapping is:

1. Get the SAI OID of all the buffer profiles in ASIC_DB at the beginning of the test, and store it to set `P1`
2. Get the SAI OID of all the buffer profiles in ASIC_DB after a new buffer profile has been created, and stored it to `P2`
3. The newly created buffer profile in ASIC_DB should be `P2 - P1`.

However, sometimes there can be more than one OIDs in `P2 - P1`. This is because the old profile hasn't been removed from the ASIC, which typically caused by timing issues, which fails the test.
To make the test case stable, we will retry for 5 seconds to make sure the old profile is removed and the OID of the new profile can be fetched.