### PR TITLE
[acl mirror action] Mirror session ref count fix at acl rule attachment

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -1225,13 +1225,6 @@ bool AclRuleMirror::create()
         SWSS_LOG_THROW("Failed to get mirror session state for session %s", m_sessionName.c_str());
     }
 
-    // Increase session reference count regardless of state to deny
-    // attempt to remove mirror session with attached ACL rules.
-    if (!m_pMirrorOrch->increaseRefCount(m_sessionName))
-    {
-        SWSS_LOG_THROW("Failed to increase mirror session reference count for session %s", m_sessionName.c_str());
-    }
-
     if (!state)
     {
         return true;
@@ -1252,6 +1245,11 @@ bool AclRuleMirror::create()
     if (!AclRule::create())
     {
         return false;
+    }
+
+    if (!m_pMirrorOrch->increaseRefCount(m_sessionName))
+    {
+        SWSS_LOG_THROW("Failed to increase mirror session reference count for session %s", m_sessionName.c_str());
     }
 
     m_state = true;

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -790,12 +790,11 @@ class TestMirror(object):
         self.remove_ip_address("Ethernet32", "20.0.0.0/31")
         self.set_interface_status(dvs, "Ethernet32", "down")
 
-    def test_AclBindMirror(self, dvs, testlog):
+    def _test_AclBindMirror(self, dvs, testlog, create_seq_test=False):
         """
         This test tests ACL associated with mirror session with DSCP value
         The DSCP value is tested on both with mask and without mask
         """
-        self.setup_db(dvs)
 
         session = "MIRROR_SESSION"
         acl_table = "MIRROR_TABLE"
@@ -805,16 +804,18 @@ class TestMirror(object):
         self.set_interface_status(dvs, "Ethernet32", "up")
         self.add_ip_address("Ethernet32", "20.0.0.0/31")
         self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
-        self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+        if create_seq_test == False:
+            self.add_route(dvs, "4.4.4.4", "20.0.0.1")
 
         # create mirror session
         self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
-        assert self.get_mirror_session_state(session)["status"] == "active"
+        assert self.get_mirror_session_state(session)["status"] == ("active" if create_seq_test == False else "inactive")
 
-        # assert mirror session in asic database
+        # check mirror session in asic database
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
-        assert len(tbl.getKeys()) == 1
-        mirror_session_oid = tbl.getKeys()[0]
+        assert len(tbl.getKeys()) == (1 if create_seq_test == False else 0)
+        if create_seq_test == False:
+            mirror_session_oid = tbl.getKeys()[0]
 
         # create acl table
         self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"])
@@ -822,10 +823,25 @@ class TestMirror(object):
         # create acl rule with dscp value 48
         self.create_mirror_acl_dscp_rule(acl_table, acl_rule, "48", session)
 
-        # assert acl rule is created
+        # acl rule creation check
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
         rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
-        assert len(rule_entries) == 1
+        assert len(rule_entries) == (1 if create_seq_test == False else 0)
+
+        if create_seq_test == True:
+            self.add_route(dvs, "4.4.4.4", "20.0.0.1")
+
+            assert self.get_mirror_session_state(session)["status"] == "active"
+
+            # assert mirror session in asic database
+            tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
+            assert len(tbl.getKeys()) == 1
+            mirror_session_oid = tbl.getKeys()[0]
+
+            # assert acl rule is created
+            tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
+            rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
+            assert len(rule_entries) == 1
 
         (status, fvs) = tbl.get(rule_entries[0])
         assert status == True
@@ -872,6 +888,12 @@ class TestMirror(object):
         self.remove_neighbor("Ethernet32", "20.0.0.1")
         self.remove_ip_address("Ethernet32", "20.0.0.0/31")
         self.set_interface_status(dvs, "Ethernet32", "down")
+
+    def test_AclBindMirror(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        self._test_AclBindMirror(dvs, testlog)
+        self._test_AclBindMirror(dvs, testlog, create_seq_test=True)
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->


**Why I did it**
Retry logic was introduced to ACL rule mirror action in https://github.com/Azure/sonic-swss/pull/1486

This assumes that mirror session may not be ready when the associated ACL rule is processed.

If mirror entry exists (CONFIG_DB processed) but mirror session is not created in sai/asic, `AclRuleMirror::create()` is called twice, one at processing CONFIG_DB ACL rule config, and one at later mirror session activation notify (i.e., mirror session creation event in sai/asic). In this case, mirror session reference count is incremented twice for the same rule, and mirror session removal will fail due to non-zero ref count even if ACL rule is removed.

**What I did**
This PR fixes the above scenario. 

**How I verified it**
Fix is validated by developing vs test, which is piggy-backed onto `test_AclBindMirror`


**Details if related**
##### vs test failure before the change
```
=========================================================================== FAILURES ===========================================================================
________________________________________________________________ TestMirror.test_AclBindMirror _________________________________________________________________

self = <test_mirror.TestMirror object at 0x7fd282c40ef0>, dvs = <conftest.DockerVirtualSwitch object at 0x7fd282c3def0>
testlog = <function testlog at 0x7fd282f8d378>

    def test_AclBindMirror(self, dvs, testlog):
        self.setup_db(dvs)
    
        self._test_AclBindMirror(dvs, testlog)
>       self._test_AclBindMirror(dvs, testlog, create_seq_test=True)

test_mirror.py:896: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <test_mirror.TestMirror object at 0x7fd282c40ef0>, dvs = <conftest.DockerVirtualSwitch object at 0x7fd282c3def0>
testlog = <function testlog at 0x7fd282f8d378>, create_seq_test = True

    def _test_AclBindMirror(self, dvs, testlog, create_seq_test=False):
        """
        This test tests ACL associated with mirror session with DSCP value
        The DSCP value is tested on both with mask and without mask
        """
    
        session = "MIRROR_SESSION"
        acl_table = "MIRROR_TABLE"
        acl_rule = "MIRROR_RULE"
    
        # bring up port; assign ip; create neighbor; create route
        self.set_interface_status(dvs, "Ethernet32", "up")
        self.add_ip_address("Ethernet32", "20.0.0.0/31")
        self.add_neighbor("Ethernet32", "20.0.0.1", "02:04:06:08:10:12")
        if create_seq_test == False:
            self.add_route(dvs, "4.4.4.4", "20.0.0.1")
    
        # create mirror session
        self.create_mirror_session(session, "3.3.3.3", "4.4.4.4", "0x6558", "8", "100", "0")
        assert self.get_mirror_session_state(session)["status"] == ("active" if create_seq_test == False else "inactive")
    
        # check mirror session in asic database
        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
        assert len(tbl.getKeys()) == (1 if create_seq_test == False else 0)
        if create_seq_test == False:
            mirror_session_oid = tbl.getKeys()[0]
    
        # create acl table
        self.create_acl_table(acl_table, ["Ethernet0", "Ethernet4"])
    
        # create acl rule with dscp value 48
        self.create_mirror_acl_dscp_rule(acl_table, acl_rule, "48", session)
    
        # acl rule creation check
        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
        assert len(rule_entries) == (1 if create_seq_test == False else 0)
    
        if create_seq_test == True:
            self.add_route(dvs, "4.4.4.4", "20.0.0.1")
    
            assert self.get_mirror_session_state(session)["status"] == "active"
    
            # assert mirror session in asic database
            tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
            assert len(tbl.getKeys()) == 1
            mirror_session_oid = tbl.getKeys()[0]
    
            # assert acl rule is created
            tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
            rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
            assert len(rule_entries) == 1
    
        (status, fvs) = tbl.get(rule_entries[0])
        assert status == True
        for fv in fvs:
            if fv[0] == "SAI_ACL_ENTRY_ATTR_FIELD_DSCP":
                assert fv[1] == "48&mask:0x3f"
            if fv[0] == "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS":
                assert fv[1] == "1:" + mirror_session_oid
    
        # remove acl rule
        self.remove_mirror_acl_dscp_rule(acl_table, acl_rule)
    
        # create acl rule with dscp value 16/16
        self.create_mirror_acl_dscp_rule(acl_table, acl_rule, "16/16", session)
    
        # assert acl rule is created
        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY")
        rule_entries = [k for k in tbl.getKeys() if k not in dvs.asicdb.default_acl_entries]
        assert len(rule_entries) == 1
    
        (status, fvs) = tbl.get(rule_entries[0])
        assert status == True
        for fv in fvs:
            if fv[0] == "SAI_ACL_ENTRY_ATTR_FIELD_DSCP":
                assert fv[1] == "16&mask:0x10"
            if fv[0] == "SAI_ACL_ENTRY_ATTR_ACTION_MIRROR_INGRESS":
                assert fv[1] == "1:" + mirror_session_oid
    
        # remove acl rule
        self.remove_mirror_acl_dscp_rule(acl_table, acl_rule)
    
        # remove acl table
        self.remove_acl_table(acl_table)
    
        # remove mirror session
        self.remove_mirror_session(session)
    
        # assert no mirror session in asic database
        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
>       assert len(tbl.getKeys()) == 0
E       assert 1 == 0
E         +1
E         -0

test_mirror.py:884: AssertionError
=================================================================== short test summary info ====================================================================
FAILED test_mirror.py::TestMirror::test_AclBindMirror - assert 1 == 0
================================================================= 1 failed in 87.26s (0:01:27) =================================================================
```