### PR TITLE
[vnet/vxlan] Add support of multiple mappers for the VxLAN tunnel

### DIFF
--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -353,6 +353,20 @@ def create_vxlan_tunnel(dvs, name, src_ip):
     )
 
 
+def create_vxlan_tunnel_map(dvs, tunnel_name, tunnel_map_entry_name, vlan, vni_id):
+    conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+
+    # create the VXLAN tunnel map entry in Config DB
+    create_entry_tbl(
+        conf_db,
+        "VXLAN_TUNNEL_MAP", '|', "%s|%s" % (tunnel_name, tunnel_map_entry_name),
+        [
+            ("vni",  vni_id),
+            ("vlan", vlan),
+        ],
+    )
+
+
 def get_lo(dvs):
     asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
     vr_id = get_default_vr_id(dvs)
@@ -450,12 +464,12 @@ class VnetVxlanVrfTunnel(object):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
         global loopback_id, def_vr_id
 
-        tunnel_map_id  = get_created_entries(asic_db, self.ASIC_TUNNEL_MAP, self.tunnel_map_ids, 2)
+        tunnel_map_id  = get_created_entries(asic_db, self.ASIC_TUNNEL_MAP, self.tunnel_map_ids, 3)
         tunnel_id      = get_created_entry(asic_db, self.ASIC_TUNNEL_TABLE, self.tunnel_ids)
         tunnel_term_id = get_created_entry(asic_db, self.ASIC_TUNNEL_TERM_ENTRY, self.tunnel_term_ids)
 
         # check that the vxlan tunnel termination are there
-        assert how_many_entries_exist(asic_db, self.ASIC_TUNNEL_MAP) == (len(self.tunnel_map_ids) + 2), "The TUNNEL_MAP wasn't created"
+        assert how_many_entries_exist(asic_db, self.ASIC_TUNNEL_MAP) == (len(self.tunnel_map_ids) + 3), "The TUNNEL_MAP wasn't created"
         assert how_many_entries_exist(asic_db, self.ASIC_TUNNEL_MAP_ENTRY) == len(self.tunnel_map_entry_ids), "The TUNNEL_MAP_ENTRY is created"
         assert how_many_entries_exist(asic_db, self.ASIC_TUNNEL_TABLE) == (len(self.tunnel_ids) + 1), "The TUNNEL wasn't created"
         assert how_many_entries_exist(asic_db, self.ASIC_TUNNEL_TERM_ENTRY) == (len(self.tunnel_term_ids) + 1), "The TUNNEL_TERM_TABLE_ENTRY wasm't created"
@@ -466,9 +480,15 @@ class VnetVxlanVrfTunnel(object):
                         }
                 )
 
-        check_object(asic_db, self.ASIC_TUNNEL_MAP, tunnel_map_id[1],
+        check_object(asic_db, self.ASIC_TUNNEL_MAP, tunnel_map_id[2],
                         {
                             'SAI_TUNNEL_MAP_ATTR_TYPE': 'SAI_TUNNEL_MAP_TYPE_VIRTUAL_ROUTER_ID_TO_VNI',
+                        }
+                )
+
+        check_object(asic_db, self.ASIC_TUNNEL_MAP, tunnel_map_id[1],
+                        {
+                            'SAI_TUNNEL_MAP_ATTR_TYPE': 'SAI_TUNNEL_MAP_TYPE_VNI_TO_VLAN_ID',
                         }
                 )
 
@@ -476,8 +496,8 @@ class VnetVxlanVrfTunnel(object):
                     {
                         'SAI_TUNNEL_ATTR_TYPE': 'SAI_TUNNEL_TYPE_VXLAN',
                         'SAI_TUNNEL_ATTR_UNDERLAY_INTERFACE': loopback_id,
-                        'SAI_TUNNEL_ATTR_DECAP_MAPPERS': '1:%s' % tunnel_map_id[0],
-                        'SAI_TUNNEL_ATTR_ENCAP_MAPPERS': '1:%s' % tunnel_map_id[1],
+                        'SAI_TUNNEL_ATTR_DECAP_MAPPERS': '2:%s,%s' % (tunnel_map_id[0], tunnel_map_id[1]),
+                        'SAI_TUNNEL_ATTR_ENCAP_MAPPERS': '1:%s' % tunnel_map_id[2],
                         'SAI_TUNNEL_ATTR_ENCAP_SRC_IP': src_ip,
                     }
                 )
@@ -505,7 +525,7 @@ class VnetVxlanVrfTunnel(object):
         time.sleep(2)
 
         if (self.tunnel_map_map.get(tunnel_name) is None):
-            tunnel_map_id = get_created_entries(asic_db, self.ASIC_TUNNEL_MAP, self.tunnel_map_ids, 2)
+            tunnel_map_id = get_created_entries(asic_db, self.ASIC_TUNNEL_MAP, self.tunnel_map_ids, 3)
         else:
             tunnel_map_id = self.tunnel_map_map[tunnel_name]
 
@@ -517,7 +537,7 @@ class VnetVxlanVrfTunnel(object):
         check_object(asic_db, self.ASIC_TUNNEL_MAP_ENTRY, tunnel_map_entry_id[0],
             {
                 'SAI_TUNNEL_MAP_ENTRY_ATTR_TUNNEL_MAP_TYPE': 'SAI_TUNNEL_MAP_TYPE_VIRTUAL_ROUTER_ID_TO_VNI',
-                'SAI_TUNNEL_MAP_ENTRY_ATTR_TUNNEL_MAP': tunnel_map_id[1],
+                'SAI_TUNNEL_MAP_ENTRY_ATTR_TUNNEL_MAP': tunnel_map_id[2],
                 'SAI_TUNNEL_MAP_ENTRY_ATTR_VIRTUAL_ROUTER_ID_KEY': self.vr_map[vnet_name].get('ing'),
                 'SAI_TUNNEL_MAP_ENTRY_ATTR_VNI_ID_VALUE': vni_id,
             }
@@ -1078,3 +1098,23 @@ class TestVnetOrch(object):
 
         vnet_obj.check_default_vnet_entry(dvs, 'Vnet_5')
         vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet_5', '4789')
+
+    '''
+    Test 6 - Test VxLAN tunnel with multiple maps
+    '''
+    def test_vnet_vxlan_multi_map(self, dvs, testlog):
+        vnet_obj = self.get_vnet_obj()
+
+        tunnel_name = 'tunnel_v4'
+
+        vnet_obj.fetch_exist_entries(dvs)
+
+        create_vxlan_tunnel(dvs, tunnel_name, '10.1.0.32')
+        create_vnet_entry(dvs, 'Vnet1', tunnel_name, '10001', "")
+
+        vnet_obj.check_vnet_entry(dvs, 'Vnet1')
+        vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet1', '10001')
+        vnet_obj.check_vxlan_tunnel(dvs, tunnel_name, '10.1.0.32')
+
+        create_vxlan_tunnel_map(dvs, tunnel_name, 'map_1', 'Vlan1000', '1000')
+


### PR DESCRIPTION
Changes provide functionality to configure different types of mappers for the same VxLAN tunnel.
In order to be able to use 1 tunnel with both VLAN and VRF mappers instead of creaing 2 tunnels.

Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added functionality to configure different types of mappers for the same VxLAN tunnel.

**Why I did it**
In order to be able to use 1 tunnel with both VLAN and VRF mappers instead of creating 2 tunnels.

**How I verified it**

***Manual tests***
* Run "VNET" test (it configures tunnel with VRF mappers)
* Run "wr_arp" test (it configures tunnel map with VLAN mapper)
* Verify that test passed
* Verify configuration in ASIC DB

***VS tests***
```
sudo pytest -v test_vnet.py
===================================== test session starts ======================================
platform linux -- Python 3.6.9, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/vsamotiy/wd/sonic-swss/tests
plugins: flaky-3.7.0
collected 6 items                                                                                                                                                                                                                                    

test_vnet.py::TestVnetOrch::test_vnet_orch_1 PASSED                                       [ 16%]
test_vnet.py::TestVnetOrch::test_vnet_orch_2 PASSED                                       [ 33%]
test_vnet.py::TestVnetOrch::test_vnet_orch_3 PASSED                                       [ 50%]
test_vnet.py::TestVnetOrch::test_vnet_orch_4 SKIPPED (Failing. Under investigation)       [ 66%]
test_vnet.py::TestVnetOrch::test_vnet_orch_5 PASSED                                       [ 83%]
test_vnet.py::TestVnetOrch::test_vnet_vxlan_multi_map PASSED                              [100%]

============================ 5 passed, 1 skipped in 317.33s (0:05:17) ==========================
```

**Details if related**
N/A