### PR TITLE
Rename m_stateTunnelVlanMapTable to m_stateNeighSuppressVlanTable.

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -183,7 +183,7 @@ VxlanMgr::VxlanMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb,
         m_stateVrfTable(stateDb, STATE_VRF_TABLE_NAME),
         m_stateVxlanTable(stateDb, STATE_VXLAN_TABLE_NAME),
         m_stateVlanTable(stateDb, STATE_VLAN_TABLE_NAME),
-        m_stateTunnelVlanMapTable(stateDb, STATE_NEIGH_SUPPRESS_VLAN_TABLE_NAME),
+        m_stateNeighSuppressVlanTable(stateDb, STATE_NEIGH_SUPPRESS_VLAN_TABLE_NAME),
         m_stateVxlanTunnelTable(stateDb, STATE_VXLAN_TUNNEL_TABLE_NAME)
 {
     getAllVxlanNetDevices();
@@ -606,7 +606,7 @@ bool VxlanMgr::doVxlanTunnelMapCreateTask(const KeyOpFieldsValuesTuple & t)
     vector<FieldValueTuple> fvVector;
     FieldValueTuple s("netdev", vxlan_dev_name);
     fvVector.push_back(s);
-    m_stateTunnelVlanMapTable.set(key,fvVector);
+    m_stateNeighSuppressVlanTable.set(key,fvVector);
 
     return true;
 }
@@ -655,7 +655,7 @@ bool VxlanMgr::doVxlanTunnelMapDeleteTask(const KeyOpFieldsValuesTuple & t)
     found = vxlan_dev_name.find(vlan_delimiter);
     std::string key = "Vlan" + vxlan_dev_name.substr(found+1,vxlan_dev_name.length());
     SWSS_LOG_INFO("Delete Tunnel Map for %s -> %s ", key.c_str(), vxlan_dev_name.c_str());
-    m_stateTunnelVlanMapTable.del(key);
+    m_stateNeighSuppressVlanTable.del(key);
     return true;
 }
 

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -75,7 +75,7 @@ private:
     /*
     * Query the state of vrf by STATE_VRF_TABLE
     * Return
-    *  true: The state of vrf is OK 
+    *  true: The state of vrf is OK
     *  false: the vrf hasn't been created
     */
     bool isVrfStateOk(const std::string & vrfName);
@@ -90,7 +90,7 @@ private:
 
     ProducerStateTable m_appVxlanTunnelTable,m_appVxlanTunnelMapTable,m_appEvpnNvoTable;
     Table m_cfgVxlanTunnelTable,m_cfgVnetTable,m_stateVrfTable,m_stateVxlanTable, m_appSwitchTable;
-    Table m_stateVlanTable, m_stateTunnelVlanMapTable, m_stateVxlanTunnelTable;
+    Table m_stateVlanTable, m_stateNeighSuppressVlanTable, m_stateVxlanTunnelTable;
 
     /*
     * Vxlan Tunnel Cache


### PR DESCRIPTION

**What I did**
Rename m_stateTunnelVlanMapTable to m_stateNeighSuppressVlanTable.
**Why I did it**
I think rename state table can reduce the confusion.