### PR TITLE
cisco-8000 pfc-wd support

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -11,7 +11,9 @@ dist_swss_DATA = \
 		 pfc_detect_broadcom.lua \
 		 pfc_detect_barefoot.lua \
 		 pfc_detect_nephos.lua \
+		 pfc_detect_cisco-8000.lua \
 		 pfc_restore.lua \
+		 pfc_restore_cisco-8000.lua \
 		 port_rates.lua \
 		 watermark_queue.lua \
 		 watermark_pg.lua \

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -37,6 +37,7 @@ const char state_db_key_delimiter  = '|';
 #define VS_PLATFORM_SUBSTRING   "vs"
 #define NPS_PLATFORM_SUBSTRING  "nephos"
 #define MRVL_PLATFORM_SUBSTRING "marvell"
+#define CISCO_8000_PLATFORM_SUBSTRING "cisco-8000"
 
 #define CONFIGDB_KEY_SEPARATOR "|"
 #define DEFAULT_KEY_SEPARATOR  ":"

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -488,6 +488,27 @@ bool OrchDaemon::init()
                     queueStatIds,
                     queueAttrIds,
                     PFC_WD_POLL_MSECS));
+    } else if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+    {
+        static const vector<sai_port_stat_t> portStatIds;
+
+        static const vector<sai_queue_stat_t> queueStatIds =
+        {
+            SAI_QUEUE_STAT_PACKETS,
+        };
+
+        static const vector<sai_queue_attr_t> queueAttrIds =
+        {
+            SAI_QUEUE_ATTR_PAUSE_STATUS,
+        };
+
+        m_orchList.push_back(new PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdSaiDlrInitHandler>(
+                    m_configDb,
+                    pfc_wd_tables,
+                    portStatIds,
+                    queueStatIds,
+                    queueAttrIds,
+                    PFC_WD_POLL_MSECS));
     }
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));

--- a/orchagent/pfc_detect_cisco-8000.lua
+++ b/orchagent/pfc_detect_cisco-8000.lua
@@ -1,0 +1,73 @@
+-- KEYS - queue IDs
+-- ARGV[1] - counters db index
+-- ARGV[2] - counters table name
+-- ARGV[3] - poll time interval
+-- return queue Ids that satisfy criteria
+
+local counters_db = ARGV[1]
+local counters_table_name = ARGV[2]
+local poll_time = tonumber(ARGV[3])
+
+local rets = {}
+
+redis.call('SELECT', counters_db)
+
+-- Iterate through each queue
+local n = table.getn(KEYS)
+for i = n, 1, -1 do
+    local counter_keys = redis.call('HKEYS', counters_table_name .. ':' .. KEYS[i])
+    local counter_num = 0
+    local old_counter_num = 0
+    local pfc_wd_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_STATUS')
+    local pfc_wd_action = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_ACTION')
+    local big_red_switch_mode = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'BIG_RED_SWITCH_MODE')
+    if not big_red_switch_mode and (pfc_wd_status == 'operational' or pfc_wd_action == 'alert') then
+        local detection_time = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME')
+        if detection_time then
+            detection_time = tonumber(detection_time)
+            local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT')
+            if not time_left  then
+                time_left = detection_time
+            else
+                time_left = tonumber(time_left)
+            end
+
+            local queue_index = redis.call('HGET', 'COUNTERS_QUEUE_INDEX_MAP', KEYS[i])
+            local port_id = redis.call('HGET', 'COUNTERS_QUEUE_PORT_MAP', KEYS[i])
+
+            -- Get PFC status
+            local queue_pause_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS')
+
+            if queue_pause_status then
+
+                -- DEBUG CODE START. Uncomment to enable
+                local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
+                -- DEBUG CODE END.
+
+		-- Check actual condition of queue being in PFC storm
+		if (queue_pause_status == 'true')
+		    -- DEBUG CODE START. Uncomment to enable
+		    or (debug_storm == "enabled")
+		    -- DEBUG CODE END.
+		    then
+		    if time_left <= poll_time then
+			redis.call('PUBLISH', 'PFC_WD_ACTION', '["' .. KEYS[i] .. '","storm"]')
+			time_left = detection_time
+		    else
+			time_left = time_left - poll_time
+		    end
+		else
+		    if pfc_wd_action == 'alert' and pfc_wd_status ~= 'operational' then
+			redis.call('PUBLISH', 'PFC_WD_ACTION', '["' .. KEYS[i] .. '","restore"]')
+		    end
+		    time_left = detection_time
+		end
+
+                -- Save values for next run
+                redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_DETECTION_TIME_LEFT', time_left)
+            end
+        end
+    end
+end
+
+return rets

--- a/orchagent/pfc_restore_cisco-8000.lua
+++ b/orchagent/pfc_restore_cisco-8000.lua
@@ -1,0 +1,62 @@
+-- KEYS - queue IDs
+-- ARGV[1] - counters db index
+-- ARGV[2] - counters table name
+-- ARGV[3] - poll time interval
+-- return queue Ids that satisfy criteria
+
+local counters_db = ARGV[1]
+local counters_table_name = ARGV[2]
+local poll_time = tonumber(ARGV[3])
+
+local rets = {}
+
+redis.call('SELECT', counters_db)
+
+-- Iterate through each queue
+local n = table.getn(KEYS)
+for i = n, 1, -1 do
+    local counter_keys = redis.call('HKEYS', counters_table_name .. ':' .. KEYS[i])
+    local pfc_wd_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_STATUS')
+    local restoration_time = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME')
+    local pfc_wd_action = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_ACTION')
+    local big_red_switch_mode = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'BIG_RED_SWITCH_MODE')
+    if not big_red_switch_mode and pfc_wd_status ~= 'operational'  and pfc_wd_action ~= 'alert' and restoration_time and restoration_time ~= '' then
+        restoration_time = tonumber(restoration_time)
+        local time_left = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME_LEFT')
+        if not time_left then
+            time_left = restoration_time
+        else
+            time_left = tonumber(time_left)
+        end
+
+        local queue_index = redis.call('HGET', 'COUNTERS_QUEUE_INDEX_MAP', KEYS[i])
+        local port_id = redis.call('HGET', 'COUNTERS_QUEUE_PORT_MAP', KEYS[i])
+
+        -- DEBUG CODE START. Uncomment to enable
+        local debug_storm = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'DEBUG_STORM')
+        -- DEBUG CODE END.
+
+        -- Check actual condition of queue being restored from PFC storm
+        local queue_pause_status = redis.call('HGET', counters_table_name .. ':' .. KEYS[i], 'SAI_QUEUE_ATTR_PAUSE_STATUS')
+
+        if (queue_pause_status == 'false')
+            -- DEBUG CODE START. Uncomment to enable
+            and (debug_storm ~= "enabled")
+            -- DEBUG CODE END.
+            then
+            if time_left <= 0 then
+                redis.call('PUBLISH', 'PFC_WD_ACTION', '["' .. KEYS[i] .. '","restore"]')
+                time_left = restoration_time
+            else
+                time_left = time_left - poll_time
+            end
+        else
+            time_left = restoration_time
+        end
+
+        -- Save values for next run
+        redis.call('HSET', counters_table_name .. ':' .. KEYS[i], 'PFC_WD_RESTORATION_TIME_LEFT', time_left)
+    end
+end
+
+return rets

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -163,4 +163,15 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
         sai_object_id_t m_originalPgBufferProfile = SAI_NULL_OBJECT_ID;
 };
 
+// PFC queue that implements drop action by draining queue via SAI
+// attribute SAI_QUEUE_ATTR_PFC_DLR_INIT.
+class PfcWdSaiDlrInitHandler: public PfcWdActionHandler
+{
+    public:
+        PfcWdSaiDlrInitHandler(sai_object_id_t port, sai_object_id_t queue,
+                uint8_t queueId, shared_ptr<Table> countersTable);
+        virtual ~PfcWdSaiDlrInitHandler(void);
+        virtual bool getHwCounters(PfcWdHwStats& counters);
+};
+
 #endif

--- a/orchagent/pfcwdorch.cpp
+++ b/orchagent/pfcwdorch.cpp
@@ -666,7 +666,12 @@ PfcWdSwOrch<DropHandler, ForwardHandler>::PfcWdSwOrch(
 
     string detectSha, restoreSha;
     string detectPluginName = "pfc_detect_" + platform + ".lua";
-    string restorePluginName = "pfc_restore.lua";
+    string restorePluginName;
+    if (platform == CISCO_8000_PLATFORM_SUBSTRING) {
+        restorePluginName = "pfc_restore_" + platform + ".lua";
+    } else {
+        restorePluginName = "pfc_restore.lua";
+    }
 
     try
     {
@@ -1056,3 +1061,4 @@ bool PfcWdSwOrch<DropHandler, ForwardHandler>::bake()
 // Trick to keep member functions in a separate file
 template class PfcWdSwOrch<PfcWdZeroBufferHandler, PfcWdLossyHandler>;
 template class PfcWdSwOrch<PfcWdAclHandler, PfcWdLossyHandler>;
+template class PfcWdSwOrch<PfcWdSaiDlrInitHandler, PfcWdSaiDlrInitHandler>;


### PR DESCRIPTION
<!--![image](https://user-images.githubusercontent.com/77468614/118554647-91e80e80-b716-11eb-9511-165b92564f10.png)Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add support in sonic-swss for cisco-8000 to detect and recover the port/queue from pfc-wd events. 

**Why I did it
Support for cisco-8000 platform for pfc-wd is missing in SONiC 

**How I verified it**
interoperability with a Hardware based Traffic Generator to detect and recover the port/queue using the pfc-wd capability

**Details if related**

The support does the following: 
 - Uses SAI queue attributes for PFC-WD detection and recovery action
 - Queues monitored querying SAI_QUEUE_ATTR_PAUSE_STATUS attribute on PFC-WD config
 - On WD detection, initiate recovery using SAI_QUEUE_ATTR_PFC_DLR_INIT
    : Create PfcWdSaiDlrInitHandler object
    : ASIC configured to DROP packets for the queue
 - When queue is out of pause state for restoration_time, restore queue state
    : ASIC configured to NOT DROP packets for the queue
    : Destroy PfcWdSaiDlrInitHandler object