### PR TITLE
[swss]: Allow portsyncd to run on system without ports

### DIFF
--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -88,10 +88,8 @@ int main(int argc, char **argv)
 
         if (!handlePortConfigFromConfigDB(p, cfgDb, warm))
         {
-            // if port config is missing in ConfigDB
-            // program will exit with failure
-            SWSS_LOG_THROW("ConfigDB does not have port information, exiting...");
-            return EXIT_FAILURE;
+            SWSS_LOG_NOTICE("ConfigDB does not have port information, "
+                            "however ports can be added later on, continuing...");
         }
 
         LinkSync sync(&appl_db, &state_db);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Remove Portsyncd error exit if there are no ports in config DB.

**Why I did it**
Allow system with no ports in config db run without errors
This is needed for modular system which should boot properly without line cards.

**How I verified it**
Remove ports from config DB and verify proper init flow. 

**Details if related**