### PR TITLE
[ACL] Match TCP protocol while matching TCP_FLAG

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -35,6 +35,8 @@ extern CrmOrch *gCrmOrch;
 #define MIN_VLAN_ID 1    // 0 is a reserved VLAN ID
 #define MAX_VLAN_ID 4095 // 4096 is a reserved VLAN ID
 
+const int TCP_PROTOCOL_NUM = 6; // TCP protocol number
+
 acl_rule_attr_lookup_t aclMatchLookup =
 {
     { MATCH_IN_PORTS,          SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS },
@@ -645,7 +647,7 @@ void AclRule::updateInPorts()
     attr.id = SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS;
     attr.value = m_matches[SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS];
     attr.value.aclfield.enable = true;
-    
+
     status = sai_acl_api->set_acl_entry_attribute(m_ruleOid, &attr);
     if (status != SAI_STATUS_SUCCESS)
     {
@@ -1378,14 +1380,14 @@ bool AclTable::create()
         attr.id = SAI_ACL_TABLE_ATTR_ACL_STAGE;
         attr.value.s32 = (stage == ACL_STAGE_INGRESS) ? SAI_ACL_STAGE_INGRESS : SAI_ACL_STAGE_EGRESS;
         table_attrs.push_back(attr);
-        
+
         if (stage == ACL_STAGE_INGRESS)
         {
             attr.id = SAI_ACL_TABLE_ATTR_FIELD_IN_PORTS;
             attr.value.booldata = true;
             table_attrs.push_back(attr);
         }
-        
+
         sai_status_t status = sai_acl_api->create_acl_table(&m_oid, gSwitchId, (uint32_t)table_attrs.size(), table_attrs.data());
 
         if (status == SAI_STATUS_SUCCESS)
@@ -2985,11 +2987,11 @@ AclRule* AclOrch::getAclRule(string table_id, string rule_id)
 bool AclOrch::updateAclRule(string table_id, string rule_id, string attr_name, void *data, bool oper)
 {
     SWSS_LOG_ENTER();
-    
+
     sai_object_id_t table_oid = getTableById(table_id);
     string attr_value;
 
-    if (table_oid == SAI_NULL_OBJECT_ID) 
+    if (table_oid == SAI_NULL_OBJECT_ID)
     {
         SWSS_LOG_ERROR("Failed to update ACL rule in ACL table %s. Table doesn't exist", table_id.c_str());
         return false;
@@ -3002,29 +3004,29 @@ bool AclOrch::updateAclRule(string table_id, string rule_id, string attr_name, v
         return false;
     }
 
-    switch (aclMatchLookup[attr_name]) 
+    switch (aclMatchLookup[attr_name])
     {
         case SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS:
         {
             sai_object_id_t port_oid = *(sai_object_id_t *)data;
             vector<sai_object_id_t> in_ports = rule_it->second->getInPorts();
 
-            if (oper == RULE_OPER_ADD) 
+            if (oper == RULE_OPER_ADD)
             {
                 in_ports.push_back(port_oid);
-            } 
-            else 
+            }
+            else
             {
                 for (auto port_iter = in_ports.begin(); port_iter != in_ports.end(); port_iter++)
                 {
-                    if (*port_iter == port_oid) 
+                    if (*port_iter == port_oid)
                     {
                         in_ports.erase(port_iter);
                         break;
                     }
                 }
             }
-            
+
             for (const auto& port_iter: in_ports)
             {
                 Port p;
@@ -3277,14 +3279,22 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                 it = consumer.m_toSync.erase(it);
                 return;
             }
-
+            bool bHasTCPFlag = false;
+            bool bHasIPProtocol = false;
             for (const auto& itr : kfvFieldsValues(t))
             {
                 string attr_name = to_upper(fvField(itr));
                 string attr_value = fvValue(itr);
 
                 SWSS_LOG_INFO("ATTRIBUTE: %s %s", attr_name.c_str(), attr_value.c_str());
-
+                if (attr_name == MATCH_TCP_FLAGS)
+                {
+                    bHasTCPFlag = true;
+                }
+                if (attr_name == MATCH_IP_PROTOCOL)
+                {
+                    bHasIPProtocol = true;
+                }
                 if (newRule->validateAddPriority(attr_name, attr_value))
                 {
                     SWSS_LOG_INFO("Added priority attribute");
@@ -3302,6 +3312,21 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                     SWSS_LOG_ERROR("Unknown or invalid rule attribute '%s : %s'", attr_name.c_str(), attr_value.c_str());
                     bAllAttributesOk = false;
                     break;
+                }
+            }
+            // If acl rule is to match TCP_FLAGS, and IP_PROTOCOL is not set
+            // we set IP_PROTOCOL to 6 to match TCP explicitly
+            if (bHasTCPFlag && !bHasIPProtocol)
+            {
+                string attr_name = MATCH_IP_PROTOCOL;
+                string attr_value = std::to_string(TCP_PROTOCOL_NUM);
+                if (newRule->validateAddMatch(attr_name, attr_value))
+                {
+                    SWSS_LOG_INFO("Automatically added match attribute '%s : %s'", attr_name.c_str(), attr_value.c_str());
+                }
+                else
+                {
+                    SWSS_LOG_ERROR("Failed to add attribute '%s : %s'", attr_name.c_str(), attr_value.c_str());
                 }
             }
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3291,7 +3291,7 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                 {
                     bHasTCPFlag = true;
                 }
-                if (attr_name == MATCH_IP_PROTOCOL)
+                if (attr_name == MATCH_IP_PROTOCOL || attr_name == MATCH_NEXT_HEADER)
                 {
                     bHasIPProtocol = true;
                 }
@@ -3314,11 +3314,20 @@ void AclOrch::doAclRuleTask(Consumer &consumer)
                     break;
                 }
             }
-            // If acl rule is to match TCP_FLAGS, and IP_PROTOCOL is not set
-            // we set IP_PROTOCOL to 6 to match TCP explicitly
+            // If acl rule is to match TCP_FLAGS, and IP_PROTOCOL(NEXT_HEADER) is not set
+            // we set IP_PROTOCOL(NEXT_HEADER) to 6 to match TCP explicitly
             if (bHasTCPFlag && !bHasIPProtocol)
             {
-                string attr_name = MATCH_IP_PROTOCOL;
+                string attr_name;
+                if (type == ACL_TABLE_MIRRORV6 || type == ACL_TABLE_L3V6)
+                {
+                    attr_name = MATCH_NEXT_HEADER;
+                }
+                else
+                {
+                    attr_name = MATCH_IP_PROTOCOL;
+
+                }
                 string attr_value = std::to_string(TCP_PROTOCOL_NUM);
                 if (newRule->validateAddMatch(attr_name, attr_value))
                 {

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -298,19 +298,6 @@ class TestAcl:
         dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
         dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleTCPFlags(self, dvs_acl, l3v6_acl_table):
-        config_qualifiers = {"TCP_FLAGS": "0x07/0x3f"}
-        expected_sai_qualifiers = {
-            "SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS":
-                dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f")
-        }
-
-        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
-        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
-
-        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
-        dvs_acl.verify_no_acl_rules()
-
     def test_V6AclRuleL4SrcPortRange(self, dvs_acl, l3v6_acl_table):
         config_qualifiers = {"L4_SRC_PORT_RANGE": "1-100"}
         expected_sai_qualifiers = {

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -97,7 +97,7 @@ class TestAcl:
             "SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS":
                 dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f"),
             "SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL":
-            dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
+                dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
         }
         dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
         dvs_acl.verify_acl_rule(expected_sai_qualifiers)
@@ -115,7 +115,7 @@ class TestAcl:
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
         dvs_acl.verify_no_acl_rules()
 
-    def test_V6AclRuleNextHeaderAppendedForTCPFlags(self, dvs_acl, l3_acl_table):
+    def test_V6AclRuleNextHeaderAppendedForTCPFlags(self, dvs_acl, l3v6_acl_table):
         """
         Verify next heder (6) will be appended for IPv6 ACL rules matching TCP_FLAGS
         """
@@ -124,7 +124,7 @@ class TestAcl:
             "SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS":
                 dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f"),
             "SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER":
-            dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
+                dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
         }
 
         dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)

--- a/tests/test_acl.py
+++ b/tests/test_acl.py
@@ -88,6 +88,23 @@ class TestAcl:
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
         dvs_acl.verify_no_acl_rules()
 
+    def test_AclRuleTCPProtocolAppendedForTCPFlags(self, dvs_acl, l3_acl_table):
+        """
+        Verify TCP Protocol number (6) will be appended for ACL rules matching TCP_FLAGS
+        """
+        config_qualifiers = {"TCP_FLAGS": "0x07/0x3f"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS":
+                dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f"),
+            "SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL":
+            dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
+        }
+        dvs_acl.create_acl_rule(L3_TABLE_NAME, L3_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+
+        dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
     def test_AclRuleNextHeader(self, dvs_acl, l3_acl_table):
         config_qualifiers = {"NEXT_HEADER": "6"}
 
@@ -96,6 +113,24 @@ class TestAcl:
         dvs_acl.verify_no_acl_rules()
 
         dvs_acl.remove_acl_rule(L3_TABLE_NAME, L3_RULE_NAME)
+        dvs_acl.verify_no_acl_rules()
+
+    def test_V6AclRuleNextHeaderAppendedForTCPFlags(self, dvs_acl, l3_acl_table):
+        """
+        Verify next heder (6) will be appended for IPv6 ACL rules matching TCP_FLAGS
+        """
+        config_qualifiers = {"TCP_FLAGS": "0x07/0x3f"}
+        expected_sai_qualifiers = {
+            "SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS":
+                dvs_acl.get_simple_qualifier_comparator("7&mask:0x3f"),
+            "SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER":
+            dvs_acl.get_simple_qualifier_comparator("6&mask:0xff")
+        }
+
+        dvs_acl.create_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME, config_qualifiers)
+        dvs_acl.verify_acl_rule(expected_sai_qualifiers)
+
+        dvs_acl.remove_acl_rule(L3V6_TABLE_NAME, L3V6_RULE_NAME)
         dvs_acl.verify_no_acl_rules()
 
     def test_AclRuleInOutPorts(self, dvs_acl, l3_acl_table):


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR updates ```aclorch``` to match ```TCP``` protocol number while matching ```TCP_FLAGS```.

**Why I did it**
We found that ACL rules that only matches ```TCP_FLAGS``` will also capture some UDP packets if we don't explicitly require to match TCP protocol. The issue is only detected on TD3 platform for IPv6 for now.
For example, follow ACL rule will catch UDP packets
```
...
                  "19": {
                                "actions": {
                                    "config": {
                                        "forwarding-action": "DROP"
                                    }
                                },
                                "config": {
                                    "sequence-id": 19
                                },
                                "transport": {
                                    "config": {
                                        "tcp-flags": ["TCP_RST", "TCP_URG"]
                                    }
                                }
                            },
...
``` 
To address the issue, this PR updates ```aclorch```. When an ACL rule is to match ```TCP_FLAGS```, we will also try to match ```TCP``` protocol number if it's not set explicitly.

**How I verified it**
The feature is verified by rebuilding orchagent and running in swss container. And some ACL rules that are to match ```TCP_FLAGS``` are applied, we can see the added log is printed out
```
syslog.1:Aug  5 03:11:39.221010 str2-7050cx3-acs-02 INFO swss#orchagent: :- doAclRuleTask: Automatically added match attribute 'IP_PROTOCOL : 6'
syslog.1:Aug  5 03:11:39.530558 str2-7050cx3-acs-02 INFO swss#orchagent: :- doAclRuleTask: Automatically added match attribute 'IP_PROTOCOL : 6'
syslog.1:Aug  5 03:30:59.586244 str2-7050cx3-acs-02 INFO swss#orchagent: :- doAclRuleTask: Automatically added match attribute 'IP_PROTOCOL : 6'
syslog.1:Aug  5 03:30:59.758548 str2-7050cx3-acs-02 INFO swss#orchagent: :- doAclRuleTask: Automatically added match attribute 'IP_PROTOCOL : 6'
```
And the ```ACL_ENTRY``` in ASIC_DB also shows that ```IP_PROTOCOL``` **6** is added automatically.
For IPv4
```
{'SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS': '36&mask:0x24', 'SAI_ACL_ENTRY_ATTR_FIELD_IP_PROTOCOL': '6&mask:0xff', 'SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION': 'SAI_PACKET_ACTION_DROP', 'SAI_ACL_ENTRY_ATTR_PRIORITY': '9981', 'SAI_ACL_ENTRY_ATTR_ACTION_COUNTER': 'oid:0x9000000000844', 'SAI_ACL_ENTRY_ATTR_FIELD_ETHER_TYPE': '2048&mask:0xffff', 'SAI_ACL_ENTRY_ATTR_ADMIN_STATE': 'true', 'SAI_ACL_ENTRY_ATTR_TABLE_ID': 'oid:0x700000000080b'}
```
For IPv6
```
{'SAI_ACL_ENTRY_ATTR_FIELD_TCP_FLAGS': '36&mask:0x24', 'SAI_ACL_ENTRY_ATTR_ACTION_PACKET_ACTION': 'SAI_PACKET_ACTION_DROP', 'SAI_ACL_ENTRY_ATTR_FIELD_ACL_IP_TYPE': 'SAI_ACL_IP_TYPE_IPV6ANY&mask:0xffffffffffffffff', 'SAI_ACL_ENTRY_ATTR_PRIORITY': '9981', 'SAI_ACL_ENTRY_ATTR_FIELD_IPV6_NEXT_HEADER': '6&mask:0xff', 'SAI_ACL_ENTRY_ATTR_ACTION_COUNTER': 'oid:0x90000000007dd', 'SAI_ACL_ENTRY_ATTR_ADMIN_STATE': 'true', 'SAI_ACL_ENTRY_ATTR_TABLE_ID': 'oid:0x70000000007a8'}
```
The feature is also verified by running ```test_acl``` in sonic-mgmt. Test cases can pass with the patch.

**Details if related**
https://github.com/Azure/sonic-buildimage/issues/8290