### PR TITLE
[request parser] Allow request parser to parse multiple values

### DIFF
--- a/orchagent/request_parser.h
+++ b/orchagent/request_parser.h
@@ -5,6 +5,7 @@
 #include "ipprefix.h"
 #include <sstream>
 #include <set>
+#include <vector>
 
 typedef enum _request_types_t
 {
@@ -18,6 +19,9 @@ typedef enum _request_types_t
     REQ_T_VLAN,
     REQ_T_UINT,
     REQ_T_SET,
+    REQ_T_MAC_ADDRESS_LIST,
+    REQ_T_IP_LIST,
+    REQ_T_UINT_LIST,
 } request_types_t;
 
 typedef struct _request_description
@@ -146,6 +150,24 @@ public:
         return table_name_;
     }
 
+    const std::vector<swss::IpAddress>& getAttrIPList(const std::string& attr_name) const
+    {
+        assert(is_parsed_);
+        return attr_item_ip_list_.at(attr_name);
+    }
+
+    const std::vector<swss::MacAddress>& getAttrMacAddressList(const std::string& attr_name) const
+    {
+        assert(is_parsed_);
+        return attr_item_mac_addresses_list_.at(attr_name);
+    }
+
+    const std::vector<uint64_t>& getAttrUintList(const std::string& attr_name) const
+    {
+        assert(is_parsed_);
+        return attr_item_uint_list_.at(attr_name);
+    }
+
 protected:
     Request(const request_description_t& request_description, const char key_separator)
         : request_description_(request_description),
@@ -167,6 +189,9 @@ private:
     uint64_t parseUint(const std::string& str);
     uint16_t parseVlan(const std::string& str);
     std::set<std::string> parseSet(const std::string& str);
+    std::vector<swss::IpAddress> parseIpAddressList(const std::string& str);
+    std::vector<swss::MacAddress> parseMacAddressList(const std::string& str);
+    std::vector<uint64_t> parseUintList(const std::string& str);
 
     sai_packet_action_t parsePacketAction(const std::string& str);
 
@@ -194,6 +219,9 @@ private:
     std::unordered_map<std::string, swss::IpPrefix> attr_item_ip_prefix_;
     std::unordered_map<std::string, uint64_t> attr_item_uint_;
     std::unordered_map<std::string, std::set<std::string>> attr_item_set_;
+    std::unordered_map<std::string, std::vector<swss::IpAddress>> attr_item_ip_list_;
+    std::unordered_map<std::string, std::vector<swss::MacAddress>> attr_item_mac_addresses_list_;
+    std::unordered_map<std::string, std::vector<uint64_t>> attr_item_uint_list_;
 };
 
 #endif // __REQUEST_PARSER_H


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add an option for request parser to parse strings that contains multiple IP address, MAC address, or unsigned int. Return the values in a vector.

**Why I did it**
To enable overlay ECMP, the request may contain values with multiple nexthops. This PR aims to properly parse the request in such a scenario.

**How I verified it**

**Details if related**
