### PR TITLE
[RIF] Change rif_rates.lua script to calculate rates correctly

### DIFF
--- a/orchagent/port_rates.lua
+++ b/orchagent/port_rates.lua
@@ -11,7 +11,7 @@ local function logit(msg)
 end
 
 local counters_db = ARGV[1]
-local counters_table_name = ARGV[2] 
+local counters_table_name = ARGV[2]
 local rates_table_name = "RATES"
 
 -- Get configuration
@@ -51,7 +51,7 @@ for i = 1, n do
         local out_non_ucast_pkts_last = redis.call('HGET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS_last')
         local in_octets_last = redis.call('HGET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_OCTETS_last')
         local out_octets_last = redis.call('HGET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_OCTETS_last')
-        
+
         -- Calculate new rates values
         local rx_bps_new = (in_octets - in_octets_last)/delta
         local tx_bps_new = (out_octets - out_octets_last)/delta
@@ -69,7 +69,7 @@ for i = 1, n do
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_BPS', alpha*rx_bps_new + one_minus_alpha*rx_bps_old)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_PPS', alpha*rx_pps_new + one_minus_alpha*rx_pps_old)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_BPS', alpha*tx_bps_new + one_minus_alpha*tx_bps_old)
-            redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', alpha*tx_pps_new + one_minus_alpha*tx_pps_old)  
+            redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', alpha*tx_pps_new + one_minus_alpha*tx_pps_old)
         else
             -- Store unsmoothed initial rates values in DB
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_BPS', rx_bps_new)
@@ -77,17 +77,18 @@ for i = 1, n do
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_BPS', tx_bps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', tx_pps_new)
             redis.call('HSET', state_table, 'INIT_DONE', 'DONE')
-        end        
+        end
     else
-        -- Set old COUNTERS values
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_UCAST_PKTS_last', in_ucast_pkts)
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS_last', in_non_ucast_pkts)
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_UCAST_PKTS_last', out_ucast_pkts)
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS_last', out_non_ucast_pkts)
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_OCTETS_last', in_octets)
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_OCTETS_last', out_octets)        
         redis.call('HSET', state_table, 'INIT_DONE', 'COUNTERS_LAST')
     end
+
+    -- Set old COUNTERS values
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_UCAST_PKTS_last', in_ucast_pkts)
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_NON_UCAST_PKTS_last', in_non_ucast_pkts)
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_UCAST_PKTS_last', out_ucast_pkts)
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_NON_UCAST_PKTS_last', out_non_ucast_pkts)
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_IN_OCTETS_last', in_octets)
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_PORT_STAT_IF_OUT_OCTETS_last', out_octets)
 end
 
 return logtable

--- a/orchagent/rif_rates.lua
+++ b/orchagent/rif_rates.lua
@@ -11,7 +11,7 @@ local function logit(msg)
 end
 
 local counters_db = ARGV[1]
-local counters_table_name = ARGV[2] 
+local counters_table_name = ARGV[2]
 local rates_table_name = "RATES"
 
 -- Get configuration
@@ -43,7 +43,7 @@ for i = 1, n do
         local in_pkts_last = redis.call('HGET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last')
         local out_octets_last = redis.call('HGET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last')
         local out_pkts_last = redis.call('HGET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last')
-        
+
         -- Calculate new rates values
         local rx_bps_new = (in_octets - in_octets_last)/delta
         local tx_bps_new = (out_octets - out_octets_last)/delta
@@ -61,7 +61,7 @@ for i = 1, n do
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_BPS', alpha*rx_bps_new + one_minus_alpha*rx_bps_old)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_PPS', alpha*rx_pps_new + one_minus_alpha*rx_pps_old)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_BPS', alpha*tx_bps_new + one_minus_alpha*tx_bps_old)
-            redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', alpha*tx_pps_new + one_minus_alpha*tx_pps_old)   
+            redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', alpha*tx_pps_new + one_minus_alpha*tx_pps_old)
         else
             -- Store unsmoothed initial rates values in DB
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'RX_BPS', rx_bps_new)
@@ -69,15 +69,16 @@ for i = 1, n do
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_BPS', tx_bps_new)
             redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'TX_PPS', tx_pps_new)
             redis.call('HSET', state_table, 'INIT_DONE', 'DONE')
-        end        
+        end
     else
-        -- Set old COUNTERS values
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_OCTETS_last', in_octets)
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last', in_pkts)
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last', out_octets)
-        redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last', out_pkts)      
         redis.call('HSET', state_table, 'INIT_DONE', 'COUNTERS_LAST')
     end
+
+    -- Set old COUNTERS values
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_OCTETS_last', in_octets)
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last', in_pkts)
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last', out_octets)
+    redis.call('HSET', rates_table_name .. ':' .. KEYS[i], 'SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last', out_pkts)
 end
 
 return logtable


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Signed-off-by: noaOrMlnx noaor@nvidia.com
**What I did**
Change rif_rates.lua and port_rates.lua scripts to calculate rates properly - rates_table_names table should be updated after each iteration and not only once.

**Why I did it**
Fix issue - https://github.com/Azure/sonic-buildimage/issues/8392

**How I verified it**
Checked that when sending traffic, the output of 'show interfaces counters rif' and the rates appear in RATES table, counter db are close.  

```
admin@sonic:~$ show interfaces counters rif -p 5
The rates are calculated within 5 seconds period
    IFACE    RX_OK     RX_BPS    RX_PPS    RX_ERR    TX_OK    TX_BPS    TX_PPS    TX_ERR
---------  -------  ---------  --------  --------  -------  --------  --------  --------
Ethernet0        5  83.90 B/s    1.00/s         1        0  0.00 B/s    0.00/s         0
```

```
127.0.0.1:6379[2]> hgetall RATES:oid:0x6000000000d9d
 1) "SAI_ROUTER_INTERFACE_STAT_IN_OCTETS_last"
 2) "3948"
 3) "SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last"
 4) "47"
 5) "SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last"
 6) "0"
 7) "SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last"
 8) "0"
 9) "RX_BPS"
10) "77.634107320096575"
11) "RX_PPS"
12) "0.92421556333448329"
13) "TX_BPS"
14) "0"
15) "TX_PPS"
16) "0"

```

before the change:
```
admin@sonic:~$ show interfaces  counters rif -p 5
The rates are calculated within 5 seconds period
     IFACE    RX_OK       RX_BPS     RX_PPS    RX_ERR    TX_OK    TX_BPS    TX_PPS    TX_ERR
----------  -------  -----------  ---------  --------  -------  --------  --------  --------
Ethernet0        0     0.00 B/s     0.00/s         0        0  0.00 B/s    0.00/s         0
Ethernet28   29,894  501.05 KB/s  5964.85/s         1        0  0.00 B/s    0.00/s         0
```

```
127.0.0.1:6379[2]> hgetall "RATES:oid:0x6000000000517"
1) "SAI_ROUTER_INTERFACE_STAT_IN_OCTETS_last"
2) "17856552"
3) "SAI_ROUTER_INTERFACE_STAT_IN_PACKETS_last"
4) "212578"
5) "SAI_ROUTER_INTERFACE_STAT_OUT_OCTETS_last"
6) "0"
7) "SAI_ROUTER_INTERFACE_STAT_OUT_PACKETS_last"
8) "0"
9) "RX_BPS"
10) "67.774654124880783"
11) "RX_PPS"
12) "0.80684145386762807"
13) "TX_BPS"
14) "0"
15) "TX_PPS"
16) "0"

```

**Details if related**
