### PR TITLE
Mac for kernel static neigh programmed for voq neighs in VOQ chassis with port type inband interface in VS platforms

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1145,6 +1145,42 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
                     if(ibif.m_type != Port::VLAN)
                     {
                         mac_address = gMacAddress;
+
+                        // For VS platforms, the mac of the static neigh should not be same as asic's own mac.
+                        // This is because host originated packets will have same mac for both src and dst which
+                        // will result in host NOT sending packet out. To address this problem which is specific
+                        // to port type inband interfaces, set the mac to the neighbor's owner asic's mac. Since
+                        // the owner asic's mac is not readily avaiable here, the owner asic mac is derived from
+                        // the switch id and lower 5 bytes of asic mac which is assumed to be same for all asics
+                        // in the VS system.
+                        // Therefore to make VOQ chassis systems work in VS platform based setups like the setups 
+                        // using KVMs, it is required that all asics have same base mac in the format given below
+                        // <lower 5 bytes of mac same for all asics>:<6th byte = switch_id>
+
+                        string platform = getenv("ASIC_VENDOR") ? getenv("ASIC_VENDOR") : "";
+
+                        if (platform == VS_PLATFORM_SUBSTRING)
+                        {
+                            int8_t sw_id = -1;
+                            uint8_t egress_asic_mac[ETHER_ADDR_LEN];
+
+                            gMacAddress.getMac(egress_asic_mac);
+
+                            if (p.m_type == Port::LAG)
+                            {
+                                sw_id = (int8_t) p.m_system_lag_info.switch_id;
+                            }
+                            else if (p.m_type == Port::PHY || p.m_type == Port::SYSTEM)
+                            {
+                                sw_id = (int8_t) p.m_system_port_info.switch_id;
+                            }
+
+                            if(sw_id != -1)
+                            {
+                                egress_asic_mac[5] = sw_id;
+                                mac_address = MacAddress(egress_asic_mac);
+                            }
+                        }
                     }
                     vector<FieldValueTuple> fvVector;
                     FieldValueTuple mac("neigh", mac_address.to_string());


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

This patch is to make VOQ chassis with port type inband interface work
in VS platform based setups such as setups with KVMs

Currently with port type inband interface, kernel static neighbors for voq
neighbors are programmed with mac = local asic's mac. Because of this,
packets generated by host destined to voq neighbors will have both src and
dst mac same. This is fine for forwarding by hardware where recycle port is
used for inband interface. However, for VS platforms, since src mac = dst
mac, host's ip stack drops the packet. To fix this problem, for VS
platforms, if the inband interface is port type, staic neibhbors for voq
neighbors are programmed with mac = neighbors's owner asic's mac. With
this change, since src mac and dst mac are different and since we also
program neighbors for all the remote asics, the packet will be sent out
correctly.

NOTE:
    Since in local asic, the remote neigh's owner asic mac is not available
it is derived from the switch id and lower 5 bytes of local asic mac.
Therefore, to have VOQ chassis with port type inband interface work in VS
platforms, it is required that asic macs are programmed in the following
format:
<higher 5 bytes same for all asics>:<6th byte = switch id of the asic>

**Why I did it**

To fix problem related to packet forwarding by linux ip stack for the packets generated by host destined to remote voq neighbors via port type inband interfaces in VOQ chassis systems in KVM based testbed using VS platforms. i.e., this patch is to fix the issue https://github.com/Azure/sonic-buildimage/issues/7434

**How I verified it**

Executed the T2 topology test scripts made for testing VOQ chassis in KVM based test setups and verified that iBGP connections among inband interfaces of all the asics are established successfully.
