### PR TITLE
Revert recirc port change

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2235,11 +2235,6 @@ bool PortsOrch::initPort(const string &alias, const string &role, const int inde
 {
     SWSS_LOG_ENTER();
 
-    if (role == "Rec" || role == "Inb")
-    {
-        return doProcessRecircPort(alias, role, lane_set, SET_COMMAND);
-    }
-
     /* Determine if the lane combination exists in switch */
     if (m_portListLaneMap.find(lane_set) != m_portListLaneMap.end())
     {
@@ -2291,6 +2286,11 @@ bool PortsOrch::initPort(const string &alias, const string &role, const int inde
                 notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
 
                 m_portList[alias].m_init = true;
+
+                if (role == "Rec" || role == "Inb")
+                {
+                    m_recircPortRole[alias] = role;
+                }
 
                 SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
             }
@@ -2751,16 +2751,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
             }
             else
             {
-                /* Skip configuring recirc port for now because the current SAI implementation of some vendors
-                 * have limiited support for recirc port. This check can be removed once SAI implementation
-                 * is enhanced/changed in the future.
-                 */
-                if (m_recircPortRole.find(alias) != m_recircPortRole.end())
-                {
-                    it = consumer.m_toSync.erase(it);
-                    continue;
-                }
-
                 if (!an_str.empty())
                 {
                     if (autoneg_mode_map.find(an_str) == autoneg_mode_map.end())
@@ -5906,80 +5896,6 @@ bool PortsOrch::getRecircPort(Port &port, string role)
     }
     SWSS_LOG_ERROR("Failed to find recirc port with role %s", role.c_str());
     return false;
-}
-
-bool PortsOrch::doProcessRecircPort(string alias, string role, set<int> lane_set, string op)
-{
-    SWSS_LOG_ENTER();
-
-    if (op == SET_COMMAND)
-    {
-        if (m_recircPortRole.find(alias) != m_recircPortRole.end())
-        {
-            SWSS_LOG_DEBUG("Recirc port %s already added", alias.c_str());
-            return true;
-        }
-
-        /* Find pid of recirc port */ 
-        sai_object_id_t port_id = SAI_NULL_OBJECT_ID;
-        if (m_portListLaneMap.find(lane_set) != m_portListLaneMap.end())
-        {
-            port_id = m_portListLaneMap[lane_set];
-        }
-
-        if (port_id == SAI_NULL_OBJECT_ID)
-        {
-            SWSS_LOG_ERROR("Failed to find port id for recirc port %s", alias.c_str());
-            return false;
-        }
-
-        Port p(alias, Port::PHY);
-        p.m_port_id = port_id;
-        p.m_init = true;
-        m_recircPortRole[alias] = role;
-        setPort(alias, p);
-
-        string lane_str = "";
-        for (auto lane : lane_set)
-        {
-            lane_str += to_string(lane) + " ";
-        }
-        SWSS_LOG_NOTICE("Added recirc port %s, pid:%" PRIx64 " lanes:%s",
-                        alias.c_str(), port_id, lane_str.c_str());
-
-        /* Create host intf for recirc port */
-        if(addHostIntfs(p, p.m_alias, p.m_hif_id))
-        {
-            SWSS_LOG_NOTICE("Created host intf for recycle port %s", p.m_alias.c_str());
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Failed to Create host intf for recirc port %s", p.m_alias.c_str());
-        }
-
-        if(setHostIntfsOperStatus(p, true))
-        {
-            SWSS_LOG_NOTICE("Set host intf oper status UP for recirc port %s", p.m_alias.c_str());
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Failed to set host intf oper status for recirc port %s", p.m_alias.c_str());
-        }
-
-        PortUpdate update = { p, true };
-        notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
-        return true;
-    }
-    else if (op == DEL_COMMAND)
-    {
-        SWSS_LOG_ERROR("Delete recirc port is not supported.");
-        return false;
-    }
-    else
-    {
-        SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
-        return false;
-    }
 }
 
 bool PortsOrch::addSystemPorts()

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -318,7 +318,6 @@ private:
     bool initGearboxPort(Port &port);
 
     map<string, string> m_recircPortRole;
-    bool doProcessRecircPort(string alias, string role, set<int> laneSet, string op);
 
     //map key is tuple of <attached_switch_id, core_index, core_port_index>
     map<tuple<int, int, int>, sai_object_id_t> m_systemPortOidMap;


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Revert the special handling for recirc port.

**Why I did it**
Recirc port support has been added to recent versions of DNX SAI. The earlier special handling for recirc port is not required anymore and thus reverted.

**How I verified it**
I tested the PR with SAI 5.0.0.5 and verified inband port came up and functioned correctly.

**Details if related**
