### PR TITLE
[configure.ac] Add the option of passing libnl path to configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ AC_ARG_WITH(libnl-3.0-inc,
  AC_SUBST(LIBNL_INC_DIR, "${withval}")])
 
 if test "${with_libnl_3_0_inc+set}" != set; then
-    CFLAGS_COMMON+=" I/usr/include/libnl3"
+    CFLAGS_COMMON+=" -I/usr/include/libnl3"
 fi
 
 CFLAGS_COMMON+=" -Werror"

--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,6 @@ AC_HEADER_STDC
 AC_CHECK_LIB([hiredis], [redisConnect],,
     AC_MSG_ERROR([libhiredis is not installed.]))
 
-AC_CHECK_LIB([nl-genl-3], [genl_connect])
-
 AC_CHECK_LIB([team], [team_alloc],
     AM_CONDITIONAL(HAVE_LIBTEAM, true),
    [AC_MSG_WARN([libteam is not installed.])
@@ -46,7 +44,27 @@ AC_ARG_WITH(extra-lib,
                           prefix where extra libraries are installed],
 [AC_SUBST(LDFLAGS, "$LDFLAGS -L${withval}")])
 
-CFLAGS_COMMON="-std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/libnl3 -I/usr/include/swss"
+AC_ARG_WITH(extra-usr-lib,
+[  --with-extra-usr-lib=DIR
+                          prefix where extra libraries are installed],
+[AC_SUBST(LDFLAGS, "$LDFLAGS -L${withval}")])
+
+AC_CHECK_LIB([nl-3], [nl_addr_alloc])
+AC_CHECK_LIB([nl-genl-3], [nl_socket_get_cb])
+AC_CHECK_LIB([nl-route-3], [nl_object_alloc])
+AC_CHECK_LIB([nl-nf-3], [nfnl_connect])
+
+CFLAGS_COMMON="-std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/swss"
+
+AC_ARG_WITH(libnl-3.0-inc,
+[  --with-libnl-3.0-inc=DIR
+                           prefix where libnl-3.0 includes are installed],
+[AC_SUBST(CPPFLAGS, "$CPPFLAGS -I${withval}")
+ AC_SUBST(LIBNL_INC_DIR, "${withval}")])
+
+if test "${with_libnl_3_0_inc+set}" != set; then
+    CFLAGS_COMMON+=" I/usr/include/libnl3"
+fi
 
 CFLAGS_COMMON+=" -Werror"
 CFLAGS_COMMON+=" -Wno-reorder"

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AC_ARG_WITH(extra-usr-lib,
 
 AC_CHECK_LIB([nl-3], [nl_addr_alloc])
 AC_CHECK_LIB([nl-genl-3], [nl_socket_get_cb])
-AC_CHECK_LIB([nl-route-3], [nl_object_alloc])
+AC_CHECK_LIB([nl-route-3], [rtnl_route_nh_get_encap_mpls_dst])
 AC_CHECK_LIB([nl-nf-3], [nfnl_connect])
 
 CFLAGS_COMMON="-std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/swss"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add the option of passing custmol built libnl path to configure script

**Why I did it**
MPLS feature in sonic-buildimage requires a libnl patch to be applied before building libnl. Since this build is not installed in usual locations (/usr/lib/..) LGTM analysis fails. This change gives the option of passing libnl library location to 'configure' script and generate libraries to be linked.

In case the options are not passed, the configure script defaults to earlier behavior where it checks for LIBNL in usual locations
**How I verified it**

```
root@samaddik-vm-01:/var/sonic/src/sonic-swss# ./configure --prefix=/usr --with-extra-inc=/lgtm/usr/include --with-extra-lib=/lgtm/lib/x86_64-linux-gnu    --with-extra-usr-lib=/lgtm/usr/lib/x86_64-linux-gnu --with-libnl-3.0-inc=/lgtm/usr/include/libnl3; dh_auto_build 
.
.
mv -f .deps/gearsyncd-phyparser.Tpo .deps/gearsyncd-phyparser.Po                                                                                                                                                                                                                                                                                                          
/bin/bash ../libtool  --tag=CXX   --mode=link g++  -g -O2  -L/lgtm/lib/x86_64-linux-gnu -L/lgtm/usr/lib/x86_64-linux-gnu -o gearsyncd gearsyncd-gearboxutils.o gearsyncd-gearsyncd.o gearsyncd-gearparserbase.o gearsyncd-gearboxparser.o gearsyncd-phyparser.o -lnl-3 -lnl-route-3 -lswsscommon    -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis                   
libtool: link: g++ -g -O2 -o gearsyncd gearsyncd-gearboxutils.o gearsyncd-gearsyncd.o gearsyncd-gearparserbase.o gearsyncd-gearboxparser.o gearsyncd-phyparser.o  -L/lgtm/lib/x86_64-linux-gnu -L/lgtm/usr/lib/x86_64-linux-gnu -lswsscommon -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis                                                                          
make[2]: Leaving directory '/var/sonic/src/sonic-swss/gearsyncd'                                                                                                                                                                                                                                                                                                          
make[2]: Entering directory '/var/sonic/src/sonic-swss'                                                                                                                                                                                                                                                                                                                   
make[2]: Leaving directory '/var/sonic/src/sonic-swss'                                                                                                                                                                                                                                                                                                                    
make[1]: Leaving directory '/var/sonic/src/sonic-swss'    

root@samaddik-vm-01:/var/sonic/src/sonic-swss# find . -name Makefile | xargs grep LIBS | grep "nl-nf-3"
./tests/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./tests/mock_tests/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./portsyncd/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./natsyncd/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./orchagent/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 
./fpmsyncd/Makefile:LIBS = -lnl-nf-3 -lnl-route-3 -lnl-genl-3 -lnl-3 -lhiredis 

root@samaddik-vm-01:/var/sonic/src/sonic-swss# find . -name Makefile | xargs grep libnl3 | grep include
./tests/Makefile:CPPFLAGS =  -I/lgtm/usr/include -I/lgtm/usr/include/swss -I/lgtm/usr/include/sai -I/lgtm/usr/include/libnl3
./tests/Makefile:LIBNL_INC_DIR = /lgtm/usr/include/libnl3
./tests/mock_tests/Makefile:CPPFLAGS =  -I/lgtm/usr/include -I/lgtm/usr/include/swss -I/lgtm/usr/include/sai -I/lgtm/usr/include/libnl3
./tests/mock_tests/Makefile:LIBNL_INC_DIR = /lgtm/usr/include/libnl3
./Makefile:CPPFLAGS =  -I/lgtm/usr/include -I/lgtm/usr/include/swss -I/lgtm/usr/include/sai -I/lgtm/usr/include/libnl3
./Makefile:LIBNL_INC_DIR = /lgtm/usr/include/libnl3

```

Without the 'include' option:

```
root@samaddik-vm-01:/var/sonic/src/sonic-swss# find . -name Makefile | xargs grep libnl3 | grep include
./tests/Makefile:CFLAGS_COMMON = -std=c++14 -Wall -fPIC -Wno-write-strings -I/usr/include/swss I/usr/include/libnl3 
.
.

```

**Details if related**
