### PR TITLE
[crm] Fix for Issue Azure/sonic-buildimage#8036

### DIFF
--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -565,6 +565,16 @@ void CrmOrch::getResAvailableCounters()
                 sai_status_t status = sai_object_type_get_availability(gSwitchId, objType, 0, nullptr, &availCount);
                 if (status != SAI_STATUS_SUCCESS)
                 {
+                    if ((status == SAI_STATUS_NOT_SUPPORTED) ||
+                        (status == SAI_STATUS_NOT_IMPLEMENTED) ||
+                        SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) ||
+                        SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status))
+                    {
+                        // mark unsupported resources
+                        res.second.resStatus = CrmResourceStatus::CRM_RES_NOT_SUPPORTED;
+                        SWSS_LOG_NOTICE("CRM Resource %s not supported", crmResTypeNameMap.at(res.first).c_str());
+                        break;
+                    }
                     SWSS_LOG_ERROR("Failed to get availability for object_type %u , rv:%d", objType, status);
                     break;
                 }
@@ -585,6 +595,16 @@ void CrmOrch::getResAvailableCounters()
                 sai_status_t status = sai_object_type_get_availability(gSwitchId, objType, 1, &attr, &availCount);
                 if (status != SAI_STATUS_SUCCESS)
                 {
+                    if ((status == SAI_STATUS_NOT_SUPPORTED) ||
+                        (status == SAI_STATUS_NOT_IMPLEMENTED) ||
+                        SAI_STATUS_IS_ATTR_NOT_SUPPORTED(status) ||
+                        SAI_STATUS_IS_ATTR_NOT_IMPLEMENTED(status))
+                    {
+                        // mark unsupported resources
+                        res.second.resStatus = CrmResourceStatus::CRM_RES_NOT_SUPPORTED;
+                        SWSS_LOG_NOTICE("CRM Resource %s not supported", crmResTypeNameMap.at(res.first).c_str());
+                        break;
+                    }
                     SWSS_LOG_ERROR("Failed to get availability for object_type %u , rv:%d", objType, status);
                     break;
                 }


### PR DESCRIPTION
**What I did**
Added more appropriate log message for CRM queries of MPLS_INSEG and MPLS_NEXTHOP resources when platform does not support these resource types.

**Why I did it**
Mellanox has raised the issue officially here: https://github.com/Azure/sonic-buildimage/issues/8036

**How I verified it**
System test with VS SAI modified to return NOT_SUPPORTED.

**Details if related**
N/A