### PR TITLE
 @dr412113 L2 forwarding enhancements

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -305,12 +305,6 @@ void FdbOrch::update(sai_fdb_event_t        type,
         {
             update.port.m_fdb_count--;
             m_portsOrch->setPort(update.port.m_alias, update.port);
-
-            // this is not posted in last PR but its present in gerrit
-            if ((update.port.m_fdb_count == 0) && (update.port.m_vlan_members.empty()))
-            {
-                m_portsOrch->removeBridgePort(update.port);
-            }
         }
         if (!vlan.m_alias.empty())
         {
@@ -692,15 +686,16 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
     std::string data;
     std::vector<swss::FieldValueTuple> values;
 
-    Port vlan;
-    Port port;
-
     consumer.pop(op, data, values);
 
     if (&consumer == m_flushNotificationsConsumer)
     {
         if (op == "ALL")
         {
+            /*
+             * so far only support flush all the FDB entries
+             * flush per port and flush per vlan will be added later.
+             */
             status = sai_fdb_api->flush_fdb_entries(gSwitchId, 0, NULL);
             if (status != SAI_STATUS_SUCCESS)
             {
@@ -711,22 +706,14 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
         }
         else if (op == "PORT")
         {
-            if (!m_portsOrch->getPort(data, port))
-            {
-                SWSS_LOG_ERROR("could not locate port from data %s", data.c_str());
-                return;
-            }
-            flushFDBEntries(port.m_bridge_port_id, SAI_NULL_OBJECT_ID);
+            /*place holder for flush port fdb*/
+            SWSS_LOG_ERROR("Received unsupported flush port fdb request");
             return;
         }
         else if (op == "VLAN")
         {
-            if (!m_portsOrch->getPort(data, vlan))
-            {
-                SWSS_LOG_ERROR("could not locate vlan from data %s", data.c_str());
-                return;
-            }
-            flushFDBEntries(SAI_NULL_OBJECT_ID, vlan.m_vlan_info.vlan_oid);
+            /*place holder for flush vlan fdb*/
+            SWSS_LOG_ERROR("Received unsupported flush vlan fdb request");
             return;
         }
         else
@@ -739,12 +726,6 @@ void FdbOrch::doTask(NotificationConsumer& consumer)
     {
         uint32_t count;
         sai_fdb_event_notification_data_t *fdbevent = nullptr;
-        extern void handle_fdb_event(_In_ const std::string &data);
-        /* The sai_redis fdb handling is moved here so that both
-         * reference count updates (sai_redis and portsOrch)
-         * happen in same context to avoid any mismatch.
-         */
-        handle_fdb_event(data);
 
         sai_deserialize_fdb_event_ntf(data, count, &fdbevent);
 

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -108,7 +108,6 @@ public:
     VlanInfo            m_vlan_info;
     MacAddress          m_mac;
     sai_object_id_t     m_bridge_port_id = 0;   // TODO: port could have multiple bridge port IDs
-    sai_object_id_t     m_bridge_port_admin_state = 0;   // TODO: port could have multiple bridge port IDs
     sai_vlan_id_t       m_port_vlan_id = DEFAULT_PORT_VLAN_ID;  // Port VLAN ID
     sai_object_id_t     m_rif_id = 0;
     sai_object_id_t     m_vr_id = 0;

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -108,6 +108,7 @@ public:
     VlanInfo            m_vlan_info;
     MacAddress          m_mac;
     sai_object_id_t     m_bridge_port_id = 0;   // TODO: port could have multiple bridge port IDs
+    sai_object_id_t     m_bridge_port_admin_state = 0;   // TODO: port could have multiple bridge port IDs
     sai_vlan_id_t       m_port_vlan_id = DEFAULT_PORT_VLAN_ID;  // Port VLAN ID
     sai_object_id_t     m_rif_id = 0;
     sai_object_id_t     m_vr_id = 0;
@@ -117,7 +118,15 @@ public:
     sai_object_id_t     m_tunnel_id = 0;
     sai_object_id_t     m_ingress_acl_table_group_id = 0;
     sai_object_id_t     m_egress_acl_table_group_id = 0;
-    vlan_members_t      m_vlan_members;
+    /* there can be a large number of vlan members
+     * which will cause performance impact, as
+     * getPort copies the whole structure. 
+     * Performance issue are seen during mac event 
+     * processing with large number of vlans on a 
+     * port. Large data should not be added to this
+     * structure.
+     */
+    //vlan_members_t      m_vlan_members;
     sai_object_id_t     m_parent_port_id = 0;
     uint32_t            m_dependency_bitmap = 0;
     sai_port_oper_status_t m_oper_status = SAI_PORT_OPER_STATUS_UNKNOWN;

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -108,6 +108,7 @@ public:
     VlanInfo            m_vlan_info;
     MacAddress          m_mac;
     sai_object_id_t     m_bridge_port_id = 0;   // TODO: port could have multiple bridge port IDs
+    sai_object_id_t     m_bridge_port_admin_state = 0;   // TODO: port could have multiple bridge port IDs
     sai_vlan_id_t       m_port_vlan_id = DEFAULT_PORT_VLAN_ID;  // Port VLAN ID
     sai_object_id_t     m_rif_id = 0;
     sai_object_id_t     m_vr_id = 0;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -611,35 +611,12 @@ bool PortsOrch::getPort(sai_object_id_t id, Port &port)
 {
     SWSS_LOG_ENTER();
 
-    for (const auto& portIter: m_portList)
-    {
-        switch (portIter.second.m_type)
-        {
-        case Port::PHY:
-        case Port::SYSTEM:
-            if(portIter.second.m_port_id == id)
-            {
-                port = portIter.second;
-                return true;
-            }
-            break;
-        case Port::LAG:
-            if(portIter.second.m_lag_id == id)
-            {
-                port = portIter.second;
-                return true;
-            }
-            break;
-        case Port::VLAN:
-            if (portIter.second.m_vlan_info.vlan_oid == id)
-            {
-                port = portIter.second;
-                return true;
-            }
-            break;
-        default:
-            continue;
-        }
+    auto itr = portOidToName.find(id);
+    if (itr == portOidToName.end())
+        return false;
+    else {
+        getPort(itr->second, port);
+        return true;
     }
 
     return false;
@@ -661,15 +638,13 @@ bool PortsOrch::getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port
 {
     SWSS_LOG_ENTER();
 
-    for (auto &it: m_portList)
-    {
-        if (it.second.m_bridge_port_id == bridge_port_id)
-        {
-            port = it.second;
-            return true;
-        }
+    auto itr = portOidToName.find(bridge_port_id);
+    if (itr == portOidToName.end())
+        return false;
+    else {
+        getPort(itr->second, port);
+        return true;
     }
-
     return false;
 }
 
@@ -2073,6 +2048,7 @@ bool PortsOrch::initPort(const string &alias, const int index, const set<int> &l
 
                 /* Add port to port list */
                 m_portList[alias] = p;
+                portOidToName[id] = alias;
                 m_port_ref_count[alias] = 0;
                 m_portOidToIndex[id] = index;
 
@@ -3034,24 +3010,24 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
         }
         else if (op == DEL_COMMAND)
         {
+            int ret = true;
+
             if (vlan.m_members.find(port_alias) != vlan.m_members.end())
             {
-                if (removeVlanMember(vlan, port))
-                {
-                    if (port.m_vlan_members.empty())
-                    {
-                        removeBridgePort(port);
-                    }
-                    it = consumer.m_toSync.erase(it);
-                }
-                else
-                {
-                    it++;
-                }
+                ret = removeVlanMember(vlan, port);
+            }
+            if ((ret == true) && port.m_vlan_members.empty())
+            {
+                ret = removeBridgePort(port);
+            }
+            if (ret == true)
+            {
+                it = consumer.m_toSync.erase(it);
             }
             else
-                /* Cannot locate the VLAN */
-                it = consumer.m_toSync.erase(it);
+            {
+                it++;
+            }
         }
         else
         {
@@ -3131,8 +3107,7 @@ void PortsOrch::doLagTask(Consumer &consumer)
                 switch_id = -1;
             }
 
-            // Create a new LAG when the new alias comes
-            if (m_portList.find(alias) == m_portList.end())
+            if (!addLag(alias))
             {
                 if (!addLag(alias, lag_id, switch_id))
                 {
@@ -3671,6 +3646,36 @@ bool PortsOrch::addBridgePort(Port &port)
 
     if (port.m_bridge_port_id != SAI_NULL_OBJECT_ID)
     {
+        /* If the port is being added to the first VLAN,
+         * set bridge port admin status to UP.
+         * This can happen if the port was just removed from
+         * last VLAN and fdb flush is still in progress.
+         */
+        if (port.m_vlan_members.empty())
+        {
+            if (port.m_fdb_count > 0)
+            {
+                return false;
+            } 
+            sai_attribute_t attr;
+            attr.id = SAI_BRIDGE_PORT_ATTR_ADMIN_STATE;
+            attr.value.booldata = true;
+            sai_status_t status = sai_bridge_api->set_bridge_port_attribute(port.m_bridge_port_id, &attr);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to set bridge port %s admin status to UP, rv:%d",
+                    port.m_alias.c_str(), status);
+                return false;
+            }
+            port.m_bridge_port_admin_state = true;   
+            m_portList[port.m_alias] = port;
+            if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
+            {
+                SWSS_LOG_ERROR("Failed to set %s for hostif of port %s",
+                        hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_KEEP], port.m_alias.c_str());
+                return false;
+            }
+        }
         return true;
     }
 
@@ -3748,6 +3753,8 @@ bool PortsOrch::addBridgePort(Port &port)
         }
     }
 
+    port.m_bridge_port_admin_state = true;
+
     if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
     {
         SWSS_LOG_ERROR("Failed to set %s for hostif of port %s",
@@ -3755,6 +3762,7 @@ bool PortsOrch::addBridgePort(Port &port)
         return false;
     }
     m_portList[port.m_alias] = port;
+    portOidToName[port.m_bridge_port_id] = port.m_alias;
     SWSS_LOG_NOTICE("Add bridge port %s to default 1Q bridge", port.m_alias.c_str());
 
     return true;
@@ -3768,13 +3776,7 @@ bool PortsOrch::removeBridgePort(Port &port)
     {
         return true;
     }
-    /* Set bridge port admin status to DOWN */
-    sai_attribute_t attr;
-    attr.id = SAI_BRIDGE_PORT_ATTR_ADMIN_STATE;
-    attr.value.booldata = false;
-
-    sai_status_t status = sai_bridge_api->set_bridge_port_attribute(port.m_bridge_port_id, &attr);
-    if (status != SAI_STATUS_SUCCESS)
+    if (port.m_bridge_port_admin_state)
     {
         SWSS_LOG_ERROR("Failed to set bridge port %s admin status to DOWN, rv:%d",
             port.m_alias.c_str(), status);
@@ -3797,7 +3799,7 @@ bool PortsOrch::removeBridgePort(Port &port)
     SWSS_LOG_INFO("Flush FDB entries for port %s", port.m_alias.c_str());
 
     /* Remove bridge port */
-    status = sai_bridge_api->remove_bridge_port(port.m_bridge_port_id);
+    sai_status_t status = sai_bridge_api->remove_bridge_port(port.m_bridge_port_id);
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove bridge port %s from default 1Q bridge, rv:%d",
@@ -3808,6 +3810,7 @@ bool PortsOrch::removeBridgePort(Port &port)
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
+    portOidToName.erase(port.m_bridge_port_id);
     port.m_bridge_port_id = SAI_NULL_OBJECT_ID;
 
     SWSS_LOG_NOTICE("Remove bridge port %s from default 1Q bridge", port.m_alias.c_str());
@@ -3876,7 +3879,7 @@ bool PortsOrch::addVlan(string vlan_alias)
         }
     }
 
-    SWSS_LOG_NOTICE("Create an empty VLAN %s vid:%hu", vlan_alias.c_str(), vlan_id);
+    SWSS_LOG_NOTICE("Create an empty VLAN %s vid:%hu vlan_oid 0x%lx", vlan_alias.c_str(), vlan_id, vlan_oid);
 
     Port vlan(vlan_alias, Port::VLAN);
     vlan.m_vlan_info.vlan_oid = vlan_oid;
@@ -3884,6 +3887,7 @@ bool PortsOrch::addVlan(string vlan_alias)
     vlan.m_members = set<string>();
     m_portList[vlan_alias] = vlan;
     m_port_ref_count[vlan_alias] = 0;
+    portOidToName[vlan_oid] =  vlan_alias;
 
     return true;
 }
@@ -3891,6 +3895,15 @@ bool PortsOrch::addVlan(string vlan_alias)
 bool PortsOrch::removeVlan(Port vlan)
 {
     SWSS_LOG_ENTER();
+
+    /* If there are still fdb entries associated with the VLAN,
+       return false for retry */
+    if (vlan.m_fdb_count > 0)
+    {
+        SWSS_LOG_NOTICE("VLAN %s still has assiciated FDB entries", vlan.m_alias.c_str());
+        return false;
+    }
+
     if (m_port_ref_count[vlan.m_alias] > 0)
     {
         SWSS_LOG_ERROR("Failed to remove ref count %d VLAN %s",
@@ -3931,6 +3944,7 @@ bool PortsOrch::removeVlan(Port vlan)
     SWSS_LOG_NOTICE("Remove VLAN %s vid:%hu", vlan.m_alias.c_str(),
             vlan.m_vlan_info.vlan_id);
 
+    portOidToName.erase(vlan.m_vlan_info.vlan_oid);
     m_portList.erase(vlan.m_alias);
     m_port_ref_count.erase(vlan.m_alias);
 
@@ -4127,6 +4141,7 @@ bool PortsOrch::addLag(string lag_alias, uint32_t spa_id, int32_t switch_id)
     lag.m_members = set<string>();
     m_portList[lag_alias] = lag;
     m_port_ref_count[lag_alias] = 0;
+    portOidToName[lag_id] = lag_alias;
 
     PortUpdate update = { lag, true };
     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
@@ -4181,6 +4196,11 @@ bool PortsOrch::removeLag(Port lag)
         return false;
     }
 
+    if (lag.m_bridge_port_id != SAI_NULL_OBJECT_ID)
+    {
+        return false;
+    }
+
     sai_status_t status = sai_lag_api->remove_lag(lag.m_lag_id);
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -4194,6 +4214,7 @@ bool PortsOrch::removeLag(Port lag)
 
     SWSS_LOG_NOTICE("Remove LAG %s lid:%" PRIx64, lag.m_alias.c_str(), lag.m_lag_id);
 
+    portOidToName.erase(lag.m_lag_id);
     m_portList.erase(lag.m_alias);
     m_port_ref_count.erase(lag.m_alias);
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -611,12 +611,35 @@ bool PortsOrch::getPort(sai_object_id_t id, Port &port)
 {
     SWSS_LOG_ENTER();
 
-    auto itr = portOidToName.find(id);
-    if (itr == portOidToName.end())
-        return false;
-    else {
-        getPort(itr->second, port);
-        return true;
+    for (const auto& portIter: m_portList)
+    {
+        switch (portIter.second.m_type)
+        {
+        case Port::PHY:
+        case Port::SYSTEM:
+            if(portIter.second.m_port_id == id)
+            {
+                port = portIter.second;
+                return true;
+            }
+            break;
+        case Port::LAG:
+            if(portIter.second.m_lag_id == id)
+            {
+                port = portIter.second;
+                return true;
+            }
+            break;
+        case Port::VLAN:
+            if (portIter.second.m_vlan_info.vlan_oid == id)
+            {
+                port = portIter.second;
+                return true;
+            }
+            break;
+        default:
+            continue;
+        }
     }
 
     return false;
@@ -638,13 +661,15 @@ bool PortsOrch::getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port
 {
     SWSS_LOG_ENTER();
 
-    auto itr = portOidToName.find(bridge_port_id);
-    if (itr == portOidToName.end())
-        return false;
-    else {
-        getPort(itr->second, port);
-        return true;
+    for (auto &it: m_portList)
+    {
+        if (it.second.m_bridge_port_id == bridge_port_id)
+        {
+            port = it.second;
+            return true;
+        }
     }
+
     return false;
 }
 
@@ -2048,7 +2073,6 @@ bool PortsOrch::initPort(const string &alias, const int index, const set<int> &l
 
                 /* Add port to port list */
                 m_portList[alias] = p;
-                portOidToName[id] = alias;
                 m_port_ref_count[alias] = 0;
                 m_portOidToIndex[id] = index;
 
@@ -3010,24 +3034,24 @@ void PortsOrch::doVlanMemberTask(Consumer &consumer)
         }
         else if (op == DEL_COMMAND)
         {
-            int ret = true;
-
             if (vlan.m_members.find(port_alias) != vlan.m_members.end())
             {
-                ret = removeVlanMember(vlan, port);
-            }
-            if ((ret == true) && port.m_vlan_members.empty())
-            {
-                ret = removeBridgePort(port);
-            }
-            if (ret == true)
-            {
-                it = consumer.m_toSync.erase(it);
+                if (removeVlanMember(vlan, port))
+                {
+                    if (port.m_vlan_members.empty())
+                    {
+                        removeBridgePort(port);
+                    }
+                    it = consumer.m_toSync.erase(it);
+                }
+                else
+                {
+                    it++;
+                }
             }
             else
-            {
-                it++;
-            }
+                /* Cannot locate the VLAN */
+                it = consumer.m_toSync.erase(it);
         }
         else
         {
@@ -3107,7 +3131,8 @@ void PortsOrch::doLagTask(Consumer &consumer)
                 switch_id = -1;
             }
 
-            if (!addLag(alias))
+            // Create a new LAG when the new alias comes
+            if (m_portList.find(alias) == m_portList.end())
             {
                 if (!addLag(alias, lag_id, switch_id))
                 {
@@ -3646,36 +3671,6 @@ bool PortsOrch::addBridgePort(Port &port)
 
     if (port.m_bridge_port_id != SAI_NULL_OBJECT_ID)
     {
-        /* If the port is being added to the first VLAN,
-         * set bridge port admin status to UP.
-         * This can happen if the port was just removed from
-         * last VLAN and fdb flush is still in progress.
-         */
-        if (port.m_vlan_members.empty())
-        {
-            if (port.m_fdb_count > 0)
-            {
-                return false;
-            } 
-            sai_attribute_t attr;
-            attr.id = SAI_BRIDGE_PORT_ATTR_ADMIN_STATE;
-            attr.value.booldata = true;
-            sai_status_t status = sai_bridge_api->set_bridge_port_attribute(port.m_bridge_port_id, &attr);
-            if (status != SAI_STATUS_SUCCESS)
-            {
-                SWSS_LOG_ERROR("Failed to set bridge port %s admin status to UP, rv:%d",
-                    port.m_alias.c_str(), status);
-                return false;
-            }
-            port.m_bridge_port_admin_state = true;   
-            m_portList[port.m_alias] = port;
-            if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
-            {
-                SWSS_LOG_ERROR("Failed to set %s for hostif of port %s",
-                        hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_KEEP], port.m_alias.c_str());
-                return false;
-            }
-        }
         return true;
     }
 
@@ -3753,8 +3748,6 @@ bool PortsOrch::addBridgePort(Port &port)
         }
     }
 
-    port.m_bridge_port_admin_state = true;
-
     if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
     {
         SWSS_LOG_ERROR("Failed to set %s for hostif of port %s",
@@ -3762,7 +3755,6 @@ bool PortsOrch::addBridgePort(Port &port)
         return false;
     }
     m_portList[port.m_alias] = port;
-    portOidToName[port.m_bridge_port_id] = port.m_alias;
     SWSS_LOG_NOTICE("Add bridge port %s to default 1Q bridge", port.m_alias.c_str());
 
     return true;
@@ -3776,7 +3768,13 @@ bool PortsOrch::removeBridgePort(Port &port)
     {
         return true;
     }
-    if (port.m_bridge_port_admin_state)
+    /* Set bridge port admin status to DOWN */
+    sai_attribute_t attr;
+    attr.id = SAI_BRIDGE_PORT_ATTR_ADMIN_STATE;
+    attr.value.booldata = false;
+
+    sai_status_t status = sai_bridge_api->set_bridge_port_attribute(port.m_bridge_port_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set bridge port %s admin status to DOWN, rv:%d",
             port.m_alias.c_str(), status);
@@ -3799,7 +3797,7 @@ bool PortsOrch::removeBridgePort(Port &port)
     SWSS_LOG_INFO("Flush FDB entries for port %s", port.m_alias.c_str());
 
     /* Remove bridge port */
-    sai_status_t status = sai_bridge_api->remove_bridge_port(port.m_bridge_port_id);
+    status = sai_bridge_api->remove_bridge_port(port.m_bridge_port_id);
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove bridge port %s from default 1Q bridge, rv:%d",
@@ -3810,7 +3808,6 @@ bool PortsOrch::removeBridgePort(Port &port)
             return parseHandleSaiStatusFailure(handle_status);
         }
     }
-    portOidToName.erase(port.m_bridge_port_id);
     port.m_bridge_port_id = SAI_NULL_OBJECT_ID;
 
     SWSS_LOG_NOTICE("Remove bridge port %s from default 1Q bridge", port.m_alias.c_str());
@@ -3879,7 +3876,7 @@ bool PortsOrch::addVlan(string vlan_alias)
         }
     }
 
-    SWSS_LOG_NOTICE("Create an empty VLAN %s vid:%hu vlan_oid 0x%lx", vlan_alias.c_str(), vlan_id, vlan_oid);
+    SWSS_LOG_NOTICE("Create an empty VLAN %s vid:%hu", vlan_alias.c_str(), vlan_id);
 
     Port vlan(vlan_alias, Port::VLAN);
     vlan.m_vlan_info.vlan_oid = vlan_oid;
@@ -3887,7 +3884,6 @@ bool PortsOrch::addVlan(string vlan_alias)
     vlan.m_members = set<string>();
     m_portList[vlan_alias] = vlan;
     m_port_ref_count[vlan_alias] = 0;
-    portOidToName[vlan_oid] =  vlan_alias;
 
     return true;
 }
@@ -3895,15 +3891,6 @@ bool PortsOrch::addVlan(string vlan_alias)
 bool PortsOrch::removeVlan(Port vlan)
 {
     SWSS_LOG_ENTER();
-
-    /* If there are still fdb entries associated with the VLAN,
-       return false for retry */
-    if (vlan.m_fdb_count > 0)
-    {
-        SWSS_LOG_NOTICE("VLAN %s still has assiciated FDB entries", vlan.m_alias.c_str());
-        return false;
-    }
-
     if (m_port_ref_count[vlan.m_alias] > 0)
     {
         SWSS_LOG_ERROR("Failed to remove ref count %d VLAN %s",
@@ -3944,7 +3931,6 @@ bool PortsOrch::removeVlan(Port vlan)
     SWSS_LOG_NOTICE("Remove VLAN %s vid:%hu", vlan.m_alias.c_str(),
             vlan.m_vlan_info.vlan_id);
 
-    portOidToName.erase(vlan.m_vlan_info.vlan_oid);
     m_portList.erase(vlan.m_alias);
     m_port_ref_count.erase(vlan.m_alias);
 
@@ -4141,7 +4127,6 @@ bool PortsOrch::addLag(string lag_alias, uint32_t spa_id, int32_t switch_id)
     lag.m_members = set<string>();
     m_portList[lag_alias] = lag;
     m_port_ref_count[lag_alias] = 0;
-    portOidToName[lag_id] = lag_alias;
 
     PortUpdate update = { lag, true };
     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
@@ -4196,11 +4181,6 @@ bool PortsOrch::removeLag(Port lag)
         return false;
     }
 
-    if (lag.m_bridge_port_id != SAI_NULL_OBJECT_ID)
-    {
-        return false;
-    }
-
     sai_status_t status = sai_lag_api->remove_lag(lag.m_lag_id);
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -4214,7 +4194,6 @@ bool PortsOrch::removeLag(Port lag)
 
     SWSS_LOG_NOTICE("Remove LAG %s lid:%" PRIx64, lag.m_alias.c_str(), lag.m_lag_id);
 
-    portOidToName.erase(lag.m_lag_id);
     m_portList.erase(lag.m_alias);
     m_port_ref_count.erase(lag.m_alias);
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -207,6 +207,11 @@ private:
     map<set<int>, sai_object_id_t> m_portListLaneMap;
     map<set<int>, tuple<string, uint32_t, int, string, int>> m_lanesAliasSpeedMap;
     map<string, Port> m_portList;
+    /* mapping from SAI object ID to Name for faster 
+     * retrieval of Port/VLAN from object ID for events
+     * coming from SAI
+     */
+    unordered_map<sai_object_id_t, string> portOidToName;
     unordered_map<sai_object_id_t, int> m_portOidToIndex;
     map<string, uint32_t> m_port_ref_count;
     unordered_set<string> m_pendingPortSet;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -207,11 +207,6 @@ private:
     map<set<int>, sai_object_id_t> m_portListLaneMap;
     map<set<int>, tuple<string, uint32_t, int, string, int>> m_lanesAliasSpeedMap;
     map<string, Port> m_portList;
-    /* mapping from SAI object ID to Name for faster 
-     * retrieval of Port/VLAN from object ID for events
-     * coming from SAI
-     */
-    unordered_map<sai_object_id_t, string> portOidToName;
     unordered_map<sai_object_id_t, int> m_portOidToIndex;
     map<string, uint32_t> m_port_ref_count;
     unordered_set<string> m_pendingPortSet;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -143,6 +143,7 @@ public:
     string m_inbandPortName = "";
     bool isInbandPort(const string &alias);
     bool setVoqInbandIntf(string &alias, string &type);
+    bool getPortVlanMembers(Port &port, vlan_members_t &vlan_members);
 
 private:
     unique_ptr<Table> m_counterTable;
@@ -207,6 +208,12 @@ private:
     map<set<int>, sai_object_id_t> m_portListLaneMap;
     map<set<int>, tuple<string, uint32_t, int, string, int>> m_lanesAliasSpeedMap;
     map<string, Port> m_portList;
+    map<string, vlan_members_t> m_portVlanMember;
+    /* mapping from SAI object ID to Name for faster
+     * retrieval of Port/VLAN from object ID for events
+     * coming from SAI
+     */
+    unordered_map<sai_object_id_t, string> portOidToName;
     unordered_map<sai_object_id_t, int> m_portOidToIndex;
     map<string, uint32_t> m_port_ref_count;
     unordered_set<string> m_pendingPortSet;


### PR DESCRIPTION
**What I did**

- Invoke flush Fdb entries per port/vlan
- Instead of maintaining the vlan-members inside Port structure, added a new portVlanmap for vlan members.
 /* Performance issue are seen during mac event processing with large number of vlans on a
 * port. Large data should not be added to port structure. */
- created a portOidToName map to improve performace
- delay lag delete until bridge port is deleted
- delay bridge port removal until all asociated fdb entries are
removed. delete bridge port from portsorch instead of fdborch


**Why I did it**

To improve FDB performance.

**How I verified it**

Verified all basic mac learning operations.

**Details if related**
