### PR TITLE
[Mux] Add support for mux metrics to State DB

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -5,6 +5,9 @@
 #include <unordered_set>
 #include <stdexcept>
 #include <inttypes.h>
+#include <math.h>
+#include <chrono>
+#include <time.h>
 
 #include "sai.h"
 #include "ipaddress.h"
@@ -405,6 +408,8 @@ void MuxCable::setState(string new_state)
         return;
     }
 
+    mux_cb_orch_->updateMuxMetricState(mux_name_, new_state, true);
+
     MuxState state = state_;
     state_ = ns;
 
@@ -418,6 +423,8 @@ void MuxCable::setState(string new_state)
         st_chg_failed_ = true;
         throw std::runtime_error("Failed to handle state transition");
     }
+
+    mux_cb_orch_->updateMuxMetricState(mux_name_, new_state, false);
 
     st_chg_in_progress_ = false;
     st_chg_failed_ = false;
@@ -1261,9 +1268,10 @@ bool MuxOrch::delOperation(const Request& request)
     return true;
 }
 
-MuxCableOrch::MuxCableOrch(DBConnector *db, const std::string& tableName):
+MuxCableOrch::MuxCableOrch(DBConnector *db, DBConnector *sdb, const std::string& tableName):
               Orch2(db, tableName, request_),
-              app_tunnel_route_table_(db, APP_TUNNEL_ROUTE_TABLE_NAME)
+              app_tunnel_route_table_(db, APP_TUNNEL_ROUTE_TABLE_NAME),
+              mux_metric_table_(sdb, STATE_MUX_METRICS_TABLE_NAME)
 {
     mux_table_ = unique_ptr<Table>(new Table(db, APP_HW_MUX_CABLE_TABLE_NAME));
 }
@@ -1274,6 +1282,26 @@ void MuxCableOrch::updateMuxState(string portName, string muxState)
     FieldValueTuple tuple("state", muxState);
     tuples.push_back(tuple);
     mux_table_->set(portName, tuples);
+}
+
+void MuxCableOrch::updateMuxMetricState(string portName, string muxState, bool start)
+{
+    string msg = "orch_switch_" + muxState;
+    msg += start? "_start": "_end";
+
+    auto now  = std::chrono::system_clock::now();
+    auto now_t = std::chrono::system_clock::to_time_t(now);
+    auto dur = now - std::chrono::system_clock::from_time_t(now_t);
+    auto micros = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
+
+    std::tm* now_tm= std::gmtime(&now_t);
+
+    char buf[256];
+    std::strftime(buf, 256, "%Y-%b-%d %H:%M:%S.",now_tm);
+
+    string time = string(buf) + to_string(micros);
+
+    mux_metric_table_.hset(portName, msg, time);
 }
 
 void MuxCableOrch::addTunnelRoute(const NextHopKey &nhKey)
@@ -1349,7 +1377,7 @@ MuxStateOrch::MuxStateOrch(DBConnector *db, const std::string& tableName) :
               Orch2(db, tableName, request_),
               mux_state_table_(db, STATE_MUX_CABLE_TABLE_NAME)
 {
-     SWSS_LOG_ENTER();
+    SWSS_LOG_ENTER();
 }
 
 void MuxStateOrch::updateMuxState(string portName, string muxState)

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1294,10 +1294,11 @@ void MuxCableOrch::updateMuxMetricState(string portName, string muxState, bool s
     auto dur = now - std::chrono::system_clock::from_time_t(now_t);
     auto micros = std::chrono::duration_cast<std::chrono::microseconds>(dur).count();
 
-    std::tm* now_tm= std::gmtime(&now_t);
+    std::tm now_tm;
+    gmtime_r(&now_t, &now_tm);
 
     char buf[256];
-    std::strftime(buf, 256, "%Y-%b-%d %H:%M:%S.",now_tm);
+    std::strftime(buf, 256, "%Y-%b-%d %H:%M:%S.", &now_tm);
 
     string time = string(buf) + to_string(micros);
 

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -228,9 +228,10 @@ public:
 class MuxCableOrch : public Orch2
 {
 public:
-    MuxCableOrch(DBConnector *db, const std::string& tableName);
+    MuxCableOrch(DBConnector *db, DBConnector *sdb, const std::string& tableName);
 
     void updateMuxState(string portName, string muxState);
+    void updateMuxMetricState(string portName, string muxState, bool start);
     void addTunnelRoute(const NextHopKey &nhKey);
     void removeTunnelRoute(const NextHopKey &nhKey);
 
@@ -240,6 +241,7 @@ private:
 
     unique_ptr<Table> mux_table_;
     MuxCableRequest request_;
+    swss::Table mux_metric_table_;
     ProducerStateTable app_tunnel_route_table_;
 };
 

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -259,7 +259,7 @@ bool OrchDaemon::init()
     MuxOrch *mux_orch = new MuxOrch(m_configDb, mux_tables, tunnel_decap_orch, gNeighOrch, gFdbOrch);
     gDirectory.set(mux_orch);
 
-    MuxCableOrch *mux_cb_orch = new MuxCableOrch(m_applDb, APP_MUX_CABLE_TABLE_NAME);
+    MuxCableOrch *mux_cb_orch = new MuxCableOrch(m_applDb, m_stateDb, APP_MUX_CABLE_TABLE_NAME);
     gDirectory.set(mux_cb_orch);
 
     MuxStateOrch *mux_st_orch = new MuxStateOrch(m_stateDb, STATE_HW_MUX_CABLE_TABLE_NAME);


### PR DESCRIPTION
**What I did**

Log mux state change events to State DB (required for bookkeeping) 

```
127.0.0.1:6379[6]> HGETALL "MUX_METRICS_TABLE|Ethernet4"
1) "orch_switch_standby_start"
2) "2021-May-25 14:43:57.85633"
3) "orch_switch_standby_end"
4) "2021-May-25 14:43:57.93600"
```

**Why I did it**
Part of the overall mux metric changes by linkmgrd, xcvrd ([PR](https://github.com/Azure/sonic-platform-daemons/pull/185))

**How I verified it**

Execute mux state change and verify the State DB tables. 

**Details if related**
