### PR TITLE
[qosorch] Dot1p map list initialization fix

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -232,7 +232,7 @@ bool Dot1pToTcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple 
     sai_qos_map_list_t dot1p_map_list;
 
     // Allocated resources are freed in freeAttribResources() call
-    dot1p_map_list.list = new sai_qos_map_t[kfvFieldsValues(tuple).size()];
+    dot1p_map_list.list = new sai_qos_map_t[kfvFieldsValues(tuple).size()]();
     int i = 0;
     for (const auto &fv : kfvFieldsValues(tuple))
     {


### PR DESCRIPTION

**What I did**

- For DOT1P QOS map, the map list in api that coverts \<field, value\> to attributes was not initialized correctly. So "color" field in the key was sending garbage. Because of this, orchagent serialization function is unable to translate and serialize the attribute
value properly and returns warning. During subsequent operation which comes with a different garbage, this was treated as a different "color" and syncd/SAI returns error saying "modification not implemented". This is fixed by initializing the dotp1 map list attribute.

**Why I did it**
- Because of the initialization issue described above, we we unable to configure dot1p map. So this fix was done.

**How I verified it**

- Used dot1p configuration (in DSCP_TO_TC_MAP table) and observed that there are no "modification not implemented" error logs from syncd.

