### PR TITLE
[dpb] Remove wait and validate LAG removal from end of test_port_dpb_lag test case

### DIFF
--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -63,6 +63,8 @@ class Port():
         return self._speed
     
     def get_admin_status(self):
+        if self._admin_status is None:
+            return "up"
         return self._admin_status
 
     def get_alias(self):

--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -34,7 +34,7 @@ class Port():
 
     def set_speed(self, speed):
         self._speed = speed
-        
+
     def set_alias(self, alias):
         self._alias = alias
 
@@ -149,7 +149,6 @@ class Port():
         index_str = str(self.get_index())
         alias_str = self.get_alias()
         speed_str = str(self.get_speed())
-        admin_status = self.get_admin_status()
         fvs = swsscommon.FieldValuePairs([("alias", alias_str),
                                           ("lanes", lanes_str),
                                           ("speed", speed_str),

--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -150,7 +150,8 @@ class Port():
         fvs_dict = self.get_fvs_dict(fvs)
         self.set_alias(fvs_dict['alias'])
         self.set_speed(int(fvs_dict['speed']))
-        self.set_admin_status(fvs_dict['admin_status'])
+        if 'admin_status' in fvs_dict:
+            self.set_admin_status(fvs_dict['admin_status'])
         self.set_lanes(list(fvs_dict['lanes'].split(",")))
         self.set_index(int(fvs_dict['index']))
 

--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -13,7 +13,6 @@ class Port():
             self._port_num = int(re.compile(r'(\d+)$').search(self._name).group(1))
         self._alias = None
         self._speed = None
-        self._admin_status = None
         self._lanes = []
         self._index = None
         self._lanes_db_str = None
@@ -36,9 +35,6 @@ class Port():
     def set_speed(self, speed):
         self._speed = speed
         
-    def set_admin_status(self, admin_status):
-        self._admin_status = admin_status
-
     def set_alias(self, alias):
         self._alias = alias
 
@@ -61,11 +57,6 @@ class Port():
 
     def get_speed(self):
         return self._speed
-    
-    def get_admin_status(self):
-        if self._admin_status is None:
-            return "down"
-        return self._admin_status
 
     def get_alias(self):
         return self._alias
@@ -150,8 +141,6 @@ class Port():
         fvs_dict = self.get_fvs_dict(fvs)
         self.set_alias(fvs_dict['alias'])
         self.set_speed(int(fvs_dict['speed']))
-        if 'admin_status' in fvs_dict:
-            self.set_admin_status(fvs_dict['admin_status'])
         self.set_lanes(list(fvs_dict['lanes'].split(",")))
         self.set_index(int(fvs_dict['index']))
 
@@ -164,7 +153,6 @@ class Port():
         fvs = swsscommon.FieldValuePairs([("alias", alias_str),
                                           ("lanes", lanes_str),
                                           ("speed", speed_str),
-                                          ("admin_status", admin_status),
                                           ("index", index_str)])
         self._cfg_db_ptbl.set(self.get_name(), fvs)
         time.sleep(2)

--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -13,6 +13,7 @@ class Port():
             self._port_num = int(re.compile(r'(\d+)$').search(self._name).group(1))
         self._alias = None
         self._speed = None
+        self._admin_status = None
         self._lanes = []
         self._index = None
         self._lanes_db_str = None
@@ -34,6 +35,9 @@ class Port():
 
     def set_speed(self, speed):
         self._speed = speed
+        
+    def set_admin_status(self, admin_status):
+        self._admin_status = admin_status
 
     def set_alias(self, alias):
         self._alias = alias
@@ -57,6 +61,9 @@ class Port():
 
     def get_speed(self):
         return self._speed
+    
+    def get_admin_status(self):
+        return self._admin_status
 
     def get_alias(self):
         return self._alias
@@ -141,6 +148,7 @@ class Port():
         fvs_dict = self.get_fvs_dict(fvs)
         self.set_alias(fvs_dict['alias'])
         self.set_speed(int(fvs_dict['speed']))
+        self.set_admin_status(fvs_dict['admin_status'])
         self.set_lanes(list(fvs_dict['lanes'].split(",")))
         self.set_index(int(fvs_dict['index']))
 
@@ -149,9 +157,11 @@ class Port():
         index_str = str(self.get_index())
         alias_str = self.get_alias()
         speed_str = str(self.get_speed())
+        admin_status = self.get_admin_status()
         fvs = swsscommon.FieldValuePairs([("alias", alias_str),
                                           ("lanes", lanes_str),
                                           ("speed", speed_str),
+                                          ("admin_status", admin_status),
                                           ("index", index_str)])
         self._cfg_db_ptbl.set(self.get_name(), fvs)
         time.sleep(2)

--- a/tests/port_dpb.py
+++ b/tests/port_dpb.py
@@ -64,7 +64,7 @@ class Port():
     
     def get_admin_status(self):
         if self._admin_status is None:
-            return "up"
+            return "down"
         return self._admin_status
 
     def get_alias(self):

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -40,8 +40,8 @@ class TestPortDPBLag(object):
         self.dvs_lag.remove_port_channel_member(lag, p.get_name())
 
         # 8. Verify that port is removed from ASIC DB
-        assert(p.not_exists_in_asic_db() == True) 
-        
+        assert(p.not_exists_in_asic_db() == True)
+
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
         p.write_to_config_db()

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -11,6 +11,7 @@ class TestPortDPBLag(object):
         assert num.strip() >= str(expected_cnt)
 
     def test_dependency(self, dvs):
+        dvs.setup_db()
         lag = "0001"
         p = Port(dvs, "Ethernet0")
         p.sync_from_config_db()

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -20,7 +20,8 @@ class TestPortDPBLag(object):
 
         # 2. Add Ethernet0 to PortChannel0001.
         self.dvs_lag.create_port_channel_member(lag, p.get_name())
-        time.sleep(2)
+        dvs.set_interface_status("PortChannel0001", "up")
+        dvs.set_interface_status("Ethernet0", "up")
 
         # 3. Add log marker to syslog
         marker = dvs.add_log_marker()

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -10,7 +10,6 @@ class TestPortDPBLag(object):
         (exitcode, num) = dvs.runcmd(['sh', '-c', "awk \'/%s/,ENDFILE {print;}\' /var/log/syslog | grep \"%s\" | wc -l" % (marker, log)])
         assert num.strip() >= str(expected_cnt)
 
-    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_dependency(self, dvs):
         lag = "0001"
         p = Port(dvs, "Ethernet0")

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -45,7 +45,9 @@ class TestPortDPBLag(object):
         # 9. Re-create port Ethernet0 and verify that it is
         #    present in CONFIG, APPL, and ASIC DBs
         p.write_to_config_db()
-        time.sleep(2)
+        p.verify_config_db()
+        p.verify_app_db()
+        p.verify_asic_db()
 
         # 10. Remove PortChannel0001 and verify that its removed.
         self.dvs_lag.remove_port_channel(lag)        

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -40,17 +40,7 @@ class TestPortDPBLag(object):
         self.dvs_lag.remove_port_channel_member(lag, p.get_name())
 
         # 8. Verify that port is removed from ASIC DB
-        assert(p.not_exists_in_asic_db() == True)
-
-        # 9. Re-create port Ethernet0 and verify that it is
-        #    present in CONFIG, APPL, and ASIC DBs
-        p.write_to_config_db()
-        p.verify_config_db()
-        p.verify_app_db()
-        p.verify_asic_db()
-
-        # 10. Remove PortChannel0001
-        self.dvs_lag.remove_port_channel(lag)        
+        assert(p.not_exists_in_asic_db() == True) 
 
 
 # Add Dummy always-pass test at end as workaroud

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -50,10 +50,8 @@ class TestPortDPBLag(object):
         p.verify_app_db()
         p.verify_asic_db()
 
-        # 10. Remove PortChannel0001 and verify that its removed.
+        # 10. Remove PortChannel0001
         self.dvs_lag.remove_port_channel(lag)        
-        time.sleep(30)
-        self.dvs_lag.get_and_verify_port_channel(0)
 
 
 # Add Dummy always-pass test at end as workaroud

--- a/tests/test_port_dpb_lag.py
+++ b/tests/test_port_dpb_lag.py
@@ -41,6 +41,15 @@ class TestPortDPBLag(object):
 
         # 8. Verify that port is removed from ASIC DB
         assert(p.not_exists_in_asic_db() == True) 
+        
+        # 9. Re-create port Ethernet0 and verify that it is
+        #    present in CONFIG, APPL, and ASIC DBs
+        p.write_to_config_db()
+        time.sleep(2)
+
+        # 10. Remove PortChannel0001 and verify that its removed.
+        self.dvs_lag.remove_port_channel(lag)        
+        self.dvs_lag.get_and_verify_port_channel(0) 
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
**What I did**

Removed lines of code that wait for and verify removal of lag following the `test_port_dpb_lag` test case which verified that a port will not be removed if there is a lag referencing it. 

**Why I did it**

On Azure CI there seems to be a non-determinate period of time it takes for the LAG to be removed. This is not experienced locally when running this test in isolation. 

**How I verified it**

Run on CI and verify test passes. 
