### PR TITLE
[System Port] Initialize system port 'type' variable

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -41,7 +41,7 @@ struct VlanInfo
 struct SystemPortInfo
 {
     std::string alias = "";
-    sai_system_port_type_t type;
+    sai_system_port_type_t type = SAI_SYSTEM_PORT_TYPE_LOCAL;
     sai_object_id_t local_port_oid = 0;
     uint32_t port_id = 0;
     uint32_t switch_id = 0;


### PR DESCRIPTION
**What I did**
Initialize System port type variable to SAI_SYSTEM_PORT_TYPE_LOCAL

**Why I did it**

Fix PR builds failed with kvm-t1-lag tests on route_check script. 

**How I verified it**

**Details if related**

Logs:

1. Route add failed for get nexthop:

`Mar 25 06:17:38.194329 vlab-03 INFO swss#orchagent: :- addRoute: Failed to get next hop 10.0.0.33@Ethernet64 for 100.1.0.17/32`

2.  During add Nexthop, the alias field got replaced due to incorrect return value returned as [True  ](https://github.com/Azure/sonic-swss/blob/master/orchagent/neighorch.cpp#L174)

3. Nexthop alias field became [empty ](https://github.com/Azure/sonic-swss/blob/master/orchagent/neighorch.cpp#L181)while adding to cache, which resulted in mismatch of route get

`Mar 25 20:32:44.180521 vlab-03 NOTICE swss#orchagent: :- addNextHop: RCF: Existing Nexthops IP:10.0.0.33, Alias:, nhid:0x40000000006aa`
