### PR TITLE
[sub intf] Port object reference count update

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -727,6 +727,8 @@ bool PortsOrch::getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port
 
 bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp, const uint32_t &mtu)
 {
+    SWSS_LOG_ENTER();
+
     size_t found = alias.find(VLAN_SUB_INTERFACE_SEPARATOR);
     if (found == string::npos)
     {
@@ -804,15 +806,19 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
         }
     }
 
-    parentPort.m_child_ports.insert(p.m_alias);
+    parentPort.m_child_ports.insert(alias);
+    increasePortRefCount(parentPort.m_alias);
 
     m_portList[alias] = p;
+    m_port_ref_count[alias] = 0;
     port = p;
     return true;
 }
 
 bool PortsOrch::removeSubPort(const string &alias)
 {
+    SWSS_LOG_ENTER();
+
     auto it = m_portList.find(alias);
     if (it == m_portList.end())
     {
@@ -827,6 +833,12 @@ bool PortsOrch::removeSubPort(const string &alias)
         return false;
     }
 
+    if (m_port_ref_count[alias] > 0)
+    {
+        SWSS_LOG_ERROR("Unable to remove sub interface %s: ref count %u", alias.c_str(), m_port_ref_count[alias]);
+        return false;
+    }
+
     Port parentPort;
     if (!getPort(port.m_parent_port_id, parentPort))
     {
@@ -836,6 +848,10 @@ bool PortsOrch::removeSubPort(const string &alias)
     if (!parentPort.m_child_ports.erase(alias))
     {
         SWSS_LOG_WARN("Sub interface %s not associated to parent port %s", alias.c_str(), parentPort.m_alias.c_str());
+    }
+    else
+    {
+        decreasePortRefCount(parentPort.m_alias);
     }
     m_portList[parentPort.m_alias] = parentPort;
 
@@ -4173,6 +4189,7 @@ bool PortsOrch::addVlan(string vlan_alias)
 bool PortsOrch::removeVlan(Port vlan)
 {
     SWSS_LOG_ENTER();
+
     if (m_port_ref_count[vlan.m_alias] > 0)
     {
         SWSS_LOG_ERROR("Failed to remove ref count %d VLAN %s",

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3062,6 +3062,13 @@ void PortsOrch::doPortTask(Consumer &consumer)
         }
         else if (op == DEL_COMMAND)
         {
+            if (m_port_ref_count[alias] > 0)
+            {
+                SWSS_LOG_WARN("Unable to remove port %s: ref count %u", alias.c_str(), m_port_ref_count[alias]);
+                it++;
+                continue;
+            }
+
             SWSS_LOG_NOTICE("Deleting Port %s", alias.c_str());
             auto port_id = m_portList[alias].m_port_id;
             auto hif_id = m_portList[alias].m_hif_id;

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -813,7 +813,6 @@ class TestSubPortIntf(object):
                 # Add lag members to test physical port host interface vlan tag attribute
                 self.add_lag_members(parent_port, self.LAG_MEMBERS_UNDER_TEST)
                 self.asic_db.wait_for_n_keys(ASIC_LAG_MEMBER_TABLE, len(self.LAG_MEMBERS_UNDER_TEST))
-
         if vrf_name:
             self.create_vrf(vrf_name)
             vrf_oid = self.get_newly_created_oid(ASIC_VIRTUAL_ROUTER_TABLE, [vrf_oid])

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -368,7 +368,6 @@ class TestSubPortIntf(object):
 
         vrf_oid = self.default_vrf_oid
         old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
-        old_lag_oids = self.get_oids(ASIC_LAG_TABLE)
 
         self.set_parent_port_admin_status(dvs, parent_port, "up")
         if parent_port.startswith(LAG_PREFIX):
@@ -572,15 +571,9 @@ class TestSubPortIntf(object):
         # Remove ip addresses from APPL_DB
         self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
         self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
-
         # Remove sub port interface from APPL_DB
         self.remove_sub_port_intf_profile_appl_db(sub_port_intf_name)
         self.check_sub_port_intf_profile_removal(rif_oid)
-
-        # Remove lag
-        if parent_port.startswith(LAG_PREFIX):
-            self.remove_lag(parent_port)
-            self.check_lag_removal(parent_port_oid)
 
         # Remove vrf if created
         if vrf_name:
@@ -804,7 +797,6 @@ class TestSubPortIntf(object):
 
         vrf_oid = self.default_vrf_oid
         old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
-        old_lag_oids = self.get_oids(ASIC_LAG_TABLE)
 
         self.set_parent_port_admin_status(dvs, parent_port, "up")
         if parent_port.startswith(LAG_PREFIX):

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -518,6 +518,7 @@ class TestSubPortIntf(object):
         # Remove ip addresses from APPL_DB
         self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
         self.remove_sub_port_intf_ip_addr_appl_db(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
+
         # Remove sub port interface from APPL_DB
         self.remove_sub_port_intf_profile_appl_db(sub_port_intf_name)
         self.check_sub_port_intf_profile_removal(rif_oid)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
#### At sub port Port object instantiation
- Init sub port Port object reference count
- Increase parent port Port object reference count

#### At sub port Port object removal
- Check sub port Port object reference count drops to zero
- Decrease parent port Port object reference count

#### At physical port removal
- Check physical port Port object reference count drops to zero


**Why I did it**
Enhancement


**How I verified it**
#### vs test extension
Issue parent port removal at APPL_DB level before removing sub port interface. Verify that parent port persists in ASIC_DB until sub interface is removed.

Without the change, extended vs test fails:
##### Physical port
```
========================================================================== FAILURES ===========================================================================
_________________________________________________________ TestSubPortIntf.test_sub_port_intf_removal __________________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7f92a4f56748>, dvs = <conftest.DockerVirtualSwitch object at 0x7f92a4f569e8>

    def test_sub_port_intf_removal(self, dvs):
        self.connect_dbs(dvs)
    
        self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
        self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
    
        self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, vrf_name=self.VRF_UNDER_TEST)
        self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, vrf_name=self.VRF_UNDER_TEST)
    
        self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, vrf_name=self.VNET_UNDER_TEST)
        self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, vrf_name=self.VNET_UNDER_TEST)
    
>       self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, removal_seq_test=True)

test_sub_port_intf.py:1058: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_sub_port_intf.py:945: in _test_sub_port_intf_removal
    self.check_sub_port_intf_fvs(self.state_db, state_tbl_name, sub_port_intf_name, fv_dict)
test_sub_port_intf.py:334: in check_sub_port_intf_fvs
    db.wait_for_field_match(table_name, key, fv_dict)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dvslib.dvs_database.DVSDatabase object at 0x7f92a4ea3710>, table_name = 'PORT_TABLE', key = 'Ethernet64.10', expected_fields = {'state': 'ok'}
polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True), failure_message = None

    def wait_for_field_match(
        self,
        table_name: str,
        key: str,
        expected_fields: Dict[str, str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> Dict[str, str]:
        """Wait for the entry stored at `key` to have the specified field/values and retrieve it.
    
        This method is useful if you only care about the contents of a subset of the fields stored
        in the specified entry.
    
        Args:
            table_name: The name of the table where the entry is stored.
            key: The key that maps to the entry being checked.
            expected_fields: The fields and their values we expect to see in the entry.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The entry stored at `key`. If no entry is found, then an empty Dict is returned.
        """
    
        def access_function():
            fv_pairs = self.get_entry(table_name, key)
            return (
                all(fv_pairs.get(k) == v for k, v in expected_fields.items()),
                fv_pairs,
            )
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            message = failure_message or (
                f"Expected field/value pairs not found: expected={expected_fields}, "
                f'received={result}, key="{key}", table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Expected field/value pairs not found: expected={'state': 'ok'}, received={}, key="Ethernet64.10", table="PORT_TABLE"

dvslib/dvs_database.py:203: AssertionError
=================================================================== short test summary info ===================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_removal - AssertionError: Expected field/value pairs not found: expected={'state': 'ok'}, ...
================================================================ 1 failed in 90.46s (0:01:30) =================================================================
root@5bf4ef40dc91:/var/wendani/src/sonic-buildimage/src/sonic-swss/tests# 
```

##### LAG
```
========================================================================== FAILURES ===========================================================================
_________________________________________________________ TestSubPortIntf.test_sub_port_intf_removal __________________________________________________________

self = <test_sub_port_intf.TestSubPortIntf object at 0x7fe7bc392278>, dvs = <conftest.DockerVirtualSwitch object at 0x7fe7c07cf7b8>

    def test_sub_port_intf_removal(self, dvs):
        self.connect_dbs(dvs)
    
        self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
        self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
    
        self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, vrf_name=self.VRF_UNDER_TEST)
        self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, vrf_name=self.VRF_UNDER_TEST)
    
        self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, vrf_name=self.VNET_UNDER_TEST)
        self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, vrf_name=self.VNET_UNDER_TEST)
    
        #self._test_sub_port_intf_removal(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, removal_seq_test=True)
>       self._test_sub_port_intf_removal(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, removal_seq_test=True)

test_sub_port_intf.py:1059: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_sub_port_intf.py:992: in _test_sub_port_intf_removal
    self.check_sub_port_intf_profile_removal(rif_oid)
test_sub_port_intf.py:272: in check_sub_port_intf_profile_removal
    self.asic_db.wait_for_deleted_keys(ASIC_RIF_TABLE, [rif_oid])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dvslib.dvs_database.DVSDatabase object at 0x7fe7bc3d6cc0>, table_name = 'ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE'
deleted_keys = ['oid:0x6000000000616'], polling_config = PollingConfig(polling_interval=0.01, timeout=5.0, strict=True), failure_message = None

    def wait_for_deleted_keys(
        self,
        table_name: str,
        deleted_keys: List[str],
        polling_config: PollingConfig = PollingConfig(),
        failure_message: str = None,
    ) -> List[str]:
        """Wait for the specfied keys to no longer exist in the table.
    
        Args:
            table_name: The name of the table from which to fetch the keys.
            deleted_keys: The keys we expect to be removed from the table.
            polling_config: The parameters to use to poll the db.
            failure_message: The message to print if the call times out. This will only take effect
                if the PollingConfig is set to strict.
    
        Returns:
            The keys stored in the table. If no keys are found, then an empty List is returned.
        """
    
        def access_function():
            keys = self.get_keys(table_name)
            return (all(key not in keys for key in deleted_keys), keys)
    
        status, result = wait_for_result(
            access_function, self._disable_strict_polling(polling_config)
        )
    
        if not status:
            expected = [key for key in result if key not in deleted_keys]
            message = failure_message or (
                f"Unexpected keys found: expected={expected}, received={result}, "
                f'table="{table_name}"'
            )
>           assert not polling_config.strict, message
E           AssertionError: Unexpected keys found: expected=['oid:0x60000000005a7'], received=('oid:0x60000000005a7', 'oid:0x6000000000616'), table="ASIC_STATE:SAI_OBJECT_TYPE_ROUTER_INTERFACE"

dvslib/dvs_database.py:437: AssertionError
=================================================================== short test summary info ===================================================================
FAILED test_sub_port_intf.py::TestSubPortIntf::test_sub_port_intf_removal - AssertionError: Unexpected keys found: expected=['oid:0x60000000005a7'], receive...
================================================================ 1 failed in 89.77s (0:01:29) =================================================================
```

syslog
```
497323 Apr 17 00:44:30.911338 9faa323d761d ERR #orchagent: :- removeLag: Failed to remove LAG PortChannel1 lid:2000000000615
497324 Apr 17 00:44:30.911364 9faa323d761d ERR #orchagent: :- handleSaiRemoveStatus: Encountered failure in remove operation, exiting orchagent, SAI API: SAI_A
       PI_LAG, status: SAI_STATUS_OBJECT_IN_USE
497325 Apr 17 00:44:30.911904 9faa323d761d NOTICE #orchagent: :- uninitialize: begin
497326 Apr 17 00:44:30.911975 9faa323d761d NOTICE #orchagent: :- uninitialize: begin
497327 Apr 17 00:44:30.911990 9faa323d761d NOTICE #orchagent: :- ~RedisChannel: join ntf thread begin
497328 Apr 17 00:44:30.912075 9faa323d761d NOTICE #orchagent: :- ~RedisChannel: join ntf thread end
497329 Apr 17 00:44:30.912152 9faa323d761d NOTICE #orchagent: :- clear_local_state: clearing local state
497330 Apr 17 00:44:30.912172 9faa323d761d NOTICE #orchagent: :- meta_init_db: begin
497331 Apr 17 00:44:30.913144 9faa323d761d NOTICE #orchagent: :- meta_init_db: end
497332 Apr 17 00:44:30.913164 9faa323d761d NOTICE #orchagent: :- uninitialize: end
497333 Apr 17 00:44:30.913224 9faa323d761d NOTICE #orchagent: :- stopRecording: stopped recording
497334 Apr 17 00:44:30.913237 9faa323d761d NOTICE #orchagent: :- stopRecording: closed recording file: sairedis.rec
497335 Apr 17 00:44:30.913597 9faa323d761d NOTICE #orchagent: :- uninitialize: end
497336 Apr 17 00:44:31.980229 9faa323d761d INFO #supervisord 2021-04-17 00:44:31,979 INFO exited: orchagent (exit status 1; not expected)
```


**Details if related**
Contains, and therefore after https://github.com/Azure/sonic-swss/pull/1642

Incremental change to https://github.com/Azure/sonic-swss/pull/1642 base can be found at https://github.com/wendani/sonic-swss/pull/9

- [ ] https://github.com/Azure/sonic-swss/pull/1642
