### PR TITLE
[debugcounterorch] check if counter type is supported before querying…

### DIFF
--- a/orchagent/debug_counter/drop_counter.cpp
+++ b/orchagent/debug_counter/drop_counter.cpp
@@ -342,6 +342,61 @@ unordered_set<string> DropCounter::getSupportedDropReasons(sai_debug_counter_att
     return supported_drop_reasons;
 }
 
+// Returns a set of supported counter types.
+unordered_set<string> DropCounter::getSupportedCounterTypes()
+{
+    sai_status_t status = SAI_STATUS_FAILURE;
+
+    const auto& countersTypeLookup = getDebugCounterTypeLookup();
+    unordered_set<string> supportedCounterTypes;
+
+    sai_s32_list_t enumValuesCapabilities;
+    vector<int32_t> saiCounterTypes;
+
+    const auto* meta = sai_metadata_get_attr_metadata(SAI_OBJECT_TYPE_DEBUG_COUNTER,
+                                                      SAI_DEBUG_COUNTER_ATTR_TYPE);
+    if (!meta)
+    {
+        SWSS_LOG_THROW("SAI BUG: metadata null pointer returned by "
+                       "sai_metadata_get_attr_metadata for SAI_DEBUG_COUNTER_ATTR_TYPE");
+    }
+
+    if (!meta->isenum || !meta->enummetadata)
+    {
+        SWSS_LOG_THROW("SAI BUG: SAI_DEBUG_COUNTER_ATTR_TYPE value type is not an enum");
+    }
+
+    saiCounterTypes.assign(meta->enummetadata->valuescount, 0);
+
+    enumValuesCapabilities.count = static_cast<uint32_t>(saiCounterTypes.size());
+    enumValuesCapabilities.list = saiCounterTypes.data();
+
+    status = sai_query_attribute_enum_values_capability(gSwitchId,
+                                                        SAI_OBJECT_TYPE_DEBUG_COUNTER,
+                                                        SAI_DEBUG_COUNTER_ATTR_TYPE,
+                                                        &enumValuesCapabilities);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_NOTICE("This device does not support querying drop counters");
+        return {};
+    }
+
+    for (uint32_t i = 0; i < enumValuesCapabilities.count; i++)
+    {
+        auto enumValue = static_cast<sai_debug_counter_type_t>(enumValuesCapabilities.list[i]);
+        for (const auto& it: countersTypeLookup)
+        {
+            if (it.second == enumValue)
+            {
+                supportedCounterTypes.emplace(it.first);
+                break;
+            }
+        }
+    }
+
+    return supportedCounterTypes;
+}
+
 // serializeSupportedDropReasons takes a list of drop reasons and returns that
 // list as a string.
 //

--- a/orchagent/debug_counter/drop_counter.cpp
+++ b/orchagent/debug_counter/drop_counter.cpp
@@ -357,13 +357,15 @@ unordered_set<string> DropCounter::getSupportedCounterTypes()
                                                       SAI_DEBUG_COUNTER_ATTR_TYPE);
     if (!meta)
     {
-        SWSS_LOG_THROW("SAI BUG: metadata null pointer returned by "
+        SWSS_LOG_ERROR("SAI BUG: metadata null pointer returned by "
                        "sai_metadata_get_attr_metadata for SAI_DEBUG_COUNTER_ATTR_TYPE");
+        return {};
     }
 
     if (!meta->isenum || !meta->enummetadata)
     {
-        SWSS_LOG_THROW("SAI BUG: SAI_DEBUG_COUNTER_ATTR_TYPE value type is not an enum");
+        SWSS_LOG_ERROR("SAI BUG: SAI_DEBUG_COUNTER_ATTR_TYPE value type is not an enum");
+        return {};
     }
 
     saiCounterTypes.assign(meta->enummetadata->valuescount, 0);

--- a/orchagent/debug_counter/drop_counter.h
+++ b/orchagent/debug_counter/drop_counter.h
@@ -34,6 +34,7 @@ class DropCounter : public DebugCounter
 
         static std::unordered_set<std::string> getSupportedDropReasons(sai_debug_counter_attr_t drop_reason_type);
         static std::string serializeSupportedDropReasons(std::unordered_set<std::string> drop_reasons);
+        static std::unordered_set<std::string> getSupportedCounterTypes();
         static uint64_t getSupportedDebugCounterAmounts(sai_debug_counter_type_t counter_type);
 
     private:

--- a/orchagent/debugcounterorch.cpp
+++ b/orchagent/debugcounterorch.cpp
@@ -183,6 +183,7 @@ void DebugCounterOrch::publishDropCounterCapabilities()
 {
     supported_ingress_drop_reasons = DropCounter::getSupportedDropReasons(SAI_DEBUG_COUNTER_ATTR_IN_DROP_REASON_LIST);
     supported_egress_drop_reasons  = DropCounter::getSupportedDropReasons(SAI_DEBUG_COUNTER_ATTR_OUT_DROP_REASON_LIST);
+    supported_counter_types        = DropCounter::getSupportedCounterTypes();
 
     string ingress_drop_reason_str = DropCounter::serializeSupportedDropReasons(supported_ingress_drop_reasons);
     string egress_drop_reason_str = DropCounter::serializeSupportedDropReasons(supported_egress_drop_reasons);
@@ -190,6 +191,12 @@ void DebugCounterOrch::publishDropCounterCapabilities()
     for (auto const &counter_type : DebugCounter::getDebugCounterTypeLookup())
     {
         string drop_reasons;
+
+        if (!supported_counter_types.count(counter_type.first))
+        {
+            continue;
+        }
+
         if (counter_type.first == PORT_INGRESS_DROPS || counter_type.first == SWITCH_INGRESS_DROPS)
         {
             drop_reasons = ingress_drop_reason_str;
@@ -212,8 +219,6 @@ void DebugCounterOrch::publishDropCounterCapabilities()
         {
             continue;
         }
-
-        supported_counter_types.emplace(counter_type.first);
 
         vector<FieldValueTuple> fieldValues;
         fieldValues.push_back(FieldValueTuple("count", num_counters));


### PR DESCRIPTION
… object availability count

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

DEPENDS: https://github.com/Azure/sonic-sairedis/pull/842
ALSO: https://github.com/Azure/sonic-sairedis/pull/843

**What I did**

Implemented check for debug counter type support prio to querying unsupported counter type availablility counter. 

**Why I did it**
This is done in order to prevent error message seen on mellanox platform:
```
Mar 11 16:28:42.945332 ptr-sonic-n2-t3 ERR syncd#SDK: [SAI_DEBUG_COUNTER.ERR] mlnx_sai_debug_counter.c[324]- mlnx_debug_counter_availability_get: Unsupported debug counter type - 1
Mar 11 16:28:42.948092 ptr-sonic-n2-t3 ERR syncd#SDK: [SAI_DEBUG_COUNTER.ERR] mlnx_sai_debug_counter.c[324]- mlnx_debug_counter_availability_get: Unsupported debug counter type - 0
```

**How I verified it**
1. Run on mellanox and observe no errors.
2. Run VS test for debug counters:
```                                                                                                                 
tests/test_drop_counters.py::TestDropCounters::test_deviceCapabilitiesTablePopulated PASSED               [  6%]
tests/test_drop_counters.py::TestDropCounters::test_flexCounterGroupInitialized PASSED                    [ 12%]
tests/test_drop_counters.py::TestDropCounters::test_createAndRemoveDropCounterBasic PASSED                [ 18%]
tests/test_drop_counters.py::TestDropCounters::test_createAndRemoveDropCounterReversed PASSED             [ 25%]
tests/test_drop_counters.py::TestDropCounters::test_createCounterWithInvalidCounterType PASSED            [ 31%] 
tests/test_drop_counters.py::TestDropCounters::test_createCounterWithInvalidDropReason PASSED             [ 37%]
tests/test_drop_counters.py::TestDropCounters::test_addReasonToInitializedCounter PASSED                  [ 43%]
tests/test_drop_counters.py::TestDropCounters::test_removeReasonFromInitializedCounter PASSED             [ 50%]
tests/test_drop_counters.py::TestDropCounters::test_removeAllDropReasons PASSED                           [ 56%]
tests/test_drop_counters.py::TestDropCounters::test_addDropReasonMultipleTimes PASSED                     [ 62%]
tests/test_drop_counters.py::TestDropCounters::test_addInvalidDropReason PASSED                           [ 68%]
tests/test_drop_counters.py::TestDropCounters::test_removeDropReasonMultipleTimes PASSED                  [ 75%]
tests/test_drop_counters.py::TestDropCounters::test_removeNonexistentDropReason PASSED                    [ 81%]
tests/test_drop_counters.py::TestDropCounters::test_removeInvalidDropReason PASSED                        [ 87%]
tests/test_drop_counters.py::TestDropCounters::test_createAndDeleteMultipleCounters PASSED                [ 93%]
tests/test_drop_counters.py::test_nonflaky_dummy PASSED                                                   [100%]
```

**Details if related**
