### PR TITLE
Remove buffer drop counter when port is deleted

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2423,6 +2423,13 @@ void PortsOrch::deInitPort(string alias, sai_object_id_t port_id)
     {
         port_stat_manager.clearCounterIdList(p.m_port_id);
     }
+
+    if (flex_counters_orch->getPortBufferDropCountersState())
+    {
+        port_buffer_drop_stat_manager.clearCounterIdList(p.m_port_id);
+    }
+
+
     /* remove port name map from counter table */
     m_counter_db->hdel(COUNTERS_PORT_NAME_MAP, alias);
 


### PR DESCRIPTION
Signed-off-by: tomeri tomeri@nvidia.com

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
I added the removal of port buffer drop counter on the deinit port flow.
it was added to the deInitPort function.

**Why I did it**
the buffer drop counter was never removed when port was deleted.
this flex counter was create on the initPort function but it was removed when the port was deleted

**How I verified it**
removed and created a port and check the FLEX_COUNTER redis table

FLEX_COUNTER_TABLE:PORT_BUFFER_DROP_STAT table

**Details if related**
