### PR TITLE
[Makefile] Reorder libsaimetadata and libswsscommon

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -71,7 +71,7 @@ orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.
 
 orchagent_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 orchagent_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-orchagent_LDADD = -lnl-3 -lnl-route-3 -lpthread -lsairedis -lswsscommon -lsaimeta -lsaimetadata -lzmq
+orchagent_LDADD = -lnl-3 -lnl-route-3 -lpthread -lsairedis -lsaimeta -lsaimetadata -lswsscommon -lzmq
 
 routeresync_SOURCES = routeresync.cpp
 routeresync_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)


### PR DESCRIPTION
This is possible workaround for cross compile issues with json.hpp
symbols generated on armhf architecture.

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Changed libs order to change symbol resolve order in runtime for swsscommon

**Why I did it**
To workaround possible issue related to cross compile armhf arch

**How I verified it**
Build locally on marvell device

**Details if related**
Main issue explained here: https://github.com/Azure/sonic-sairedis/issues/801