### PR TITLE
[acl] Add regression test for `config acl` CLI command

### DIFF
--- a/tests/test_acl_cli.py
+++ b/tests/test_acl_cli.py
@@ -1,0 +1,33 @@
+class TestAclCli:
+    def test_AddTableMultipleTimes(self, dvs, dvs_acl):
+        dvs.runcmd("config acl add table TEST L3 -p Ethernet0")
+
+        cdb = dvs.get_config_db()
+        cdb.wait_for_field_match(
+            "ACL_TABLE",
+            "TEST",
+            {"ports": "Ethernet0"}
+        )
+
+        # Verify that subsequent updates don't delete "ports" from config DB
+        dvs.runcmd("config acl add table TEST L3 -p Ethernet4")
+        cdb.wait_for_field_match(
+            "ACL_TABLE",
+            "TEST",
+            {"ports": "Ethernet4"}
+        )
+
+        # Verify that subsequent updates propagate to ASIC DB
+        L3_BIND_PORTS = ["Ethernet0", "Ethernet4", "Ethernet8", "Ethernet12"]
+        dvs.runcmd(f"config acl add table TEST L3 -p {','.join(L3_BIND_PORTS)}")
+        acl_table_id = dvs_acl.get_acl_table_ids(1)[0]
+        acl_table_group_ids = dvs_acl.get_acl_table_group_ids(len(L3_BIND_PORTS))
+
+        dvs_acl.verify_acl_table_group_members(acl_table_id, acl_table_group_ids, 1)
+        dvs_acl.verify_acl_table_port_binding(acl_table_id, L3_BIND_PORTS, 1)
+
+
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass


### PR DESCRIPTION
Add a new test case to catch the bug where calling "config acl add table" multiple
times causes the "ports" field to be deleted from config DB.

Signed-off-by: Danny Allen <daall@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did/why I did it**
I added a test case to guard against regressions like the one described in https://github.com/Azure/sonic-utilities/pull/1519.

**How I verified it**
Ran the test case w/ and w/o the change from 1519.
