### PR TITLE
[fdb & vs test/mirror] Populate FdbEntry port_name in APPL_DB SET path

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -439,7 +439,6 @@ void FdbOrch::update(sai_fdb_event_t        type,
             SWSS_LOG_ERROR("Unsupported FDB Flush: [ %s , %s ] = { port: - }",
                            update.entry.mac.to_string().c_str(),
                            vlanName.c_str());
-
         }
         else
         {
@@ -666,7 +665,6 @@ void FdbOrch::doTask(Consumer& consumer)
                 it = consumer.m_toSync.erase(it);
             else
                 it++;
-
         }
         else
         {

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -163,8 +163,8 @@ void FdbOrch::update(sai_fdb_event_t        type,
     update.type = "dynamic";
     Port vlan;
 
-    SWSS_LOG_INFO("FDB event:%d, MAC: %s , BVID: 0x%" PRIx64 " , \
-                   bridge port ID: 0x%" PRIx64 ".",
+    SWSS_LOG_INFO("FDB event:%d, MAC: %s , BVID: 0x%" PRIx64 " , "
+                   "bridge port ID: 0x%" PRIx64 ".",
                    type, update.entry.mac.to_string().c_str(),
                    entry->bv_id, bridge_port_id);
 
@@ -362,8 +362,8 @@ void FdbOrch::update(sai_fdb_event_t        type,
     }
     case SAI_FDB_EVENT_FLUSHED:
 
-        SWSS_LOG_INFO("FDB Flush event received: [ %s , 0x%" PRIx64 " ], \
-                       bridge port ID: 0x%" PRIx64 ".",
+        SWSS_LOG_INFO("FDB Flush event received: [ %s , 0x%" PRIx64 " ], "
+                       "bridge port ID: 0x%" PRIx64 ".",
                        update.entry.mac.to_string().c_str(), entry->bv_id,
                        bridge_port_id);
 
@@ -373,8 +373,8 @@ void FdbOrch::update(sai_fdb_event_t        type,
 
             if (!m_portsOrch->getPort(entry->bv_id, vlan))
             {
-                SWSS_LOG_NOTICE("FdbOrch notification: Failed to locate vlan\
-                                port from bv_id 0x%" PRIx64, entry->bv_id);
+                SWSS_LOG_NOTICE("FdbOrch notification: Failed to locate vlan "
+                                "port from bv_id 0x%" PRIx64, entry->bv_id);
                 return;
             }
             vlanName = "Vlan" + to_string(vlan.m_vlan_info.vlan_id);
@@ -881,8 +881,8 @@ void FdbOrch::notifyObserversFDBFlush(Port &port, sai_object_id_t& bvid)
         if ((itr->first.port_name == port.m_alias) &&
             (itr->first.bv_id == bvid))
         {
-            SWSS_LOG_INFO("Adding MAC learnt on [ port:%s , bvid:0x%" PRIx64 "]\
-                           to ARP flush", port.m_alias.c_str(), bvid);
+            SWSS_LOG_INFO("Adding MAC learnt on [ port:%s , bvid:0x%" PRIx64 "] "
+                          "to ARP flush", port.m_alias.c_str(), bvid);
             FdbEntry entry;
             entry.mac = itr->first.mac;
             entry.bv_id = itr->first.bv_id;

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -919,7 +919,6 @@ void FdbOrch::updatePortOperState(const PortOperStateUpdate& update)
             }
             notifyObserversFDBFlush(p, vlan.m_vlan_info.vlan_oid);
         }
-
     }
     return;
 }

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -646,6 +646,7 @@ void FdbOrch::doTask(Consumer& consumer)
                 port = tunnel_orch->getTunnelPortName(remote_ip);
             }
 
+            entry.port_name = port;
 
             FdbData fdbData;
             fdbData.bridge_port_id = SAI_NULL_OBJECT_ID;

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -73,8 +73,8 @@ bool FdbOrch::storeFdbEntryState(const FdbUpdate& update)
 
     if (!m_portsOrch->getPort(entry.bv_id, vlan))
     {
-        SWSS_LOG_NOTICE("FdbOrch notification: Failed to locate \
-                         vlan port from bv_id 0x%" PRIx64, entry.bv_id);
+        SWSS_LOG_NOTICE("FdbOrch notification: Failed to locate "
+                        "vlan port from bv_id 0x%" PRIx64, entry.bv_id);
         return false;
     }
 

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -576,6 +576,7 @@ bool MirrorOrch::getNeighborInfo(const string& name, MirrorEntry& session)
             !m_neighOrch->getNeighborEntry(session.nexthopInfo.nexthop,
                 session.neighborInfo.neighbor, session.neighborInfo.mac)))
     {
+        session.neighborInfo.mac = MacAddress();
         return false;
     }
 

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -351,6 +351,8 @@ class TestMirror(object):
         assert self.get_mirror_session_state(session)["status"] == "inactive"
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
         assert len(tbl.getKeys()) == 0
+        # Allow time for neighor flush to occur
+        time.sleep(1)
 
         # restore port oper status up
         self.set_port_oper_status(dvs, "Ethernet4", "up")
@@ -372,8 +374,6 @@ class TestMirror(object):
         assert self.get_mirror_session_state(session)["status"] == "inactive"
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
         assert len(tbl.getKeys()) == 0
-        # Allow time for neighor flush to occur
-        time.sleep(1)
 
         # restore fdb entry to ethernet4
         self.create_fdb("6", "66-66-66-66-66-66", "Ethernet4")

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -355,7 +355,7 @@ class TestMirror(object):
         # restore port oper status up
         self.set_port_oper_status(dvs, "Ethernet4", "up")
 
-        # restore fdb entry to ethernet4
+        # restore fdb entry to ethernet 4
         self.create_fdb("6", "66-66-66-66-66-66", "Ethernet4")
         assert self.get_mirror_session_state(session)["status"] == "inactive"
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
@@ -373,7 +373,7 @@ class TestMirror(object):
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
         assert len(tbl.getKeys()) == 0
 
-        # restore fdb entry to ethernet4
+        # restore fdb entry to ethernet 4
         self.create_fdb("6", "66-66-66-66-66-66", "Ethernet4")
         assert self.get_mirror_session_state(session)["status"] == "active"
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
@@ -385,7 +385,7 @@ class TestMirror(object):
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
         assert len(tbl.getKeys()) == 0
 
-        # restore fdb entry to ethernet4
+        # restore fdb entry to ethernet 4
         self.create_fdb("6", "66-66-66-66-66-66", "Ethernet4")
         assert self.get_mirror_session_state(session)["status"] == "active"
         tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")

--- a/tests/test_mirror.py
+++ b/tests/test_mirror.py
@@ -252,8 +252,6 @@ class TestMirror(object):
 
     def flush_fdb(self, op, data):
         ntf = swsscommon.NotificationProducer(self.adb, "FLUSHFDBREQUEST")
-        op = "ALL"
-        data = "ALL"
         fvs = swsscommon.FieldValuePairs()
         ntf.send(op, data, fvs)
         time.sleep(1)


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->


**Why I did it**

In setting fdb entry via APPL_DB, which is used by warm-reboot and vs test, restore populating FdbEntry port_name, the operation of which was introduced in https://github.com/Azure/sonic-swss/pull/1242, but removed (by mistake) in https://github.com/Azure/sonic-swss/pull/1275.

Due to the absence of port_name, the corresponding entry is not notified at port oper status change for (synchronous) neighbor flush (to NeighborOrch) nor for (asynchronous) `FDB_CHANGE` update (to MirrorOrch), the latter of which matters if the port serves as a mirror monitor port.

Missing `port_name` for FdbEntry created from APPL_DB SET path
```
Jul 19 05:41:31.403733 9faa323d761d NOTICE #orchagent: :- update: Fdb entry vlan oid: 0x260000000005f6, mac: 36:51:05:aa:c8:1d, dst port: Ethernet4
Jul 19 05:41:31.403736 9faa323d761d NOTICE #orchagent: :- update: Fdb entry vlan oid: 0x260000000005f6, mac: 66:66:66:66:66:66, dst port:
Jul 19 05:41:31.403738 9faa323d761d NOTICE #orchagent: :- update: Fdb entry vlan oid: 0x260000000005f6, mac: d6:c9:fe:7a:94:29, dst port: Ethernet4
```

**What I did**

1. Extend vs test coverage for mirror monitor port in directly connected vlan subnet:
    - vlan member port oper status change 
    - fdb flush from APPL_DB


2. Fix space in syslog message
```
Jul 19 00:12:33.216334 9faa323d761d INFO #orchagent: :- update: FDB event:3, MAC: 00:00:00:00:00:00 , BVID: 0x0 ,                    bridge port ID: 0x3a0000000005f7.
Jul 19 00:12:33.216345 9faa323d761d INFO #orchagent: :- update: FDB Flush event received: [ 00:00:00:00:00:00 , 0x0 ],                        bridge port ID: 0x3a0000000005f7.


Jul 19 01:30:45.186820 9faa323d761d INFO #orchagent: :- notifyObserversFDBFlush: Adding MAC learnt on [ port:Ethernet4 , bvid:0x260000000005f6]                           to ARP flush
Jul 19 01:30:45.186827 9faa323d761d INFO #orchagent: :- notifyObserversFDBFlush: Adding MAC learnt on [ port:Ethernet4 , bvid:0x260000000005f6]                           to ARP flush
```


**How I verified it**

vs test


**Details if related**

In https://github.com/Azure/sonic-swss/pull/1242, port oper status change on vlan member port triggers fdb flush on that port, which further triggers neighbor flush. An asynchronous fdb event (FLUSHED event in the vs case) will be notified from sai/asic, and triggers update to observers. If the port serves as a mirror monitor port, we expect mirror session to be removed from sai/asic.

FdbEntry `port_name` does not participate in key equivalence comparison as dicated by `FdbEntry::operator==()`


vs test failure log before the change
```
=========================================================================== FAILURES ============================================================================
_____________________________________________________________ TestMirror.test_MirrorToVlanAddRemove _____________________________________________________________

self = <test_mirror.TestMirror object at 0x7f74777169b0>, dvs = <conftest.DockerVirtualSwitch object at 0x7f747b9737f0>
testlog = <function testlog at 0x7f7477747378>

    @pytest.mark.skipif(StrictVersion(distro.linux_distribution()[1]) <= StrictVersion('8.9'), reason="Debian 8.9 or before has no support")
    def test_MirrorToVlanAddRemove(self, dvs, testlog):
        """
        This test covers basic mirror session creation and removal operation
        with destination port sits in a VLAN
        Opeartion flow:
        1. Create mirror session
        2. Create VLAN; assign IP; create neighbor; create FDB
           The session should be up only at this time.
        3. Remove FDB; remove neighbor; remove IP; remove VLAN
        4. Remove mirror session
        """
        self.setup_db(dvs)
    
        session = "TEST_SESSION"
    
        marker = dvs.add_log_marker()
        # create mirror session
        self.create_mirror_session(session, "5.5.5.5", "6.6.6.6", "0x6558", "8", "100", "0")
        assert self.get_mirror_session_state(session)["status"] == "inactive"
        self.check_syslog(dvs, marker, "Attached next hop observer .* for destination IP 6.6.6.6", 1)
    
        # create vlan; create vlan member
        self.create_vlan(dvs, "6")
        self.create_vlan_member("6", "Ethernet4")
    
        # bring up vlan and member
        self.set_interface_status(dvs, "Vlan6", "up")
        self.set_interface_status(dvs, "Ethernet4", "up")
    
        # add ip address to vlan 6
        self.add_ip_address("Vlan6", "6.6.6.0/24")
        assert self.get_mirror_session_state(session)["status"] == "inactive"
    
        # create neighbor to vlan 6
        self.add_neighbor("Vlan6", "6.6.6.6", "66:66:66:66:66:66")
        assert self.get_mirror_session_state(session)["status"] == "inactive"
    
        dvs.runcmd("swssloglevel -l INFO -c orchagent")
        # create fdb entry to ethernet4
        self.create_fdb("6", "66-66-66-66-66-66", "Ethernet4")
        assert self.get_mirror_session_state(session)["status"] == "active"
    
        # check asic database
        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_MIRROR_SESSION")
        mirror_entries = tbl.getKeys()
        assert len(mirror_entries) == 1
    
        (status, fvs) = tbl.get(mirror_entries[0])
        assert status == True
        assert len(fvs) == 16
        for fv in fvs:
            if fv[0] == "SAI_MIRROR_SESSION_ATTR_MONITOR_PORT":
                assert dvs.asicdb.portoidmap[fv[1]] == "Ethernet4"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_TYPE":
                assert fv[1] == "SAI_MIRROR_SESSION_TYPE_ENHANCED_REMOTE"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_ERSPAN_ENCAPSULATION_TYPE":
                assert fv[1] == "SAI_ERSPAN_ENCAPSULATION_TYPE_MIRROR_L3_GRE_TUNNEL"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_IPHDR_VERSION":
                assert fv[1] == "4"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_TOS":
                assert fv[1] == "32"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_TTL":
                assert fv[1] == "100"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_SRC_IP_ADDRESS":
                assert fv[1] == "5.5.5.5"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_DST_IP_ADDRESS":
                assert fv[1] == "6.6.6.6"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_SRC_MAC_ADDRESS":
                assert fv[1] == dvs.runcmd("bash -c \"ip link show eth0 | grep ether | awk '{print $2}'\"")[1].strip().upper()
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS":
                assert fv[1] == "66:66:66:66:66:66"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_GRE_PROTOCOL_TYPE":
                assert fv[1] == "25944" # 0x6558
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_VLAN_HEADER_VALID":
                assert fv[1] == "true"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_VLAN_TPID":
                assert fv[1] == "33024"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_VLAN_ID":
                assert fv[1] == "6"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_VLAN_PRI":
                assert fv[1] == "0"
            elif fv[0] == "SAI_MIRROR_SESSION_ATTR_VLAN_CFI":
                assert fv[1] == "0"
            else:
                assert False
    
        # test port oper status down that triggers fdb flush on port, which further triggers neighbor flush
        self.set_port_oper_status(dvs, "Ethernet4", "down")
>       assert self.get_mirror_session_state(session)["status"] == "inactive"
E       AssertionError: assert 'active' == 'inactive'
E         - inactive
E         ? --
E         + active

test_mirror.py:350: AssertionError
==================================================================== short test summary info ====================================================================
FAILED test_mirror.py::TestMirror::test_MirrorToVlanAddRemove - AssertionError: assert 'active' == 'inactive'
================================================================= 1 failed in 72.40s (0:01:12) ==================================================================
```
