### PR TITLE
[SWSS] VOQ Nexthop for remote VOQ LC should be created on inband OIF.

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -191,7 +191,7 @@ bool NeighOrch::addNextHop(const NextHopKey &nh)
     }
 
     NextHopKey nexthop(nh);
-    if (m_intfsOrch->isRemoteSystemPortIntf(nexthop.alias))
+    if (m_intfsOrch->isRemoteSystemPortIntf(nh.alias))
     {
         //For remote system ports kernel nexthops are always on inband. Change the key
         Port inbp;
@@ -202,7 +202,7 @@ bool NeighOrch::addNextHop(const NextHopKey &nh)
     }
 
     assert(!hasNextHop(nexthop));
-    sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nexthop.alias);
+    sai_object_id_t rif_id = m_intfsOrch->getRouterIntfsId(nh.alias);
 
     vector<sai_attribute_t> next_hop_attrs;
 


### PR DESCRIPTION
**What I did**

VOQ nexthop for remote neighbors should be created on local inband port only for the kernel purpose. SAI should use actual RIF of the remote system port interface. https://github.com/Azure/sonic-swss/pull/1686 seems to be break this condition and this change address it. 

**Why I did it**
VOQ nexthop for remote neighbors should be created on local inband port only for the kernel purpose. SAI should use actual RIF of the remote system port interface. https://github.com/Azure/sonic-swss/pull/1686 seems to be break this condition and this change address it. 

**How I verified it**
Test on VOQ chassis. 

**Details if related**
