### PR TITLE
Update MACsec SA PN counter to support SAI API 1.8

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -31,14 +31,9 @@ constexpr bool DEFAULT_ENABLE_ENCRYPT = true;
 constexpr bool DEFAULT_SCI_IN_SECTAG = false;
 constexpr sai_macsec_cipher_suite_t DEFAULT_CIPHER_SUITE = SAI_MACSEC_CIPHER_SUITE_GCM_AES_128;
 
-static const std::vector<std::string> macsec_egress_sa_attrs =
+static const std::vector<std::string> macsec_sa_attrs =
     {
-        "SAI_MACSEC_SA_ATTR_XPN",
-};
-
-static const std::vector<std::string> macsec_ingress_sa_attrs =
-    {
-        "SAI_MACSEC_SA_ATTR_MINIMUM_XPN",
+        "SAI_MACSEC_SA_ATTR_CURRENT_XPN",
 };
 
 template <typename T, typename... Args>
@@ -1722,16 +1717,15 @@ task_process_status MACsecOrch::createMACsecSA(
         sc->m_sa_ids.erase(an);
     });
 
+    installCounter(CounterType::MACSEC_SA_ATTR, port_sci_an, sc->m_sa_ids[an], macsec_sa_attrs);
     std::vector<FieldValueTuple> fvVector;
     fvVector.emplace_back("state", "ok");
     if (direction == SAI_MACSEC_DIRECTION_EGRESS)
     {
-        installCounter(CounterType::MACSEC_SA_ATTR, port_sci_an, sc->m_sa_ids[an], macsec_egress_sa_attrs);
         m_state_macsec_egress_sa.set(swss::join('|', port_name, sci, an), fvVector);
     }
     else
     {
-        installCounter(CounterType::MACSEC_SA_ATTR, port_sci_an, sc->m_sa_ids[an], macsec_ingress_sa_attrs);
         m_state_macsec_ingress_sa.set(swss::join('|', port_name, sci, an), fvVector);
     }
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Rename XPN attributes from `SAI_MACSEC_SA_ATTR_MINIMUM_XPN` and `SAI_MACSEC_SA_ATTR_XPN` to `SAI_MACSEC_SA_ATTR_CURRENT_XPN`

**Why I did it**
Due to https://github.com/opencomputeproject/SAI/pull/1169 that refactors the attributes about XPN,  a new attributes `SAI_MACSEC_SA_ATTR_CURRENT_XPN` for both ingress and egress was introduced for reading the Packet number. So move the original attributes to the new one.
