### PR TITLE
[vs] Stablize test portchannel: test_Portchannel_oper_down end-of-test cleanup fix

### DIFF
--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -214,7 +214,6 @@ class TestPortchannel(object):
         assert len(intf_entries) == 1
         assert intf_entries[0] == "40.0.0.6/31"
 
-
         # set oper_status for PortChannels
         ps = swsscommon.ProducerStateTable(self.pdb, "LAG_TABLE")
         fvs = swsscommon.FieldValuePairs([("admin_status", "up"),("mtu", "9100"),("oper_status", "up")])
@@ -234,8 +233,8 @@ class TestPortchannel(object):
         time.sleep(1)
 
         ps = swsscommon.ProducerStateTable(self.pdb, "ROUTE_TABLE")
-        fvs = swsscommon.FieldValuePairs([("nexthop","40.0.0.1,40.0.0.3,40.0.0.5,40.0.0.7"), ("ifname", "PortChannel001,PortChannel002,PortChannel003,PortChannel004")])
-
+        fvs = swsscommon.FieldValuePairs([("nexthop","40.0.0.1,40.0.0.3,40.0.0.5,40.0.0.7"),
+                                          ("ifname", "PortChannel001,PortChannel002,PortChannel003,PortChannel004")])
         ps.set("2.2.2.0/24", fvs)
         time.sleep(1)
 
@@ -284,6 +283,11 @@ class TestPortchannel(object):
         keys = nhg_member_tbl.getKeys()
         assert len(keys) == 3
 
+        # remove route entry
+        ps = swsscommon.ProducerStateTable(self.pdb, "ROUTE_TABLE")
+        ps._del("2.2.2.0/24")
+        time.sleep(1)
+
         # remove IP address
         tbl = swsscommon.Table(self.cdb, "PORTCHANNEL_INTERFACE")
         tbl._del("PortChannel001|40.0.0.0/31")
@@ -306,6 +310,19 @@ class TestPortchannel(object):
         assert len(intf_entries) == 0
 
         tbl = swsscommon.Table(self.pdb, "INTF_TABLE:PortChannel004")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # remove router interfaces
+        tbl = swsscommon.Table(self.cdb, "PORTCHANNEL_INTERFACE")
+        tbl._del("PortChannel001")
+        tbl._del("PortChannel002")
+        tbl._del("PortChannel003")
+        tbl._del("PortChannel004")
+        time.sleep(1)
+
+        # check application database
+        tbl = swsscommon.Table(self.pdb, "INTF_TABLE")
         intf_entries = tbl.getKeys()
         assert len(intf_entries) == 0
 

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -346,7 +346,6 @@ class TestPortchannel(object):
         dvs.servers[0].runcmd("ip link set up dev eth0")
         time.sleep(1)
 
-    @pytest.mark.skip(reason="This test is not stable enough")
     def test_Portchannel_tpid(self, dvs, testlog):
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -1,7 +1,6 @@
 import time
 import re
 import json
-import pytest
 import itertools
 
 from swsscommon import swsscommon


### PR DESCRIPTION
Signed-off-by: Wenda Ni <wonda.ni@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Why I did it**
Frequent failure seen on `test_portchannel.py::TestPortchannel::test_Portchannel_tpid` from https://github.com/Azure/sonic-swss/pull/1642 vs pipeline, apart from https://github.com/Azure/sonic-buildimage/issues/7791

Looks like preceding test `test_Portchannel_oper_down` end-of-test cleanup is not clear. Lag removal retry is left over in `doTask` to the subsequent test
```
227829 Jun  3 18:11:18.929051 9faa323d761d ERR #orchagent: :- removeLag: Failed to remove ref count 1 LAG PortChannel001
227830 Jun  3 18:11:18.929057 9faa323d761d ERR #orchagent: :- removeLag: Failed to remove ref count 1 LAG PortChannel002
227831 Jun  3 18:11:18.929061 9faa323d761d ERR #orchagent: :- removeLag: Failed to remove ref count 1 LAG PortChannel003
227832 Jun  3 18:11:18.929064 9faa323d761d ERR #orchagent: :- removeLag: Failed to remove ref count 1 LAG PortChannel004
```

**What I did**
In `test_Portchannel_oper_down` cleanup, remove route entry and router interface so that portchannel object can be removed properly.

**How I verified it**
Run vs test on portchannel 10 times
```
for i in `seq 0 9`; do pytest -s -v test_portchannel.py::TestPortchannel --dvsname=vs; done
```

##### Before the change
`test_Portchannel_tpid` can fail 9 out of 10 runs

##### After the change
`test_Portchannel_tpid` succeeds 10 out of 10 runs


**Details if related**
Fixes https://github.com/Azure/sonic-swss/issues/1779