### PR TITLE
[Dynamic Buffer Calc] Don't update pools when ingress_lossless_pool is created during initialization

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -946,7 +946,10 @@ void BufferMgrDynamic::refreshSharedHeadroomPool(bool enable_state_updated_by_ra
             updateBufferPoolToDb(INGRESS_LOSSLESS_PG_POOL_NAME, ingressLosslessPool);
     }
 
-    checkSharedBufferPoolSize();
+    if (m_portInitDone)
+    {
+        checkSharedBufferPoolSize();
+    }
 }
 
 // Main flows


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix bug: Don't update pools when ingress_lossless_pool is created during initialization.
- This bug increases the converging time of fast reboot for ~5 seconds.
- It can also cause error logs during system startup:
  ```
  Mar 29 11:57:32.640257 mtbc-sonic-03-2700 ERR swss#orchagent: message repeated 19408 times: [ :- resolveFieldRefArray: Failed to parse profile reference:[BUFFER_PROFILE_TABLE:ingress_lossy_profile]]
  ```

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
Fix the bug.

**How I verified it**
Run regression and vs test.

**Details if related**
The buffer pools will be created after a short-timer and then won't be updated until the initialization has finished. The idea is to call `recalculateSharedBufferPool` from `checkSharedBufferPoolSize` only once during initialization. The motivation is to avoid repeatedly updating buffer pools when items in BUFFER_PG have been created for each port. So the flow we expected:
```
1. Start a short-timer
2. The buffer pools are being configured
3. On timer timeout: create all the buffer pools to APPL_DB.
   The buffer pool size can be inaccurate but it doesn't matter since the system is starting.
   The motivation is to create the buffer pool in APPL_DB and ASIC_DB, which paves the way for other buffer tables to be created.
4. Handle other buffer tables: BUFFER_PROFILE, BUFFER_PG, BUFFER_QUEUE, BUFFER_PORT_INGRESS_PROFILE_LIST_TABLE, and BUFFER_PORT_INGRESS_PROFILE_LIST_TABLE
5. On initialization done, update buffer pools to APPL_DB. Now the buffer pools will be updated with the accurate size
```
However, when the ingress_lossless_pool is created it will trigger the buffer pools to be updated for the shared headroom pool. If this happens during initialization, it causes the buffer pools created after ingress_lossless_pool unable to be created until the initialization has been done because the buffer pools can only be updated to APPL_DB once during initialization.
For example, assume the buffer pools are created in the following order:
```
1. egress_lossless_pool
2. egress_lossy_pool
3. ingress_lossless_pool
4. ingress_lossy_pool
```
In step 3, it won't call `recalculateSharedBufferPool` because it has been called when handling `ingress_lossless_pool`. This causes `ingress_lossy_pool` which follows `ingress_lossless_pool` can not be created until initialization finished, which in turn causes the entries depending on `ingress_lossy_pool` can not be created, and there will be error logs reported by bufferorch.
Fix: Don't trigger updating buffer pools when creating ingress_lossless_pool during initialization.
