### PR TITLE
Fix for delay flex counters flow

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4714,6 +4714,10 @@ void PortsOrch::generatePortCounterMap()
     auto port_counter_stats = generateCounterStats(PORT_STAT_COUNTER_FLEX_COUNTER_GROUP);
     for (const auto& it: m_portList)
     {
+        if (it.first == "CPU")
+        {
+            continue;
+        }
         port_stat_manager.setCounterIdList(it.second.m_port_id, CounterType::PORT, port_counter_stats);
     }
 


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Exclude installing flex counter for CPU interface (mgmt) for proper query counter capability.
Fixing this PR: https://github.com/Azure/sonic-swss/pull/1646

**Why I did it**
The CPU interface does not suppose to be inserted to flex counter DB.
In addition, if we query the counter statistics capability by this interface it will cause all port counters id lists to be empty and break lua port rates functionality.

**How I verified it**
Enable all counters group types and observe all ID lists for ports populated correctly.

**Details if related**
