### PR TITLE
[orchagent][ports] Add port reference increment / decrement to lag member add / remove flows

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4806,6 +4806,8 @@ bool PortsOrch::addLagMember(Port &lag, Port &port, bool enableForwarding)
         }
     }
 
+    increasePortRefCount(port.m_alias);
+
     LagMemberUpdate update = { lag, port, true };
     notify(SUBJECT_TYPE_LAG_MEMBER_CHANGE, static_cast<void *>(&update));
 
@@ -4851,6 +4853,9 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
             return false;
         }
     }
+
+    decreasePortRefCount(port.m_alias);
+
     LagMemberUpdate update = { lag, port, false };
     notify(SUBJECT_TYPE_LAG_MEMBER_CHANGE, static_cast<void *>(&update));
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3221,11 +3221,11 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     throw runtime_error("Remove hostif for the port failed");
                 }
+		m_portList[alias].m_hif_id = SAI_NULL_OBJECT_ID;
 
                 Port p;
                 if (getPort(port_id, p))
                 {
-		    p.m_hif_id = null;
                     PortUpdate update = {p, false};
                     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
                 }
@@ -4844,7 +4844,7 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
 
     if (lag.m_bridge_port_id > 0)
     {
-        if (port.m_hif_id && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+        if (port.m_hif_id != SAI_NULL_OBJECT_ID && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {
             SWSS_LOG_ERROR("Failed to set %s for hostif of port %s which is leaving LAG %s",
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str(), lag.m_alias.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3221,7 +3221,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     throw runtime_error("Remove hostif for the port failed");
                 }
-		m_portList[alias].m_hif_id = SAI_NULL_OBJECT_ID;
+                m_portList[alias].m_hif_id = SAI_NULL_OBJECT_ID;
 
                 Port p;
                 if (getPort(port_id, p))

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3225,6 +3225,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 Port p;
                 if (getPort(port_id, p))
                 {
+		    p.m_hif_id = null;
                     PortUpdate update = {p, false};
                     notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
                 }
@@ -4843,16 +4844,7 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
 
     if (lag.m_bridge_port_id > 0)
     {
-        bool hostif_exists = true;
-        sai_attribute_t attr;
-        attr.id = SAI_HOSTIF_ATTR_START;
-
-        sai_status_t status = sai_hostif_api->get_hostif_attribute(port.m_hif_id, 1, &attr);
-        if (status != SAI_STATUS_SUCCESS)
-        {
-	    hostif_exists = false;
-        }
-        if (hostif_exists && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+        if (port.m_hif_id && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {
             SWSS_LOG_ERROR("Failed to set %s for hostif of port %s which is leaving LAG %s",
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str(), lag.m_alias.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3221,7 +3221,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     throw runtime_error("Remove hostif for the port failed");
                 }
-                m_portList[alias].m_hif_id = SAI_NULL_OBJECT_ID;
 
                 Port p;
                 if (getPort(port_id, p))
@@ -4846,7 +4845,7 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
 
     if (lag.m_bridge_port_id > 0)
     {
-        if (port.m_hif_id != SAI_NULL_OBJECT_ID && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+        if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {
             SWSS_LOG_ERROR("Failed to set %s for hostif of port %s which is leaving LAG %s",
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str(), lag.m_alias.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4843,7 +4843,16 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
 
     if (lag.m_bridge_port_id > 0)
     {
-        if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
+        bool hostif_exists = true;
+        sai_attribute_t attr;
+        attr.id = SAI_HOSTIF_ATTR_START;
+
+        sai_status_t status = sai_hostif_api->get_hostif_attribute(port.m_hif_id, 1, &attr);
+        if (status != SAI_STATUS_SUCCESS)
+        {
+	    hostif_exists = false;
+        }
+        if (hostif_exists && !setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
         {
             SWSS_LOG_ERROR("Failed to set %s for hostif of port %s which is leaving LAG %s",
                     hostif_vlan_tag[SAI_HOSTIF_VLAN_TAG_STRIP], port.m_alias.c_str(), lag.m_alias.c_str());

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -15,16 +15,18 @@ class TestPortDPBLag(object):
         p = Port(dvs, "Ethernet0")
         p.sync_from_config_db()
 
-        # 1. Create PortChannel0001
+        # 1. Create PortChannel0001.
         self.dvs_lag.create_port_channel(lag)
+        time.sleep(2)
 
-        # 2. Add Ethernet0 to PortChannel0001
+        # 2. Add Ethernet0 to PortChannel0001.
         self.dvs_lag.create_port_channel_member(lag, p.get_name())
+        time.sleep(2)
 
         # 3. Add log marker to syslog
         marker = dvs.add_log_marker()
 
-        # 4. Delete Ethernet0 from config DB. Sleep for 5 seconds.
+        # 4. Delete Ethernet0 from config DB.
         p.delete_from_config_db()
         time.sleep(2)
 
@@ -39,6 +41,7 @@ class TestPortDPBLag(object):
 
         # 7. Remove port from LAG
         self.dvs_lag.remove_port_channel_member(lag, p.get_name())
+        time.sleep(2)
 
         # 8. Verify that port is removed from ASIC DB
         assert(p.not_exists_in_asic_db() == True)
@@ -46,12 +49,14 @@ class TestPortDPBLag(object):
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
         p.write_to_config_db()
+        time.sleep(2)
         p.verify_config_db()
         p.verify_app_db()
         p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
         self.dvs_lag.remove_port_channel(lag)
+        time.sleep(2)
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -11,48 +11,48 @@ class TestPortDPBLag(object):
         assert num.strip() >= str(expected_cnt)
 
     def test_dependency(self, dvs):
-        lag = "0001"
-        p = Port(dvs, "Ethernet0")
-        p.sync_from_config_db()
+        #lag = "0001"
+        #p = Port(dvs, "Ethernet0")
+        #p.sync_from_config_db()
 
         # 1. Create PortChannel0001.
         self.dvs_lag.create_port_channel(lag)
         time.sleep(2)
 
         # 2. Add Ethernet0 to PortChannel0001.
-        self.dvs_lag.create_port_channel_member(lag, p.get_name())
-        time.sleep(2)
+        #self.dvs_lag.create_port_channel_member(lag, p.get_name())
+        #time.sleep(2)
 
         # 3. Add log marker to syslog
-        marker = dvs.add_log_marker()
+        #marker = dvs.add_log_marker()
 
         # 4. Delete Ethernet0 from config DB.
-        p.delete_from_config_db()
-        time.sleep(2)
+        #p.delete_from_config_db()
+        #time.sleep(2)
 
         # 5. Verify that we are waiting in portsorch for the port
         #    to be removed from LAG, by looking at the log
-        self.check_syslog(dvs, marker, "Unable to remove port Ethernet0: ref count 1", 1)
+        #self.check_syslog(dvs, marker, "Unable to remove port Ethernet0: ref count 1", 1)
 
         # 6. Also verify that port is still present in ASIC DB.
-        assert(p.exists_in_asic_db() == True)
+        #assert(p.exists_in_asic_db() == True)
 
         # 7. Remove port from LAG
-        dvs.add_log_marker()
-        self.dvs_lag.remove_port_channel_member(lag, p.get_name())
-        time.sleep(2)
+        #dvs.add_log_marker()
+        #self.dvs_lag.remove_port_channel_member(lag, p.get_name())
+        #time.sleep(2)
 
         # 8. Verify that port is removed from ASIC DB
-        assert(p.not_exists_in_asic_db() == True)
+        #assert(p.not_exists_in_asic_db() == True)
 
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
-        dvs.add_log_marker()
-        p.write_to_config_db()
-        time.sleep(2)
-        p.verify_config_db()
-        p.verify_app_db()
-        p.verify_asic_db()
+        #dvs.add_log_marker()
+        #p.write_to_config_db()
+        #time.sleep(2)
+        #p.verify_config_db()
+        #p.verify_app_db()
+        #p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
         dvs.add_log_marker()

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -12,16 +12,16 @@ class TestPortDPBLag(object):
 
     def test_dependency(self, dvs):
         lag = "0001"
-        #p = Port(dvs, "Ethernet0")
-        #p.sync_from_config_db()
+        p = Port(dvs, "Ethernet0")
+        p.sync_from_config_db()
 
         # 1. Create PortChannel0001.
         self.dvs_lag.create_port_channel(lag)
         time.sleep(2)
 
         # 2. Add Ethernet0 to PortChannel0001.
-        #self.dvs_lag.create_port_channel_member(lag, p.get_name())
-        #time.sleep(2)
+        self.dvs_lag.create_port_channel_member(lag, p.get_name())
+        time.sleep(2)
 
         # 3. Add log marker to syslog
         #marker = dvs.add_log_marker()
@@ -39,8 +39,8 @@ class TestPortDPBLag(object):
 
         # 7. Remove port from LAG
         #dvs.add_log_marker()
-        #self.dvs_lag.remove_port_channel_member(lag, p.get_name())
-        #time.sleep(2)
+        self.dvs_lag.remove_port_channel_member(lag, p.get_name())
+        time.sleep(2)
 
         # 8. Verify that port is removed from ASIC DB
         #assert(p.not_exists_in_asic_db() == True)

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -17,7 +17,6 @@ class TestPortDPBLag(object):
 
         # 1. Create PortChannel0001.
         self.dvs_lag.create_port_channel(lag)
-        time.sleep(2)
 
         # 2. Add Ethernet0 to PortChannel0001.
         self.dvs_lag.create_port_channel_member(lag, p.get_name())
@@ -39,7 +38,6 @@ class TestPortDPBLag(object):
 
         # 7. Remove port from LAG
         self.dvs_lag.remove_port_channel_member(lag, p.get_name())
-        time.sleep(2)
 
         # 8. Verify that port is removed from ASIC DB
         assert(p.not_exists_in_asic_db() == True)
@@ -47,18 +45,13 @@ class TestPortDPBLag(object):
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
         p.write_to_config_db()
-        time.sleep(2)
         p.verify_config_db()
         p.verify_app_db()
         p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
-        dvs.add_log_marker()
         self.dvs_lag.remove_port_channel(lag)        
-        time.sleep(30)
-        (exitcode, output) = dvs.runcmd(['tail', '-1000', '/var/log/syslog'])
-        print(output)
-        raise ValueError("Force fail to check syslog.")
+        time.sleep(10)
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -11,7 +11,7 @@ class TestPortDPBLag(object):
         assert num.strip() >= str(expected_cnt)
 
     def test_dependency(self, dvs):
-        #lag = "0001"
+        lag = "0001"
         #p = Port(dvs, "Ethernet0")
         #p.sync_from_config_db()
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -38,7 +38,6 @@ class TestPortDPBLag(object):
         assert(p.exists_in_asic_db() == True)
 
         # 7. Remove port from LAG
-        #dvs.add_log_marker()
         self.dvs_lag.remove_port_channel_member(lag, p.get_name())
         time.sleep(2)
 
@@ -47,21 +46,16 @@ class TestPortDPBLag(object):
 
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
-        dvs.add_log_marker()
         p.write_to_config_db()
         time.sleep(2)
-        #p.verify_config_db()
-        #p.verify_app_db()
-        #p.verify_asic_db()
+        p.verify_config_db()
+        p.verify_app_db()
+        p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
-        dvs.add_log_marker()
-        self.dvs_lag.remove_port_channel(lag)
-        
+        self.dvs_lag.remove_port_channel(lag)        
         time.sleep(5)
-        (exitcode, output) = dvs.runcmd(['tail', '-1000', '/var/log/syslog'])
-        print(output)
-        
+      
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -24,12 +24,14 @@ class TestPortDPBLag(object):
         # 3. Add log marker to syslog
         marker = dvs.add_log_marker()
 
-        # 4. Delete Ethernet0 from config DB. Sleep for 2 seconds.
+        # 4. Delete Ethernet0 from config DB. Sleep for 5 seconds.
         p.delete_from_config_db()
         time.sleep(2)
 
         # 5. Verify that we are waiting in portsorch for the port
         #    to be removed from LAG, by looking at the log
+        (exitcode, output) = dvs.runcmd(['cat', '/var/log/syslog'])
+        print(output)
         self.check_syslog(dvs, marker, "Unable to remove port Ethernet0: ref count 1", 1)
 
         # 6. Also verify that port is still present in ASIC DB.

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -51,7 +51,7 @@ class TestPortDPBLag(object):
 
         # 10. Remove PortChannel0001 and verify that its removed.
         self.dvs_lag.remove_port_channel(lag)        
-        time.sleep(10)
+        time.sleep(30)
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -47,9 +47,9 @@ class TestPortDPBLag(object):
 
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
-        #dvs.add_log_marker()
-        #p.write_to_config_db()
-        #time.sleep(2)
+        dvs.add_log_marker()
+        p.write_to_config_db()
+        time.sleep(2)
         #p.verify_config_db()
         #p.verify_app_db()
         #p.verify_asic_db()

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -38,6 +38,7 @@ class TestPortDPBLag(object):
         assert(p.exists_in_asic_db() == True)
 
         # 7. Remove port from LAG
+        dvs.add_log_marker()
         self.dvs_lag.remove_port_channel_member(lag, p.get_name())
         time.sleep(2)
 
@@ -46,17 +47,22 @@ class TestPortDPBLag(object):
 
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
+        dvs.add_log_marker()
         p.write_to_config_db()
         time.sleep(2)
-        p.verify_config_db()
-        p.verify_app_db()
-        p.verify_asic_db()
+        #p.verify_config_db()
+        #p.verify_app_db()
+        #p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
+        dvs.add_log_marker()
         self.dvs_lag.remove_port_channel(lag)
+        
         time.sleep(5)
         (exitcode, output) = dvs.runcmd(['cat', '/var/log/syslog'])
         print(output)
+        
+        dvs.add_log_marker()
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -53,8 +53,12 @@ class TestPortDPBLag(object):
         p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
+        dvs.add_log_marker()
         self.dvs_lag.remove_port_channel(lag)        
         time.sleep(30)
+        (exitcode, output) = dvs.runcmd(['tail', '-1000', '/var/log/syslog'])
+        print(output)
+        raise ValueError("Force fail to check syslog.")
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -17,18 +17,18 @@ class TestPortDPBLag(object):
 
         # 1. Create PortChannel0001.
         self.dvs_lag.create_port_channel(lag)
-        time.sleep(5)
+        time.sleep(2)
 
         # 2. Add Ethernet0 to PortChannel0001.
         self.dvs_lag.create_port_channel_member(lag, p.get_name())
-        time.sleep(5)
+        time.sleep(2)
 
         # 3. Add log marker to syslog
         marker = dvs.add_log_marker()
 
         # 4. Delete Ethernet0 from config DB.
         p.delete_from_config_db()
-        time.sleep(5)
+        time.sleep(2)
 
         # 5. Verify that we are waiting in portsorch for the port
         #    to be removed from LAG, by looking at the log
@@ -39,7 +39,7 @@ class TestPortDPBLag(object):
 
         # 7. Remove port from LAG
         self.dvs_lag.remove_port_channel_member(lag, p.get_name())
-        time.sleep(5)
+        time.sleep(2)
 
         # 8. Verify that port is removed from ASIC DB
         assert(p.not_exists_in_asic_db() == True)
@@ -47,7 +47,7 @@ class TestPortDPBLag(object):
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
         p.write_to_config_db()
-        time.sleep(5)
+        time.sleep(2)
         p.verify_config_db()
         p.verify_app_db()
         p.verify_asic_db()
@@ -55,6 +55,8 @@ class TestPortDPBLag(object):
         # 10. Remove PortChannel0001 and verify that its removed.
         self.dvs_lag.remove_port_channel(lag)
         time.sleep(5)
+        (exitcode, output) = dvs.runcmd(['cat', '/var/log/syslog'])
+        print(output)
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -24,18 +24,18 @@ class TestPortDPBLag(object):
         time.sleep(2)
 
         # 3. Add log marker to syslog
-        #marker = dvs.add_log_marker()
+        marker = dvs.add_log_marker()
 
         # 4. Delete Ethernet0 from config DB.
-        #p.delete_from_config_db()
-        #time.sleep(2)
+        p.delete_from_config_db()
+        time.sleep(2)
 
         # 5. Verify that we are waiting in portsorch for the port
         #    to be removed from LAG, by looking at the log
-        #self.check_syslog(dvs, marker, "Unable to remove port Ethernet0: ref count 1", 1)
+        self.check_syslog(dvs, marker, "Unable to remove port Ethernet0: ref count 1", 1)
 
         # 6. Also verify that port is still present in ASIC DB.
-        #assert(p.exists_in_asic_db() == True)
+        assert(p.exists_in_asic_db() == True)
 
         # 7. Remove port from LAG
         #dvs.add_log_marker()
@@ -43,7 +43,7 @@ class TestPortDPBLag(object):
         time.sleep(2)
 
         # 8. Verify that port is removed from ASIC DB
-        #assert(p.not_exists_in_asic_db() == True)
+        assert(p.not_exists_in_asic_db() == True)
 
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -17,23 +17,21 @@ class TestPortDPBLag(object):
 
         # 1. Create PortChannel0001.
         self.dvs_lag.create_port_channel(lag)
-        time.sleep(2)
+        time.sleep(5)
 
         # 2. Add Ethernet0 to PortChannel0001.
         self.dvs_lag.create_port_channel_member(lag, p.get_name())
-        time.sleep(2)
+        time.sleep(5)
 
         # 3. Add log marker to syslog
         marker = dvs.add_log_marker()
 
         # 4. Delete Ethernet0 from config DB.
         p.delete_from_config_db()
-        time.sleep(2)
+        time.sleep(5)
 
         # 5. Verify that we are waiting in portsorch for the port
         #    to be removed from LAG, by looking at the log
-        (exitcode, output) = dvs.runcmd(['cat', '/var/log/syslog'])
-        print(output)
         self.check_syslog(dvs, marker, "Unable to remove port Ethernet0: ref count 1", 1)
 
         # 6. Also verify that port is still present in ASIC DB.
@@ -41,7 +39,7 @@ class TestPortDPBLag(object):
 
         # 7. Remove port from LAG
         self.dvs_lag.remove_port_channel_member(lag, p.get_name())
-        time.sleep(2)
+        time.sleep(5)
 
         # 8. Verify that port is removed from ASIC DB
         assert(p.not_exists_in_asic_db() == True)
@@ -49,14 +47,14 @@ class TestPortDPBLag(object):
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
         p.write_to_config_db()
-        time.sleep(2)
+        time.sleep(5)
         p.verify_config_db()
         p.verify_app_db()
         p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
         self.dvs_lag.remove_port_channel(lag)
-        time.sleep(2)
+        time.sleep(5)
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -1,0 +1,59 @@
+import time
+import pytest
+from port_dpb import Port
+from port_dpb import DPB
+
+@pytest.mark.usefixtures('dpb_setup_fixture')
+@pytest.mark.usefixtures('dvs_lag_manager')
+class TestPortDPBLag(object):
+    def check_syslog(self, dvs, marker, log, expected_cnt):
+        (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \"%s\" | wc -l" % (marker, log)])
+        assert num.strip() >= str(expected_cnt)
+
+    def test_dependency(self, dvs):
+        lag = "0001"
+        p = Port(dvs, "Ethernet0")
+        p.sync_from_config_db()
+
+        # 1. Create PortChannel0001
+        self.dvs_lag.create_port_channel(lag)
+
+        # 2. Add Ethernet0 to PortChannel0001
+        self.dvs_lag.create_port_channel_member(lag, p.get_name())
+
+        # 3. Add log marker to syslog
+        marker = dvs.add_log_marker()
+
+        # 4. Delete Ethernet0 from config DB. Sleep for 2 seconds.
+        p.delete_from_config_db()
+        time.sleep(2)
+
+        # 5. Verify that we are waiting in portsorch for the port
+        #    to be removed from LAG, by looking at the log
+        self.check_syslog(dvs, marker, "Unable to remove port Ethernet0: ref count 1", 1)
+
+        # 6. Also verify that port is still present in ASIC DB.
+        assert(p.exists_in_asic_db() == True)
+
+        # 7. Remove port from LAG
+        self.dvs_lag.remove_port_channel_member(lag, p.get_name())
+
+        # 8. Verify that port is removed from ASIC DB
+        assert(p.not_exists_in_asic_db() == True)
+
+        # 9. Re-create port Ethernet0 and verify that it is
+        #    present in CONFIG, APPL, and ASIC DBs
+        p.write_to_config_db()
+        p.verify_config_db()
+        p.verify_app_db()
+        p.verify_asic_db()
+
+        # 10. Remove PortChannel0001 and verify that its removed.
+        self.dvs_lag.remove_port_channel(lag)
+        self.dvs_lag.get_and_verify_port_channel(0)
+
+
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -54,7 +54,7 @@ class TestPortDPBLag(object):
 
         # 10. Remove PortChannel0001 and verify that its removed.
         self.dvs_lag.remove_port_channel(lag)        
-        time.sleep(60)
+        time.sleep(30)
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -50,19 +50,18 @@ class TestPortDPBLag(object):
         dvs.add_log_marker()
         p.write_to_config_db()
         time.sleep(2)
-        #p.verify_config_db()
-        #p.verify_app_db()
-        #p.verify_asic_db()
+        p.verify_config_db()
+        p.verify_app_db()
+        p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
         dvs.add_log_marker()
         self.dvs_lag.remove_port_channel(lag)
         
         time.sleep(5)
-        (exitcode, output) = dvs.runcmd(['cat', '/var/log/syslog'])
+        (exitcode, output) = dvs.runcmd(['tail', '-1000', '/var/log/syslog'])
         print(output)
         
-        dvs.add_log_marker()
         self.dvs_lag.get_and_verify_port_channel(0)
 
 

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -54,8 +54,7 @@ class TestPortDPBLag(object):
 
         # 10. Remove PortChannel0001 and verify that its removed.
         self.dvs_lag.remove_port_channel(lag)        
-        time.sleep(5)
-      
+        time.sleep(60)
         self.dvs_lag.get_and_verify_port_channel(0)
 
 


### PR DESCRIPTION
**What I did**

Added code to increment the port reference counter on the creation of a lag membership that involves that port. Also added code to decrement the counter on the removal of that lag membership as well. This prevents the port from being removed before the lag membership is. 

Fixes https://github.com/Azure/sonic-buildimage/issues/7782

**Why I did it**

In some cases (particularly in the dynamic port breakout flow) if a LAG membership was removed at the same time a port was removed the host interface would be deleted before the membership removal was processed. This would result in orchagent attempting to strip the VLAN tag from a non-existent host interface causing a crash. 

**How I verified it**

Tested previously broken flow on a MSN2700

```
root@r-panther-23:/home/admin# config portchannel add PortChannel0004
root@r-panther-23:/home/admin# config portchannel member add PortChannel0004 Ethernet16
root@r-panther-23:/home/admin# config vlan add 2147
root@r-panther-23:/home/admin# config vlan member add --untagged 2147 PortChannel0004
root@r-panther-23:/home/admin# config int ip add Vlan2147 10.0.0.2/24
root@r-panther-23:/home/admin# config int break Ethernet16 2x50G[40G,25G,10G] -f -y

Running Breakout Mode : 1x100G[50G,40G,25G,10G]
Target Breakout Mode : 2x50G[40G,25G,10G]

Ports to be deleted :
 {
    "Ethernet16": "100000"
}
Ports to be added :
 {
    "Ethernet16": "50000",
    "Ethernet18": "50000"
}

After running Logic to limit the impact

Final list of ports to be deleted :
 {
    "Ethernet16": "100000"
}
Final list of ports to be added :
 {
    "Ethernet16": "50000",
    "Ethernet18": "50000"
}
Note: Below table(s) have no YANG models:
FEATURE, KDUMP, SNMP, SNMP_COMMUNITY, XCVRD_LOG,
Below Config can not be verified, It may cause harm to the system
 {}
Do you wish to Continue? [y/N]: y
Breakout process got successfully completed.
Please note loaded setting will be lost after system reboot. To preserve setting, run `config save`.
root@r-panther-23:/home/admin#
```
