### PR TITLE
Resolve neighbor when nexthop does not exist

### DIFF
--- a/orchagent/neighorch.h
+++ b/orchagent/neighorch.h
@@ -74,6 +74,8 @@ public:
     bool addInbandNeighbor(string alias, IpAddress ip_address);
     bool delInbandNeighbor(string alias, IpAddress ip_address);
 
+    bool resolveNeighborEntry(const NeighborEntry &, const MacAddress &);
+
 private:
     PortsOrch *m_portsOrch;
     IntfsOrch *m_intfsOrch;
@@ -93,7 +95,6 @@ private:
     bool clearNextHopFlag(const NextHopKey &, const uint32_t);
 
     void processFDBFlushUpdate(const FdbFlushUpdate &);
-    bool resolveNeighborEntry(const NeighborEntry &, const MacAddress &);
 
     void doTask(Consumer &consumer);
     void doVoqSystemNeighTask(Consumer &consumer);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Resolve neighbor entries if nexthop does not exist when adding routes. 

**Why I did it**
In some scenarios, such as adding static routes, the nexthop may not be available, this PR would trigger an attempt to resolve the neighbor.

**How I verified it**

**Details if related**
Add a static route with unavailable nexthop and verify that the route is successfully configured.
```
admin@vlab-01:~$ sudo sonic-cfggen -a '{"STATIC_ROUTE":{"10.13.0.0/24": {"nexthop": "192.168.0.10,192.168.0.11,192.168.0.12"}}}' --write-to-db
admin@vlab-01:~$ show ip route 10.13.0.0
Routing entry for 10.13.0.0/24
  Known via "static", distance 1, metric 0, best
  Last update 00:00:39 ago
  * 192.168.0.10, via Vlan1000, weight 1
  * 192.168.0.11, via Vlan1000, weight 1
  * 192.168.0.12, via Vlan1000, weight 1


admin@vlab-01:~$ sonic-db-cli APPL_DB hgetall "ROUTE_TABLE:10.13.0.0/24"
{'ifname': 'Vlan1000,Vlan1000,Vlan1000', 'nexthop': '192.168.0.10,192.168.0.11,192.168.0.12'}
admin@vlab-01:~$ sonic-db-cli ASIC_DB keys "*10.13.0.0*"
ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{"dest":"10.13.0.0/24","switch_id":"oid:0x21000000000000","vr":"oid:0x3000000000022"}
```

syslog
```
Apr 13 02:45:24.830163 vlab-01 DEBUG bgp#bgpcfgd: Received message : '('10.13.0.0/24', 'SET', (('nexthop', '192.168.0.10,192.168.0.11,192.168.0.12'),))'
Apr 13 02:45:24.831262 vlab-01 DEBUG bgp#bgpcfgd: Static route 10.13.0.0/24 is scheduled for updates
Apr 13 02:45:24.832379 vlab-01 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-f', '/tmp/tmp5j66zjuy']'.
Apr 13 02:45:24.998767 vlab-01 INFO swss#nbrmgrd: :- setNeighbor: Resolve request for '192.168.0.10'
Apr 13 02:45:25.009191 vlab-01 INFO swss#nbrmgrd: :- setNeighbor: Resolve request for '192.168.0.11'
Apr 13 02:45:25.021983 vlab-01 INFO swss#nbrmgrd: :- setNeighbor: Resolve request for '192.168.0.12'
Apr 13 02:45:25.028524 vlab-01 INFO swss#nbrmgrd: :- setNeighbor: Resolve request for '192.168.0.10'
Apr 13 02:45:25.028669 vlab-01 INFO swss#nbrmgrd: :- setNeighbor: Resolve request for '192.168.0.11'
Apr 13 02:45:25.032315 vlab-01 INFO swss#nbrmgrd: :- setNeighbor: Resolve request for '192.168.0.12'
Apr 13 02:45:25.039890 vlab-01 NOTICE swss#orchagent: :- addNeighbor: Created neighbor ip 192.168.0.10, fe:54:00:48:9b:84 on Vlan1000
Apr 13 02:45:25.047284 vlab-01 NOTICE swss#orchagent: :- addNextHop: Created next hop 192.168.0.10 on Vlan1000
Apr 13 02:45:25.050046 vlab-01 NOTICE swss#orchagent: :- addNeighbor: Created neighbor ip 192.168.0.11, fe:54:00:48:9b:84 on Vlan1000
Apr 13 02:45:25.053426 vlab-01 NOTICE swss#orchagent: :- addNextHop: Created next hop 192.168.0.11 on Vlan1000
Apr 13 02:45:25.056272 vlab-01 NOTICE swss#orchagent: :- addNeighbor: Created neighbor ip 192.168.0.12, fe:54:00:20:40:d3 on Vlan1000
Apr 13 02:45:25.059121 vlab-01 NOTICE swss#orchagent: :- addNextHop: Created next hop 192.168.0.12 on Vlan1000
Apr 13 02:45:25.062235 vlab-01 NOTICE swss#orchagent: :- addNextHopGroup: Create next hop group 192.168.0.10@Vlan1000,192.168.0.11@Vlan1000,192.168.0.12@Vlan1000
```