### PR TITLE
Ignore ALREADY_EXIST error in FDB creation

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -709,10 +709,10 @@ task_process_status Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t stat
                     return task_success;
                 case SAI_STATUS_ITEM_ALREADY_EXISTS:
                     /*
-                    *  In FDB creation, there are scenarios where the hardware learns an FDB entry before orchagent.
-                    *  In such cases, the FDB SAI creation would report the status of SAI_STATUS_ITEM_ALREADY_EXISTS,
-                    *  and orchagent should ignore the error and treat it as entry was explicitly created.
-                    */
+                     *  In FDB creation, there are scenarios where the hardware learns an FDB entry before orchagent.
+                     *  In such cases, the FDB SAI creation would report the status of SAI_STATUS_ITEM_ALREADY_EXISTS,
+                     *  and orchagent should ignore the error and treat it as entry was explicitly created.
+                     */
                     return task_success;
                 default:
                     SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -704,6 +704,9 @@ task_process_status Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t stat
         case SAI_API_FDB:
             switch (status)
             {
+                case SAI_STATUS_SUCCESS:
+                    SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
+                    return task_success;
                 case SAI_STATUS_ITEM_ALREADY_EXISTS:
                     /*
                     *  In FDB creation, there are scenarios where the hardware learns an FDB entry before orchagent.
@@ -711,7 +714,12 @@ task_process_status Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t stat
                     *  and orchagent should ignore the error and treat it as entry was explicitly created.
                     */
                     return task_success;
+                default:
+                    SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
+                                sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    exit(EXIT_FAILURE);
             }
+            break;
         default:
             switch (status)
             {

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -699,15 +699,30 @@ task_process_status Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t stat
      *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
-    switch (status)
+    switch (api)
     {
-        case SAI_STATUS_SUCCESS:
-            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
-            return task_success;
+        case SAI_API_FDB:
+            switch (status)
+            {
+                case SAI_STATUS_ITEM_ALREADY_EXISTS:
+                    /*
+                    *  In FDB creation, there are scenarios where the hardware learns an FDB entry before orchagent.
+                    *  In such cases, the FDB SAI creation would report the status of SAI_STATUS_ITEM_ALREADY_EXISTS,
+                    *  and orchagent should ignore the error and treat it as entry was explicitly created.
+                    */
+                    return task_success;
+            }
         default:
-            SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
-                        sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
-            exit(EXIT_FAILURE);
+            switch (status)
+            {
+                case SAI_STATUS_SUCCESS:
+                    SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
+                    return task_success;
+                default:
+                    SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
+                                sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    exit(EXIT_FAILURE);
+            }
     }
     return task_need_retry;
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Ignore ALREADY_EXIST error in FDB creation.
Fix: https://github.com/Azure/sonic-buildimage/issues/7798

**Why I did it**
In FDB creation, there are scenarios where the hardware learns an FDB entry before orchagent. In such cases, the FDB SAI creation would report the status of SAI_STATUS_ITEM_ALREADY_EXISTS, and orchagent should ignore the error and treat it as entry was explicitly created.

**How I verified it**

**Details if related**
