### PR TITLE
[bufferpool] Support for buffer pool type both

### DIFF
--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -315,6 +315,10 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
                 {
                     attr.value.u32 = SAI_BUFFER_POOL_TYPE_EGRESS;
                 }
+                else if (type == buffer_value_both)
+                {
+                    attr.value.u32 = SAI_BUFFER_POOL_TYPE_BOTH;
+                }
                 else
                 {
                     SWSS_LOG_ERROR("Unknown pool type specified:%s", type.c_str());

--- a/orchagent/bufferorch.h
+++ b/orchagent/bufferorch.h
@@ -25,6 +25,7 @@ const string buffer_static_th_field_name    = "static_th";
 const string buffer_profile_field_name      = "profile";
 const string buffer_value_ingress           = "ingress";
 const string buffer_value_egress            = "egress";
+const string buffer_value_both              = "both";
 const string buffer_profile_list_field_name = "profile_list";
 const string buffer_headroom_type_field_name= "headroom_type";
 

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -232,7 +232,7 @@ bool Dot1pToTcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple 
     sai_qos_map_list_t dot1p_map_list;
 
     // Allocated resources are freed in freeAttribResources() call
-    dot1p_map_list.list = new sai_qos_map_t[kfvFieldsValues(tuple).size()];
+    dot1p_map_list.list = new sai_qos_map_t[kfvFieldsValues(tuple).size()]();
     int i = 0;
     for (const auto &fv : kfvFieldsValues(tuple))
     {

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -232,7 +232,7 @@ bool Dot1pToTcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple 
     sai_qos_map_list_t dot1p_map_list;
 
     // Allocated resources are freed in freeAttribResources() call
-    dot1p_map_list.list = new sai_qos_map_t[kfvFieldsValues(tuple).size()]();
+    dot1p_map_list.list = new sai_qos_map_t[kfvFieldsValues(tuple).size()];
     int i = 0;
     for (const auto &fv : kfvFieldsValues(tuple))
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Changes done to allow orchagent accepting "both" type for buffer pool
configuration.
 
**Why I did it**

Currently sonic supports only 'ingress' and 'egress' types of buffer pools.
Since some devices like DNX based switches only support buffer pool
type 'both', we are unable to create buffer pools for these devices.
This patch fixes this problem by enhancing buffer pool configuration to
accept "both" type. 

**How I verified it**

In a switch that uses DNX arch based chips (like VOQ chassis using line cards with Jerico family of switches), the following configuration is applied
```
"BUFFER_POOL": {
        "lossless_pool": {
            "size": "12766208",
            "type": "both",
            "mode": "dynamic"
        }
 }
```
when the switch became operational, it was observed, there are no error logs indicating invalid parameter or failure of buffer pool creation.

**Details if needed**
- This PR is fix for the issue https://github.com/Azure/sonic-buildimage/issues/7497