### PR TITLE
[Mux orch] Fix tunnel based NHs for IPv6 and ECMP routes

### DIFF
--- a/cfgmgr/tunnelmgr.cpp
+++ b/cfgmgr/tunnelmgr.cpp
@@ -64,10 +64,21 @@ static int cmdIpTunnelRouteAdd(const std::string& pfx, std::string & res)
     // ip route add/replace {{ip prefix}} dev {{tunnel intf}}
     // Replace route if route already exists
     ostringstream cmd;
-    cmd << IP_CMD " route replace "
-        << shellquote(pfx)
-        << " dev "
-        << TUNIF;
+    if (IpPrefix(pfx).isV4())
+    {
+        cmd << IP_CMD " route replace "
+            << shellquote(pfx)
+            << " dev "
+            << TUNIF;
+    }
+    else
+    {
+        cmd << IP_CMD " -6 route replace "
+            << shellquote(pfx)
+            << " dev "
+            << TUNIF;
+    }
+
     return swss::exec(cmd.str(), res);
 }
 
@@ -75,10 +86,21 @@ static int cmdIpTunnelRouteDel(const std::string& pfx, std::string & res)
 {
     // ip route del {{ip prefix}} dev {{tunnel intf}}
     ostringstream cmd;
-    cmd << IP_CMD " route del "
-        << shellquote(pfx)
-        << " dev "
-        << TUNIF;
+    if (IpPrefix(pfx).isV4())
+    {
+        cmd << IP_CMD " route del "
+            << shellquote(pfx)
+            << " dev "
+            << TUNIF;
+    }
+    else
+    {
+        cmd << IP_CMD " -6 route del "
+            << shellquote(pfx)
+            << " dev "
+            << TUNIF;
+    }
+
     return swss::exec(cmd.str(), res);
 }
 

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1278,12 +1278,6 @@ void MuxCableOrch::updateMuxState(string portName, string muxState)
 
 void MuxCableOrch::addTunnelRoute(const NextHopKey &nhKey)
 {
-    if (!nhKey.ip_address.isV4())
-    {
-        SWSS_LOG_INFO("IPv6 tunnel route add '%s' - (Not Implemented)", nhKey.ip_address.to_string().c_str());
-        return;
-    }
-
     vector<FieldValueTuple> data;
     string key, alias = nhKey.alias;
 
@@ -1299,12 +1293,6 @@ void MuxCableOrch::addTunnelRoute(const NextHopKey &nhKey)
 
 void MuxCableOrch::removeTunnelRoute(const NextHopKey &nhKey)
 {
-    if (!nhKey.ip_address.isV4())
-    {
-        SWSS_LOG_INFO("IPv6 tunnel route remove '%s' - (Not Implemented)", nhKey.ip_address.to_string().c_str());
-        return;
-    }
-
     string key, alias = nhKey.alias;
 
     IpPrefix pfx = nhKey.ip_address.to_string();

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -313,7 +313,10 @@ bool NeighOrch::isNextHopFlagSet(const NextHopKey &nexthop, const uint32_t nh_fl
 
     auto nhop = m_syncdNextHops.find(nexthop);
 
-    assert(nhop != m_syncdNextHops.end());
+    if (nhop == m_syncdNextHops.end())
+    {
+        return false;
+    }
 
     if (nhop->second.nh_flags & nh_flag)
     {


### PR DESCRIPTION
**What I did**

1. In case of standby mux, associated routes may come to orch with ifname of `tun0`. Handle the case when nexthop is non-zero
2. For ECMP, multiple nexthop IPs can have the same sai nexthop id (tunnel NH). Existing data structure is unable to handle such case. Added a secondary map if nexthops are shared
3. VS test to cover both cases. 

**Why I did it**
For dual tor SLB support

**How I verified it**

**Details if related**
