### PR TITLE
[Dynamic buffer calc] Update pool sizes during initialization from timer only

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -455,10 +455,16 @@ void BufferMgrDynamic::recalculateSharedBufferPool()
     }
 }
 
-void BufferMgrDynamic::checkSharedBufferPoolSize()
+void BufferMgrDynamic::checkSharedBufferPoolSize(bool force_update_during_initialization = false)
 {
     // PortInitDone indicates all steps of port initialization has been done
     // Only after that does the buffer pool size update starts
+    if (!m_portInitDone && !force_update_during_initialization)
+    {
+        SWSS_LOG_INFO("Skip buffer pool updating during initialization");
+        return;
+    }
+
     if (!m_portInitDone)
     {
         vector<FieldValueTuple> values;
@@ -2060,5 +2066,5 @@ void BufferMgrDynamic::doTask(Consumer &consumer)
 
 void BufferMgrDynamic::doTask(SelectableTimer &timer)
 {
-    checkSharedBufferPoolSize();
+    checkSharedBufferPoolSize(true);
 }

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -228,7 +228,7 @@ private:
 
     // Meta flows
     void calculateHeadroomSize(buffer_profile_t &headroom);
-    void checkSharedBufferPoolSize();
+    void checkSharedBufferPoolSize(bool force_update_during_initialization);
     void recalculateSharedBufferPool();
     task_process_status allocateProfile(const std::string &speed, const std::string &cable, const std::string &mtu, const std::string &threshold, const std::string &gearbox_model, std::string &profile_name);
     void releaseProfile(const std::string &profile_name);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This is a supplement of Azure/sonic-swss#1685. In that PR, most of the cases in which the buffer pool updated during initialization have been avoided but there are still some rare cases not covered. Eg., it will try to recalculate the pool size because the lossless PSs are removed if one port is admin down.
In this PR, we will make sure that the buffer pools will be updated only once during initialization.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

**How I verified it**
Run regression and manual test

**Details if related**
