### PR TITLE
Fix sFlow sampling-rate and admin-state

### DIFF
--- a/cfgmgr/sflowmgr.cpp
+++ b/cfgmgr/sflowmgr.cpp
@@ -108,9 +108,8 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
 
             if (m_gEnable && m_intfAllConf)
             {
-                // If the Local Conf is already present, dont't override it even though the speed is changed
-                if (new_port || (speed_change && 
-                   !(m_sflowPortConfMap[key].local_rate_cfg || m_sflowPortConfMap[key].local_admin_cfg)))
+                // If the Local rate Conf is already present, dont't override it even though the speed is changed
+                if (new_port || (speed_change && !m_sflowPortConfMap[key].local_rate_cfg))
                 {
                     vector<FieldValueTuple> fvs;
                     sflowGetGlobalInfo(fvs, m_sflowPortConfMap[key].speed);

--- a/cfgmgr/sflowmgr.cpp
+++ b/cfgmgr/sflowmgr.cpp
@@ -83,7 +83,8 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
             if (sflowPortConf == m_sflowPortConfMap.end())
             {
                 new_port = true;
-                port_info.local_conf = false;
+                port_info.local_rate_cfg = false;
+                port_info.local_admin_cfg = false;
                 port_info.speed = SFLOW_ERROR_SPEED_STR;
                 port_info.rate = "";
                 port_info.admin = "";
@@ -108,7 +109,8 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
             if (m_gEnable && m_intfAllConf)
             {
                 // If the Local Conf is already present, dont't override it even though the speed is changed
-                if (new_port || (speed_change && !m_sflowPortConfMap[key].local_conf))
+                if (new_port || (speed_change && 
+                   !(m_sflowPortConfMap[key].local_rate_cfg || m_sflowPortConfMap[key].local_admin_cfg)))
                 {
                     vector<FieldValueTuple> fvs;
                     sflowGetGlobalInfo(fvs, m_sflowPortConfMap[key].speed);
@@ -121,7 +123,8 @@ void SflowMgr::sflowUpdatePortInfo(Consumer &consumer)
             auto sflowPortConf = m_sflowPortConfMap.find(key);
             if (sflowPortConf != m_sflowPortConfMap.end())
             {
-                bool local_cfg = m_sflowPortConfMap[key].local_conf;
+                bool local_cfg = m_sflowPortConfMap[key].local_rate_cfg ||
+                                 m_sflowPortConfMap[key].local_admin_cfg;
 
                 m_sflowPortConfMap.erase(key);
                 if ((m_intfAllConf && m_gEnable) || local_cfg)
@@ -138,7 +141,7 @@ void SflowMgr::sflowHandleSessionAll(bool enable)
 {
     for (auto it: m_sflowPortConfMap)
     {
-        if (!it.second.local_conf)
+        if (!(it.second.local_rate_cfg || it.second.local_admin_cfg))
         {
             vector<FieldValueTuple> fvs;
             sflowGetGlobalInfo(fvs, it.second.speed);
@@ -158,12 +161,19 @@ void SflowMgr::sflowHandleSessionLocal(bool enable)
 {
     for (auto it: m_sflowPortConfMap)
     {
-        if (it.second.local_conf)
+        if (it.second.local_admin_cfg || it.second.local_rate_cfg)
         {
             vector<FieldValueTuple> fvs;
             sflowGetPortInfo(fvs, it.second);
             if (enable)
             {
+                /* Use global admin state if there is not a local one */
+                if (!it.second.local_admin_cfg) 
+                {
+                    FieldValueTuple fv1("admin_state", "up");
+                    fvs.push_back(fv1);
+                }
+
                 m_appSflowSessionTable.set(it.first, fvs);
             }
             else
@@ -194,7 +204,7 @@ void SflowMgr::sflowGetGlobalInfo(vector<FieldValueTuple> &fvs, string speed)
 
 void SflowMgr::sflowGetPortInfo(vector<FieldValueTuple> &fvs, SflowPortInfo &local_info)
 {
-    if (local_info.admin.length() > 0)
+    if (local_info.local_admin_cfg)
     {
         FieldValueTuple fv1("admin_state", local_info.admin);
         fvs.push_back(fv1);
@@ -217,6 +227,7 @@ void SflowMgr::sflowCheckAndFillValues(string alias, vector<FieldValueTuple> &va
         {
             rate_present = true;
             m_sflowPortConfMap[alias].rate = fvValue(i);
+            m_sflowPortConfMap[alias].local_rate_cfg = true;
             FieldValueTuple fv(fvField(i), fvValue(i));
             fvs.push_back(fv);
         }
@@ -224,6 +235,7 @@ void SflowMgr::sflowCheckAndFillValues(string alias, vector<FieldValueTuple> &va
         {
             admin_present = true;
             m_sflowPortConfMap[alias].admin = fvValue(i);
+            m_sflowPortConfMap[alias].local_admin_cfg = true;
             FieldValueTuple fv(fvField(i), fvValue(i));
             fvs.push_back(fv);
         }
@@ -235,7 +247,11 @@ void SflowMgr::sflowCheckAndFillValues(string alias, vector<FieldValueTuple> &va
 
     if (!rate_present)
     {
-        if (m_sflowPortConfMap[alias].rate == "")
+        /* Go back to default sample-rate if there is not existing rate OR
+         * if a local config has been done but the rate has been removed
+         */
+        if (m_sflowPortConfMap[alias].rate == "" ||
+            m_sflowPortConfMap[alias].local_rate_cfg)
         {
             string speed = m_sflowPortConfMap[alias].speed;
 
@@ -249,6 +265,7 @@ void SflowMgr::sflowCheckAndFillValues(string alias, vector<FieldValueTuple> &va
             }
             m_sflowPortConfMap[alias].rate = rate;
         }
+        m_sflowPortConfMap[alias].local_rate_cfg = false;
         FieldValueTuple fv("sample_rate", m_sflowPortConfMap[alias].rate);
         fvs.push_back(fv);
     }
@@ -257,9 +274,10 @@ void SflowMgr::sflowCheckAndFillValues(string alias, vector<FieldValueTuple> &va
     {
         if (m_sflowPortConfMap[alias].admin == "")
         {
-            /* By default admin state is enable if not set explicitly */
+            /* By default admin state is enabled if not set explicitly */
             m_sflowPortConfMap[alias].admin = "up";
         }
+        m_sflowPortConfMap[alias].local_admin_cfg = false;
         FieldValueTuple fv("admin_state", m_sflowPortConfMap[alias].admin);
         fvs.push_back(fv);
     }
@@ -347,7 +365,6 @@ void SflowMgr::doTask(Consumer &consumer)
                     }
                     vector<FieldValueTuple> fvs;
                     sflowCheckAndFillValues(key, values, fvs);
-                    m_sflowPortConfMap[key].local_conf = true;
                     if (m_gEnable)
                     {
                         m_appSflowSessionTable.set(key, fvs);
@@ -384,7 +401,8 @@ void SflowMgr::doTask(Consumer &consumer)
                 else
                 {
                     m_appSflowSessionTable.del(key);
-                    m_sflowPortConfMap[key].local_conf = false;
+                    m_sflowPortConfMap[key].local_rate_cfg = false;
+                    m_sflowPortConfMap[key].local_admin_cfg = false;
                     m_sflowPortConfMap[key].rate = "";
                     m_sflowPortConfMap[key].admin = "";
 

--- a/cfgmgr/sflowmgr.h
+++ b/cfgmgr/sflowmgr.h
@@ -32,7 +32,8 @@ namespace swss {
 
 struct SflowPortInfo
 {
-    bool        local_conf;
+    bool        local_rate_cfg;
+    bool        local_admin_cfg;
     std::string speed;
     std::string rate;
     std::string admin;

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -203,6 +203,8 @@ class TestSflow:
 
         session_params = {"admin_state": "down"}
         self.cdb.create_entry("SFLOW_SESSION", "all", session_params)
+        # Wait for the APPL_DB from sflowmgrd
+        time.sleep(2)
         expected_fields = {"sample_rate": "256", "admin_state": "up"}
         appldb.wait_for_field_negative_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
         expected_fields = {"sample_rate": "512", "admin_state": "up"}
@@ -212,7 +214,40 @@ class TestSflow:
         self.cdb.delete_entry("SFLOW_SESSION", "Ethernet0")
         self.cdb.delete_entry("SFLOW_SESSION", "Ethernet4")
 
-
+    def test_InterfaceDefaultSampleRate(self, dvs, testlog):
+        '''
+        This test checks if the SflowMgr updates sflow session table in APPL_DB with default rate.
+        Steps to verify the issue:
+        1) Enable sflow globally
+        2) Configure sample rate for Ethernet0
+        3) Verify whether sample rate is reflected in the Ethernet0 interfaces
+        4) Remove sample rate for Ethernet0
+        5) Verify whether sample rate of Ethernet0 interface moved to default sample rate
+        '''
+        self.setup_sflow(dvs)
+    
+        time.sleep(2)
+        port_oid = self.adb.port_name_map["Ethernet0"]
+        expected_fields = {"SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE": "oid:0x0"}
+        fvs = self.adb.wait_for_field_negative_match("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid, expected_fields)
+        sample_session = fvs["SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE"]
+        speed = fvs["SAI_PORT_ATTR_SPEED"]
+        rate = self.speed_rate_table.get(speed, None)
+        assert rate
+    
+        appldb = dvs.get_app_db()
+        # create the interface session
+        session_params = {"sample_rate": "256"}
+        self.cdb.create_entry("SFLOW_SESSION", "Ethernet0", session_params)
+        expected_fields = {"sample_rate": "256"}
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
+    
+        session_params = {"NULL": "NULL"}
+        self.cdb.create_entry("SFLOW_SESSION", "Ethernet0", session_params)
+        expected_fields = {"sample_rate": rate}
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
+    
+        self.cdb.delete_entry("SFLOW_SESSION", "Ethernet0")
     def test_Teardown(self, dvs, testlog):
         self.setup_sflow(dvs)
 

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -175,6 +175,43 @@ class TestSflow:
         time.sleep(1) 
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet4", {"sample_rate": "256"})
     
+    def test_InterfaceDisableAllUpdate(self, dvs, testlog):
+        '''  
+        This test checks if the SflowMgr updates sflow session table in APPL_DB when user has not configured the admin_status.
+        Steps to verify the issue:
+        1) Enable sflow globally
+        2) Configure sample rate for Ethernet0
+        3) Configure sample rate for Ethernet4
+        4) verify whether sample rates are reflected in the Ethernet0 & Ethernet4 interfaces
+        5) Execute sflow disable all command to disable all interfaces
+        6) Verify whether all interfaces are disabled (without the fix, interfaces were shown with admin up with configured rate, 
+           this is not expected).
+        '''
+        self.setup_sflow(dvs)
+
+        appldb = dvs.get_app_db()
+        # create the interface session
+        session_params = {"sample_rate": "256"}
+        self.cdb.create_entry("SFLOW_SESSION", "Ethernet0", session_params)
+        expected_fields = {"sample_rate": "256"}
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
+        
+        session_params = {"sample_rate": "512"}
+        self.cdb.create_entry("SFLOW_SESSION", "Ethernet4", session_params)
+        expected_fields = {"sample_rate": "512"}
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet4", expected_fields)
+
+        session_params = {"admin_state": "down"}
+        self.cdb.create_entry("SFLOW_SESSION", "all", session_params)
+        expected_fields = {"sample_rate": "256", "admin_state": "up"}
+        appldb.wait_for_field_negative_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
+        expected_fields = {"sample_rate": "512", "admin_state": "up"}
+        appldb.wait_for_field_negative_match("SFLOW_SESSION_TABLE", "Ethernet4", expected_fields)
+
+        self.cdb.delete_entry("SFLOW_SESSION", "all")
+        self.cdb.delete_entry("SFLOW_SESSION", "Ethernet0")
+        self.cdb.delete_entry("SFLOW_SESSION", "Ethernet4")
+
 
     def test_Teardown(self, dvs, testlog):
         self.setup_sflow(dvs)

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -204,10 +204,9 @@ class TestSflow:
         session_params = {"admin_state": "down"}
         self.cdb.create_entry("SFLOW_SESSION", "all", session_params)
         # Wait for the APPL_DB from sflowmgrd
-        time.sleep(2)
-        expected_fields = {"sample_rate": "256", "admin_state": "up"}
+        expected_fields = {"admin_state": "up", "sample_rate": "256"}
         appldb.wait_for_field_negative_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
-        expected_fields = {"sample_rate": "512", "admin_state": "up"}
+        expected_fields = {"admin_state": "up", "sample_rate": "512"}
         appldb.wait_for_field_negative_match("SFLOW_SESSION_TABLE", "Ethernet4", expected_fields)
 
         self.cdb.delete_entry("SFLOW_SESSION", "all")
@@ -226,11 +225,9 @@ class TestSflow:
         '''
         self.setup_sflow(dvs)
     
-        time.sleep(2)
         port_oid = self.adb.port_name_map["Ethernet0"]
         expected_fields = {"SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE": "oid:0x0"}
         fvs = self.adb.wait_for_field_negative_match("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid, expected_fields)
-        sample_session = fvs["SAI_PORT_ATTR_INGRESS_SAMPLEPACKET_ENABLE"]
         speed = fvs["SAI_PORT_ATTR_SPEED"]
         rate = self.speed_rate_table.get(speed, None)
         assert rate
@@ -239,15 +236,16 @@ class TestSflow:
         # create the interface session
         session_params = {"sample_rate": "256"}
         self.cdb.create_entry("SFLOW_SESSION", "Ethernet0", session_params)
-        expected_fields = {"sample_rate": "256"}
+        expected_fields = {"admin_state": "up", "sample_rate": "256"}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
     
         session_params = {"NULL": "NULL"}
         self.cdb.create_entry("SFLOW_SESSION", "Ethernet0", session_params)
-        expected_fields = {"sample_rate": rate}
+        expected_fields = {"admin_state": "up", "sample_rate": rate}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
     
         self.cdb.delete_entry("SFLOW_SESSION", "Ethernet0")
+    
     def test_Teardown(self, dvs, testlog):
         self.setup_sflow(dvs)
 

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -239,12 +239,9 @@ class TestSflow:
         expected_fields = {"admin_state": "up", "sample_rate": "256"}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
    
-        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0) 
-        tbl = swsscommon.Table(cdb, "SFLOW_SESSION")
-        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
-        tbl.set("Ethernet0", fvs)
+        tbl = swsscommon.Table(dvs.cdb, "SFLOW_SESSION")
+        tbl.hdel("Ethernet0","sample_rate")
         
-        time.sleep(2)
         expected_fields = {"admin_state": "up", "sample_rate": rate}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
     

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -1,4 +1,5 @@
 import time
+from swsscommon import swsscommon
 
 class TestSflow:
     speed_rate_table = {
@@ -238,8 +239,10 @@ class TestSflow:
         expected_fields = {"admin_state": "up", "sample_rate": "256"}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
     
-        self.cdb.update_entry("SFLOW_SESSION", "Ethernet0", {"NULL": "NULL"})
-        self.cdb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", {})
+        tbl = swsscommon.Table(self.cdb, "SFLOW_SESSION")
+        fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
+        tbl.set("Ethernet0", fvs)
+
         expected_fields = {"admin_state": "up", "sample_rate": rate}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
     

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -238,11 +238,13 @@ class TestSflow:
         self.cdb.create_entry("SFLOW_SESSION", "Ethernet0", session_params)
         expected_fields = {"admin_state": "up", "sample_rate": "256"}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
-    
-        tbl = swsscommon.Table(self.cdb, "SFLOW_SESSION")
+   
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0) 
+        tbl = swsscommon.Table(cdb, "SFLOW_SESSION")
         fvs = swsscommon.FieldValuePairs([("NULL", "NULL")])
         tbl.set("Ethernet0", fvs)
-
+        
+        time.sleep(2)
         expected_fields = {"admin_state": "up", "sample_rate": rate}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
     

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -204,10 +204,9 @@ class TestSflow:
         session_params = {"admin_state": "down"}
         self.cdb.create_entry("SFLOW_SESSION", "all", session_params)
         # Wait for the APPL_DB from sflowmgrd
-        expected_fields = {"admin_state": "up", "sample_rate": "256"}
-        appldb.wait_for_field_negative_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
-        expected_fields = {"admin_state": "up", "sample_rate": "512"}
-        appldb.wait_for_field_negative_match("SFLOW_SESSION_TABLE", "Ethernet4", expected_fields)
+        expected_fields = {}
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
+        appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet4", expected_fields)
 
         self.cdb.delete_entry("SFLOW_SESSION", "all")
         self.cdb.delete_entry("SFLOW_SESSION", "Ethernet0")
@@ -239,8 +238,8 @@ class TestSflow:
         expected_fields = {"admin_state": "up", "sample_rate": "256"}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
     
-        session_params = {"NULL": "NULL"}
-        self.cdb.create_entry("SFLOW_SESSION", "Ethernet0", session_params)
+        self.cdb.update_entry("SFLOW_SESSION", "Ethernet0", {"NULL": "NULL"})
+        self.cdb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", {})
         expected_fields = {"admin_state": "up", "sample_rate": rate}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
     

--- a/tests/test_sflow.py
+++ b/tests/test_sflow.py
@@ -239,7 +239,8 @@ class TestSflow:
         expected_fields = {"admin_state": "up", "sample_rate": "256"}
         appldb.wait_for_field_match("SFLOW_SESSION_TABLE", "Ethernet0", expected_fields)
    
-        tbl = swsscommon.Table(dvs.cdb, "SFLOW_SESSION")
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        tbl = swsscommon.Table(cdb, "SFLOW_SESSION")
         tbl.hdel("Ethernet0","sample_rate")
         
         expected_fields = {"admin_state": "up", "sample_rate": rate}


### PR DESCRIPTION
Fixed incorrect interface admin-status when 'all' interface is disabled but there are local sampling-rate configurations.
The original changes are present in the [PR ](https://github.com/Azure/sonic-swss/pull/1224)

Signed-off-by: Venkatesan Mahalingam <venkatesan_mahalinga@dell.com>

**What I did**
Fixed a bug where the interface sFlow admin-status is not correct if the user configures a custom sFlow sampling-rate. (UT performed here)

As a side-effect of this fix, users can now restore the default sFlow sampling-rate with the default option using: config sflow interface sampling-rate Ethernet4 default
This is not tested here but will be tested when the config script update PR is submitted to sonic-utilities. The sFlow corresponding HLD and command-line reference will also be updated.

**Why I did it**
If the user ONLY configures a custom (local) sFlow sampling-rate for a interface, the interface's admin-status should still adhere to the global interface admin-status.

**How I verified it**
1) UT cases (added the sonic-vs test case)
2) Manual testing - see below
```

root@L6:/home/admin# show sflow

sFlow Global Information:
  sFlow Admin State:          up
  sFlow Polling Interval:     default
  sFlow AgentID:              default

  0 Collectors configured:
root@L6:/home/admin# show sflow interface

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   |   Sampling Rate |
+=============+===============+=================+
| Ethernet0   | up            |             256 |
+-------------+---------------+-----------------+
| Ethernet4   | up            |             512 |
+-------------+---------------+-----------------+
| Ethernet8   | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet12  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet16  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet20  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet24  | up            |          100000 |
+-------------+---------------+-----------------+
............
...........
root@L6:/home/admin# config sflow interface disable all
root@L6:/home/admin# show sflow interface

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   | Sampling Rate   |
+=============+===============+=================+
+-------------+---------------+-----------------+
root@L6:/home/admin#
root@L6:/home/admin#
root@L6:/home/admin# config sflow interface enable all
root@L6:/home/admin# show sflow interface

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   |   Sampling Rate |
+=============+===============+=================+
| Ethernet0   | up            |             256 |
+-------------+---------------+-----------------+
| Ethernet4   | up            |             512 |
+-------------+---------------+-----------------+
| Ethernet8   | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet12  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet16  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet20  | up            |          100000 |

.............
............
root@L6:/home/admin# config sflow interface sample-rate Ethernet0 default
root@L6:/home/admin# show sflow interface

sFlow interface configurations
+-------------+---------------+-----------------+
| Interface   | Admin State   |   Sampling Rate |
+=============+===============+=================+
| Ethernet0   | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet4   | up            |             512 |
+-------------+---------------+-----------------+
| Ethernet8   | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet12  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet16  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet20  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet24  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet28  | up            |          100000 |
+-------------+---------------+-----------------+
| Ethernet32  | up            |          100000 |
+-------------+---------------+-----------------+

...................


```