### PR TITLE
[MACsec]: Support switchId and portId for gearbox

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -231,8 +231,14 @@ public:
             {
                 return nullptr;
             }
-            m_port_id = std::make_unique<sai_object_id_t>(port->m_port_id);
-            // TODO: If the MACsec was enabled at the gearbox, should use line port id as the port id.
+            if (port->m_line_side_id != SAI_NULL_OBJECT_ID)
+            {
+                m_port_id = std::make_unique<sai_object_id_t>(port->m_line_side_id);
+            }
+            else
+            {
+                m_port_id = std::make_unique<sai_object_id_t>(port->m_port_id);
+            }
         }
         return m_port_id.get();
     }
@@ -241,12 +247,22 @@ public:
     {
         if (m_switch_id == nullptr)
         {
-            if (gSwitchId == SAI_NULL_OBJECT_ID)
+            auto port = get_port();
+            sai_object_id_t switchId;
+            if (port == nullptr || port->m_switch_id == SAI_NULL_OBJECT_ID)
+            {
+                switchId = gSwitchId;
+            }
+            else
+            {
+                switchId = port->m_switch_id;
+            }
+            if (switchId == SAI_NULL_OBJECT_ID)
             {
                 SWSS_LOG_ERROR("Switch ID cannot be found");
                 return nullptr;
             }
-            m_switch_id = std::make_unique<sai_object_id_t>(gSwitchId);
+            m_switch_id = std::make_unique<sai_object_id_t>(switchId);
         }
         return m_switch_id.get();
     }

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -152,6 +152,9 @@ public:
     SystemPortInfo   m_system_port_info;
     SystemLagInfo    m_system_lag_info;
 
+    sai_object_id_t  m_switch_id = 0;
+    sai_object_id_t  m_line_side_id = 0;
+
     bool m_fec_cfg = false;
     bool m_an_cfg = false;
 };

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5140,6 +5140,9 @@ bool PortsOrch::initGearboxPort(Port &port)
 
             sai_deserialize_object_id(phyOidStr, phyOid);
 
+            SWSS_LOG_NOTICE("BOX: Gearbox port %s assigned phyOid 0x%" PRIx64, port.m_alias.c_str(), phyOid);
+            port.m_switch_id = phyOid;
+
             /* Create SYSTEM-SIDE port */
             attrs.clear();
 
@@ -5305,6 +5308,7 @@ bool PortsOrch::initGearboxPort(Port &port)
 
             SWSS_LOG_NOTICE("BOX: Connected Gearbox ports; system-side:0x%" PRIx64 " to line-side:0x%" PRIx64, systemPort, linePort);
             m_gearboxPortListLaneMap[port.m_port_id] = make_tuple(systemPort, linePort);
+            port.m_line_side_id = linePort;
         }
     }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
To support MACsec on Arista 7280cr3, which uses external gearbox chips, the switch Id and port Id used in MACsec SAI APIs have to be coming from the context of the gearbox chips. This change implements it by saving the Ids in initGearboxPort() and used them in MACsecOrchContext.

**Why I did it**

**How I verified it**

**Details if related**
