### PR TITLE
[intfmgrd] reach reconciled state at start when there are no interfaces configuration to process

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -195,10 +195,10 @@ void IntfMgr::buildIntfReplayList(void)
 
     m_cfgLoopbackIntfTable.getKeys(intfList);
     std::copy( intfList.begin(), intfList.end(), std::inserter( m_pendingReplayIntfList, m_pendingReplayIntfList.end() ) );
-        
+
     m_cfgVlanIntfTable.getKeys(intfList);
     std::copy( intfList.begin(), intfList.end(), std::inserter( m_pendingReplayIntfList, m_pendingReplayIntfList.end() ) );
-        
+
     m_cfgLagIntfTable.getKeys(intfList);
     std::copy( intfList.begin(), intfList.end(), std::inserter( m_pendingReplayIntfList, m_pendingReplayIntfList.end() ) );
 
@@ -207,6 +207,7 @@ void IntfMgr::buildIntfReplayList(void)
 
 void IntfMgr::setWarmReplayDoneState()
 {
+    replayDone = true;
     WarmStart::setWarmStartState("intfmgrd", WarmStart::REPLAYED);
     // There is no operation to be performed for intfmgr reconcillation
     // Hence mark it reconciled right away
@@ -717,7 +718,6 @@ bool IntfMgr::doIntfAddrTask(const vector<string>& keys,
 void IntfMgr::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
-    static bool replayDone = false;
 
     string table_name = consumer.getTableName();
 
@@ -773,10 +773,9 @@ void IntfMgr::doTask(Consumer &consumer)
 
         it = consumer.m_toSync.erase(it);
     }
-    
+
     if (!replayDone && WarmStart::isWarmStart() && m_pendingReplayIntfList.empty() )
     {
         setWarmReplayDoneState();
-        replayDone = true;
     }
 }

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -207,7 +207,7 @@ void IntfMgr::buildIntfReplayList(void)
 
 void IntfMgr::setWarmReplayDoneState()
 {
-    replayDone = true;
+    m_replayDone = true;
     WarmStart::setWarmStartState("intfmgrd", WarmStart::REPLAYED);
     // There is no operation to be performed for intfmgr reconcillation
     // Hence mark it reconciled right away
@@ -774,7 +774,7 @@ void IntfMgr::doTask(Consumer &consumer)
         it = consumer.m_toSync.erase(it);
     }
 
-    if (!replayDone && WarmStart::isWarmStart() && m_pendingReplayIntfList.empty() )
+    if (!m_replayDone && WarmStart::isWarmStart() && m_pendingReplayIntfList.empty() )
     {
         setWarmReplayDoneState();
     }

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -44,6 +44,10 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
     {
         //Build the interface list to be replayed to Kernel
         buildIntfReplayList();
+        if (m_pendingReplayIntfList.empty())
+        {
+            setWarmReplayDoneState();
+        }
     }
 }
 
@@ -199,6 +203,14 @@ void IntfMgr::buildIntfReplayList(void)
     std::copy( intfList.begin(), intfList.end(), std::inserter( m_pendingReplayIntfList, m_pendingReplayIntfList.end() ) );
 
     SWSS_LOG_INFO("Found %d Total Intfs to be replayed", (int)m_pendingReplayIntfList.size() );
+}
+
+void IntfMgr::setWarmReplayDoneState()
+{
+    WarmStart::setWarmStartState("intfmgrd", WarmStart::REPLAYED);
+    // There is no operation to be performed for intfmgr reconcillation
+    // Hence mark it reconciled right away
+    WarmStart::setWarmStartState("intfmgrd", WarmStart::RECONCILED);
 }
 
 bool IntfMgr::isIntfCreated(const string &alias)
@@ -764,10 +776,7 @@ void IntfMgr::doTask(Consumer &consumer)
     
     if (!replayDone && WarmStart::isWarmStart() && m_pendingReplayIntfList.empty() )
     {
+        setWarmReplayDoneState();
         replayDone = true;
-        WarmStart::setWarmStartState("intfmgrd", WarmStart::REPLAYED);
-        // There is no operation to be performed for intfmgr reconcillation
-        // Hence mark it reconciled right away
-        WarmStart::setWarmStartState("intfmgrd", WarmStart::RECONCILED);
     }
 }

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -39,6 +39,7 @@ private:
     bool isIntfChangeVrf(const std::string &alias, const std::string &vrfName);
     int getIntfIpCount(const std::string &alias);
     void buildIntfReplayList(void);
+    void setWarmReplayDoneState();
 
     void addLoopbackIntf(const std::string &alias);
     void delLoopbackIntf(const std::string &alias);

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -55,7 +55,7 @@ private:
     bool setIntfProxyArp(const std::string &alias, const std::string &proxy_arp);
     bool setIntfGratArp(const std::string &alias, const std::string &grat_arp);
 
-    bool replayDone {false};
+    bool m_replayDone {false};
 };
 
 }

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -54,6 +54,8 @@ private:
 
     bool setIntfProxyArp(const std::string &alias, const std::string &proxy_arp);
     bool setIntfGratArp(const std::string &alias, const std::string &grat_arp);
+
+    bool replayDone {false};
 };
 
 }

--- a/tests/test_warm_reboot.py
+++ b/tests/test_warm_reboot.py
@@ -77,6 +77,7 @@ def swss_app_check_RestoreCount_single(state_db, restore_count, name):
                 assert int(fv[1]) == restore_count[key] + 1
             elif fv[0] == "state":
                 assert fv[1] == "reconciled" or fv[1] == "disabled"
+    return status, fvs
 
 def swss_app_check_warmstart_state(state_db, name, state):
     warmtbl = swsscommon.Table(state_db, swsscommon.STATE_WARM_RESTART_TABLE_NAME)
@@ -444,6 +445,28 @@ class TestWarmReboot(object):
         intf_tbl._del("Vlan16")
         intf_tbl._del("Vlan20")
         time.sleep(2)
+
+    def test_IntfMgrdWarmRestartNoInterfaces(self, dvs, testlog):
+        """ Tests that intfmgrd reaches reconciled state when
+        there are no interfaces in configuration. """
+
+        state_db = swsscommon.DBConnector(swsscommon.STATE_DB, dvs.redis_sock, 0)
+        restore_count = swss_get_RestoreCount(dvs, state_db)
+
+        dvs.runcmd("config warm_restart enable swss")
+        dvs.runcmd("supervisorctl restart intfmgrd")
+
+        reached_desired_state = False
+        retries = 10
+        delay = 2
+        for _ in range(retries):
+            ok, fvs = swss_app_check_RestoreCount_single(state_db, restore_count, "intfmgrd")
+            if ok and dict(fvs)["state"] == "reconciled":
+                reached_desired_state = True
+                break
+            time.sleep(delay)
+
+        assert reached_desired_state, "intfmgrd haven't reached desired state 'reconciled', after {} sec it was {}".format(retries * delay, dict(fvs)["state"])
 
     def test_swss_neighbor_syncup(self, dvs, testlog):
 


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

If there is no pending configuration intfmgrd should reach reconciled state immediately. Same does for example vlanmgrd.

**Why I did it**

fdbsyncd waits till intfmgrd reaches reconciled state otherwise exits with exception about timeout. As a result sanity checkers complain about that.

**How I verified it**

I tested it on the switch by running warm-reboot and observed no fdbsyncd failure.
Also I wrote a simple test for intfmgrd warm restart when there are no interfaces in config_db.

**Details if related**
