### PR TITLE
[MACsec]: Add MACsec cipher suite option

### DIFF
--- a/cfgmgr/macsecmgr.h
+++ b/cfgmgr/macsecmgr.h
@@ -17,6 +17,13 @@ namespace swss {
 class MACsecMgr : public Orch
 {
 public:
+    enum MACSEC_CIPHER_SUITE
+    {
+        GCM_AES_128,
+        GCM_AES_256,
+        GCM_AES_XPN_128,
+        GCM_AES_XPN_256,
+    };
     using Orch::doTask;
     MACsecMgr(DBConnector *cfgDb, DBConnector *stateDb, const std::vector<std::string> &tableNames);
     ~MACsecMgr();
@@ -28,7 +35,7 @@ public:
     struct MACsecProfile
     {
         std::uint32_t       priority;
-        std::string         cipher_suite;
+        MACSEC_CIPHER_SUITE cipher_suite;
         std::string         primary_cak;
         std::string         primary_ckn;
         std::string         fallback_cak;


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add MACsec cipher suite option to support 256 bits and XPN cipher

**Why I did it**
The MACsec for SONiC needs to support 256 bits cipher and XPN feature

**How I verified it**
To set the cipher suite like GCM-AES-256 in config db and look at the app db whether the MACsec cipher of the target port is GCM-AES-256.

**Details if related**
