### PR TITLE
[macsecmgrd] MACsec XPN changes

### DIFF
--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -52,6 +52,32 @@ static void lexical_convert(const std::string &policy_str, MACsecMgr::MACsecProf
     }
 }
 
+static void lexical_convert(const std::string &cipher_str, MACsecMgr::MACsecProfile::CipherSuite & cipher_suite)
+{
+    SWSS_LOG_ENTER();
+
+    if (boost::iequals(cipher_str, "GCM-AES-128"))
+    {
+        cipher_suite = MACsecMgr::MACsecProfile::CipherSuite::GCM_AES_128;
+    }
+    else if (boost::iequals(cipher_str, "GCM-AES-256"))
+    {
+        cipher_suite = MACsecMgr::MACsecProfile::CipherSuite::GCM_AES_256;
+    }
+    else if (boost::iequals(cipher_str, "GCM-AES-XPN-128"))
+    {
+        cipher_suite = MACsecMgr::MACsecProfile::CipherSuite::GCM_AES_XPN_128;
+    }
+    else if (boost::iequals(cipher_str, "GCM-AES-XPN-256"))
+    {
+        cipher_suite = MACsecMgr::MACsecProfile::CipherSuite::GCM_AES_XPN_256;
+    }
+    else
+    {
+        throw std::invalid_argument("Invalid cipher_suite : " + cipher_str);
+    }
+}
+
 template<class T>
 static bool get_value(
     const MACsecMgr::TaskArgs & ta,
@@ -685,6 +711,20 @@ bool MACsecMgr::configureMACsec(
             network_id,
             "mka_priority",
             profile.priority);
+
+        wpa_cli_exec_and_check(
+            session.sock,
+            port_name,
+            network_id,
+            "macsec_ciphersuite",
+            profile.cipher_suite);
+
+        wpa_cli_exec_and_check(
+            session.sock,
+            port_name,
+            network_id,
+            "macsec_include_sci",
+            (profile.send_sci ? 1 : 0));
 
         wpa_cli_exec_and_check(
             session.sock,

--- a/cfgmgr/macsecmgr.h
+++ b/cfgmgr/macsecmgr.h
@@ -28,7 +28,13 @@ public:
     struct MACsecProfile
     {
         std::uint32_t       priority;
-        std::string         cipher_suite;
+        enum CipherSuite
+        {
+            GCM_AES_128,
+            GCM_AES_256,
+            GCM_AES_XPN_128,
+            GCM_AES_XPN_256,
+        }                   cipher_suite;
         std::string         primary_cak;
         std::string         primary_ckn;
         std::string         fallback_cak;

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -219,7 +219,7 @@ public:
 
     sai_object_id_t *get_port_id()
     {
-        if(m_port_id == nullptr)
+        if (m_port_id == nullptr)
         {
             auto port = get_port();
             if (port == nullptr)

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -2231,7 +2231,9 @@ bool MACsecOrch::createMACsecACLDataEntry(
     if (sci_in_sectag)
     {
         attr.id = SAI_ACL_ENTRY_ATTR_FIELD_MACSEC_SCI;
-        attr.value.u64 = sci;
+        attr.value.aclfield.enable = true;
+        attr.value.aclfield.mask.u64 = 0xFFFFFFFFFFFFFFFF;
+        attr.value.aclfield.data.u64 = sci;
         attrs.push_back(attr);
     }
 

--- a/tests/test_macsec.py
+++ b/tests/test_macsec.py
@@ -102,34 +102,34 @@ def gen_sci(macsec_system_identifier: str, macsec_port_identifier: int) -> str:
 
 
 def gen_sc_key(
-        seperator: str,
+        separator: str,
         port_name: str,
         macsec_system_identifier: str,
         macsec_port_identifier: int) -> str:
     sci = gen_sci(macsec_system_identifier, macsec_port_identifier)
     key = "{}{}{}".format(
         port_name,
-        seperator,
+        separator,
         sci)
     return key
 
 
 def gen_sa_key(
-        seperator: str,
+        separator: str,
         port_name: str,
         macsec_system_identifier: str,
         macsec_port_identifier: int,
         an: int):
     sc_key = gen_sc_key(
-        seperator,
+        separator,
         port_name,
         macsec_system_identifier,
         macsec_port_identifier)
-    key = "{}{}{}".format(sc_key, seperator, an)
+    key = "{}{}{}".format(sc_key, separator, an)
     return key
 
 
-def macsec_sc(seperator: str = AppDBTable.SEPARATOR):
+def macsec_sc(separator: str = AppDBTable.SEPARATOR):
     def inner(func: typing.Callable) -> typing.Callable:
         @functools.wraps(func)
         def wrap_func(
@@ -140,7 +140,7 @@ def macsec_sc(seperator: str = AppDBTable.SEPARATOR):
                 *args,
                 **kwargs) -> typing.Any:
             key = gen_sc_key(
-                seperator,
+                separator,
                 port_name,
                 macsec_system_identifier,
                 macsec_port_identifier)
@@ -149,7 +149,7 @@ def macsec_sc(seperator: str = AppDBTable.SEPARATOR):
     return inner
 
 
-def macsec_sa(seperator: str = AppDBTable.SEPARATOR):
+def macsec_sa(separator: str = AppDBTable.SEPARATOR):
     def inner(func: typing.Callable) -> typing.Callable:
         @functools.wraps(func)
         def wrap_func(
@@ -161,7 +161,7 @@ def macsec_sa(seperator: str = AppDBTable.SEPARATOR):
                 *args,
                 **kwargs) -> typing.Any:
             key = gen_sa_key(
-                seperator,
+                separator,
                 port_name,
                 macsec_system_identifier,
                 macsec_port_identifier,
@@ -216,8 +216,8 @@ class WPASupplicantMock(object):
         self.app_port_table[port_name] = {"enable": True}
 
     @macsec_sc()
-    def create_receive_sc(self, sci: str, ssci: int):
-        self.app_receive_sc_table[sci] = {"ssci": ssci}
+    def create_receive_sc(self, sci: str):
+        self.app_receive_sc_table[sci] = {"NULL": "NULL"}
         self.state_receive_sc_table.wait(sci)
 
     @macsec_sc()
@@ -226,8 +226,8 @@ class WPASupplicantMock(object):
         self.state_receive_sc_table.wait_delete(sci)
 
     @macsec_sc()
-    def create_transmit_sc(self, sci: str, ssci: int):
-        self.app_transmit_sc_table[sci] = {"sci": sci, "encoding_an": 0}
+    def create_transmit_sc(self, sci: str):
+        self.app_transmit_sc_table[sci] = {"encoding_an": 0}
         self.state_transmit_sc_table.wait(sci)
 
     @macsec_sc()
@@ -240,6 +240,7 @@ class WPASupplicantMock(object):
             sak: str,
             auth_key: str,
             lowest_acceptable_pn: int,
+            ssci: int,
             salt: str) -> bool:
         # Check SAK is hex string
         int(sak, 16)
@@ -268,17 +269,20 @@ class WPASupplicantMock(object):
             sak: str,
             auth_key: str,
             lowest_acceptable_pn: int,
+            ssci: int,
             salt: str):
         assert(
             self.check_valid_sa_parameter(
                 sak,
                 auth_key,
                 lowest_acceptable_pn,
+                ssci,
                 salt),
             "Wrong parameter to MACsec receive SA")
         self.app_receive_sa_table[sai] = {
             "active": False, "sak": sak, "auth_key": auth_key,
-            "lowest_acceptable_pn": lowest_acceptable_pn, "salt": salt}
+            "lowest_acceptable_pn": lowest_acceptable_pn,
+            "ssci": ssci, "salt": salt}
 
     @macsec_sa()
     def delete_receive_sa(self, sai: str):
@@ -298,17 +302,19 @@ class WPASupplicantMock(object):
             sak: str,
             auth_key: str,
             init_pn: int,
+            ssci: int,
             salt: str):
         assert(
             self.check_valid_sa_parameter(
                 sak,
                 auth_key,
                 init_pn,
+                ssci,
                 salt),
             "Wrong parameter to MACsec receive SA")
         self.app_transmit_sa_table[sai] = {
             "sak": sak, "auth_key": auth_key,
-            "next_pn": init_pn, "salt": salt}
+            "next_pn": init_pn, "ssci": ssci, "salt": salt}
 
     @macsec_sa()
     def delete_transmit_sa(self, sai: str):
@@ -388,8 +394,7 @@ class TestMACsec(object):
             wpa: WPASupplicantMock,
             port_name: str,
             local_mac_address: str,
-            macsec_port_identifier: int,
-            ssci: int):
+            macsec_port_identifier: int):
         wpa.init_macsec_port(port_name)
         wpa.config_macsec_port(port_name, {"enable_protect": True})
         wpa.config_macsec_port(port_name, {"enable_encrypt": True})
@@ -403,8 +408,7 @@ class TestMACsec(object):
         wpa.create_transmit_sc(
             port_name,
             local_mac_address,
-            macsec_port_identifier,
-            ssci)
+            macsec_port_identifier)
 
     def establish_macsec(
             self,
@@ -422,8 +426,7 @@ class TestMACsec(object):
         wpa.create_receive_sc(
             port_name,
             peer_mac_address,
-            macsec_port_identifier,
-            ssci)
+            macsec_port_identifier)
         wpa.create_receive_sa(
             port_name,
             peer_mac_address,
@@ -432,6 +435,7 @@ class TestMACsec(object):
             sak,
             auth_key,
             packet_number,
+            ssci,
             salt)
         wpa.create_transmit_sa(
             port_name,
@@ -441,6 +445,7 @@ class TestMACsec(object):
             sak,
             auth_key,
             packet_number,
+            ssci,
             salt)
         wpa.set_enable_receive_sa(
             port_name,
@@ -468,6 +473,7 @@ class TestMACsec(object):
             sak: str,
             packet_number: int,
             auth_key: str,
+            ssci: int,
             salt: str):
         wpa.create_receive_sa(
             port_name,
@@ -477,6 +483,7 @@ class TestMACsec(object):
             sak,
             auth_key,
             packet_number,
+            ssci,
             salt)
         wpa.create_transmit_sa(
             port_name,
@@ -486,6 +493,7 @@ class TestMACsec(object):
             sak,
             auth_key,
             packet_number,
+            ssci,
             salt)
         wpa.set_enable_receive_sa(
             port_name,
@@ -606,8 +614,7 @@ class TestMACsec(object):
             wpa,
             port_name,
             local_mac_address,
-            macsec_port_identifier,
-            ssci)
+            macsec_port_identifier)
         self.establish_macsec(
             wpa,
             port_name,
@@ -654,6 +661,7 @@ class TestMACsec(object):
             sak,
             packet_number,
             auth_key,
+            ssci,
             salt)
         assert(
             inspector.get_macsec_sa(


### PR DESCRIPTION
What I did
Updated macsecmgrd to program XPN information when starting wpa-supplicant.

Why I did it
MACsec XPN support.

How I verified it
System tests on Juniper platform which supports MACsec XPN.

Details if related
N/A