### PR TITLE
[vstest] VS test failure fix after fabric port orch PR merge

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ NUM_PORTS = 32
 # FIXME: Voq asics will have 16 fabric ports created (defined in Azure/sonic-buildimage#6185).
 # Right now, we set FABRIC_NUM_PORTS to 0, and change to 16 when PR#6185 merges. PR#6185 can't
 # be merged before this PR. Otherwise it will cause swss voq test failures.
-FABRIC_NUM_PORTS = 0
+FABRIC_NUM_PORTS = 16
 
 def ensure_system(cmd):
     rc, output = subprocess.getstatusoutput(cmd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,9 +33,7 @@ from buffer_model import enable_dynamic_buffer
 # a dynamic number of ports. GitHub Issue: Azure/sonic-swss#1384.
 NUM_PORTS = 32
 
-# FIXME: Voq asics will have 16 fabric ports created (defined in Azure/sonic-buildimage#6185).
-# Right now, we set FABRIC_NUM_PORTS to 0, and change to 16 when PR#6185 merges. PR#6185 can't
-# be merged before this PR. Otherwise it will cause swss voq test failures.
+# Voq asics will have 16 fabric ports created (defined in Azure/sonic-buildimage#7629).
 FABRIC_NUM_PORTS = 16
 
 def ensure_system(cmd):
@@ -526,22 +524,12 @@ class DockerVirtualSwitch:
 
         # Verify that all ports have been created
         asic_db = self.get_asic_db()
-
-        # Verify that we have "at least" NUM_PORTS + FABRIC_NUM_PORTS, rather exact number.
-        # Right now, FABRIC_NUM_PORTS = 0. So it essentially waits for at least NUM_PORTS.
-        # This will allow us to merge Azure/sonic-buildimage#6185 that creates 16 fabric ports.
-        # When PR#6185 merges, FABRIC_NUM_PORTS should be 16, and so this verification (at least
-        # NUM_PORTS) still holds.
-        # Will update FABRIC_NUM_PORTS to 16, and revert back to wait exact NUM_PORTS + FABRIC_NUM_PORTS
-        # when PR#6185 merges.
-        wait_at_least_n_keys = True
-
-        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT", num_ports + 1, wait_at_least_n_keys)  # +1 CPU Port
+        asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_PORT", num_ports + 1)  # +1 CPU Port
 
         # Verify that fabric ports are monitored in STATE_DB
         if metadata.get('switch_type', 'npu') in ['voq', 'fabric']:
             self.get_state_db()
-            self.state_db.wait_for_n_keys("FABRIC_PORT_TABLE", FABRIC_NUM_PORTS, wait_at_least_n_keys)
+            self.state_db.wait_for_n_keys("FABRIC_PORT_TABLE", FABRIC_NUM_PORTS)
 
     def net_cleanup(self) -> None:
         """Clean up network, remove extra links."""

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -136,7 +136,6 @@ class TestVirtualChassis(object):
                 spcfg = ast.literal_eval(value)
                 assert spcfg['count'] == sp_count, "Number of systems ports configured is invalid"
 
-    @pytest.mark.skip(reason="This test is not stable enough")
     def test_chassis_app_db_sync(self, vct):
         """Test chassis app db syncing.
 
@@ -213,7 +212,6 @@ class TestVirtualChassis(object):
                     # Remote system ports's switch id should not match local switch id
                     assert spcfginfo["attached_switch_id"] != lc_switch_id, "RIF system port with wrong switch_id"
 
-    @pytest.mark.skip(reason="This test is not stable enough")
     def test_chassis_system_neigh(self, vct):
         """Test neigh record create/delete and syncing to chassis app db.
 
@@ -470,7 +468,6 @@ class TestVirtualChassis(object):
         # Cleanup inband if configuration
         self.del_inbandif_port(vct, inband_port)
         
-    @pytest.mark.skip(reason="This test is not stable enough")
     def test_chassis_system_lag(self, vct):
         """Test PortChannel in VOQ based chassis systems.
         

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -1,4 +1,3 @@
-import pytest
 from swsscommon import swsscommon
 from dvslib.dvs_database import DVSDatabase
 import ast

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -603,7 +603,6 @@ class TestVirtualChassis(object):
                     
                     break
 
-    @pytest.mark.skip(reason="This test is not stable enough")
     def test_chassis_system_lag_id_allocator_table_full(self, vct):
         """Test lag id allocator table full.
         
@@ -681,7 +680,6 @@ class TestVirtualChassis(object):
                     
                     break
 
-    @pytest.mark.skip(reason="This test is not stable enough")
     def test_chassis_system_lag_id_allocator_del_id(self, vct):
         """Test lag id allocator's release id and re-use id processing.
         


### PR DESCRIPTION
**What I did**

- In tests/conftest.py Set the FABRIC_NUM_PORTS to 16. This is required since addition of
fabric port orch adds 16 fabrics in asic db internally.
- in tests/test_virtual_chassis.py added back the skipped tests

**Why I did it**

Fix for virtual chassis tests failure issue https://github.com/Azure/sonic-swss/issues/1809

**How I verified it**

With sonic-buildimage PR https://github.com/Azure/sonic-buildimage/pull/8008, run the vs test. All tests from test_virtual_chassis.py should pass consistently

**Details if related**

This PR is dependent on sonic-buildimage PR https://github.com/Azure/sonic-buildimage/pull/8008
