### PR TITLE
[orchagent] Remove default prefix in non default vrf

### DIFF
--- a/orchagent/nexthopgroupkey.h
+++ b/orchagent/nexthopgroupkey.h
@@ -33,6 +33,7 @@ public:
 
     NextHopGroupKey(const std::string &nexthops, const std::string &weights)
     {
+        m_overlay_nexthops = false;
         std::vector<std::string> nhv = tokenize(nexthops, NHG_DELIMITER);
         std::vector<std::string> wtv = tokenize(weights, NHG_DELIMITER);
         for (uint32_t i = 0; i < nhv.size(); i++)

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1906,7 +1906,7 @@ bool RouteOrch::removeRoute(RouteBulkContext& ctx)
     auto& object_statuses = ctx.object_statuses;
 
     // set to blackhole for default route
-    if (ipPrefix.isDefaultRoute())
+    if (ipPrefix.isDefaultRoute() && vrf_id == gVirtualRouterId)
     {
         sai_attribute_t attr;
         attr.id = SAI_ROUTE_ENTRY_ATTR_PACKET_ACTION;
@@ -1950,7 +1950,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
     auto it_status = object_statuses.begin();
 
     // set to blackhole for default route
-    if (ipPrefix.isDefaultRoute())
+    if (ipPrefix.isDefaultRoute() && vrf_id == gVirtualRouterId)
     {
         sai_status_t status = *it_status++;
         if (status != SAI_STATUS_SUCCESS)
@@ -2030,7 +2030,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
     SWSS_LOG_INFO("Remove route %s with next hop(s) %s",
             ipPrefix.to_string().c_str(), it_route->second.to_string().c_str());
 
-    if (ipPrefix.isDefaultRoute())
+    if (ipPrefix.isDefaultRoute() && vrf_id == gVirtualRouterId)
     {
         it_route_table->second[ipPrefix] = NextHopGroupKey();
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

1. Remove default prefix in non-default VRF instead of setting it to blackhole
2. Initialize `m_overlay_nexthops` in overloaded constructor. 


**Why I did it**
To fix https://github.com/Azure/sonic-buildimage/issues/6504

1. To remove default routes in non default VRF
2. To avoid garbage in `m_overlay_nexthops`. 

**How I verified it**
1. Add t0 topology
2. Load config generated by this test vrf/test_vrf.py::TestVrfDeletion::test_vrf1_neigh_after_restore
3. `sudo config vrf del Vrf1`
4. `redis-cli -n 6 keys "*VRF*"`
5. check that there is entries only for Vrf2. e.g:
```
1) "VRF_OBJECT_TABLE|Vrf2"
2) "VRF_TABLE|Vrf2"
```

**Details if related**
