### PR TITLE
[VS Test Stability] Temporarily skip flaky tests

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -49,6 +49,9 @@ jobs:
       sudo docker load -i ../docker-sonic-vs.gz
       docker ps
       ip netns list
+      uname -a
+      sudo /sbin/ip link add Vrf1 type vrf table 1001 || { echo 'vrf command failed' ; exit 1; }
+      sudo /sbin/ip link del Vrf1 type vrf table 1001
       pushd tests
       sudo py.test -v --force-flaky --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
     displayName: "Run vs tests"

--- a/tests/test_port_dpb_system.py
+++ b/tests/test_port_dpb_system.py
@@ -623,6 +623,7 @@ class TestPortDPBSystem(object):
         dvs_acl.verify_acl_table_count(0)
         self.dvs_vlan.get_and_verify_vlan_ids(0)
 
+    @pytest.mark.skip(reason="This test is not stable enough")
     def test_dpb_arp_flush(self, dvs):
         dvs.setup_db()
         dvs_asic_db = dvs.get_asic_db()
@@ -673,6 +674,7 @@ class TestPortDPBSystem(object):
         dvs.change_port_breakout_mode("Ethernet0", "1x100G[40G]")
         dpb.verify_port_breakout_mode(dvs, "Ethernet0", "1x100G[40G]")
 
+    @pytest.mark.skip(reason="This test is not stable enough")
     def test_dpb_arp_flush_vlan(self, dvs):
         dvs.setup_db()
         dvs_asic_db = dvs.get_asic_db()
@@ -736,6 +738,7 @@ class TestPortDPBSystem(object):
         # Remove VLAN(note that member was removed during port breakout)
         self.dvs_vlan.remove_vlan(vlanID)
 
+    @pytest.mark.skip(reason="This test is not stable enough")
     def test_dpb_arp_flush_on_port_oper_shut(self, dvs):
         dvs.setup_db()
         dvs_asic_db = dvs.get_asic_db()
@@ -800,6 +803,7 @@ class TestPortDPBSystem(object):
         self.dvs_vlan.remove_vlan_member(vlanID, portName)
         self.dvs_vlan.remove_vlan(vlanID)
 
+    @pytest.mark.skip(reason="This test is not stable enough")
     def test_dpb_arp_flush_on_vlan_member_remove(self, dvs):
         dvs.setup_db()
         dvs_asic_db = dvs.get_asic_db()

--- a/tests/test_port_dpb_system.py
+++ b/tests/test_port_dpb_system.py
@@ -205,6 +205,7 @@ class TestPortDPBSystem(object):
         # Verify DPB is successful
         dpb.verify_port_breakout_mode(dvs, "Ethernet0", breakoutMode1)
 
+    @pytest.mark.skip(reason="This test is not stable enough")
     def test_port_breakout_with_acl(self, dvs, dvs_acl):
         dvs.setup_db()
         dpb = DPB()
@@ -540,6 +541,7 @@ class TestPortDPBSystem(object):
         status, result = wait_for_result(_check_route_absent, ROUTE_CHECK_POLLING)
         assert status == True
 
+    @pytest.mark.skip(reason="This test is not stable enough")
     def test_cli_command_negative(self, dvs, dvs_acl):
         dvs.setup_db()
         dpb = DPB()

--- a/tests/test_portchannel.py
+++ b/tests/test_portchannel.py
@@ -329,6 +329,7 @@ class TestPortchannel(object):
         dvs.servers[0].runcmd("ip link set up dev eth0")
         time.sleep(1)
 
+    @pytest.mark.skip(reason="This test is not stable enough")
     def test_Portchannel_tpid(self, dvs, testlog):
         adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)


### PR DESCRIPTION
**What I did**

1. Skip flaky tests - DPB ARP flush, LAG TPID
Issue details - https://github.com/Azure/sonic-swss/issues/1778, https://github.com/Azure/sonic-swss/issues/1779
2. Abort test if VRF cannot be configured. Example failure
```
Linux fv-az234-728 5.8.0-1033-azure #35~20.04.1-Ubuntu SMP Wed May 19 06:46:04 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
+ sudo /sbin/ip link add Vrf1 type vrf table
Command line is not complete. Try option "help"
+ echo 'vrf command failed'
+ exit 1
vrf command failed
```

**Why I did it**
Unblock PRs.

**How I verified it**
By - https://github.com/Azure/sonic-swss/pull/1775

**Details if related**
