### PR TITLE
[subinf] Fix kernel mtu inheritance from parent

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -449,7 +449,7 @@ bool IntfMgr::isIntfStateOk(const string &alias)
     return false;
 }
 
-bool IntfMgr::doSubIntfHostIntfUpdateTask(const vector<string> &keys,
+bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
         const vector<FieldValueTuple> &fvTuples,
         const string &op)
 {
@@ -835,7 +835,7 @@ void IntfMgr::doTask(Consumer &consumer)
             if ((table_name == CFG_PORT_TABLE_NAME)
                     || (table_name == CFG_LAG_TABLE_NAME))
             {
-                if (!doSubIntfHostIntfUpdateTask(keys, data, op))
+                if (!doHostSubIntfUpdateTask(keys, data, op))
                 {
                     it++;
                 }

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -463,6 +463,7 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
         {
             return false;
         }
+        SWSS_LOG_NOTICE("do host sub interface task, op: set");
 
         string mtu = "";
         for (const auto &fv : fvTuples)
@@ -486,6 +487,7 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
                     SWSS_LOG_NOTICE("Sub interface ip link set mtu %s failure. Runtime error: %s", mtu.c_str(), e.what());
                     return false;
                 }
+                SWSS_LOG_NOTICE("Sub interface %s ip link set mtu %s succeeded", alias.c_str(), mtu.c_str());
             }
         }
     }

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -483,7 +483,7 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
                 }
                 catch (const std::runtime_error &e)
                 {
-                    SWSS_LOG_NOTICE("Sub interface ip link set mtu failure. Runtime error: %s", e.what());
+                    SWSS_LOG_NOTICE("Sub interface ip link set mtu %s failure. Runtime error: %s", mtu.c_str(), e.what());
                     return false;
                 }
             }

--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -466,7 +466,6 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
         {
             return false;
         }
-        SWSS_LOG_NOTICE("do host sub interface task, op: set");
 
         string mtu = "";
         string parentAdminStatus = "";
@@ -492,10 +491,10 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
                 }
                 catch (const std::runtime_error &e)
                 {
-                    SWSS_LOG_NOTICE("Sub interface ip link set mtu %s failure. Runtime error: %s", mtu.c_str(), e.what());
+                    SWSS_LOG_DEBUG("Sub interface ip link set mtu %s failure. Runtime error: %s", mtu.c_str(), e.what());
                     return false;
                 }
-                SWSS_LOG_NOTICE("Sub interface %s ip link set mtu %s succeeded", alias.c_str(), mtu.c_str());
+                SWSS_LOG_INFO("Sub interface %s ip link set mtu %s succeeded", alias.c_str(), mtu.c_str());
             }
         }
 
@@ -525,11 +524,6 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
                 {
                     adminStatus = "up";
                 }
-                SWSS_LOG_NOTICE("Parent %s admin %s, sub interface %s admin %s",
-                        parentAlias.c_str(),
-                        parentAdminStatus.c_str(),
-                        alias.c_str(),
-                        adminStatus.c_str());
 
                 if (adminStatus == "down")
                 {
@@ -539,10 +533,10 @@ bool IntfMgr::doHostSubIntfUpdateTask(const vector<string> &keys,
                     }
                     catch (const std::runtime_error &e)
                     {
-                        SWSS_LOG_NOTICE("Sub interface ip link set admin status %s failure. Runtime error: %s", adminStatus.c_str(), e.what());
+                        SWSS_LOG_DEBUG("Sub interface ip link set admin status %s failure. Runtime error: %s", adminStatus.c_str(), e.what());
                         return false;
                     }
-                    SWSS_LOG_NOTICE("Sub interface %s ip link set admin status %s succeeded", alias.c_str(), adminStatus.c_str());
+                    SWSS_LOG_INFO("Sub interface %s ip link set admin status %s succeeded", alias.c_str(), adminStatus.c_str());
                 }
             }
         }

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -19,8 +19,9 @@ public:
 
 private:
     ProducerStateTable m_appIntfTableProducer;
-    Table m_cfgIntfTable, m_cfgVlanIntfTable, m_cfgLagIntfTable, m_cfgLoopbackIntfTable;
+    Table m_cfgIntfTable, m_cfgVlanIntfTable, m_cfgLagIntfTable, m_cfgLoopbackIntfTable, m_cfgSubIntfTable;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateVrfTable, m_stateIntfTable;
+    Table m_appPortTable, m_appLagTable;
 
     std::unordered_set<std::string> m_subIntfList;
     std::unordered_map<std::string, std::unordered_set<std::string>> m_portSubIntfSet;

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -22,7 +22,8 @@ private:
     Table m_cfgIntfTable, m_cfgVlanIntfTable, m_cfgLagIntfTable, m_cfgLoopbackIntfTable;
     Table m_statePortTable, m_stateLagTable, m_stateVlanTable, m_stateVrfTable, m_stateIntfTable;
 
-    std::set<std::string> m_subIntfList;
+    std::unordered_set<std::string> m_subIntfList;
+    std::unordered_map<std::string, std::unordered_set<std::string>> m_portSubIntfSet;
     std::set<std::string> m_loopbackIntfList;
     std::set<std::string> m_pendingReplayIntfList;
 
@@ -33,6 +34,7 @@ private:
 
     bool doIntfGeneralTask(const std::vector<std::string>& keys, std::vector<FieldValueTuple> data, const std::string& op);
     bool doIntfAddrTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
+    bool doSubIntfHostIntfUpdateTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
     void doTask(Consumer &consumer);
 
     bool isIntfStateOk(const std::string &alias);

--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -34,7 +34,7 @@ private:
 
     bool doIntfGeneralTask(const std::vector<std::string>& keys, std::vector<FieldValueTuple> data, const std::string& op);
     bool doIntfAddrTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
-    bool doSubIntfHostIntfUpdateTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
+    bool doHostSubIntfUpdateTask(const std::vector<std::string>& keys, const std::vector<FieldValueTuple>& data, const std::string& op);
     void doTask(Consumer &consumer);
 
     bool isIntfStateOk(const std::string &alias);

--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -48,6 +48,8 @@ int main(int argc, char **argv)
             CFG_LOOPBACK_INTERFACE_TABLE_NAME,
             CFG_VLAN_SUB_INTF_TABLE_NAME,
             CFG_VOQ_INBAND_INTERFACE_TABLE_NAME,
+            CFG_PORT_TABLE_NAME,
+            CFG_LAG_TABLE_NAME,
         };
 
         DBConnector cfgDb("CONFIG_DB", 0);

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -138,6 +138,9 @@ class TestSubPortIntf(object):
         self.asic_db.wait_for_n_keys(ASIC_HOSTIF_TABLE, hostif_cnt + 1)
         dvs.asicdb._generate_oid_to_interface_mapping()
 
+        (ec, out) = dvs.runcmd(['bash', '-c', "ip link set {} mtu {}".format(port_name, self.port_fvs[port_name]["mtu"])])
+        assert ec == 0
+
         for key, fvs in self.buf_pg_fvs.items():
             if port_name in key:
                 self.config_db.create_entry("BUFFER_PG", key, fvs)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -904,6 +904,11 @@ class TestSubPortIntf(object):
                 self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
                 self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)
 
+        # Remove lag
+        if parent_port.startswith(LAG_PREFIX):
+            self.remove_lag(parent_port)
+            self.asic_db.wait_for_n_keys(ASIC_LAG_TABLE, 0)
+
     def test_sub_port_intf_parent_port_admin_status_change(self, dvs):
         self.connect_dbs(dvs)
 

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -318,6 +318,11 @@ class TestSubPortIntf(object):
 
         wait_for_result(_access_function)
 
+    def check_sub_port_intf_mtu_kernel(self, dvs, port_name, mtu):
+        (ec, out) = dvs.runcmd(['bash', '-c', "ip link show {} | grep 'mtu {}'".format(port_name, mtu)])
+        assert ec == 0
+        assert mtu in out
+
     def check_sub_port_intf_vrf_bind_kernel(self, dvs, port_name, vrf_name):
         (ec, out) = dvs.runcmd(['bash', '-c', "ip link show {} | grep {}".format(port_name, vrf_name)])
         assert ec == 0
@@ -976,9 +981,15 @@ class TestSubPortIntf(object):
 
         rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
 
+        # Verify sub port interface mtu in linux kernel
+        self.check_sub_port_intf_mtu_kernel(dvs, sub_port_intf_name, DEFAULT_MTU)
+
         # Change parent port mtu
         mtu = "8888"
         dvs.set_mtu(parent_port, mtu)
+
+        # Verify sub port interface mtu in linux kernel
+        self.check_sub_port_intf_mtu_kernel(dvs, sub_port_intf_name, mtu)
 
         # Verify that sub port router interface entry in ASIC_DB has the updated mtu
         fv_dict = {
@@ -989,6 +1000,9 @@ class TestSubPortIntf(object):
 
         # Restore parent port mtu
         dvs.set_mtu(parent_port, DEFAULT_MTU)
+
+        # Verify sub port interface mtu in linux kernel
+        self.check_sub_port_intf_mtu_kernel(dvs, sub_port_intf_name, DEFAULT_MTU)
 
         # Verify that sub port router interface entry in ASIC_DB has the default mtu
         fv_dict = {

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -37,6 +37,8 @@ VRF_NAME = "vrf_name"
 
 ETHERNET_PREFIX = "Ethernet"
 LAG_PREFIX = "PortChannel"
+VRF_PREFIX = "Vrf"
+VNET_PREFIX = "Vnet"
 
 VLAN_SUB_INTERFACE_SEPARATOR = "."
 APPL_DB_SEPARATOR = ":"

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -326,6 +326,18 @@ class TestSubPortIntf(object):
         assert ec == 0
         assert mtu in out
 
+    def check_sub_port_intf_admin_status_kernel(self, dvs, port_name, admin_up):
+        up = "UP"
+        if admin_up == True:
+            up = "," + up
+        (ec, out) = dvs.runcmd(['bash', '-c', "ip link show {} | grep {}".format(port_name, up)])
+        if admin_up == True:
+            assert ec == 0
+            assert up in out
+        else:
+            assert ec == 1
+            assert up not in out
+
     def check_sub_port_intf_vrf_bind_kernel(self, dvs, port_name, vrf_name):
         (ec, out) = dvs.runcmd(['bash', '-c', "ip link show {} | grep {}".format(port_name, vrf_name)])
         assert ec == 0
@@ -624,6 +636,9 @@ class TestSubPortIntf(object):
         self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
         self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
 
+        # Verify sub port interface admin status in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=True)
+
         fv_dict = {
             ADMIN_STATUS: "up",
         }
@@ -642,6 +657,9 @@ class TestSubPortIntf(object):
 
         # Change sub port interface admin status to down
         self.set_sub_port_intf_admin_status(sub_port_intf_name, "down")
+
+        # Verify sub port interface admin status change in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
 
         # Verify that sub port interface admin status change is synced to APP_DB by Intfmgrd
         fv_dict = {
@@ -663,6 +681,9 @@ class TestSubPortIntf(object):
 
         # Change sub port interface admin status to up
         self.set_sub_port_intf_admin_status(sub_port_intf_name, "up")
+
+        # Verify sub port interface admin status change in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=True)
 
         # Verify that sub port interface admin status change is synced to APP_DB by Intfmgrd
         fv_dict = {

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -998,6 +998,34 @@ class TestSubPortIntf(object):
         }
         self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
 
+        # Change parent port mtu
+        mtu = "6666"
+        dvs.set_mtu(parent_port, mtu)
+
+        # Verify sub port interface mtu in linux kernel
+        self.check_sub_port_intf_mtu_kernel(dvs, sub_port_intf_name, mtu)
+
+        # Verify that sub port router interface entry in ASIC_DB has the updated mtu
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": mtu,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Change parent port mtu
+        mtu = "7777"
+        dvs.set_mtu(parent_port, mtu)
+
+        # Verify sub port interface mtu in linux kernel
+        self.check_sub_port_intf_mtu_kernel(dvs, sub_port_intf_name, mtu)
+
+        # Verify that sub port router interface entry in ASIC_DB has the updated mtu
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": mtu,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
         # Restore parent port mtu
         dvs.set_mtu(parent_port, DEFAULT_MTU)
 

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -906,6 +906,10 @@ class TestSubPortIntf(object):
         self.connect_dbs(dvs)
 
         self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
+        self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST)
+
+        self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, self.VRF_UNDER_TEST)
+        self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, self.VRF_UNDER_TEST)
 
     def _test_sub_port_intf_remove_ip_addrs(self, dvs, sub_port_intf_name, vrf_name=None):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)

--- a/tests/test_sub_port_intf.py
+++ b/tests/test_sub_port_intf.py
@@ -733,6 +733,180 @@ class TestSubPortIntf(object):
         self._test_sub_port_intf_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST, self.VRF_UNDER_TEST)
         self._test_sub_port_intf_admin_status_change(dvs, self.LAG_SUB_PORT_INTERFACE_UNDER_TEST, self.VRF_UNDER_TEST)
 
+    def _test_sub_port_intf_parent_port_admin_status_change(self, dvs, sub_port_intf_name, vrf_name=None):
+        substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
+        parent_port = substrs[0]
+
+        vrf_oid = self.default_vrf_oid
+        old_rif_oids = self.get_oids(ASIC_RIF_TABLE)
+
+        # Set parent port admin status up
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+        if vrf_name:
+            self.create_vrf(vrf_name)
+            vrf_oid = self.get_newly_created_oid(ASIC_VIRTUAL_ROUTER_TABLE, [vrf_oid])
+        self.create_sub_port_intf_profile(sub_port_intf_name, vrf_name)
+
+        self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        if vrf_name is None or not vrf_name.startswith(VNET_PREFIX):
+            self.add_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
+
+        # Verify sub port interface admin status up in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=True)
+        # Verify sub port interface admin status up in APP_DB
+        fv_dict = {
+            ADMIN_STATUS: "up",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify sub port interface admin status up in ASIC_DB
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Set parent port admin status down, with sub port interface admin status up
+        self.set_parent_port_admin_status(dvs, parent_port, "down")
+
+        # Verify sub port interface admin status down in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
+        # Verify that sub port interface admin status in APP_DB stays unchanged (admin status up)
+        fv_dict = {
+            ADMIN_STATUS: "up",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB stays unchanged (admin status up)
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Set parent port admin status up, with sub port interface admin status up
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+
+        # Verify sub port interface admin status up in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=True)
+        # Verify that sub port interface admin status in APP_DB stays unchanged (admin status up)
+        fv_dict = {
+            ADMIN_STATUS: "up",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB stays unchanged (admin status up)
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "true",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Change sub port interface admin status to down, with parent port admin status up
+        self.set_sub_port_intf_admin_status(sub_port_intf_name, "down")
+
+        # Verify sub port interface admin status change in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
+        # Verify that sub port interface admin status change is synced to APP_DB by Intfmgrd
+        fv_dict = {
+            ADMIN_STATUS: "down",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB has the updated admin status
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Set parent port admin status down, with sub port interface admin status down
+        self.set_parent_port_admin_status(dvs, parent_port, "down")
+
+        # Verify sub port interface admin status down in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
+        # Verify that sub port interface admin status in APP_DB stays unchanged (admin down)
+        fv_dict = {
+            ADMIN_STATUS: "down",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB stays unchanged (admin down)
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Set parent port admin status up, with sub port interface admin status down
+        self.set_parent_port_admin_status(dvs, parent_port, "up")
+
+        # Verify sub port interface admin status down in linux kernel
+        self.check_sub_port_intf_admin_status_kernel(dvs, sub_port_intf_name, admin_up=False)
+        # Verify that sub port interface admin status in APP_DB stays unchanged (admin status down)
+        fv_dict = {
+            ADMIN_STATUS: "down",
+        }
+        if vrf_name:
+            fv_dict[VRF_NAME if vrf_name.startswith(VRF_PREFIX) else VNET_NAME] = vrf_name
+        self.check_sub_port_intf_fvs(self.app_db, APP_INTF_TABLE_NAME, sub_port_intf_name, fv_dict)
+        # Verify that sub port router interface entry in ASIC_DB stays unchanged (admin status down)
+        fv_dict = {
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V4_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_ADMIN_V6_STATE": "false",
+            "SAI_ROUTER_INTERFACE_ATTR_MTU": DEFAULT_MTU,
+            "SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID": vrf_oid,
+        }
+        rif_oid = self.get_newly_created_oid(ASIC_RIF_TABLE, old_rif_oids)
+        self.check_sub_port_intf_fvs(self.asic_db, ASIC_RIF_TABLE, rif_oid, fv_dict)
+
+        # Remove IP addresses
+        ip_addrs = [
+            self.IPV4_ADDR_UNDER_TEST,
+        ]
+        self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV4_ADDR_UNDER_TEST)
+        if vrf_name is None or not vrf_name.startswith(VNET_PREFIX):
+            ip_addrs.append(self.IPV6_ADDR_UNDER_TEST)
+            self.remove_sub_port_intf_ip_addr(sub_port_intf_name, self.IPV6_ADDR_UNDER_TEST)
+        self.check_sub_port_intf_ip_addr_removal(sub_port_intf_name, ip_addrs)
+
+        # Remove a sub port interface
+        self.remove_sub_port_intf_profile(sub_port_intf_name)
+        self.check_sub_port_intf_profile_removal(rif_oid)
+
+        # Remove vrf if created
+        if vrf_name:
+            self.remove_vrf(vrf_name)
+            self.check_vrf_removal(vrf_oid)
+            if vrf_name.startswith(VNET_PREFIX):
+                self.remove_vxlan_tunnel(self.TUNNEL_UNDER_TEST)
+                self.app_db.wait_for_n_keys(ASIC_TUNNEL_TABLE, 0)
+
+    def test_sub_port_intf_parent_port_admin_status_change(self, dvs):
+        self.connect_dbs(dvs)
+
+        self._test_sub_port_intf_parent_port_admin_status_change(dvs, self.SUB_PORT_INTERFACE_UNDER_TEST)
+
     def _test_sub_port_intf_remove_ip_addrs(self, dvs, sub_port_intf_name, vrf_name=None):
         substrs = sub_port_intf_name.split(VLAN_SUB_INTERFACE_SEPARATOR)
         parent_port = substrs[0]


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**Why I did it**

Sub port interface inherits mtu from parent port. This should hold for both kernel and SAI/ASIC.

At kernel side, decreasing parent port mtu, sub port interface mtu will decrease accordingly. However, this is not true in the reverse direction: Increasing parent port mtu, sub port interface mtu will not increase automatically. Treatment from user software, specifically, intfmgrd, is therefore needed to fill the gap for mtu inheritance from parent port.

The SAI/ASIC side mtu of sub port interface is not affected by this PR.

**What I did**
Have IntfMgr subscribe to CONFIG PORT and LAG table to listen to parent port mtu change, and set the corresponding mtu value to sub port interface in kernel.

Because the operation of parent port mtu change is issued from `portmgrd` or `teammgrd`, which is a separate process from intfmgrd, sub port interface mtu increase may occur before its parent port mtu increase is processed by the corresponding process. In such a case, `ip link` command will fail (as sub port interface mtu cannot be larger than that of its parent), and we leverage `doTask` retry logic to ensure that the sub port interface mtu increase will succeed ultimately.

**How I verified it**
vs test

**Details if related**

Contains https://github.com/Azure/sonic-swss/pull/1873, which lays the common foundation.