### PR TITLE
[subintf] Fix kernel admin status

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -466,7 +466,6 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
         {
             return false;
         }
-        SWSS_LOG_NOTICE("do host sub interface task, op: set");
 
         string parentAdminStatus = "";
         for (const auto &fv : fvTuples)
@@ -503,11 +502,6 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
                 {
                     adminStatus = "up";
                 }
-                SWSS_LOG_NOTICE("Parent %s admin %s, sub interface %s admin %s",
-                        parentAlias.c_str(),
-                        parentAdminStatus.c_str(),
-                        alias.c_str(),
-                        adminStatus.c_str());
 
                 if (adminStatus == "down")
                 {
@@ -517,10 +511,10 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
                     }
                     catch (const std::runtime_error &e)
                     {
-                        SWSS_LOG_NOTICE("Sub interface ip link set admin status %s failure. Runtime error: %s", adminStatus.c_str(), e.what());
+                        SWSS_LOG_DEBUG("Sub interface ip link set admin status %s failure. Runtime error: %s", adminStatus.c_str(), e.what());
                         return false;
                     }
-                    SWSS_LOG_NOTICE("Sub interface %s ip link set admin status %s succeeded", alias.c_str(), adminStatus.c_str());
+                    SWSS_LOG_INFO("Sub interface %s ip link set admin status %s succeeded", alias.c_str(), adminStatus.c_str());
                 }
             }
         }

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -29,12 +29,15 @@ IntfMgr::IntfMgr(DBConnector *cfgDb, DBConnector *appDb, DBConnector *stateDb, c
         m_cfgVlanIntfTable(cfgDb, CFG_VLAN_INTF_TABLE_NAME),
         m_cfgLagIntfTable(cfgDb, CFG_LAG_INTF_TABLE_NAME),
         m_cfgLoopbackIntfTable(cfgDb, CFG_LOOPBACK_INTERFACE_TABLE_NAME),
+        m_cfgSubIntfTable(cfgDb, CFG_VLAN_SUB_INTF_TABLE_NAME),
         m_statePortTable(stateDb, STATE_PORT_TABLE_NAME),
         m_stateLagTable(stateDb, STATE_LAG_TABLE_NAME),
         m_stateVlanTable(stateDb, STATE_VLAN_TABLE_NAME),
         m_stateVrfTable(stateDb, STATE_VRF_TABLE_NAME),
         m_stateIntfTable(stateDb, STATE_INTERFACE_TABLE_NAME),
-        m_appIntfTableProducer(appDb, APP_INTF_TABLE_NAME)
+        m_appIntfTableProducer(appDb, APP_INTF_TABLE_NAME),
+        m_appPortTable(appDb, APP_PORT_TABLE_NAME),
+        m_appLagTable(appDb, APP_LAG_TABLE_NAME)
 {
     if (!WarmStart::isWarmStart())
     {
@@ -447,6 +450,91 @@ bool IntfMgr::isIntfStateOk(const string &alias)
     }
 
     return false;
+}
+
+bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
+        const vector<FieldValueTuple> &fvTuples,
+        const string &op)
+{
+    SWSS_LOG_ENTER();
+
+    string parentAlias(keys[0]);
+
+    if (op == SET_COMMAND)
+    {
+        if (!isIntfStateOk(parentAlias))
+        {
+            return false;
+        }
+        SWSS_LOG_NOTICE("do host sub interface task, op: set");
+
+        string parentAdminStatus = "";
+        for (const auto &fv : fvTuples)
+        {
+            if (fvField(fv) == "admin_status")
+            {
+                parentAdminStatus = fvValue(fv);
+            }
+        }
+
+        if (parentAdminStatus == "up")
+        {
+            string parentAdminStatusAppDb;
+            if (!parentAlias.compare(0, strlen(LAG_PREFIX), LAG_PREFIX))
+            {
+                m_appLagTable.hget(parentAlias, "admin_status", parentAdminStatusAppDb);
+            }
+            else
+            {
+                m_appPortTable.hget(parentAlias, "admin_status", parentAdminStatusAppDb);
+            }
+            if (parentAdminStatusAppDb != parentAdminStatus)
+            {
+                // Parent port admin status has not yet been synced from config db to appl db, which
+                // indicates that parent port admin status at kernel has not yet been updated from
+                // down to up by portmgrd.
+                return false;
+            }
+
+            for (const auto &alias : m_portSubIntfSet[parentAlias])
+            {
+                string adminStatus;
+                if (!m_cfgSubIntfTable.hget(alias, "admin_status", adminStatus))
+                {
+                    adminStatus = "up";
+                }
+                SWSS_LOG_NOTICE("Parent %s admin %s, sub interface %s admin %s",
+                        parentAlias.c_str(),
+                        parentAdminStatus.c_str(),
+                        alias.c_str(),
+                        adminStatus.c_str());
+
+                if (adminStatus == "down")
+                {
+                    try
+                    {
+                        setHostSubIntfAdminStatus(alias, adminStatus);
+                    }
+                    catch (const std::runtime_error &e)
+                    {
+                        SWSS_LOG_NOTICE("Sub interface ip link set admin status %s failure. Runtime error: %s", adminStatus.c_str(), e.what());
+                        return false;
+                    }
+                    SWSS_LOG_NOTICE("Sub interface %s ip link set admin status %s succeeded", alias.c_str(), adminStatus.c_str());
+                }
+            }
+        }
+    }
+    else if (op == DEL_COMMAND)
+    {
+        m_portSubIntfSet.erase(parentAlias);
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown operation: %s", op.c_str());
+    }
+
+    return true;
 }
 
 bool IntfMgr::doIntfGeneralTask(const vector<string>& keys,

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -19,8 +19,9 @@ public:
 
 private:
     ProducerStateTable m_appIntfTableProducer;
-    Table m_cfgIntfTable, m_cfgVlanIntfTable, m_cfgLagIntfTable, m_cfgLoopbackIntfTable;
+    Table m_cfgIntfTable, m_cfgVlanIntfTable, m_cfgLagIntfTable, m_cfgLoopbackIntfTable, m_cfgSubIntfTable;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateVrfTable, m_stateIntfTable;
+    Table m_appPortTable, m_appLagTable;
 
     std::set<std::string> m_subIntfList;
     std::set<std::string> m_loopbackIntfList;

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -23,7 +23,8 @@ private:
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateVrfTable, m_stateIntfTable;
     Table m_appPortTable, m_appLagTable;
 
-    std::set<std::string> m_subIntfList;
+    std::unordered_set<std::string> m_subIntfList;
+    std::unordered_map<std::string, std::unordered_set<std::string>> m_portSubIntfSet;
     std::set<std::string> m_loopbackIntfList;
     std::set<std::string> m_pendingReplayIntfList;
 
@@ -34,6 +35,7 @@ private:
 
     bool doIntfGeneralTask(const std::vector<std::string>& keys, std::vector<FieldValueTuple> data, const std::string& op);
     bool doIntfAddrTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
+    bool doHostSubIntfUpdateTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
     void doTask(Consumer &consumer);
 
     bool isIntfStateOk(const std::string &alias);

--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -48,6 +48,8 @@ int main(int argc, char **argv)
             CFG_LOOPBACK_INTERFACE_TABLE_NAME,
             CFG_VLAN_SUB_INTF_TABLE_NAME,
             CFG_VOQ_INBAND_INTERFACE_TABLE_NAME,
+            CFG_PORT_TABLE_NAME,
+            CFG_LAG_TABLE_NAME,
         };
 
         DBConnector cfgDb("CONFIG_DB", 0);

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -318,6 +318,23 @@ class TestSubPortIntf(object):
 
         wait_for_result(_access_function)
 
+    def check_sub_port_intf_mtu_kernel(self, dvs, port_name, mtu):
+        (ec, out) = dvs.runcmd(['bash', '-c', "ip link show {} | grep 'mtu {}'".format(port_name, mtu)])
+        assert ec == 0
+        assert mtu in out
+
+    def check_sub_port_intf_admin_status_kernel(self, dvs, port_name, admin_up):
+        up = "UP"
+        if admin_up == True:
+            up = "," + up
+        (ec, out) = dvs.runcmd(['bash', '-c', "ip link show {} | grep {}".format(port_name, up)])
+        if admin_up == True:
+            assert ec == 0
+            assert up in out
+        else:
+            assert ec == 1
+            assert up not in out
+
     def check_sub_port_intf_vrf_bind_kernel(self, dvs, port_name, vrf_name):
         (ec, out) = dvs.runcmd(['bash', '-c', "ip link show {} | grep {}".format(port_name, vrf_name)])
         assert ec == 0
@@ -616,6 +633,9 @@ class TestSubPortIntf(object):
         self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
         self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
 
+        # Verify sub port interface admin status in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=True)
+
         fv_dict = {
             ADMIN_STATUS: "up",
         }
@@ -634,6 +654,9 @@ class TestSubPortIntf(object):
 
         # Change sub port interface admin status to down
         self.set_sub_port_intf_admin_status(sub_port_intf_name, "down")
+
+        # Verify sub port interface admin status change in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
 
         # Verify that sub port interface admin status change is synced to APP_DB by Intfmgrd
         fv_dict = {
@@ -655,6 +678,9 @@ class TestSubPortIntf(object):
 
         # Change sub port interface admin status to up
         self.set_sub_port_intf_admin_status(sub_port_intf_name, "up")
+
+        # Verify sub port interface admin status change in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=True)
 
         # Verify that sub port interface admin status change is synced to APP_DB by Intfmgrd
         fv_dict = {

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -730,6 +730,180 @@ class TestSubPortIntf(object):
         self._test_sub_port_intf_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, self.VRF_UNDER_TEST)
         self._test_sub_port_intf_admin_status_change(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, self.VRF_UNDER_TEST)
 
+    def _test_sub_port_intf_parent_port_admin_status_change(self, dvs, sub_port_intf_name, vrf_name=None):
+        substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
+        parent_port = substrs[0]
+
+        vrf_oid = self.default_vrf_oid
+        old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
+
+        # Set parent port admin status up
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+        if vrf_name:
+            self.create_vrf(vrf_name)
+            vrf_oid = self.get_newly_created_oid(ASIC_VIRTUAL_ROUTER_TABLE, [vrf_oid])
+        self.create_sub_port_intf_profile(sub_port_intf_name, vrf_name)
+
+        self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        if vrf_name is None or not vrf_name.startswith(VNET_PREFIX):
+            self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
+
+        # Verify sub port interface admin status up in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=True)
+        # Verify sub port interface admin status up in APP_DB
+        fv_dict = {
+            ADMIN_STATUS: "up",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify sub port interface admin status up in ASIC_DB
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Set parent port admin status down, with sub port interface admin status up
+        self.set_parent_port_admin_status(dvs, parent_port, "down")
+
+        # Verify sub port interface admin status down in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
+        # Verify that sub port interface admin status in APP_DB stays unchanged (admin status up)
+        fv_dict = {
+            ADMIN_STATUS: "up",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB stays unchanged (admin status up)
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Set parent port admin status up, with sub port interface admin status up
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+
+        # Verify sub port interface admin status up in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=True)
+        # Verify that sub port interface admin status in APP_DB stays unchanged (admin status up)
+        fv_dict = {
+            ADMIN_STATUS: "up",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB stays unchanged (admin status up)
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Change sub port interface admin status to down, with parent port admin status up
+        self.set_sub_port_intf_admin_status(sub_port_intf_name, "down")
+
+        # Verify sub port interface admin status change in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
+        # Verify that sub port interface admin status change is synced to APP_DB by Intfmgrd
+        fv_dict = {
+            ADMIN_STATUS: "down",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB has the updated admin status
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Set parent port admin status down, with sub port interface admin status down
+        self.set_parent_port_admin_status(dvs, parent_port, "down")
+
+        # Verify sub port interface admin status down in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
+        # Verify that sub port interface admin status in APP_DB stays unchanged (admin down)
+        fv_dict = {
+            ADMIN_STATUS: "down",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB stays unchanged (admin down)
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Set parent port admin status up, with sub port interface admin status down
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+
+        # Verify sub port interface admin status down in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
+        # Verify that sub port interface admin status in APP_DB stays unchanged (admin status down)
+        fv_dict = {
+            ADMIN_STATUS: "down",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB stays unchanged (admin status down)
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Remove IP addresses
+        ip_addrs = [
+            self.IPV4_ADDR_UNDER_TEST,
+        ]
+        self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        if vrf_name is None or not vrf_name.startswith(VNET_PREFIX):
+            ip_addrs.append(self.IPV6_ADDR_UNDER_TEST)
+            self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
+        self.check_sub_port_intf_ip_addr_removal(sub_port_intf_name, ip_addrs)
+
+        # Remove a sub port interface
+        self.remove_sub_port_intf_profile(sub_port_intf_name)
+        self.check_sub_port_intf_profile_removal(rif_oid)
+
+        # Remove vrf if created
+        if vrf_name:
+            self.remove_vrf(vrf_name)
+            self.check_vrf_removal(vrf_oid)
+            if vrf_name.startswith(VNET_PREFIX):
+                self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
+                self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)
+
+    def test_sub_port_intf_parent_port_admin_status_change(self, dvs):
+        self.connect_dbs(dvs)
+
+        self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
+
     def _test_sub_port_intf_remove_ip_addrs(self, dvs, sub_port_intf_name, vrf_name=None):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
         parent_port = substrs[0]

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -903,6 +903,10 @@ class TestSubPortIntf(object):
         self.connect_dbs(dvs)
 
         self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
+
+        self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, self.VRF_UNDER_TEST)
+        self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, self.VRF_UNDER_TEST)
 
     def _test_sub_port_intf_remove_ip_addrs(self, dvs, sub_port_intf_name, vrf_name=None):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -901,6 +901,11 @@ class TestSubPortIntf(object):
                 self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
                 self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)
 
+        # Remove lag
+        if parent_port.startswith(LAG_PREFIX):
+            self.remove_lag(parent_port)
+            self.asic_db.wait_for_n_keys(ASIC_LAG_TABLE, 0)
+
     def test_sub_port_intf_parent_port_admin_status_change(self, dvs):
         self.connect_dbs(dvs)
 

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -37,6 +37,8 @@ VRF_NAME = "vrf_name"
 
 ETHERNET_PREFIX = "Ethernet"
 LAG_PREFIX = "PortChannel"
+VRF_PREFIX = "Vrf"
+VNET_PREFIX = "Vnet"
 
 VLAN_SUB_INTERFACE_SEPARATOR = "."
 APPL_DB_SEPARATOR = ":"


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Why I did it**
Fix https://github.com/Azure/SONiC/issues/601

Sub port interface has a separate admin status control from parent port. However, at kernel side, the admin status operation of parent port is not fully decoupled from that of sub port interface. Admin down parent port also admins down sub port, and admin up parent port also admins up sub port.

Under such a behavior, one case that need additional care from user software, specifically, `intfmgrd`, is that sub port interface is configured admin down in CONFIG_DB, and parent port goes from admin down to admin up in CONFIG_DB. Sub port interface at kernel will go from admin down to admin up accordingly, leaving its kernel-side admin status to be different from what is configured in CONFIG_DB. This may affect behavior of some control plane packets. 

Other admin status combination of {parent port, sub port interface} pair is discussed in https://github.com/Azure/SONiC/issues/601#issuecomment-798030332

The SAI/ASIC side admin status of sub port interface is not affected by this PR.

**What I did**
Have IntfMgr subscribe to CONFIG PORT and LAG table to listen to parent port admin status change. The particular status we are interested in is parent port admin status up and sub port interface admin status down. When such a case is captured, we will admin down sub port interface in kernel.

Because the operation of admin down parent port is issued from `portmgrd` or `teammgrd`, which is a separate process from `intfmgrd`, we need to make sure that parent port admin operation is completed in the first place. To this end, we will check whether parent port admin status is syncd from CONFIG DB to APPL DB. We use this as an indicator that kernel-side operation for parent port is completed as setting APPL DB is coded as the last step in *mgrd by convention.


**How I verified it**
vs test

1. Start with parent port admin up, sub port interface admin up in CONFIG_DB
2. Set parent port admin down, sub port interface remains admin up in CONFIG_DB
    - Check sub port interface admin down in kernel, and admin up in SAI/ASIC
3. Set parent port admin up, sub port interface remains admin up in CONFIG_DB
    - Check sub port interface admin up in kernel, and admin up in SAI/ASIC
4. parent port remains admin up, set sub port interface admin down in CONFIG_DB
    - Check sub port interface admin down in kernel, and admin down in SAI/ASIC
5. Set parent port admin down, sub port interface remains admin down in CONFIG_DB
    - Check sub port interface admin down in kernel, and admin down in SAI/ASIC
6. Set parent port admin up, sub port interface remains admin down in CONFIG_DB (What this PR fixes)
    - Check sub port interface admin down in kernel, and admin down in SAI/ASIC

**Details if related**
