### PR TITLE
Add router interface should remove vlan/lag member first.

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1043,6 +1043,18 @@ bool IntfsOrch::addRouterIntfs(sai_object_id_t vrf_id, Port &port)
         return true;
     }
 
+    if (port.m_lag_member_id)
+    {
+        SWSS_LOG_WARN("It's portchannel member %s", port.m_alias.c_str());
+        return false;
+    }
+
+    if (!port.m_vlan_members.empty())
+    {
+        SWSS_LOG_WARN("It's vlan member %s", port.m_alias.c_str());
+        return false;
+    }
+
     /* Create router interface if the router interface doesn't exist */
     sai_attribute_t attr;
     vector<sai_attribute_t> attrs;


### PR DESCRIPTION
***What I did***
if port member not remove form vlan/lag retrun false when add router interface.

***Why I did it***
error log
~~~
Jun 26 10:10:28.658424 as5835-54x NOTICE swss#orchagent: :- setPortPvid: Set pvid 1 to port: Ethernet2
Jun 26 10:10:28.658424 as5835-54x NOTICE swss#orchagent: :- flushFdbByPortVlan: port Ethernet2 vlan Vlan1000
Jun 26 10:10:28.659304 as5835-54x NOTICE swss#orchagent: :- setHostIntfsStripTag: Set SAI_HOSTIF_VLAN_TAG_STRIP to host interface: Ethernet2
Jun 26 10:10:28.661253 as5835-54x NOTICE swss#orchagent: :- removeBridgePort: Remove bridge port Ethernet2 from default 1Q bridge
Jun 26 10:10:28.669330 as5835-54x NOTICE swss#orchagent: :- addRouterIntfs: Create router interface Ethernet2 MTU 9100
Jun 26 10:10:28.677001 as5835-54x NOTICE swss#orchagent: :- addRouterIntfs: Create router interface Ethernet3 MTU 9100
Jun 26 10:10:28.769320 as5835-54x NOTICE swss#orchagent: :- removeVlanMember: Remove member Ethernet3  from VLAN Vlan1000 lid:3e8 vmid:27000000000c27
Jun 26 10:10:28.769320 as5835-54x NOTICE swss#orchagent: :- setPortPvid: pvid setting for router interface Ethernet3 is not allowed
Jun 26 10:10:28.769399 as5835-54x ERR swss#orchagent: :- meta_sai_validate_oid: object key SAI_OBJECT_TYPE_VLAN_MEMBER:oid:0x27000000000c27 doesn't exist
Jun 26 10:10:28.769442 as5835-54x ERR swss#orchagent: :- removeVlanMember: Failed to remove member Ethernet3 from VLAN Vlan1000 vid:3e8 vmid:27000000000c27
~~~
***How I verified it***
retry and check the syslog
~~~
Jul  5 03:59:30.971342 as4630-54pe-2 WARNING swss#orchagent: :- addRouterIntfs: It's vlan member PortChannel1
Jul  5 03:59:31.032876 as4630-54pe-2 INFO syncd#syncd: [none] _brcm_sai_vxlan_acc_port_trunk_settings:897 tid 4
Jul  5 03:59:31.036720 as4630-54pe-2 WARNING swss#orchagent: :- addRouterIntfs: It's vlan member PortChannel1
Jul  5 03:59:31.036720 as4630-54pe-2 NOTICE swss#orchagent: :- removeVlanMember: Remove member PortChannel1 from VLAN Vlan1000 lid:3e8 vmid:27000000000d8e
Jul  5 03:59:31.044600 as4630-54pe-2 INFO syncd#syncd: [none] update_match_port_rule:403 check port: c000004 and flow_port: 0 
Jul  5 03:59:31.049949 as4630-54pe-2 NOTICE swss#orchagent: :- setPortPvid: Set pvid 1 to lag: PortChannel1
Jul  5 03:59:31.049949 as4630-54pe-2 NOTICE swss#orchagent: :- flushFdbByPortVlan: port PortChannel1 vlan Vlan1000
Jul  5 03:59:31.055726 as4630-54pe-2 NOTICE swss#orchagent: :- setHostIntfsStripTag: Set SAI_HOSTIF_VLAN_TAG_STRIP to host interface: Ethernet2
Jul  5 03:59:31.058325 as4630-54pe-2 NOTICE swss#orchagent: :- setHostIntfsStripTag: Set SAI_HOSTIF_VLAN_TAG_STRIP to host interface: Ethernet3
Jul  5 03:59:31.060993 as4630-54pe-2 NOTICE swss#orchagent: :- removeBridgePort: Remove bridge port PortChannel1 from default 1Q bridge
Jul  5 03:59:31.069849 as4630-54pe-2 NOTICE swss#orchagent: :- addRouterIntfs: Create router interface PortChannel1 MTU 9100
Jul  5 03:59:31.189081 as4630-54pe-2 NOTICE syncd#syncd: :- setRifCounterList: Router interface oid:0x4100600001008 does not have supported counters
~~~