### PR TITLE
[MACsec]: Set macsec to bypass by default

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -789,6 +789,11 @@ bool MACsecOrch::initMACsecObject(sai_object_id_t switch_id)
     attr.id = SAI_MACSEC_ATTR_DIRECTION;
     attr.value.s32 = SAI_MACSEC_DIRECTION_EGRESS;
     attrs.push_back(attr);
+
+    attr.id = SAI_MACSEC_ATTR_PHYSICAL_BYPASS_ENABLE;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
     sai_status_t status = sai_macsec_api->create_macsec(
                                 &macsec_obj.first->second.m_egress_id,
                                 switch_id,
@@ -809,6 +814,11 @@ bool MACsecOrch::initMACsecObject(sai_object_id_t switch_id)
     attr.id = SAI_MACSEC_ATTR_DIRECTION;
     attr.value.s32 = SAI_MACSEC_DIRECTION_INGRESS;
     attrs.push_back(attr);
+
+    attr.id = SAI_MACSEC_ATTR_PHYSICAL_BYPASS_ENABLE;
+    attr.value.booldata = true;
+    attrs.push_back(attr);
+
     status = sai_macsec_api->create_macsec(
                                 &macsec_obj.first->second.m_ingress_id,
                                 switch_id,


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
In adapting to the MACsec driver for Arista 7280Cr3, we found it is necessary to set SAI_MACSEC_ATTR_PHYSICAL_BYPASS_ENABLE to True, to successfully change the MACsec status from enable to disable (expecting that the traffic can pass through without encryption thereafter). The reason behind is that the default value of the attribute is False, if it is False, the driver understands it as the user is not allowing to bypass MACsec, yielding the result of disabling MACsec not as expected.

**Why I did it**

**How I verified it**

**Details if related**
