### PR TITLE
[gearbox] Set context for phys based on context_id

### DIFF
--- a/gearsyncd/gearboxparser.cpp
+++ b/gearsyncd/gearboxparser.cpp
@@ -143,6 +143,14 @@ bool GearboxParser::parse()
             val = phy["bus_id"];
             attr = std::make_pair("bus_id", std::to_string(val.get<int>()));
             attrs.push_back(attr);
+            if (phy.find("context_id") == phy.end())
+            {
+                SWSS_LOG_ERROR("missing 'context_id' field in 'phys' item %d in gearbox configuration", iter);
+                return false;
+            }
+            val = phy["context_id"];
+            attr = std::make_pair("context_id", std::to_string(val.get<int>()));
+            attrs.push_back(attr);
             if (phy.find("hwinfo") == phy.end())
             {
                 SWSS_LOG_ERROR("missing 'hwinfo' field in 'phys' item %d in gearbox configuration", iter);

--- a/lib/gearboxutils.cpp
+++ b/lib/gearboxutils.cpp
@@ -185,6 +185,10 @@ std::map<int, gearbox_phy_t> GearboxUtils::loadPhyMap(Table *gearboxTable)
                 {
                     phy.bus_id = std::stoi(val.second);
                 }
+                else if (val.first == "context_id")
+                {
+                    phy.context_id = std::stoi(val.second);
+                }
             }
             gearboxPhyMap[phy.phy_id] = phy;
         }

--- a/lib/gearboxutils.h
+++ b/lib/gearboxutils.h
@@ -44,6 +44,7 @@ typedef struct
     std::string hwinfo;
     uint32_t address;
     uint32_t bus_id;
+    uint32_t context_id;
 } gearbox_phy_t;
 
 typedef struct

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -418,7 +418,7 @@ sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)
 
     /* Must be last Attribute */
     attr.id = SAI_REDIS_SWITCH_ATTR_CONTEXT;
-    attr.value.u64 = phy->phy_id;
+    attr.value.u64 = phy->context_id;
     attrs.push_back(attr);
 
     status = sai_switch_api->create_switch(&phyOid, (uint32_t)attrs.size(), attrs.data());


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
SAI_REDIS_SWITCH_ATTR_CONTEXT was set according to the phy_id in gearbox_config.json. This change will set it based on the
context_id provided in that json file. 

**Why I did it**
The reason behind it is to support the case of multiple phys sharing the same context, or simply, using one syncd process and context to support multiple phys. 

This change is depended by https://github.com/Azure/sonic-buildimage/pull/8146

**How I verified it**

**Details if related**
An example of gearbox_config.json after the change, is as below
  "phys": [
    {
      "phy_id": 1,
      "name": "phy1",
      "address": "1",
      "lib_name": "",
      "firmware_path": "/usr/share/phy_fw.bin",
      "config_file": "/usr/share/sonic/hwsku/phy1_config_1.json",
      "sai_init_config_file": "",
      "phy_access": "mdio",                                                                                                                                                                                                                                                           
      "bus_id": 0,                                                                                                                                                                                                                                                                    
      "context_id": 1,
      "hwinfo": "mdio0_0_0/0"
    },
    {
      "phy_id": 2,
      "name": "phy2",
      "address": "2",
      "lib_name": "",
      "firmware_path": "/usr/share/phy_fw.bin",                                                                                                                                                                                                                                       "config_file": "/usr/share/sonic/hwsku/phy2_config_1.json",                                                                                                                                                                                                                     "sai_init_config_file": "",
      "phy_access": "mdio",
      "bus_id": 0,
      "context_id": 1,
      "hwinfo": "mdio1_0_0/0"
    }, 