### PR TITLE
[tunneldecaporch] Set default MTU for the overlay loopback interface

### DIFF
--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -6,6 +6,8 @@
 #include "logger.h"
 #include "swssnet.h"
 
+#define OVERLAY_RIF_DEFAULT_MTU 9100
+
 extern sai_tunnel_api_t* sai_tunnel_api;
 extern sai_router_interface_api_t* sai_router_intfs_api;
 extern sai_next_hop_api_t* sai_next_hop_api;
@@ -226,6 +228,10 @@ bool TunnelDecapOrch::addDecapTunnel(string key, string type, IpAddresses dst_ip
 
     overlay_intf_attr.id = SAI_ROUTER_INTERFACE_ATTR_TYPE;
     overlay_intf_attr.value.s32 = SAI_ROUTER_INTERFACE_TYPE_LOOPBACK;
+    overlay_intf_attrs.push_back(overlay_intf_attr);
+
+    overlay_intf_attr.id = SAI_ROUTER_INTERFACE_ATTR_MTU;
+    overlay_intf_attr.value.u32 = OVERLAY_RIF_DEFAULT_MTU;
     overlay_intf_attrs.push_back(overlay_intf_attr);
 
     status = sai_router_intfs_api->create_router_interface(&overlayIfId, gSwitchId, (uint32_t)overlay_intf_attrs.size(), overlay_intf_attrs.data());


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Set default MTU for the underlay loopback interface to 9100 in order to make it working with jumbo frames.

**Why I did it**
Overlay loopback is used for IP-in-IP tunnel and without setting MTU jumbo frames are trapped to CPU but they should be successfully routed to the appropriate destination.
With this change, all internal loopback interfaces are created with 9100 MTU size (both underlay and overlay) in continues to PR https://github.com/Azure/sonic-swss/pull/1299

**How I verified it**
* Configure IP-in-IP tunnel
* Send jumbo frames and verify that they are correctly routed

**Details if related**
N/A
