### PR TITLE
Bridge mac setting and fix for mux statedb time format

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -196,7 +196,8 @@ bool VlanMgr::setHostVlanMac(int vlan_id, const string &mac)
     // The command should be generated as:
     // /sbin/ip link set Vlan{{vlan_id}} address {{mac}}
     ostringstream cmds;
-    cmds << IP_CMD " link set " VLAN_PREFIX + std::to_string(vlan_id) + " address " << shellquote(mac);
+    cmds << IP_CMD " link set " VLAN_PREFIX + std::to_string(vlan_id) + " address " << shellquote(mac) << " && "
+            IP_CMD " link set " DOT1Q_BRIDGE_NAME " address " << shellquote(mac);
 
     std::string res;
     EXEC_WITH_ERROR_THROW(cmds.str(), res);

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1300,7 +1300,17 @@ void MuxCableOrch::updateMuxMetricState(string portName, string muxState, bool s
     char buf[256];
     std::strftime(buf, 256, "%Y-%b-%d %H:%M:%S.", &now_tm);
 
-    string time = string(buf) + to_string(micros);
+    /*
+     * Prepend '0's for 6 point precision
+     */
+    const int precision = 6;
+    auto ms = to_string(micros);
+    if (ms.length() < precision)
+    {
+        ms.insert(ms.begin(), precision - ms.length(), '0');
+    }
+
+    string time = string(buf) + ms;
 
     mux_metric_table_.hset(portName, msg, time);
 }


### PR DESCRIPTION
**What I did**
1. Set bridge mac same as Vlan mac
2. Format state_db entries to have six digit precision for microseconds

**Why I did it**
Avoid flooding of self destined packets and consistent formating for MUX METRICS

**How I verified it**

1. Bridge Mac

_Prior to fix:_

```
admin@sonic$ ip link show Vlan1000
53: Vlan1000@Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP 
    link/ether **00:aa:bb:cc:dd:ee** brd ff:ff:ff:ff:ff:ff

admin@sonic$ ip link show Bridge
51: Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP 
    link/ether **94:8e:d3:04:bf:d8** brd ff:ff:ff:ff:ff:ff
```

_After fix:_

```
admin@sonic$ ip link show Vlan1000
97: Vlan1000@Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP 
    link/ether **00:00:11:22:33:44** brd ff:ff:ff:ff:ff:ff

admin@sonic$ ip link show Bridge
93: Bridge: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9100 qdisc noqueue state UP 
    link/ether **00:00:11:22:33:44** brd ff:ff:ff:ff:ff:ff
```


2. STATE_DB

Before fix:

```
admin@sonic$ redis-cli -n 6 hgetall "MUX_METRICS_TABLE|Ethernet4"
5) "orch_switch_active_start"
6) "2021-Jul-29 23:55:24.1364"             <== No fixed format
7) "orch_switch_active_end"
8) "2021-Jul-29 23:55:24.3377"

```

After fix:
```
admin@str2-7050cx3-acs-02:~$ redis-cli -n 6 hgetall "MUX_METRICS_TABLE|Ethernet4"
3) "orch_switch_standby_end"
4) "2021-Jul-30 00:03:24.000275"        <== Fixed 6 point formating

```

**Details if related**

Created a test-gap to cover Bridge mac flood scenario - https://github.com/Azure/sonic-mgmt/issues/3916