### PR TITLE
Fix error msg due to not supported "SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS"  attributes

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -431,14 +431,14 @@ void SwitchOrch::initSensorsTable()
             m_numTempSensors = attr.value.u8;
             m_numTempSensorsInitialized = true;
         }
-        else if (status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
+        else if (SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status))
         {
             m_numTempSensorsInitialized = true;
             SWSS_LOG_INFO("ASIC sensors : SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS is not supported");
         }
         else
         {
-            SWSS_LOG_ERROR("ASIC sensors : failed to get SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS: %d", status);
+            SWSS_LOG_ERROR("ASIC sensors : failed to get SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS: 0x%x", status);
         }
     }
 

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -431,7 +431,8 @@ void SwitchOrch::initSensorsTable()
             m_numTempSensors = attr.value.u8;
             m_numTempSensorsInitialized = true;
         }
-        else if (SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status))
+        else if (SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status)
+                 || status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED)
         {
             m_numTempSensorsInitialized = true;
             SWSS_LOG_INFO("ASIC sensors : SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS is not supported");


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

1.  Add more conditions to capture SAI return code due to not supported SAI attributes. Original code only judge:
`status ==  SAI_STATUS_NOT_SUPPORTED || status == SAI_STATUS_NOT_IMPLEMENTED`
Add more conditions:
`SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) || SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status)`

2.  Print the error code in hex instead of dec to make it more readable.

**Why I did it**

To eliminate below error msg on the platform which not support "SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS"

`May 10 13:02:59.806194 sonic ERR swss#orchagent: :- initSensorsTable: ASIC sensors : failed to get SAI_SWITCH_ATTR_MAX_NUMBER_OF_TEMP_SENSORS: -196608`

**How I verified it**

On the Mellanox platform, in the reboot process, the above error msg will not be observed.


**Details if related**
