### PR TITLE
[MCLAG] Improve the number of mclag enabled interfaces from 30 to abo…

### DIFF
--- a/mclagsyncd/mclag.h
+++ b/mclagsyncd/mclag.h
@@ -40,7 +40,7 @@ enum MCLAG_FDB_TYPE {
 /*
  * Largest message that can be sent to or received from the MCLAG.
  */
-#define MCLAG_MAX_MSG_LEN 4096
+#define MCLAG_MAX_MSG_LEN 8320 + 4096 /*CONFIG_MCLAG_ENABLE_INTF_LEN 8320: max number of mclag enable portchannel is 520*/
 #define MCLAG_MAX_SEND_MSG_LEN 4096
 
 typedef struct mclag_msg_hdr_t_ {


### PR DESCRIPTION
…ut 520

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Improve the number of mclag enabled interfaces from 30 to about 520.

**Why I did it**
If lots of mclag enabled interfaces are configured, only about 30 can be displayed by the command 'mclagdctl dump state'. 
This PR must work with submitted PR https://github.com/Azure/sonic-buildimage/pull/7769 in other sonic repositorie.

**How I verified it**
Test on the switch.

**Details if related**
