### PR TITLE
[warm-restart] Fix teamd container warm restart issue

### DIFF
--- a/teamsyncd/teamsync.cpp
+++ b/teamsyncd/teamsync.cpp
@@ -25,7 +25,8 @@ TeamSync::TeamSync(DBConnector *db, DBConnector *stateDb, Select *select) :
     m_select(select),
     m_lagTable(db, APP_LAG_TABLE_NAME),
     m_lagMemberTable(db, APP_LAG_MEMBER_TABLE_NAME),
-    m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME)
+    m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME),
+    m_stateWarmRestartEnableTable(stateDb, STATE_WARM_RESTART_ENABLE_TABLE_NAME)
 {
     WarmStart::initialize(TEAMSYNCD_APP_NAME, "teamd");
     WarmStart::checkWarmStart(TEAMSYNCD_APP_NAME, "teamd");
@@ -215,13 +216,25 @@ void TeamSync::removeLag(const string &lagName)
 void TeamSync::cleanTeamSync()
 {
     SWSS_LOG_ENTER();
-    SWSS_LOG_NOTICE("Cleaning up LAG teamd resources ...");
 
-    for (const auto& it: m_teamSelectables)
+    std::string team_value, system_value;
+    m_stateWarmRestartEnableTable.hget("system", "enable", system_value);
+    m_stateWarmRestartEnableTable.hget("teamd", "enable", team_value);
+    if (system_value == "true" || team_value == "true")
     {
-        /* Cleanup LAG */
-        removeLag(it.first);
+        SWSS_LOG_NOTICE("Warm restart enabled, skip cleaning teamd");
     }
+    else
+    {
+        SWSS_LOG_NOTICE("Cleaning up LAG teamd resources ...");
+
+        for (const auto& it: m_teamSelectables)
+        {
+            /* Cleanup LAG */
+            removeLag(it.first);
+        }
+    }
+
     return;
 }
 

--- a/teamsyncd/teamsync.h
+++ b/teamsyncd/teamsync.h
@@ -71,6 +71,7 @@ private:
     ProducerStateTable m_lagTable;
     ProducerStateTable m_lagMemberTable;
     Table m_stateLagTable;
+    Table m_stateWarmRestartEnableTable;
 
     bool m_warmstart;
     std::unordered_map<std::string, std::vector<FieldValueTuple>> m_stateLagTablePreserved;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fix the warm restart function of the teamd container

**Why I did it**

Originally, after stopping the teamd container, it will try to temove the LAG ports. When orchagent receive the modification, it will encounter error for removing the LAG ports because there are AclTable on them.

The error will be like:
```
May 11 02:06:16.633270 as7816-64x NOTICE swss#orchagent: :- removeLagMember: Remove member Ethernet112 from LAG PortChannel0001 lid:2000000000b10 lmid:1b000000000b14
May 11 02:06:16.634260 as7816-64x ERR swss#orchagent: :- removeLag: Failed to remove ref count 3 LAG PortChannel0001
May 11 02:06:16.634260 as7816-64x ERR swss#orchagent: :- removeLag: Failed to remove ref count 3 LAG PortChannel0002
May 11 02:06:16.634260 as7816-64x ERR swss#orchagent: :- removeLag: Failed to remove ref count 3 LAG PortChannel0003
May 11 02:06:16.634260 as7816-64x ERR swss#orchagent: :- removeLag: Failed to remove ref count 3 LAG PortChannel0004
```

**How I verified it**

1. Enable the warm-restart flag by `sudo config warm_restart enable teamd`
2. Restart the teamd container by `sudo systemctl restart teamd`
3. Check the syslog and make sure no "removeLag" orchagent error

**Details if related**

* Check the WARM_RESTART_ENABLE_TABLE for teamd when stopping the teamsyncd.
  If the teamd warm restart is enabled, skip cleaning the LAG resource