### PR TITLE
fix for CRM available bug

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -442,24 +442,24 @@ void CrmOrch::getResAvailableCounters()
             continue;
         }
 
-        sai_attribute_t attr;
-        attr.id = crmResSaiAvailAttrMap.at(res.first);
-
-        switch (attr.id)
+        switch (res.first)
         {
-            case SAI_SWITCH_ATTR_AVAILABLE_IPV4_ROUTE_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_IPV6_ROUTE_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEXTHOP_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEXTHOP_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_IPV4_NEIGHBOR_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_IPV6_NEIGHBOR_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_MEMBER_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_NEXT_HOP_GROUP_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_FDB_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_IPMC_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_SNAT_ENTRY:
-            case SAI_SWITCH_ATTR_AVAILABLE_DNAT_ENTRY:
+            case CrmResourceType::CRM_IPV4_ROUTE:
+            case CrmResourceType::CRM_IPV6_ROUTE:
+            case CrmResourceType::CRM_IPV4_NEXTHOP:
+            case CrmResourceType::CRM_IPV6_NEXTHOP:
+            case CrmResourceType::CRM_IPV4_NEIGHBOR:
+            case CrmResourceType::CRM_IPV6_NEIGHBOR:
+            case CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER:
+            case CrmResourceType::CRM_NEXTHOP_GROUP:
+            case CrmResourceType::CRM_FDB_ENTRY:
+            case CrmResourceType::CRM_IPMC_ENTRY:
+            case CrmResourceType::CRM_SNAT_ENTRY:
+            case CrmResourceType::CRM_DNAT_ENTRY:
             {
+                sai_attribute_t attr;
+                attr.id = crmResSaiAvailAttrMap.at(res.first);
+
                 sai_status_t status = sai_switch_api->get_switch_attribute(gSwitchId, 1, &attr);
                 if (status != SAI_STATUS_SUCCESS)
                 {
@@ -482,9 +482,12 @@ void CrmOrch::getResAvailableCounters()
                 break;
             }
 
-            case SAI_SWITCH_ATTR_AVAILABLE_ACL_TABLE:
-            case SAI_SWITCH_ATTR_AVAILABLE_ACL_TABLE_GROUP:
+            case CrmResourceType::CRM_ACL_TABLE:
+            case CrmResourceType::CRM_ACL_GROUP:
             {
+                sai_attribute_t attr;
+                attr.id = crmResSaiAvailAttrMap.at(res.first);
+
                 vector<sai_acl_resource_t> resources(CRM_ACL_RESOURCE_COUNT);
 
                 attr.value.aclresource.count = CRM_ACL_RESOURCE_COUNT;
@@ -512,9 +515,12 @@ void CrmOrch::getResAvailableCounters()
                 break;
             }
 
-            case SAI_ACL_TABLE_ATTR_AVAILABLE_ACL_ENTRY:
-            case SAI_ACL_TABLE_ATTR_AVAILABLE_ACL_COUNTER:
+            case CrmResourceType::CRM_ACL_ENTRY:
+            case CrmResourceType::CRM_ACL_COUNTER:
             {
+                sai_attribute_t attr;
+                attr.id = crmResSaiAvailAttrMap.at(res.first);
+
                 for (auto &cnt : res.second.countersMap)
                 {
                     sai_status_t status = sai_acl_api->get_acl_table_attribute(cnt.second.id, 1, &attr);
@@ -531,7 +537,7 @@ void CrmOrch::getResAvailableCounters()
             }
 
             default:
-                SWSS_LOG_ERROR("Failed to get CRM attribute %u. Unknown attribute.\n", attr.id);
+                SWSS_LOG_ERROR("Failed to get CRM resource type %u. Unknown resource type.\n", (uint32_t)res.first);
                 return;
         }
     }


### PR DESCRIPTION
**What I did**
Changes update switch statement in CrmOrch::getResAvailableCounters() to use CrmResourceType enum which guarantees the uniqueness of labels in the switch statement.

**Why I did it**
Previously, the switch statement in CrmOrch::getResAvailableCounters() used values from two different enums:  sai_switch_attr_t and sai_acl_table_attr_t.  There is no guarantee that the values from sai_switch_attr_t will not conflict with values from sai_acl_table_attr_t, so it is not good coding practice.  Any future development in this area should not be using values from multiple enums with overlapping values in a single switch statement.  
Additionally, future CRM development can use the new sai_object_type_get_availability() with sai_object_type_t instead of defining new SAI attrs per CrmResourceType without issue of enum conflict.
Refer to crmorch.cpp changes in https://github.com/Azure/sonic-swss/pull/1686 for an example of sai_object_type_get_availability() in CrmOrch::getResAvailableCounters().

**How I verified it**
Re-test of route and acl plus mpls CRM support in https://github.com/Azure/sonic-swss/pull/1686

**Details if related**
