### PR TITLE
[sub intf] Check parent port role

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -772,7 +772,7 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
         case Port::PHY:
             if (parentPort.m_lag_member_id != SAI_NULL_OBJECT_ID)
             {
-                SWSS_LOG_ERROR("Sub interface %s Port object creation failed: parent port %s is a LAG member",
+                SWSS_LOG_INFO("Sub interface %s Port object creation failed: parent port %s is a LAG member",
                         alias.c_str(), parentAlias.c_str());
                 return false;
             }
@@ -791,13 +791,13 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
                 //
                 // Thus, a non-NULL bridge port object id indicates the prohibition of a proper sub port usage on a
                 // physical port or LAG.
-                SWSS_LOG_ERROR("Sub interface %s Port object creation failed: parent port %s is associated with a .1Q bridge",
+                SWSS_LOG_INFO("Sub interface %s Port object creation failed: parent port %s is associated with a .1Q bridge",
                         alias.c_str(), parentAlias.c_str());
                 return false;
             }
             break;
         default:
-            SWSS_LOG_ERROR("Sub interface %s Port object creation failed: \
+            SWSS_LOG_INFO("Sub interface %s Port object creation failed: \
                     parent port %s of invalid type (must be physical port or LAG)", alias.c_str(), parentAlias.c_str());
             return false;
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -780,7 +780,7 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
         case Port::LAG:
             if (parentPort.m_bridge_port_id != SAI_NULL_OBJECT_ID)
             {
-                // If created, the created bridge port is of type port, which is associated with a .1Q bridge.
+                // Bridge port, if created, is of type port, which is associated with a .1Q bridge.
                 //
                 // This excludes the possibility of further creating a sub port as a bridge port on the physcal port
                 // or LAG because bridge port type sub port is associated with a .1D bridge, and a physical port
@@ -788,6 +788,9 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
                 //
                 // On the other hand, to create a sub port as a router interface, physical port or LAG cannot be
                 // acting as a bridge port at the same time, either.
+                //
+                // Thus, a non-NULL bridge port object id indicates the prohibition of a proper sub port usage on a
+                // physical port or LAG.
                 SWSS_LOG_ERROR("Sub interface %s Port object creation failed: parent port %s is associated with a .1Q bridge",
                         alias.c_str(), parentAlias.c_str());
                 return false;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -778,15 +778,17 @@ bool PortsOrch::addSubPort(Port &port, const string &alias, const bool &adminUp,
             }
             // fall through
         case Port::LAG:
-            if (!parentPort.m_vlan_members.empty())
+            if (parentPort.m_bridge_port_id != SAI_NULL_OBJECT_ID)
             {
-                // Parent port being a vlan member is invalid for sub port use case.
+                // If created, the created bridge port is of type port, which is associated with a .1Q bridge.
                 //
-                // Parent port being a vlan member indicates the associated bridge object is of type .1Q.
-                // This excludes the use case of creating sub port as a bridge port as bridge port type sub port
-                // is associated with a .1D bridge.
-                // On the other hand, to create sub port as a router interface, parent port cannot be a vlan member, either.
-                SWSS_LOG_ERROR("Sub interface %s Port object creation failed: parent port %s is a VLAN member",
+                // This excludes the possibility of further creating a sub port as a bridge port on the physcal port
+                // or LAG because bridge port type sub port is associated with a .1D bridge, and a physical port
+                // or LAG cannot be associated with both a .1Q bridge and a .1D bridge at the same time.
+                //
+                // On the other hand, to create a sub port as a router interface, physical port or LAG cannot be
+                // acting as a bridge port at the same time, either.
+                SWSS_LOG_ERROR("Sub interface %s Port object creation failed: parent port %s is associated with a .1Q bridge",
                         alias.c_str(), parentAlias.c_str());
                 return false;
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -957,27 +957,27 @@ class DockerVirtualSwitch:
 
         return exists, extra_info
 
-    # deps: fdb_update, fdb
+    # deps: fdb_update, fdb, sub port intf
     def create_vlan(self, vlan):
         tbl = swsscommon.Table(self.cdb, "VLAN")
         fvs = swsscommon.FieldValuePairs([("vlanid", vlan)])
         tbl.set("Vlan" + vlan, fvs)
         time.sleep(1)
 
-    # deps: fdb_update, fdb
+    # deps: fdb_update, fdb, sub port intf
     def remove_vlan(self, vlan):
         tbl = swsscommon.Table(self.cdb, "VLAN")
         tbl._del("Vlan" + vlan)
         time.sleep(1)
 
-    # deps: fdb_update, fdb
+    # deps: fdb_update, fdb, sub port intf
     def create_vlan_member(self, vlan, interface):
         tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
         fvs = swsscommon.FieldValuePairs([("tagging_mode", "untagged")])
         tbl.set("Vlan" + vlan + "|" + interface, fvs)
         time.sleep(1)
 
-    # deps: fdb_update, fdb
+    # deps: fdb_update, fdb, sub port intf
     def remove_vlan_member(self, vlan, interface):
         tbl = swsscommon.Table(self.cdb, "VLAN_MEMBER")
         tbl._del("Vlan" + vlan + "|" + interface)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -464,8 +464,6 @@ class TestSubPortIntf(object):
     def _test_sub_port_intf_parent_misconfig(self, dvs, sub_port_intf_name, grand_port, vrf_name=None):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
         parent_port = substrs[0]
-        assert parent_port.startswith(ETHERNET_PREFIX)
-        phy_ports = [parent_port]
 
         vrf_oid = self.default_vrf_oid
         rif_cnt = len(self.get_oids(ASIC_RIF_TABLE))
@@ -476,6 +474,8 @@ class TestSubPortIntf(object):
             vrf_oid = self.get_newly_created_oid(ASIC_VIRTUAL_ROUTER_TABLE, [vrf_oid])
 
         if grand_port.startswith(LAG_PREFIX):
+            assert parent_port.startswith(ETHERNET_PREFIX)
+            phy_ports = [parent_port]
             # Create lag
             self.set_parent_port_admin_status(dvs, grand_port, UP)
             # Add parent physical port to lag
@@ -489,7 +489,7 @@ class TestSubPortIntf(object):
             dvs.create_vlan("{}".format(vlan_id))
             vlan_cnt += 1
             self.asic_db.wait_for_n_keys(ASIC_VLAN_TABLE, vlan_cnt)
-            # Add parent physical port to vlan
+            # Add parent port to vlan
             vlan_member_cnt = len(self.asic_db.get_keys(ASIC_VLAN_MEMBER_TABLE))
             dvs.create_vlan_member("{}".format(vlan_id), parent_port)
             vlan_member_cnt += 1
@@ -521,7 +521,7 @@ class TestSubPortIntf(object):
             self.remove_lag(grand_port)
             self.asic_db.wait_for_n_keys(ASIC_LAG_TABLE, 0)
         else:
-            # Remove parent physical port from vlan
+            # Remove parent port from vlan
             dvs.remove_vlan_member("{}".format(vlan_id), parent_port)
             vlan_member_cnt -= 1
             self.asic_db.wait_for_n_keys(ASIC_VLAN_MEMBER_TABLE, vlan_member_cnt)
@@ -541,9 +541,11 @@ class TestSubPortIntf(object):
 
         self._test_sub_port_intf_parent_misconfig(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, self.LAG_UNDER_TEST)
         self._test_sub_port_intf_parent_misconfig(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, self.VLAN_UNDER_TEST)
+        self._test_sub_port_intf_parent_misconfig(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, self.VLAN_UNDER_TEST)
 
         self._test_sub_port_intf_parent_misconfig(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, self.LAG_UNDER_TEST, self.VRF_UNDER_TEST)
         self._test_sub_port_intf_parent_misconfig(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, self.VLAN_UNDER_TEST, self.VRF_UNDER_TEST)
+        self._test_sub_port_intf_parent_misconfig(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, self.VLAN_UNDER_TEST, self.VRF_UNDER_TEST)
 
     def _test_sub_port_intf_add_ip_addrs(self, dvs, sub_port_intf_name, vrf_name=None):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -536,6 +536,11 @@ class TestSubPortIntf(object):
             self.remove_vrf(vrf_name)
             self.check_vrf_removal(vrf_oid)
 
+        # Remove lag
+        if parent_port.startswith(LAG_PREFIX):
+            self.remove_lag(parent_port)
+            self.asic_db.wait_for_n_keys(ASIC_LAG_TABLE, 0)
+
     def test_sub_port_intf_parent_misconfig(self, dvs):
         self.connect_dbs(dvs)
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Why I did it**
Fix https://github.com/Azure/sonic-swss/issues/1616


**What I did**
Check the role of parent port, and drop further processing if the parent port setting does not qualify a valid sub port interface use case. Specifically, we will not instantiate a Port object for sub port, which is the stepping stone for sub port router interface creation, if parent port role check hits the following cases:

1) parent physical port  is a member of vlan, issue reported in https://github.com/Azure/sonic-swss/issues/1616

RIF type sub port -- physical port -- Vlan

2) parent lag is a member of vlan

RIF type sub port -- LAG-- Vlan

3) parent physical port is a member of lag

RIF type sub port -- physical port -- LAG

**How I verified it**
New vs test `test_sub_port_intf_parent_misconfig`, crafted around the steps in https://github.com/Azure/sonic-swss/issues/1616

In the case setting above, load sub port interface profile into DB (CONFIG_DB or APPL_DB), and verify that sub port router interface object is not created in ASIC DB.

Before the change, vs test fails.


**Details if related**
May need a separate PR to prevent the same incorrect config case from getting into Linux kernel.

