### PR TITLE
Fix overlay nexthop ref_count is incorrect issue when add and delete route at same time.

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -768,12 +768,9 @@ void RouteOrch::doTask(Consumer& consumer)
             {
                 removeOverlayNextHops(it_nhg.second, it_nhg.first);
             }
-            else
+            else if (m_syncdNextHopGroups[it_nhg.first].ref_count == 0)
             {
-                if (m_syncdNextHopGroups[it_nhg.first].ref_count == 0)
-                {
-                    removeNextHopGroup(it_nhg.first);
-                }
+                removeNextHopGroup(it_nhg.first);
             }
         }
     }
@@ -1462,7 +1459,7 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
                     auto old_nextHops = it_route->second;
 
                     if (old_nextHops.is_overlay_nexthop()) {
-                        nexthop = NextHopKey(it_route->second.to_string(), true);
+                        nexthop = NextHopKey(old_nextHops.to_string(), true);
                     } else {
                         nexthop = NextHopKey(it_route->second.to_string());
                     }
@@ -1742,9 +1739,8 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 m_bulkNhgReducedRefCnt.emplace(it_route->second, 0);
             } else if (ol_nextHops.is_overlay_nexthop()){
-
                 SWSS_LOG_NOTICE("Update overlay Nexthop %s", ol_nextHops.to_string().c_str());
-                m_bulkNhgReducedRefCnt.emplace(it_route->second, vrf_id);
+                m_bulkNhgReducedRefCnt.emplace(ol_nextHops, vrf_id);
             }
         }
 
@@ -1906,7 +1902,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             m_bulkNhgReducedRefCnt.emplace(it_route->second, 0);
         } else if (ol_nextHops.is_overlay_nexthop()){
             SWSS_LOG_NOTICE("Remove overlay Nexthop %s", ol_nextHops.to_string().c_str());
-            m_bulkNhgReducedRefCnt.emplace(it_route->second, vrf_id);
+            m_bulkNhgReducedRefCnt.emplace(ol_nextHops, vrf_id);
         }
     }
 

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -135,7 +135,8 @@ private:
     RouteTables m_syncdRoutes;
     NextHopGroupTable m_syncdNextHopGroups;
 
-    std::set<NextHopGroupKey> m_bulkNhgReducedRefCnt;
+    std::set<std::pair<NextHopGroupKey, sai_object_id_t>> m_bulkNhgReducedRefCnt;
+    /* m_bulkNhgReducedRefCnt: nexthop, vrf_id */
 
     NextHopObserverTable m_nextHopObservers;
 


### PR DESCRIPTION
**What I did**
reference #1501 : remove overlay nexthop  after updating the reference counter for a bulk of routes

**Why I did it**
error log
~~~
Mar 16 06:35:48.090274 accton-leaf-demo-002-leaf1 NOTICE swss#orchagent: :- removeRoutePost: Remove overlay Nexthop 10.0.0.28@vniVlan1000@10000@04:f8:f8:6a:fa:91
Mar 16 06:35:48.090333 accton-leaf-demo-002-leaf1 NOTICE swss#orchagent: :- removeOverlayNextHops: Remove overlay Nexthop 10.0.0.28@vniVlan1000@10000@04:f8:f8:6a:fa:91
Mar 16 06:35:48.090333 accton-leaf-demo-002-leaf1 NOTICE swss#orchagent: :- removeNextHopTunnel: NH tunnel remove for vtep1, ip 10.0.0.28, mac 04:f8:f8:6a:fa:91, vni 10000
Mar 16 06:35:48.090376 accton-leaf-demo-002-leaf1 NOTICE swss#orchagent: :- removeNextHop: remove NH tunnel for ip 10.0.0.28, mac 04:f8:f8:6a:fa:91, vni 10000, ref_count 1
Mar 16 06:35:48.090394 accton-leaf-demo-002-leaf1 ERR swss#orchagent: :- meta_generic_validation_remove: object 0x4000000000a1f reference count is 1, can't remove
Mar 16 06:35:48.090394 accton-leaf-demo-002-leaf1 NOTICE swss#orchagent: :- removeNextHop: delete NH tunnel for ip '10.0.0.28', mac '04:f8:f8:6a:fa:91' vni 10000 failed
~~~
**How I verified it**
test on broadcom dut , retry connect and disconnect remote vtep more than 20 times.