### PR TITLE
[MACsec]: Change the SCI value for no explict SCI

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -1457,7 +1457,7 @@ bool MACsecOrch::createMACsecSC(
     attr.value.oid = flow_id;
     attrs.push_back(attr);
     attr.id = SAI_MACSEC_SC_ATTR_MACSEC_SCI;
-    attr.value.u64 = sci;
+    attr.value.u64 = send_sci ? sci : 0xffffffffffffffff;
     attrs.push_back(attr);
     attr.id = SAI_MACSEC_SC_ATTR_ENCRYPTION_ENABLE;
     attr.value.booldata = encryption_enable;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
SCI value passed to create_macsec_sc is later used as a mask in the SC/SA matching for packets. When NO explicit SCI is included in the packet, the SCI value has to be set as a wildcard.

**Why I did it**

**How I verified it**

**Details if related**
