### PR TITLE
Fix warmboot issue PR##8367

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -1271,8 +1271,8 @@ bool FdbOrch::addFdbEntry(const FdbEntry& entry, const string& port_name,
 
     attrs.push_back(attr);
 
-    if ((fdbData.origin == FDB_ORIGIN_VXLAN_ADVERTIZED) || (fdbData.origin == FDB_ORIGIN_MCLAG_ADVERTIZED)
-            || (fdbData.type == "dynamic"))
+    if (((fdbData.origin == FDB_ORIGIN_VXLAN_ADVERTIZED) || (fdbData.origin == FDB_ORIGIN_MCLAG_ADVERTIZED))
+            && (fdbData.type == "dynamic"))
     {
         attr.id = SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE;
         attr.value.booldata = true;


### PR DESCRIPTION
**What I did**
FIx the warmboot issue PR##8367, caused by the changes made as part of the PR#1331

Fixes https://github.com/Azure/sonic-buildimage/issues/8367

**Why I did it**
During the WB when the MAC addresses are added via refillToSync(&m_fdbStateTable) , the attribute SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE is set wrongly for dynamic MAC as well.
Fix is to set SAI_FDB_ENTRY_ATTR_ALLOW_MAC_MOVE  only for the case of VXLAN or MCLAG  for fdb_type dyamic. 

