### PR TITLE
Allowing the first time FEC and AN configuration to be pushed to SAI

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -152,6 +152,8 @@ public:
     SystemPortInfo   m_system_port_info;
     SystemLagInfo    m_system_lag_info;
 
+    bool m_fec_cfg = false;
+    bool m_an_cfg = false;
 };
 
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2564,12 +2564,13 @@ void PortsOrch::doPortTask(Consumer &consumer)
             }
             else
             {
-                if (an != -1 && an != p.m_autoneg)
+                if (an != -1 && (!p.m_an_cfg || an != p.m_autoneg))
                 {
                     if (setPortAutoNeg(p.m_port_id, an))
                     {
                         SWSS_LOG_NOTICE("Set port %s AutoNeg to %u", alias.c_str(), an);
                         p.m_autoneg = an;
+                        p.m_an_cfg = true;
                         m_portList[alias] = p;
 
                         // Once AN is changed
@@ -2702,7 +2703,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     if (fec_mode_map.find(fec_mode) != fec_mode_map.end())
                     {
                         /* reset fec mode upon mode change */
-                        if (p.m_fec_mode != fec_mode_map[fec_mode])
+                        if (!p.m_fec_cfg || p.m_fec_mode != fec_mode_map[fec_mode])
                         {
                             if (p.m_admin_state_up)
                             {
@@ -2716,6 +2717,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                                 p.m_admin_state_up = false;
                                 p.m_fec_mode = fec_mode_map[fec_mode];
+                                p.m_fec_cfg = true;
 
                                 if (setPortFec(p, p.m_fec_mode))
                                 {
@@ -2733,6 +2735,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                             {
                                 /* Port is already down, setting fec mode*/
                                 p.m_fec_mode = fec_mode_map[fec_mode];
+                                p.m_fec_cfg = true;
                                 if (setPortFec(p, p.m_fec_mode))
                                 {
                                     m_portList[alias] = p;

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -12,11 +12,11 @@ class TestPortAutoNeg(object):
         adb = dvs.get_asic_db()
 
         tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
-        fvs = swsscommon.FieldValuePairs([("autoneg","on")])
+        fvs = swsscommon.FieldValuePairs([("autoneg","off")])
         tbl.set("Ethernet0", fvs)
 
         tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
-        fvs = swsscommon.FieldValuePairs([("autoneg","off"), ("speed", "1000")])
+        fvs = swsscommon.FieldValuePairs([("autoneg","on"), ("speed", "1000")])
         tbl.set("Ethernet4", fvs)
 
         # validate if autoneg false is pushed to asic db when set first time

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -6,6 +6,29 @@ from swsscommon import swsscommon
 
 
 class TestPortAutoNeg(object):
+    def test_PortAutoNegForce(self, dvs, testlog):
+
+        db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        adb = dvs.get_asic_db()
+
+        tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+        fvs = swsscommon.FieldValuePairs([("autoneg","0")])
+        tbl.set("Ethernet0", fvs)
+
+        tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+        fvs = swsscommon.FieldValuePairs([("autoneg","1"), ("speed", "1000")])
+        tbl.set("Ethernet4", fvs)
+
+        # validate if autoneg false is pushed to asic db when set first time
+        port_oid = adb.port_name_map["Ethernet0"]
+        expected_fields = {"SAI_PORT_ATTR_AUTO_NEG_MODE":"false"}
+        adb.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid, expected_fields)
+
+        # validate if autoneg true is pushed to asic db when set first time
+        port_oid = adb.port_name_map["Ethernet4"]
+        expected_fields = {"SAI_PORT_ATTR_AUTO_NEG_MODE":"true"}
+        adb.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid, expected_fields)
+
     def test_PortAutoNegCold(self, dvs, testlog):
 
         db = swsscommon.DBConnector(0, dvs.redis_sock, 0)

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -12,11 +12,11 @@ class TestPortAutoNeg(object):
         adb = dvs.get_asic_db()
 
         tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
-        fvs = swsscommon.FieldValuePairs([("autoneg","0")])
+        fvs = swsscommon.FieldValuePairs([("autoneg","on")])
         tbl.set("Ethernet0", fvs)
 
         tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
-        fvs = swsscommon.FieldValuePairs([("autoneg","1"), ("speed", "1000")])
+        fvs = swsscommon.FieldValuePairs([("autoneg","off"), ("speed", "1000")])
         tbl.set("Ethernet4", fvs)
 
         # validate if autoneg false is pushed to asic db when set first time


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Allowing the first time configuration for FEC and Autoneg to be pushed to SAI even if they are default.

**Why I did it**
In orchagent, the port struct is pre-initialized with fec = none and autoneg = false (Default SAI values). However in different hardware the underlying implementation might be different. There can also be requirement where the user values need to be forced. In current logic due to the port struct being initialized with default, fec = none or an = false configurations are not pushed from orchagent to SAI. In order to push it even in default case the conditional checks are modified.

**How I verified it**
Configure FEC as none and autoneg as false and check if ASIC DB is programmed.

**Details if related**
This change will force the FEC and autoneg configuration only if the configuration is explicitly present. There is no impact when there are no external FEC or autoneg configuration.
If an external FEC or autoneg config is present below are how different boot scenarios will be handled.
1) Warm boot will not be affected even if an external configuration is present since it will be reconciled. I tested the case and found no link flaps
2) Fast boot and Cold boot - Only if external configuration is present, it will be programmed during port initialization. No additional link flaps is seen or additional time is taken.
