### PR TITLE
[202012] Backport SAI failure handling to 202012 branch

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -2,6 +2,7 @@ INCLUDES = -I$(top_srcdir)/lib -I $(top_srcdir) -I $(top_srcdir)/orchagent -I $(
 CFLAGS_SAI = -I /usr/include/sai
 LIBNL_CFLAGS = -I/usr/include/libnl3
 LIBNL_LIBS = -lnl-genl-3 -lnl-route-3 -lnl-3
+SAIMETA_LIBS = -lsaimeta -lsaimetadata
 
 bin_PROGRAMS = vlanmgrd teammgrd portmgrd intfmgrd buffermgrd vrfmgrd nbrmgrd vxlanmgrd sflowmgrd natmgrd coppmgrd tunnelmgrd
 
@@ -24,60 +25,60 @@ endif
 vlanmgrd_SOURCES = vlanmgrd.cpp vlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vlanmgrd_LDADD = -lswsscommon
+vlanmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 teammgrd_SOURCES = teammgrd.cpp teammgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-teammgrd_LDADD = -lswsscommon
+teammgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 portmgrd_SOURCES = portmgrd.cpp portmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 portmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 portmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-portmgrd_LDADD = -lswsscommon
+portmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 intfmgrd_SOURCES = intfmgrd.cpp intfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-intfmgrd_LDADD = -lswsscommon
+intfmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 buffermgrd_SOURCES = buffermgrd.cpp buffermgr.cpp buffermgrdyn.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 buffermgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 buffermgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-buffermgrd_LDADD = -lswsscommon
+buffermgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 vrfmgrd_SOURCES = vrfmgrd.cpp vrfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vrfmgrd_LDADD = -lswsscommon
+vrfmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 nbrmgrd_SOURCES = nbrmgrd.cpp nbrmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CFLAGS)
 nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CPPFLAGS)
-nbrmgrd_LDADD = -lswsscommon $(LIBNL_LIBS)
+nbrmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS) $(LIBNL_LIBS)
 
 vxlanmgrd_SOURCES = vxlanmgrd.cpp vxlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vxlanmgrd_LDADD = -lswsscommon
+vxlanmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 sflowmgrd_SOURCES = sflowmgrd.cpp sflowmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 sflowmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 sflowmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-sflowmgrd_LDADD = -lswsscommon
+sflowmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 natmgrd_SOURCES = natmgrd.cpp natmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 natmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 natmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-natmgrd_LDADD = -lswsscommon
+natmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 coppmgrd_SOURCES = coppmgrd.cpp coppmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 coppmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 coppmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-coppmgrd_LDADD = -lswsscommon
+coppmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 
 tunnelmgrd_SOURCES = tunnelmgrd.cpp tunnelmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp shellcmd.h
 tunnelmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
 tunnelmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-tunnelmgrd_LDADD = -lswsscommon
+tunnelmgrd_LDADD = -lswsscommon $(SAIMETA_LIBS)
 

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3626,7 +3626,10 @@ sai_status_t AclOrch::createDTelWatchListTables()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create table %s", flowWLTable.description.c_str());
-        return status;
+        if (handleSaiCreateStatus(SAI_API_ACL, status) != task_success)
+        {
+            return status;
+        }
     }
 
     gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, SAI_ACL_STAGE_INGRESS, SAI_ACL_BIND_POINT_TYPE_SWITCH);
@@ -3687,14 +3690,17 @@ sai_status_t AclOrch::createDTelWatchListTables()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create table %s", dropWLTable.description.c_str());
-        return status;
+        if (handleSaiCreateStatus(SAI_API_ACL, status) != task_success)
+        {
+            return status;
+        }
     }
 
     gCrmOrch->incCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, SAI_ACL_STAGE_INGRESS, SAI_ACL_BIND_POINT_TYPE_SWITCH);
     m_AclTables[table_oid] = dropWLTable;
     SWSS_LOG_INFO("Successfully created ACL table %s, oid: %" PRIx64, dropWLTable.description.c_str(), table_oid);
 
-    return status;
+    return SAI_STATUS_SUCCESS;
 }
 
 sai_status_t AclOrch::deleteDTelWatchListTables()
@@ -3719,7 +3725,10 @@ sai_status_t AclOrch::deleteDTelWatchListTables()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to delete table %s", table_id.c_str());
-        return status;
+        if (handleSaiRemoveStatus(SAI_API_ACL, status) != task_success)
+        {
+            return status;
+        }
     }
 
     gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, SAI_ACL_STAGE_INGRESS, SAI_ACL_BIND_POINT_TYPE_SWITCH, table_oid);
@@ -3739,7 +3748,10 @@ sai_status_t AclOrch::deleteDTelWatchListTables()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to delete table %s", table_id.c_str());
-        return status;
+        if (handleSaiRemoveStatus(SAI_API_ACL, status) != task_success)
+        {
+            return status;
+        }
     }
 
     gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_TABLE, SAI_ACL_STAGE_INGRESS, SAI_ACL_BIND_POINT_TYPE_SWITCH, table_oid);

--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2311,7 +2311,11 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     else
     {
         SWSS_LOG_ERROR("Failed to get ACL entry priority min/max values, rv:%d", status);
-        throw "AclOrch initialization failure";
+        task_process_status handle_status = handleSaiGetStatus(SAI_API_SWITCH, status);
+        if (handle_status != task_process_status::task_success)
+        {
+            throw "AclOrch initialization failure";
+        }
     }
 
     queryAclActionCapability();

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -448,14 +448,17 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
             return task_process_status::task_need_retry;
         }
 
-        sai_status = sai_buffer_api->remove_buffer_pool(sai_object);
-        if (SAI_STATUS_SUCCESS != sai_status)
+        if (SAI_NULL_OBJECT_ID != sai_object)
         {
-            SWSS_LOG_ERROR("Failed to remove buffer pool %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
-            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
-            if (handle_status != task_process_status::task_success)
+            sai_status = sai_buffer_api->remove_buffer_pool(sai_object);
+            if (SAI_STATUS_SUCCESS != sai_status)
             {
-                return handle_status;
+                SWSS_LOG_ERROR("Failed to remove buffer pool %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
         }
         SWSS_LOG_NOTICE("Removed buffer pool %s with type %s", object_name.c_str(), map_type_name.c_str());
@@ -647,14 +650,17 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
             return task_process_status::task_need_retry;
         }
 
-        sai_status = sai_buffer_api->remove_buffer_profile(sai_object);
-        if (SAI_STATUS_SUCCESS != sai_status)
+        if (SAI_NULL_OBJECT_ID != sai_object)
         {
-            SWSS_LOG_ERROR("Failed to remove buffer profile %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
-            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
-            if (handle_status != task_process_status::task_success)
+            sai_status = sai_buffer_api->remove_buffer_profile(sai_object);
+            if (SAI_STATUS_SUCCESS != sai_status)
             {
-                return handle_status;
+                SWSS_LOG_ERROR("Failed to remove buffer profile %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
         }
 

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -407,7 +407,11 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
                 else if (SAI_STATUS_SUCCESS != sai_status)
                 {
                     SWSS_LOG_ERROR("Failed to modify buffer pool, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
-                    return task_process_status::task_failed;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_BUFFER, sai_status);
+                    if (handle_status != task_process_status::task_success)
+                    {
+                        return handle_status;
+                    }
                 }
             }
             SWSS_LOG_DEBUG("Modified existing pool:%" PRIx64 ", type:%s name:%s ", sai_object, map_type_name.c_str(), object_name.c_str());
@@ -418,7 +422,11 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
             if (SAI_STATUS_SUCCESS != sai_status)
             {
                 SWSS_LOG_ERROR("Failed to create buffer pool %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
-                return task_process_status::task_failed;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_BUFFER, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
             (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId = sai_object;
             SWSS_LOG_NOTICE("Created buffer pool %s with type %s", object_name.c_str(), map_type_name.c_str());
@@ -444,7 +452,11 @@ task_process_status BufferOrch::processBufferPool(KeyOpFieldsValuesTuple &tuple)
         if (SAI_STATUS_SUCCESS != sai_status)
         {
             SWSS_LOG_ERROR("Failed to remove buffer pool %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
-            return task_process_status::task_failed;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
+            if (handle_status != task_process_status::task_success)
+            {
+                return handle_status;
+            }
         }
         SWSS_LOG_NOTICE("Removed buffer pool %s with type %s", object_name.c_str(), map_type_name.c_str());
         auto it_to_delete = (m_buffer_type_maps[map_type_name])->find(object_name);
@@ -598,7 +610,11 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
                 else if (SAI_STATUS_SUCCESS != sai_status)
                 {
                     SWSS_LOG_ERROR("Failed to modify buffer profile, name:%s, sai object:%" PRIx64 ", status:%d", object_name.c_str(), sai_object, sai_status);
-                    return task_process_status::task_failed;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_BUFFER, sai_status);
+                    if (handle_status != task_process_status::task_success)
+                    {
+                        return handle_status;
+                    }
                 }
             }
         }
@@ -608,7 +624,11 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
             if (SAI_STATUS_SUCCESS != sai_status)
             {
                 SWSS_LOG_ERROR("Failed to create buffer profile %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
-                return task_process_status::task_failed;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_BUFFER, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
             (*(m_buffer_type_maps[map_type_name]))[object_name].m_saiObjectId = sai_object;
             SWSS_LOG_NOTICE("Created buffer profile %s with type %s", object_name.c_str(), map_type_name.c_str());
@@ -631,7 +651,11 @@ task_process_status BufferOrch::processBufferProfile(KeyOpFieldsValuesTuple &tup
         if (SAI_STATUS_SUCCESS != sai_status)
         {
             SWSS_LOG_ERROR("Failed to remove buffer profile %s with type %s, rv:%d", object_name.c_str(), map_type_name.c_str(), sai_status);
-            return task_process_status::task_failed;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BUFFER, sai_status);
+            if (handle_status != task_process_status::task_success)
+            {
+                return handle_status;
+            }
         }
 
         SWSS_LOG_NOTICE("Remove buffer profile %s with type %s", object_name.c_str(), map_type_name.c_str());
@@ -734,7 +758,11 @@ task_process_status BufferOrch::processQueue(KeyOpFieldsValuesTuple &tuple)
             if (sai_status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to set queue's buffer profile attribute, status:%d", sai_status);
-                return task_process_status::task_failed;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_QUEUE, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
         }
     }
@@ -857,7 +885,11 @@ task_process_status BufferOrch::processPriorityGroup(KeyOpFieldsValuesTuple &tup
                 if (sai_status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("Failed to set port:%s pg:%zd buffer profile attribute, status:%d", port_name.c_str(), ind, sai_status);
-                    return task_process_status::task_failed;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_BUFFER, sai_status);
+                    if (handle_status != task_process_status::task_success)
+                    {
+                        return handle_status;
+                    }
                 }
             }
         }
@@ -936,7 +968,11 @@ task_process_status BufferOrch::processIngressBufferProfileList(KeyOpFieldsValue
         if (sai_status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set ingress buffer profile list on port, status:%d, key:%s", sai_status, port_name.c_str());
-            return task_process_status::task_failed;
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, sai_status);
+            if (handle_status != task_process_status::task_success)
+            {
+                return handle_status;
+            }
         }
     }
 
@@ -986,7 +1022,11 @@ task_process_status BufferOrch::processEgressBufferProfileList(KeyOpFieldsValues
         if (sai_status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set egress buffer profile list on port, status:%d, key:%s", sai_status, port_name.c_str());
-            return task_process_status::task_failed;
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, sai_status);
+            if (handle_status != task_process_status::task_success)
+            {
+                return handle_status;
+            }
         }
     }
 

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -179,7 +179,11 @@ void CoppOrch::initDefaultTrapGroup()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to get default trap group, rv:%d", status);
-        throw "CoppOrch initialization failure";
+        task_process_status handle_status = handleSaiGetStatus(SAI_API_SWITCH, status);
+        if (handle_status != task_process_status::task_success)
+        {
+            throw "CoppOrch initialization failure";
+        }
     }
 
     SWSS_LOG_INFO("Get default trap group");

--- a/orchagent/copporch.cpp
+++ b/orchagent/copporch.cpp
@@ -125,7 +125,10 @@ void CoppOrch::initDefaultHostIntfTable()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create default host interface table, rv:%d", status);
-        throw "CoppOrch initialization failure";
+        if (handleSaiCreateStatus(SAI_API_HOSTIF, status) != task_success)
+        {
+            throw "CoppOrch initialization failure";
+        }
     }
 
     SWSS_LOG_NOTICE("Create default host interface table");
@@ -243,7 +246,11 @@ bool CoppOrch::createGenetlinkHostIfTable(vector<sai_hostif_trap_type_t> &trap_i
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("Failed to create hostif table entry failed, rv %d", status);
-                    return false;
+                    task_process_status handle_status = handleSaiCreateStatus(SAI_API_HOSTIF, status);
+                    if (handle_status != task_success)
+                    {
+                        return parseHandleSaiStatusFailure(handle_status);
+                    }
                 }
                 m_trapid_hostif_table_map[trap_id] = hostif_table_entry;
             }
@@ -266,7 +273,11 @@ bool CoppOrch::removeGenetlinkHostIfTable(vector<sai_hostif_trap_type_t> &trap_i
             {
                 SWSS_LOG_ERROR("Failed to delete hostif table entry %" PRId64 " \
                                rc=%d", m_trapid_hostif_table_map[trap_id], sai_status);
-                return false;
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_HOSTIF, sai_status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
             m_trapid_hostif_table_map.erase(trap_id);
         }
@@ -294,7 +305,11 @@ bool CoppOrch::applyAttributesToTrapIds(sai_object_id_t trap_group_id,
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create trap %d, rv:%d", trap_id, status);
-            return false;
+            task_process_status handle_status = handleSaiCreateStatus(SAI_API_HOSTIF, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         m_syncdTrapIds[trap_id].trap_group_obj = trap_group_id;
         m_syncdTrapIds[trap_id].trap_obj = hostif_trap_id;
@@ -323,14 +338,22 @@ bool CoppOrch::removePolicer(string trap_group_name)
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set policer to NULL for trap group %s, rc=%d", trap_group_name.c_str(), sai_status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_HOSTIF, sai_status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     sai_status = sai_policer_api->remove_policer(policer_id);
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove policer for trap group %s, rc=%d", trap_group_name.c_str(), sai_status);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_POLICER, sai_status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Remove policer for trap group %s", trap_group_name.c_str());
@@ -367,7 +390,11 @@ bool CoppOrch::createPolicer(string trap_group_name, vector<sai_attribute_t> &po
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create policer trap group %s, rc=%d", trap_group_name.c_str(), sai_status);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_POLICER, sai_status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Create policer for trap group %s", trap_group_name.c_str());
@@ -380,7 +407,11 @@ bool CoppOrch::createPolicer(string trap_group_name, vector<sai_attribute_t> &po
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to bind policer to trap group %s, rc=%d", trap_group_name.c_str(), sai_status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_HOSTIF, sai_status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Bind policer to trap group %s:", trap_group_name.c_str());
@@ -402,7 +433,11 @@ bool CoppOrch::createGenetlinkHostIf(string trap_group_name, vector<sai_attribut
     {
         SWSS_LOG_ERROR("Failed to create genetlink hostif for trap group %s, rc=%d",
                        trap_group_name.c_str(), sai_status);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_HOSTIF, sai_status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     m_trap_group_hostif_map[m_trap_group_map[trap_group_name]] = hostif_id;
@@ -430,7 +465,11 @@ bool CoppOrch::removeGenetlinkHostIf(string trap_group_name)
         {
             SWSS_LOG_ERROR("Failed to delete host info %" PRId64 " on trap group %s. rc=%d",
                            hostInfo->second, trap_group_name.c_str(), sai_status);
-            return false;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_HOSTIF, sai_status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         m_trap_group_hostif_map.erase(m_trap_group_map[trap_group_name]);
     }
@@ -489,7 +528,11 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
                 if (sai_status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("Failed to apply attribute:%d to trap group:%" PRIx64 ", name:%s, error:%d\n", trap_gr_attr.id, m_trap_group_map[trap_group_name], trap_group_name.c_str(), sai_status);
-                    return task_process_status::task_failed;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_HOSTIF, sai_status);
+                    if (handle_status != task_process_status::task_success)
+                    {
+                        return handle_status;
+                    }
                 }
                 SWSS_LOG_NOTICE("Set trap group %s to host interface", trap_group_name.c_str());
             }
@@ -503,7 +546,11 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
             if (sai_status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to create host interface trap group %s, rc=%d", trap_group_name.c_str(), sai_status);
-                return task_process_status::task_failed;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_HOSTIF, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
 
             SWSS_LOG_NOTICE("Create host interface trap group %s", trap_group_name.c_str());
@@ -534,7 +581,11 @@ task_process_status CoppOrch::processCoppRule(Consumer& consumer)
                         SWSS_LOG_ERROR("Failed to set attribute %d on trap %" PRIx64 ""
                                 " on group %s", i.id, m_syncdTrapIds[trap_id].trap_obj, 
                                 trap_group_name.c_str());
-                        return task_process_status::task_failed;
+                        task_process_status handle_status = handleSaiSetStatus(SAI_API_HOSTIF, sai_status);
+                        if (handle_status != task_process_status::task_success)
+                        {
+                            return handle_status;
+                        }
                     }
                 }
             }
@@ -724,7 +775,11 @@ bool CoppOrch::trapGroupProcessTrapIdChange (string trap_group_name,
                 {
                     SWSS_LOG_ERROR("Failed to remove trap object %" PRId64 "",
                             m_syncdTrapIds[i].trap_obj);
-                    return false;
+                    task_process_status handle_status = handleSaiRemoveStatus(SAI_API_HOSTIF, sai_status);
+                    if (handle_status != task_success)
+                    {
+                        return parseHandleSaiStatusFailure(handle_status);
+                    }
                 }
             }
         }
@@ -773,7 +828,11 @@ bool CoppOrch::trapGroupProcessTrapIdChange (string trap_group_name,
                     {
                         SWSS_LOG_ERROR("Failed to remove trap object %" PRId64 "", 
                                        m_syncdTrapIds[i].trap_obj);
-                        return false;
+                        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_HOSTIF, sai_status);
+                        if (handle_status != task_success)
+                        {
+                            return parseHandleSaiStatusFailure(handle_status);
+                        }
                     }
                     m_syncdTrapIds.erase(i);
                 }
@@ -819,7 +878,11 @@ bool CoppOrch::processTrapGroupDel (string trap_group_name)
             if (sai_status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to remove trap object %" PRId64 "", it.second.trap_obj);
-                return false;
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_HOSTIF, sai_status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
     }
@@ -834,7 +897,11 @@ bool CoppOrch::processTrapGroupDel (string trap_group_name)
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove trap group %s", trap_group_name.c_str());
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_HOSTIF, sai_status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     m_trap_group_map.erase(it_del);
@@ -1011,7 +1078,11 @@ bool CoppOrch::trapGroupUpdatePolicer (string trap_group_name,
                 SWSS_LOG_ERROR("Failed to apply attribute[%d].id=%d to policer for trap group:"
                                "%s, error:%d\n",ind, policer_attr.id, trap_group_name.c_str(),
                                sai_status);
-                return false;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_POLICER, sai_status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
     }

--- a/orchagent/crmorch.cpp
+++ b/orchagent/crmorch.cpp
@@ -474,7 +474,11 @@ void CrmOrch::getResAvailableCounters()
                         break;
                     }
                     SWSS_LOG_ERROR("Failed to get switch attribute %u , rv:%d", attr.id, status);
-                    break;
+                    task_process_status handle_status = handleSaiGetStatus(SAI_API_SWITCH, status);
+                    if (handle_status != task_process_status::task_success)
+                    {
+                        break;
+                    }
                 }
 
                 res.second.countersMap[CRM_COUNTERS_TABLE_KEY].availableCounter = attr.value.u32;
@@ -500,7 +504,11 @@ void CrmOrch::getResAvailableCounters()
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("Failed to get switch attribute %u , rv:%d", attr.id, status);
-                    break;
+                    task_process_status handle_status = handleSaiGetStatus(SAI_API_SWITCH, status);
+                    if (handle_status != task_process_status::task_success)
+                    {
+                        break;
+                    }
                 }
 
                 for (uint32_t i = 0; i < attr.value.aclresource.count; i++)

--- a/orchagent/dtelorch.cpp
+++ b/orchagent/dtelorch.cpp
@@ -35,7 +35,10 @@ DTelOrch::DTelOrch(DBConnector *db, vector<string> tableNames, PortsOrch *portOr
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("DTEL ERROR: Error creating DTel id");
-        return;
+        if (handleSaiCreateStatus(SAI_API_DTEL, status) != task_success)
+        {
+            return;
+        }
     }
 
     attr.id = SAI_DTEL_ATTR_INT_L4_DSCP;
@@ -48,7 +51,10 @@ DTelOrch::DTelOrch(DBConnector *db, vector<string> tableNames, PortsOrch *portOr
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("DTEL ERROR: Failed to set default INT L4 DSCP value/mask");
-        return;
+        if (handleSaiSetStatus(SAI_API_DTEL, status) != task_success)
+        {
+            return;
+        }
     }
 }
 
@@ -58,7 +64,10 @@ DTelOrch::~DTelOrch()
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("DTEL ERROR: Error deleting DTel id");
-        return;
+        if (handleSaiRemoveStatus(SAI_API_DTEL, status) != task_success)
+        {
+            return;
+        }
     }
 }
 
@@ -411,7 +420,10 @@ void DTelOrch::update(SubjectType type, void *cntx)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("DTEL ERROR: Failed to update sink port list on port add");
-                return;
+                if (handleSaiSetStatus(SAI_API_DTEL, status) != task_success)
+                {
+                    return;
+                }
             }
         }
     } else {
@@ -421,7 +433,10 @@ void DTelOrch::update(SubjectType type, void *cntx)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("DTEL ERROR: Failed to update sink port list on port remove");
-                return;
+                if (handleSaiSetStatus(SAI_API_DTEL, status) != task_success)
+                {
+                    return;
+                }
             }
         }
     }
@@ -506,7 +521,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to enable INT endpoint mode");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == INT_TRANSIT)
@@ -519,7 +546,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to enable INT transit mode");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == POSTCARD)
@@ -532,7 +571,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to enable DTel postcard");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == DROP_REPORT)
@@ -545,7 +596,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to enable drop report");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == QUEUE_REPORT)
@@ -558,7 +621,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to enable queue report");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == SWITCH_ID)
@@ -571,7 +646,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to set switch id");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == FLOW_STATE_CLEAR_CYCLE)
@@ -584,7 +671,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to set Dtel flow state clear cycle");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == LATENCY_SENSITIVITY)
@@ -597,7 +696,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to set Dtel latency sensitivity");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == SINK_PORT_LIST)
@@ -630,7 +741,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 status = updateSinkPortList();
                 if (status != SAI_STATUS_SUCCESS)
                 {
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == INT_L4_DSCP)
@@ -668,7 +791,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to set INT L4 DSCP value/mask");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
 
@@ -683,7 +818,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to disable INT endpoint mode");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == INT_TRANSIT)
@@ -694,7 +841,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to disable INT transit mode");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == POSTCARD)
@@ -705,7 +864,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to disable postcard mode");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == DROP_REPORT)
@@ -716,7 +887,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to disable drop report");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == QUEUE_REPORT)
@@ -727,7 +910,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to disable queue report");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == SWITCH_ID)
@@ -740,7 +935,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to reset switch id");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == FLOW_STATE_CLEAR_CYCLE)
@@ -753,7 +960,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to reset flow state clear cycle");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == LATENCY_SENSITIVITY)
@@ -766,7 +985,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to reset latency sensitivity");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == SINK_PORT_LIST)
@@ -776,7 +1007,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to reset sink port list");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
             else if (table_attr == INT_L4_DSCP)
@@ -788,7 +1031,19 @@ void DTelOrch::doDtelTableTask(Consumer &consumer)
                 if (status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("DTEL ERROR: Failed to reset INT L4 DSCP value/mask");
-                    goto dtel_table_continue;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_DTEL, status);
+                    if (handle_status != task_success)
+                    {
+                        if (parseHandleSaiStatusFailure(handle_status))
+                        {
+                            goto dtel_table_continue;
+                        }
+                        else
+                        {
+                            it++;
+                            continue;
+                        }
+                    }
                 }
             }
         }
@@ -819,7 +1074,11 @@ bool DTelOrch::deleteReportSession(const string &report_session_id)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("DTEL ERROR: Failed to delete report session %s", report_session_id.c_str());
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_DTEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     m_dTelReportSessionTable.erase(report_session_id);
@@ -917,7 +1176,19 @@ void DTelOrch::doDtelReportSessionTableTask(Consumer &consumer)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("DTEL ERROR: Failed to set INT EP report session %s", report_session_id.c_str());
-                goto report_session_table_continue;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_DTEL, status);
+                if (handle_status != task_success)
+                {
+                    if (parseHandleSaiStatusFailure(handle_status))
+                    {
+                        goto report_session_table_continue;
+                    }
+                    else
+                    {
+                        it++;
+                        continue;
+                    }
+                }
             }
 
             DTelReportSessionEntry rs_entry = { };
@@ -969,7 +1240,11 @@ bool DTelOrch::deleteINTSession(const string &int_session_id)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("DTEL ERROR: Failed to delete INT session %s", int_session_id.c_str());
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_DTEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     m_dTelINTSessionTable.erase(int_session_id);
@@ -1055,7 +1330,19 @@ void DTelOrch::doDtelINTSessionTableTask(Consumer &consumer)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("DTEL ERROR: Failed to set INT session %s", int_session_id.c_str());
-                goto int_session_table_continue;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_DTEL, status);
+                if (handle_status != task_success)
+                {
+                    if (parseHandleSaiStatusFailure(handle_status))
+                    {
+                        goto int_session_table_continue;
+                    }
+                    else
+                    {
+                        it++;
+                        continue;
+                    }
+                }
             }
 
             DTelINTSessionEntry is_entry;
@@ -1116,7 +1403,11 @@ bool DTelOrch::disableQueueReport(const string &port, const string &queue)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("DTEL ERROR: Failed to disable queue report for port %s, queue %s", port.c_str(), queue.c_str());
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_DTEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     m_dTelPortTable[port].queueTable[queue].queueReportOid = 0;
@@ -1144,7 +1435,11 @@ sai_status_t DTelOrch::enableQueueReport(const string& port, DTelQueueReportEntr
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("DTEL ERROR: Failed to enable queue report on port %s, queue %d", port.c_str(), qreport.q_ind);
-        return status;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_DTEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     return status;
@@ -1282,7 +1577,11 @@ bool DTelOrch::unConfigureEvent(string &event)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("DTEL ERROR: Failed to remove event %s", event.c_str());
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_DTEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     removeEvent(event);
@@ -1355,7 +1654,18 @@ void DTelOrch::doDtelEventTableTask(Consumer &consumer)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("DTEL ERROR: Failed to create event %s", event.c_str());
-                goto event_table_continue;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_DTEL, status);
+                if (handle_status != task_success)
+                {
+                    if (parseHandleSaiStatusFailure(handle_status))
+                    {
+                        goto event_table_continue;
+                    }
+                    else
+                    {
+                        goto event_table_skip;
+                    }
+                }
             }
 
             addEvent(event, event_oid, report_session_id);

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -503,7 +503,11 @@ bool FdbOrch::getPort(const MacAddress& mac, uint16_t vlan, Port& port)
     {
         SWSS_LOG_ERROR("Failed to get bridge port ID for FDB entry %s, rv:%d",
             mac.to_string().c_str(), status);
-        return false;
+        task_process_status handle_status = handleSaiGetStatus(SAI_API_FDB, status);
+        if (handle_status != task_process_status::task_success)
+        {
+            return false;
+        }
     }
 
     if (!m_portsOrch->getPortByBridgePortId(attr.value.oid, port))

--- a/orchagent/fgnhgorch.cpp
+++ b/orchagent/fgnhgorch.cpp
@@ -241,7 +241,11 @@ bool FgNhgOrch::writeHashBucketChange(FGNextHopGroupEntry *syncd_fg_route_entry,
     {
         SWSS_LOG_ERROR("Failed to set next hop oid %" PRIx64 " member %" PRIx64 ": %d",
             syncd_fg_route_entry->nhopgroup_members[index], nh_oid, status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_NEXT_HOP_GROUP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     setStateDbRouteEntry(ipPrefix, index, nextHop);
@@ -318,7 +322,11 @@ bool FgNhgOrch::removeFineGrainedNextHopGroup(FGNextHopGroupEntry *syncd_fg_rout
         {
             SWSS_LOG_ERROR("Failed to remove next hop group member %" PRIx64 ", rv:%d",
                 nhgm, status);
-            return false;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
     }
@@ -986,7 +994,11 @@ bool FgNhgOrch::setNewNhgMembers(FGNextHopGroupEntry &syncd_fg_route_entry, FgNh
                     SWSS_LOG_ERROR("Failed to clean-up after next-hop member creation failure");
                 }
                 
-                return false;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
 
             setStateDbRouteEntry(ipPrefix, j, bank_nh_memb);

--- a/orchagent/fgnhgorch.cpp
+++ b/orchagent/fgnhgorch.cpp
@@ -294,11 +294,15 @@ bool FgNhgOrch::createFineGrainedNextHopGroup(FGNextHopGroupEntry &syncd_fg_rout
         {
             SWSS_LOG_ERROR("Failed to query next hop group %s SAI_NEXT_HOP_GROUP_ATTR_REAL_SIZE, rv:%d",
                        nextHops.to_string().c_str(), status);
-            if (!removeFineGrainedNextHopGroup(&syncd_fg_route_entry))
+            task_process_status handle_status = handleSaiGetStatus(SAI_API_NEXT_HOP_GROUP, status);
+            if (handle_status != task_process_status::task_success)
             {
-                SWSS_LOG_ERROR("Failed to clean-up after next hop group real_size query failure");
+                if (!removeFineGrainedNextHopGroup(&syncd_fg_route_entry))
+                {
+                    SWSS_LOG_ERROR("Failed to clean-up after next hop group real_size query failure");
+                }
+                return false;
             }
-            return false;
         }
         fgNhgEntry->real_bucket_size = nhg_attr.value.u32;
     }

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -756,7 +756,11 @@ bool MirrorOrch::setUnsetPortMirror(Port port,
                 SWSS_LOG_ERROR("Failed to configure %s session on port %s: %s, status %d, sessionId %x",
                                 ingress ? "RX" : "TX", port.m_alias.c_str(),
                                 p.m_alias.c_str(), status, sessionId);
-                return false;
+                task_process_status handle_status =  handleSaiSetStatus(SAI_API_PORT, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
     }
@@ -767,7 +771,11 @@ bool MirrorOrch::setUnsetPortMirror(Port port,
         {
             SWSS_LOG_ERROR("Failed to configure %s session on port %s, status %d, sessionId %x",
                             ingress ? "RX" : "TX", port.m_alias.c_str(), status, sessionId);
-            return false;
+            task_process_status handle_status =  handleSaiSetStatus(SAI_API_PORT, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
     }
     return true;
@@ -940,7 +948,11 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
         SWSS_LOG_ERROR("Failed to activate mirroring session %s", name.c_str());
         session.status = false;
 
-        return false;
+        task_process_status handle_status =  handleSaiCreateStatus(SAI_API_MIRROR, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     session.status = true;
@@ -991,7 +1003,11 @@ bool MirrorOrch::deactivateSession(const string& name, MirrorEntry& session)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to deactivate mirroring session %s", name.c_str());
-        return false;
+        task_process_status handle_status =  handleSaiRemoveStatus(SAI_API_MIRROR, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     session.status = false;
@@ -1019,7 +1035,11 @@ bool MirrorOrch::updateSessionDstMac(const string& name, MirrorEntry& session)
     {
         SWSS_LOG_ERROR("Failed to update mirror session %s destination MAC to %s, rv:%d",
                 name.c_str(), session.neighborInfo.mac.to_string().c_str(), status);
-        return false;
+        task_process_status handle_status =  handleSaiSetStatus(SAI_API_MIRROR, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Update mirror session %s destination MAC to %s",
@@ -1049,7 +1069,11 @@ bool MirrorOrch::updateSessionDstPort(const string& name, MirrorEntry& session)
     {
         SWSS_LOG_ERROR("Failed to update mirror session %s monitor port to %s, rv:%d",
                 name.c_str(), port.m_alias.c_str(), status);
-        return false;
+        task_process_status handle_status =  handleSaiSetStatus(SAI_API_MIRROR, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Update mirror session %s monitor port to %s",
@@ -1106,7 +1130,11 @@ bool MirrorOrch::updateSessionType(const string& name, MirrorEntry& session)
         {
             SWSS_LOG_ERROR("Failed to update mirror session %s VLAN to %s, rv:%d",
                     name.c_str(), session.neighborInfo.port.m_alias.c_str(), status);
-            return false;
+            task_process_status handle_status =  handleSaiSetStatus(SAI_API_MIRROR, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
     }
 

--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -1370,7 +1370,10 @@ void MirrorOrch::updateLagMember(const LagMemberUpdate& update)
             // If LAG is empty, deactivate session
             if (update.lag.m_members.empty())
             {
-                deactivateSession(name, session);
+                if (session.status)
+                {
+                    deactivateSession(name, session);
+                }
                 session.neighborInfo.portId = SAI_OBJECT_TYPE_NULL;
             }
             // Switch to a new member of the LAG

--- a/orchagent/natorch.cpp
+++ b/orchagent/natorch.cpp
@@ -778,7 +778,11 @@ bool NatOrch::addHwDnatEntry(const IpAddress &ip_address)
         SWSS_LOG_ERROR("Failed to create %s DNAT NAT entry with ip %s and it's translated ip %s",
                        entry.entry_type.c_str(), ip_address.to_string().c_str(), entry.translated_ip.to_string().c_str());
 
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Created %s DNAT NAT entry with ip %s and it's translated ip %s",
@@ -859,7 +863,11 @@ bool NatOrch::addHwDnaptEntry(const NaptEntryKey &key)
         SWSS_LOG_ERROR("Failed to create %s DNAT NAPT entry with ip %s, port %d, prototype %s and it's translated ip %s, translated port %d",
                        entry.entry_type.c_str(), key.ip_address.to_string().c_str(), key.l4_port, key.prototype.c_str(),
                        entry.translated_ip.to_string().c_str(), entry.translated_l4_port);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Created %s DNAT NAPT entry with ip %s, port %d, prototype %s and it's translated ip %s, translated port %d",
@@ -928,7 +936,11 @@ bool NatOrch::removeHwDnatEntry(const IpAddress &dstIp)
         SWSS_LOG_INFO("Failed to remove %s DNAT NAT entry with ip %s and it's translated ip %s",
                       entry.entry_type.c_str(), dstIp.to_string().c_str(), entry.translated_ip.to_string().c_str());
 
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Removed %s DNAT NAT entry with ip %s and it's translated ip %s",
@@ -1014,7 +1026,11 @@ bool NatOrch::removeHwTwiceNatEntry(const TwiceNatEntryKey &key)
         SWSS_LOG_INFO("Failed to remove Twice NAT entry with src-ip %s, dst-ip %s",
                       key.src_ip.to_string().c_str(), key.dst_ip.to_string().c_str());
 
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     SWSS_LOG_NOTICE("Removed Twice NAT entry with src-ip %s, dst-ip %s",
                     key.src_ip.to_string().c_str(), key.dst_ip.to_string().c_str());
@@ -1110,7 +1126,11 @@ bool NatOrch::removeHwDnaptEntry(const NaptEntryKey &key)
                       entry.translated_ip.to_string().c_str(), entry.translated_l4_port);
 
 
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Removed %s DNAT NAPT entry with ip %s, port %d, prototype %s and it's translated ip %s, translated port %d",
@@ -1205,7 +1225,11 @@ bool NatOrch::removeHwTwiceNaptEntry(const TwiceNaptEntryKey &key)
         SWSS_LOG_INFO("Failed to remove Twice NAPT entry with prototype %s, src-ip %s, src port %d, dst-ip %s, dst port %d",
                        key.prototype.c_str(), key.src_ip.to_string().c_str(), key.src_l4_port,
                        key.dst_ip.to_string().c_str(), key.dst_l4_port);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Removed Twice NAPT entry with prototype %s, src-ip %s, src port %d, dst-ip %s, dst port %d",
@@ -1299,7 +1323,11 @@ bool NatOrch::addHwSnatEntry(const IpAddress &ip_address)
         SWSS_LOG_ERROR("Failed to create %s SNAT NAT entry with ip %s and it's translated ip %s",
                        entry.entry_type.c_str(), ip_address.to_string().c_str(), entry.translated_ip.to_string().c_str());
 
-        return true;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Created %s SNAT NAT entry with ip %s and it's translated ip %s",
@@ -1379,7 +1407,11 @@ bool NatOrch::addHwTwiceNatEntry(const TwiceNatEntryKey &key)
                        value.entry_type.c_str(), key.src_ip.to_string().c_str(), key.dst_ip.to_string().c_str(),
                        value.translated_src_ip.to_string().c_str(), value.translated_dst_ip.to_string().c_str());
 
-        return true;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Created %s Twice NAT entry with src ip %s, dst ip %s, translated src ip %s, translated dst ip %s",
@@ -1467,7 +1499,11 @@ bool NatOrch::addHwSnaptEntry(const NaptEntryKey &keyEntry)
                        entry.entry_type.c_str(), keyEntry.ip_address.to_string().c_str(), keyEntry.l4_port, keyEntry.prototype.c_str(),
                        entry.translated_ip.to_string().c_str(), entry.translated_l4_port);
 
-        return true;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
      }
 
      SWSS_LOG_NOTICE("Created %s SNAT NAPT entry with ip %s, port %d, prototype %s and it's translated ip %s, translated port %d",
@@ -1562,7 +1598,11 @@ bool NatOrch::addHwTwiceNaptEntry(const TwiceNaptEntryKey &key)
                        key.dst_l4_port, key.prototype.c_str(), value.translated_src_ip.to_string().c_str(), value.translated_src_l4_port,
                        value.translated_dst_ip.to_string().c_str(), value.translated_dst_l4_port);
 
-        return true;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
      }
 
 
@@ -1796,7 +1836,11 @@ bool NatOrch::addHwDnatPoolEntry(const IpAddress &ip_address)
     {
         SWSS_LOG_ERROR("Failed to create DNAT Pool entry with ip %s", ip_address.to_string().c_str());
 
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Created DNAT Pool entry with ip %s", ip_address.to_string().c_str());
@@ -1826,7 +1870,11 @@ bool NatOrch::removeHwDnatPoolEntry(const IpAddress &dstIp)
     {
         SWSS_LOG_INFO("Failed to remove DNAT Pool entry with ip %s", dstIp.to_string().c_str());
 
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NAT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Removed DNAT Pool entry with ip %s", dstIp.to_string().c_str());
@@ -2542,6 +2590,7 @@ void NatOrch::enableNatFeature(void)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to enable NAT: %d", status);
+        handleSaiSetStatus(SAI_API_SWITCH, status);
     }
 
     SWSS_LOG_INFO("NAT Query timer start ");
@@ -2580,6 +2629,7 @@ void NatOrch::disableNatFeature(void)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to disable NAT: %d", status);
+        handleSaiSetStatus(SAI_API_SWITCH, status);
     }
 
     SWSS_LOG_INFO("NAT Query timer stop ");
@@ -3663,6 +3713,7 @@ bool NatOrch::setNatCounters(const NatEntry::iterator &iter)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to clear packet counter for SNAT entry [src-ip %s]", ipAddr.to_string().c_str());
+            handleSaiSetStatus(SAI_API_NAT, status);
         }
     }
     else if (entry.nat_type == "dnat")
@@ -3670,6 +3721,7 @@ bool NatOrch::setNatCounters(const NatEntry::iterator &iter)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to clear packet counter for DNAT entry [dst-ip %s]", ipAddr.to_string().c_str());
+            handleSaiSetStatus(SAI_API_NAT, status);
         }
     }
 
@@ -3680,6 +3732,7 @@ bool NatOrch::setNatCounters(const NatEntry::iterator &iter)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to clear byte counter for SNAT entry [src-ip %s]", ipAddr.to_string().c_str());
+            handleSaiSetStatus(SAI_API_NAT, status);
         }
     }
     else if (entry.nat_type == "dnat")
@@ -3687,6 +3740,7 @@ bool NatOrch::setNatCounters(const NatEntry::iterator &iter)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to clear byte counter for DNAT entry [dst-ip %s]", ipAddr.to_string().c_str());
+            handleSaiSetStatus(SAI_API_NAT, status);
         }
     }
     /* Update the Counter values in the database */
@@ -3897,6 +3951,7 @@ bool NatOrch::setNaptCounters(const NaptEntry::iterator &iter)
         {
             SWSS_LOG_ERROR("Failed to clear packet counter for SNAPT entry for [proto %s, src-ip %s, src-port %d",
                            naptKey.prototype.c_str(), naptKey.ip_address.to_string().c_str(), naptKey.l4_port);
+            handleSaiSetStatus(SAI_API_NAT, status);
         }
     }
     else if (entry.nat_type == "dnat")
@@ -3905,6 +3960,7 @@ bool NatOrch::setNaptCounters(const NaptEntry::iterator &iter)
         {
             SWSS_LOG_ERROR("Failed to clear packet counter for DNAPT entry for [proto %s, dst-ip %s, dst-port %d]",
                            naptKey.prototype.c_str(), naptKey.ip_address.to_string().c_str(), naptKey.l4_port);
+            handleSaiSetStatus(SAI_API_NAT, status);
         }
     }
 
@@ -3916,6 +3972,7 @@ bool NatOrch::setNaptCounters(const NaptEntry::iterator &iter)
         {
             SWSS_LOG_ERROR("Failed to clear byte counter for SNAPT entry for [proto %s, src-ip %s, src-port %d",
                            naptKey.prototype.c_str(), naptKey.ip_address.to_string().c_str(), naptKey.l4_port);
+            handleSaiSetStatus(SAI_API_NAT, status);
         }
     }
     else if (entry.nat_type == "dnat")
@@ -3924,6 +3981,7 @@ bool NatOrch::setNaptCounters(const NaptEntry::iterator &iter)
         {
             SWSS_LOG_ERROR("Failed to clear byte counter for DNAPT entry for [proto %s, dst-ip %s, dst-port %d]",
                            naptKey.prototype.c_str(), naptKey.ip_address.to_string().c_str(), naptKey.l4_port);
+            handleSaiSetStatus(SAI_API_NAT, status);
         }
     }
 
@@ -3971,6 +4029,7 @@ bool NatOrch::setTwiceNatCounters(const TwiceNatEntry::iterator &iter)
     {
         SWSS_LOG_ERROR("Failed to clear packet counters for Twice NAT entry [src-ip %s, dst-ip %s]",
                         key.src_ip.to_string().c_str(), key.dst_ip.to_string().c_str());
+        handleSaiSetStatus(SAI_API_NAT, status);
     }
 
     status = sai_nat_api->set_nat_entry_attribute(&dbl_nat_entry, &nat_entry_attr_byte);
@@ -3979,6 +4038,7 @@ bool NatOrch::setTwiceNatCounters(const TwiceNatEntry::iterator &iter)
     {
         SWSS_LOG_ERROR("Failed to clear byte counters for Twice NAT entry [src-ip %s, dst-ip %s]",
                         key.src_ip.to_string().c_str(), key.dst_ip.to_string().c_str());
+        handleSaiSetStatus(SAI_API_NAT, status);
     }
 
     /* Update the Counter values in the database */
@@ -4032,6 +4092,7 @@ bool NatOrch::setTwiceNaptCounters(const TwiceNaptEntry::iterator &iter)
     {
         SWSS_LOG_ERROR("Failed to clear packet counters for Twice NAPT entry [src-ip %s, src port %d, dst-ip %s, dst port %d]",
                         key.src_ip.to_string().c_str(), key.src_l4_port, key.dst_ip.to_string().c_str(), key.dst_l4_port);
+        handleSaiSetStatus(SAI_API_NAT, status);
     }
 
     status = sai_nat_api->set_nat_entry_attribute(&dbl_nat_entry, &nat_entry_attr_byte);
@@ -4040,6 +4101,7 @@ bool NatOrch::setTwiceNaptCounters(const TwiceNaptEntry::iterator &iter)
     {
         SWSS_LOG_ERROR("Failed to clear byte counters for Twice NAPT entry [src-ip %s, src port %d, dst-ip %s, dst port %d]",
                         key.src_ip.to_string().c_str(), key.src_l4_port, key.dst_ip.to_string().c_str(), key.dst_l4_port);
+        handleSaiSetStatus(SAI_API_NAT, status);
     }
 
     /* Update the Counter values in the database */

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -199,7 +199,7 @@ bool NeighOrch::addNextHop(const IpAddress &ipAddress, const string &alias)
     {
         SWSS_LOG_ERROR("Failed to create next hop %s on %s, rv:%d",
                        ipAddress.to_string().c_str(), alias.c_str(), status);
-        return false;
+        return handleSaiCreateStatus(SAI_API_NEXT_HOP, status);
     }
 
     SWSS_LOG_NOTICE("Created next hop %s on %s",
@@ -642,7 +642,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-                return false;
+                return handleSaiCreateStatus(SAI_API_NEIGHBOR, status);
             }
         }
         SWSS_LOG_NOTICE("Created neighbor ip %s, %s on %s", ip_address.to_string().c_str(),
@@ -665,7 +665,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                                macAddress.to_string().c_str(), alias.c_str(), status);
-                return false;
+                return handleSaiRemoveStatus(SAI_API_NEIGHBOR, status);
             }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
 
@@ -689,7 +689,7 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
         {
             SWSS_LOG_ERROR("Failed to update neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-            return false;
+            return handleSaiSetStatus(SAI_API_NEIGHBOR, status);
         }
         SWSS_LOG_NOTICE("Updated neighbor %s on %s", macAddress.to_string().c_str(), alias.c_str());
     }
@@ -746,7 +746,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
                                ip_address.to_string().c_str(), alias.c_str(), status);
-                return false;
+                return handleSaiRemoveStatus(SAI_API_NEXT_HOP, status);
             }
         }
 
@@ -778,7 +778,7 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                         m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str(), status);
-                return false;
+                return handleSaiRemoveStatus(SAI_API_NEIGHBOR, status);
             }
         }
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -199,7 +199,11 @@ bool NeighOrch::addNextHop(const IpAddress &ipAddress, const string &alias)
     {
         SWSS_LOG_ERROR("Failed to create next hop %s on %s, rv:%d",
                        ipAddress.to_string().c_str(), alias.c_str(), status);
-        return handleSaiCreateStatus(SAI_API_NEXT_HOP, status);
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEXT_HOP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Created next hop %s on %s",
@@ -642,7 +646,11 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to create neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-                return handleSaiCreateStatus(SAI_API_NEIGHBOR, status);
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEIGHBOR, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
         SWSS_LOG_NOTICE("Created neighbor ip %s, %s on %s", ip_address.to_string().c_str(),
@@ -665,7 +673,11 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                                macAddress.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveStatus(SAI_API_NEIGHBOR, status);
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEIGHBOR, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
             m_intfsOrch->decreaseRouterIntfsRefCount(alias);
 
@@ -689,7 +701,11 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
         {
             SWSS_LOG_ERROR("Failed to update neighbor %s on %s, rv:%d",
                            macAddress.to_string().c_str(), alias.c_str(), status);
-            return handleSaiSetStatus(SAI_API_NEIGHBOR, status);
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_NEIGHBOR, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         SWSS_LOG_NOTICE("Updated neighbor %s on %s", macAddress.to_string().c_str(), alias.c_str());
     }
@@ -746,7 +762,11 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
                                ip_address.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveStatus(SAI_API_NEXT_HOP, status);
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
 
@@ -778,7 +798,11 @@ bool NeighOrch::removeNeighbor(const NeighborEntry &neighborEntry, bool disable)
             {
                 SWSS_LOG_ERROR("Failed to remove neighbor %s on %s, rv:%d",
                         m_syncdNeighbors[neighborEntry].mac.to_string().c_str(), alias.c_str(), status);
-                return handleSaiRemoveStatus(SAI_API_NEIGHBOR, status);
+                task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEIGHBOR, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
 

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -699,15 +699,38 @@ task_process_status Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t stat
      *          in each orch.
      *       3. Take the type of sai api into consideration.
      */
-    switch (status)
+    switch (api)
     {
-        case SAI_STATUS_SUCCESS:
-            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
-            return task_success;
+        case SAI_API_FDB:
+            switch (status)
+            {
+                case SAI_STATUS_SUCCESS:
+                    SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
+                    return task_success;
+                case SAI_STATUS_ITEM_ALREADY_EXISTS:
+                    /*
+                     *  In FDB creation, there are scenarios where the hardware learns an FDB entry before orchagent.
+                     *  In such cases, the FDB SAI creation would report the status of SAI_STATUS_ITEM_ALREADY_EXISTS,
+                     *  and orchagent should ignore the error and treat it as entry was explicitly created.
+                     */
+                    return task_success;
+                default:
+                    SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
+                                sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    exit(EXIT_FAILURE);
+            }
+            break;
         default:
-            SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
-                        sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
-            exit(EXIT_FAILURE);
+            switch (status)
+            {
+                case SAI_STATUS_SUCCESS:
+                    SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
+                    return task_success;
+                default:
+                    SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
+                                sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+                    exit(EXIT_FAILURE);
+            }
     }
     return task_need_retry;
 }

--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -10,6 +10,7 @@
 #include "tokenize.h"
 #include "logger.h"
 #include "consumerstatetable.h"
+#include "sai_serialize.h"
 
 using namespace swss;
 
@@ -683,6 +684,82 @@ Executor *Orch::getExecutor(string executorName)
     }
 
     return NULL;
+}
+
+bool Orch::handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context)
+{
+    /*
+     * This function aims to provide coarse handling of failures in sairedis create
+     * operation (i.e., notify users by throwing excepions when failures happen).
+     * Return value: true - Handled the status successfully. No need to retry this SAI operation.
+     *               false - Cannot handle the status. Need to retry the SAI operation.
+     * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_ITEM_ALREADY_EXISTS)
+     *       2. Develop fine-grain failure handling mechanisms and replace this coarse handling
+     *          in each orch.
+     *       3. Take the type of sai api into consideration.
+     */
+    switch (status)
+    {
+        case SAI_STATUS_SUCCESS:
+            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiCreateStatus");
+            return true;
+        default:
+            SWSS_LOG_ERROR("Encountered failure in create operation, exiting orchagent, SAI API: %s, status: %s",
+                        sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+            exit(EXIT_FAILURE);
+    }
+    return false;
+}
+
+bool Orch::handleSaiSetStatus(sai_api_t api, sai_status_t status, void *context)
+{
+    /*
+     * This function aims to provide coarse handling of failures in sairedis set
+     * operation (i.e., notify users by throwing excepions when failures happen).
+     * Return value: true - Handled the status successfully. No need to retry this SAI operation.
+     *               false - Cannot handle the status. Need to retry the SAI operation.
+     * TODO: 1. Add general handling logic for specific statuses
+     *       2. Develop fine-grain failure handling mechanisms and replace this coarse handling
+     *          in each orch.
+     *       3. Take the type of sai api into consideration.
+     */
+    switch (status)
+    {
+        case SAI_STATUS_SUCCESS:
+            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiSetStatus");
+            return true;
+        default:
+            SWSS_LOG_ERROR("Encountered failure in set operation, exiting orchagent, SAI API: %s, status: %s",
+                        sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+            exit(EXIT_FAILURE);
+    }
+    return false;
+}
+
+bool Orch::handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context)
+{
+    /*
+     * This function aims to provide coarse handling of failures in sairedis remove
+     * operation (i.e., notify users by throwing excepions when failures happen).
+     * Return value: true - Handled the status successfully. No need to retry this SAI operation.
+     *               false - Cannot handle the status. Need to retry the SAI operation.
+     * TODO: 1. Add general handling logic for specific statuses (e.g., SAI_STATUS_OBJECT_IN_USE,
+     *          SAI_STATUS_ITEM_NOT_FOUND)
+     *       2. Develop fine-grain failure handling mechanisms and replace this coarse handling
+     *          in each orch.
+     *       3. Take the type of sai api into consideration.
+     */
+    switch (status)
+    {
+        case SAI_STATUS_SUCCESS:
+            SWSS_LOG_WARN("SAI_STATUS_SUCCESS is not expected in handleSaiRemoveStatus");
+            return true;
+        default:
+            SWSS_LOG_ERROR("Encountered failure in remove operation, exiting orchagent, SAI API: %s, status: %s",
+                        sai_serialize_api(api).c_str(), sai_serialize_status(status).c_str());
+            exit(EXIT_FAILURE);
+    }
+    return false;
 }
 
 void Orch2::doTask(Consumer &consumer)

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -235,6 +235,11 @@ protected:
     /* Note: consumer will be owned by this class */
     void addExecutor(Executor* executor);
     Executor *getExecutor(std::string executorName);
+
+    /* Handling SAI status*/
+    virtual bool handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    virtual bool handleSaiSetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    virtual bool handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
 private:
     void removeMeFromObjsReferencedByMe(type_map &type_maps, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);
     void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -237,9 +237,10 @@ protected:
     Executor *getExecutor(std::string executorName);
 
     /* Handling SAI status*/
-    virtual bool handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
-    virtual bool handleSaiSetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
-    virtual bool handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    virtual task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    virtual task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    virtual task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    bool parseHandleSaiStatusFailure(task_process_status status);
 private:
     void removeMeFromObjsReferencedByMe(type_map &type_maps, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);
     void addConsumer(swss::DBConnector *db, std::string tableName, int pri = default_orch_pri);

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -240,6 +240,7 @@ protected:
     virtual task_process_status handleSaiCreateStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
     virtual task_process_status handleSaiSetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
     virtual task_process_status handleSaiRemoveStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
+    virtual task_process_status handleSaiGetStatus(sai_api_t api, sai_status_t status, void *context = nullptr);
     bool parseHandleSaiStatusFailure(task_process_status status);
 private:
     void removeMeFromObjsReferencedByMe(type_map &type_maps, const std::string &table, const std::string &obj_name, const std::string &field, const std::string &old_referenced_obj_name);

--- a/orchagent/policerorch.cpp
+++ b/orchagent/policerorch.cpp
@@ -224,8 +224,11 @@ void PolicerOrch::doTask(Consumer &consumer)
                 {
                     SWSS_LOG_ERROR("Failed to create policer %s, rv:%d",
                             key.c_str(), status);
-                    it++;
-                    continue;
+                    if (handleSaiCreateStatus(SAI_API_POLICER, status) == task_need_retry)
+                    {
+                        it++;
+                        continue;
+                    }
                 }
 
                 SWSS_LOG_NOTICE("Created policer %s", key.c_str());
@@ -258,8 +261,11 @@ void PolicerOrch::doTask(Consumer &consumer)
                     {
                         SWSS_LOG_ERROR("Failed to update policer %s attribute, rv:%d",
                                 key.c_str(), status);
-                        it++;
-                        continue;
+                        if (handleSaiSetStatus(SAI_API_POLICER, status) == task_need_retry)
+                        {
+                            it++;
+                            continue;
+                        }
                     }
                 }
 
@@ -290,8 +296,11 @@ void PolicerOrch::doTask(Consumer &consumer)
             {
                 SWSS_LOG_ERROR("Failed to remove policer %s, rv:%d",
                         key.c_str(), status);
-                it++;
-                continue;
+                if (handleSaiRemoveStatus(SAI_API_POLICER, status) == task_need_retry)
+                {
+                    it++;
+                    continue;
+                }
             }
 
             SWSS_LOG_NOTICE("Removed policer %s", key.c_str());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -847,11 +847,16 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
     attr.id = SAI_PORT_ATTR_ADMIN_STATE;
     attr.value.booldata = state;
 
-    if (sai_port_api->set_port_attribute(port.m_port_id, &attr) != SAI_STATUS_SUCCESS)
+    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set admin status %s to port pid:%" PRIx64,
                        state ? "UP" : "DOWN", port.m_port_id);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_INFO("Set admin status %s to port pid:%" PRIx64,
@@ -897,7 +902,11 @@ bool PortsOrch::setPortMtu(sai_object_id_t id, sai_uint32_t mtu)
     {
         SWSS_LOG_ERROR("Failed to set MTU %u to port pid:%" PRIx64 ", rv:%d",
                 attr.value.u32, id, status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     SWSS_LOG_INFO("Set MTU %u to port pid:%" PRIx64, attr.value.u32, id);
     return true;
@@ -911,10 +920,15 @@ bool PortsOrch::setPortFec(Port &port, sai_port_fec_mode_t mode)
     attr.id = SAI_PORT_ATTR_FEC_MODE;
     attr.value.s32 = mode;
 
-    if (sai_port_api->set_port_attribute(port.m_port_id, &attr) != SAI_STATUS_SUCCESS)
+    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set fec mode %d to port pid:%" PRIx64, mode, port.m_port_id);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_INFO("Set fec mode %d to port pid:%" PRIx64, mode, port.m_port_id);
@@ -974,7 +988,11 @@ bool PortsOrch::setPortPfc(sai_object_id_t portId, uint8_t pfc_bitmask)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set PFC 0x%x to port id 0x%" PRIx64 " (rc:%d)", attr.value.u8, portId, status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     if (p.m_pfc_bitmask != pfc_bitmask)
@@ -1022,7 +1040,11 @@ bool PortsOrch::setPortPfcAsym(Port &port, string pfc_asym)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set PFC mode %d to port id 0x%" PRIx64 " (rc:%d)", port.m_pfc_asym, port.m_port_id, status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     if (!setPortPfc(port.m_port_id, pfc))
@@ -1039,7 +1061,11 @@ bool PortsOrch::setPortPfcAsym(Port &port, string pfc_asym)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set RX PFC 0x%x to port id 0x%" PRIx64 " (rc:%d)", attr.value.u8, port.m_port_id, status);
-            return false;
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+            if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
         }
     }
 
@@ -1085,6 +1111,16 @@ bool PortsOrch::bindUnbindAclTableGroup(Port &port,
             attr.id = ingress ?
                     SAI_PORT_ATTR_INGRESS_ACL : SAI_PORT_ATTR_EGRESS_ACL;
             status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+            if (SAI_STATUS_SUCCESS != status)
+            {
+                SWSS_LOG_ERROR("Failed to %s %s to ACL table group %" PRIx64 ", rv:%d",
+                            bind_str.c_str(), port.m_alias.c_str(), attr.value.oid, status);
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
+            }
             break;
         }
         case Port::LAG:
@@ -1092,6 +1128,16 @@ bool PortsOrch::bindUnbindAclTableGroup(Port &port,
             attr.id = ingress ?
                     SAI_LAG_ATTR_INGRESS_ACL : SAI_LAG_ATTR_EGRESS_ACL;
             status = sai_lag_api->set_lag_attribute(port.m_lag_id, &attr);
+            if (SAI_STATUS_SUCCESS != status)
+            {
+                SWSS_LOG_ERROR("Failed to %s %s to ACL table group %" PRIx64 ", rv:%d",
+                            bind_str.c_str(), port.m_alias.c_str(), attr.value.oid, status);
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_LAG, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
+            }
             break;
         }
         case Port::VLAN:
@@ -1101,6 +1147,16 @@ bool PortsOrch::bindUnbindAclTableGroup(Port &port,
             status =
                 sai_vlan_api->set_vlan_attribute(port.m_vlan_info.vlan_oid,
                                                  &attr);
+            if (SAI_STATUS_SUCCESS != status)
+            {
+                SWSS_LOG_ERROR("Failed to %s %s to ACL table group %" PRIx64 ", rv:%d",
+                            bind_str.c_str(), port.m_alias.c_str(), attr.value.oid, status);
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
+            }
             break;
         }
         default:
@@ -1109,13 +1165,6 @@ bool PortsOrch::bindUnbindAclTableGroup(Port &port,
                            bind_str.c_str(), port.m_alias.c_str(), port.m_type);
             return false;
         }
-    }
-
-    if (SAI_STATUS_SUCCESS != status)
-    {
-        SWSS_LOG_ERROR("Failed to %s %s to ACL table group %" PRIx64 ", rv:%d",
-                       bind_str.c_str(), port.m_alias.c_str(), attr.value.oid, status);
-        return false;
     }
 
     return true;
@@ -1175,7 +1224,11 @@ bool PortsOrch::unbindRemoveAclTableGroup(sai_object_id_t  port_oid,
     if (SAI_STATUS_SUCCESS != status)
     {
         SWSS_LOG_ERROR("Failed to remove ACL table group, rv:%d", status);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_ACL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     sai_acl_bind_point_type_t bind_type;
     if (!getSaiAclBindPointType(port.m_type, bind_type))
@@ -1258,7 +1311,11 @@ bool PortsOrch::createBindAclTableGroup(sai_object_id_t  port_oid,
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create ACL table group, rv:%d", status);
-            return false;
+            task_process_status handle_status = handleSaiCreateStatus(SAI_API_ACL, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         assert(group_oid_ref != SAI_NULL_OBJECT_ID);
 
@@ -1301,7 +1358,11 @@ bool PortsOrch::unbindAclTable(sai_object_id_t  port_oid,
     if (status != SAI_STATUS_SUCCESS) {
         SWSS_LOG_ERROR("Failed to remove ACL group member: %" PRIu64 " ",
                        acl_group_member_oid);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_ACL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
 
@@ -1368,7 +1429,11 @@ bool PortsOrch::bindAclTable(sai_object_id_t  port_oid,
     {
         SWSS_LOG_ERROR("Failed to create member in ACL table group %" PRIx64 " for ACL table %" PRIx64 ", rv:%d",
                 group_oid, table_oid, status);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_ACL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     Port port;
@@ -1407,7 +1472,11 @@ bool PortsOrch::setPortPvid(Port &port, sai_uint32_t pvid)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set pvid %u to port: %s", attr.value.u32, port.m_alias.c_str());
-            return false;
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         SWSS_LOG_NOTICE("Set pvid %u to port: %s", attr.value.u32, port.m_alias.c_str());
     }
@@ -1421,7 +1490,11 @@ bool PortsOrch::setPortPvid(Port &port, sai_uint32_t pvid)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to set pvid %u to lag: %s", attr.value.u32, port.m_alias.c_str());
-            return false;
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_LAG, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         SWSS_LOG_NOTICE("Set pvid %u to lag: %s", attr.value.u32, port.m_alias.c_str());
     }
@@ -1489,7 +1562,11 @@ bool PortsOrch::setHostIntfsStripTag(Port &port, sai_hostif_vlan_tag_t strip)
         {
             SWSS_LOG_ERROR("Failed to set %s to host interface %s",
                         hostif_vlan_tag[strip], p.m_alias.c_str());
-            return false;
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_HOSTIF, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         SWSS_LOG_NOTICE("Set %s to host interface: %s",
                         hostif_vlan_tag[strip], p.m_alias.c_str());
@@ -1677,11 +1754,16 @@ bool PortsOrch::setGearboxPortAttr(Port &port, dest_port_type_t port_type, sai_p
             else
             {
                 SWSS_LOG_ERROR("BOX: Failed to set %s port attribute %d", port.m_alias.c_str(), id);
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
     }
 
-    return status == SAI_STATUS_SUCCESS;
+    return true;
 }
 
 bool PortsOrch::setPortSpeed(Port &port, sai_uint32_t speed)
@@ -1695,13 +1777,17 @@ bool PortsOrch::setPortSpeed(Port &port, sai_uint32_t speed)
     attr.value.u32 = speed;
 
     status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
-
-    if (status == SAI_STATUS_SUCCESS)
+    if (status != SAI_STATUS_SUCCESS)
     {
-        setGearboxPortsAttr(port, SAI_PORT_ATTR_SPEED, &speed);
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
-    return status == SAI_STATUS_SUCCESS;
+    setGearboxPortsAttr(port, SAI_PORT_ATTR_SPEED, &speed);
+    return true;
 }
 
 bool PortsOrch::getPortSpeed(sai_object_id_t id, sai_uint32_t &speed)
@@ -1737,8 +1823,16 @@ bool PortsOrch::setPortAdvSpeed(sai_object_id_t port_id, sai_uint32_t speed)
     attr.value.u32list.count = static_cast<uint32_t>(speeds.size());
 
     status = sai_port_api->set_port_attribute(port_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
+    }
 
-    return status == SAI_STATUS_SUCCESS;
+    return true;
 }
 
 bool PortsOrch::getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index)
@@ -1796,7 +1890,11 @@ bool PortsOrch::setPortAutoNeg(sai_object_id_t id, int an)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set AutoNeg %u to port pid:%" PRIx64, attr.value.booldata, id);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     SWSS_LOG_INFO("Set AutoNeg %u to port pid:%" PRIx64, attr.value.booldata, id);
     return true;
@@ -1927,7 +2025,11 @@ bool PortsOrch::addPort(const set<int> &lane_set, uint32_t speed, int an, string
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create port with the speed %u, rv:%d", speed, status);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     m_portListLaneMap[lane_set] = port_id;
@@ -3555,7 +3657,11 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create host interface for port %s", alias.c_str());
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_HOSTIF, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Create host interface for port %s", alias.c_str());
@@ -3578,7 +3684,11 @@ bool PortsOrch::setBridgePortLearningFDB(Port &port, sai_bridge_port_fdb_learnin
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set bridge port %" PRIx64 " learning_mode attribute: %d", bridge_port_id, status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_BRIDGE, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     SWSS_LOG_NOTICE("Disable FDB learning on bridge port %s(%" PRIx64 ")", port.m_alias.c_str(), bridge_port_id);
     return true;
@@ -3660,7 +3770,11 @@ bool PortsOrch::addBridgePort(Port &port)
     {
         SWSS_LOG_ERROR("Failed to add bridge port %s to default 1Q bridge, rv:%d",
             port.m_alias.c_str(), status);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_BRIDGE, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_KEEP))
@@ -3693,7 +3807,11 @@ bool PortsOrch::removeBridgePort(Port &port)
     {
         SWSS_LOG_ERROR("Failed to set bridge port %s admin status to DOWN, rv:%d",
             port.m_alias.c_str(), status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_BRIDGE, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     if (!setHostIntfsStripTag(port, SAI_HOSTIF_VLAN_TAG_STRIP))
@@ -3713,7 +3831,11 @@ bool PortsOrch::removeBridgePort(Port &port)
     {
         SWSS_LOG_ERROR("Failed to remove bridge port %s from default 1Q bridge, rv:%d",
             port.m_alias.c_str(), status);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_BRIDGE, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     port.m_bridge_port_id = SAI_NULL_OBJECT_ID;
 
@@ -3749,7 +3871,11 @@ bool PortsOrch::setBridgePortLearnMode(Port &port, string learn_mode)
     {
         SWSS_LOG_ERROR("Failed to set bridge port %s learning mode, rv:%d",
             port.m_alias.c_str(), status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_BRIDGE, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Set bridge port %s learning mode %s", port.m_alias.c_str(), learn_mode.c_str());
@@ -3772,7 +3898,11 @@ bool PortsOrch::addVlan(string vlan_alias)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create VLAN %s vid:%hu", vlan_alias.c_str(), vlan_id);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_VLAN, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Create an empty VLAN %s vid:%hu", vlan_alias.c_str(), vlan_id);
@@ -3826,7 +3956,11 @@ bool PortsOrch::removeVlan(Port vlan)
     {
         SWSS_LOG_ERROR("Failed to remove VLAN %s vid:%hu",
                 vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_VLAN, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     removeAclTableGroup(vlan);
@@ -3889,7 +4023,11 @@ bool PortsOrch::addVlanMember(Port &vlan, Port &port, string &tagging_mode)
     {
         SWSS_LOG_ERROR("Failed to add member %s to VLAN %s vid:%hu pid:%" PRIx64,
                 port.m_alias.c_str(), vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id, port.m_port_id);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_VLAN, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     SWSS_LOG_NOTICE("Add member %s to VLAN %s vid:%hu pid%" PRIx64,
             port.m_alias.c_str(), vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id, port.m_port_id);
@@ -3934,7 +4072,11 @@ bool PortsOrch::removeVlanMember(Port &vlan, Port &port)
     {
         SWSS_LOG_ERROR("Failed to remove member %s from VLAN %s vid:%hx vmid:%" PRIx64,
                 port.m_alias.c_str(), vlan.m_alias.c_str(), vlan.m_vlan_info.vlan_id, vlan_member_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_VLAN, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     port.m_vlan_members.erase(vlan_member);
     SWSS_LOG_NOTICE("Remove member %s from VLAN %s lid:%hx vmid:%" PRIx64,
@@ -3977,7 +4119,11 @@ bool PortsOrch::addLag(string lag_alias)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create LAG %s lid:%" PRIx64, lag_alias.c_str(), lag_id);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_LAG, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Create an empty LAG %s lid:%" PRIx64, lag_alias.c_str(), lag_id);
@@ -4027,7 +4173,11 @@ bool PortsOrch::removeLag(Port lag)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove LAG %s lid:%" PRIx64, lag.m_alias.c_str(), lag.m_lag_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_LAG, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Remove LAG %s lid:%" PRIx64, lag.m_alias.c_str(), lag.m_lag_id);
@@ -4097,7 +4247,11 @@ bool PortsOrch::addLagMember(Port &lag, Port &port, bool enableForwarding)
     {
         SWSS_LOG_ERROR("Failed to add member %s to LAG %s lid:%" PRIx64 " pid:%" PRIx64,
                 port.m_alias.c_str(), lag.m_alias.c_str(), lag.m_lag_id, port.m_port_id);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_LAG, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Add member %s to LAG %s lid:%" PRIx64 " pid:%" PRIx64,
@@ -4134,7 +4288,11 @@ bool PortsOrch::removeLagMember(Port &lag, Port &port)
     {
         SWSS_LOG_ERROR("Failed to remove member %s from LAG %s lid:%" PRIx64 " lmid:%" PRIx64,
                 port.m_alias.c_str(), lag.m_alias.c_str(), lag.m_lag_id, port.m_lag_member_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_LAG, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Remove member %s from LAG %s lid:%" PRIx64 " lmid:%" PRIx64,
@@ -4178,7 +4336,11 @@ bool PortsOrch::setCollectionOnLagMember(Port &lagMember, bool enableCollection)
         SWSS_LOG_ERROR("Failed to %s collection on LAG member %s",
             enableCollection ? "enable" : "disable",
             lagMember.m_alias.c_str());
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_LAG, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("%s collection on LAG member %s",
@@ -4205,7 +4367,11 @@ bool PortsOrch::setDistributionOnLagMember(Port &lagMember, bool enableDistribut
         SWSS_LOG_ERROR("Failed to %s distribution on LAG member %s",
             enableDistribution ? "enable" : "disable",
             lagMember.m_alias.c_str());
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_LAG, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("%s distribution on LAG member %s",
@@ -4635,7 +4801,11 @@ bool PortsOrch::removeAclTableGroup(const Port &p)
         if (ret != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to remove ingress acl table group for %s", p.m_alias.c_str());
-            return false;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_ACL, ret);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP, SAI_ACL_STAGE_INGRESS, bind_type, p.m_ingress_acl_table_group_id);
     }
@@ -4646,7 +4816,11 @@ bool PortsOrch::removeAclTableGroup(const Port &p)
         if (ret != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to remove egress acl table group for %s", p.m_alias.c_str());
-            return false;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_ACL, ret);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         gCrmOrch->decCrmAclUsedCounter(CrmResourceType::CRM_ACL_GROUP, SAI_ACL_STAGE_EGRESS, bind_type, p.m_egress_acl_table_group_id);
     }
@@ -4680,7 +4854,11 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id,
         {
             SWSS_LOG_ERROR("Failed to remove existing port serdes attr 0x%" PRIx64 " port 0x%" PRIx64,
                            port_attr.value.oid, port_id);
-            return false;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_PORT, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
     }
 
@@ -4705,7 +4883,11 @@ bool PortsOrch::setPortSerdesAttribute(sai_object_id_t port_id,
     {
         SWSS_LOG_ERROR("Failed to create port serdes for port 0x%" PRIx64,
                        port_id);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     SWSS_LOG_NOTICE("Created port serdes object 0x%" PRIx64 " for port 0x%" PRIx64, port_serdes_id, port_id);
     return true;
@@ -4736,6 +4918,7 @@ void PortsOrch::removePortSerdesAttribute(sai_object_id_t port_id)
         {
             SWSS_LOG_ERROR("Failed to remove existing port serdes attr 0x%" PRIx64 " port 0x%" PRIx64,
                            port_attr.value.oid, port_id);
+            handleSaiRemoveStatus(SAI_API_PORT, status);
             return;
         }
     }
@@ -4911,7 +5094,11 @@ bool PortsOrch::initGearboxPort(Port &port)
             {
                 SWSS_LOG_ERROR("BOX: Failed to create Gearbox system-side port for alias:%s port_id:0x%" PRIx64 " index:%d status:%d",
                         port.m_alias.c_str(), port.m_port_id, port.m_index, status);
-                return false;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_PORT, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
             SWSS_LOG_NOTICE("BOX: Created Gearbox system-side port 0x%" PRIx64 " for alias:%s index:%d",
                     systemPort, port.m_alias.c_str(), port.m_index);
@@ -4994,7 +5181,11 @@ bool PortsOrch::initGearboxPort(Port &port)
             {
                 SWSS_LOG_ERROR("BOX: Failed to create Gearbox line-side port for alias:%s port_id:0x%" PRIx64 " index:%d status:%d",
                    port.m_alias.c_str(), port.m_port_id, port.m_index, status);
-                return false;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_PORT, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
             SWSS_LOG_NOTICE("BOX: Created Gearbox line-side port 0x%" PRIx64 " for alias:%s index:%d",
                 linePort, port.m_alias.c_str(), port.m_index);
@@ -5013,7 +5204,11 @@ bool PortsOrch::initGearboxPort(Port &port)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("BOX: Failed to connect Gearbox system-side:0x%" PRIx64 " to line-side:0x%" PRIx64 "; status:%d", systemPort, linePort, status);
-                return false;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_PORT, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
 
             SWSS_LOG_NOTICE("BOX: Connected Gearbox ports; system-side:0x%" PRIx64 " to line-side:0x%" PRIx64, systemPort, linePort);

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -864,7 +864,11 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
                 if (sai_status != SAI_STATUS_SUCCESS)
                 {
                     SWSS_LOG_ERROR("fail to set scheduler attribute, id:%d", attr.id);
-                    return task_process_status::task_failed;
+                    task_process_status handle_status = handleSaiSetStatus(SAI_API_SCHEDULER, sai_status);
+                    if (handle_status != task_process_status::task_success)
+                    {
+                        return handle_status;
+                    }
                 }
             }
         }
@@ -875,7 +879,11 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
             {
                 SWSS_LOG_ERROR("Failed to create scheduler profile [%s:%s], rv:%d",
                                qos_map_type_name.c_str(), qos_object_name.c_str(), sai_status);
-                return task_process_status::task_failed;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_SCHEDULER, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return handle_status;
+                }
             }
             SWSS_LOG_NOTICE("Created [%s:%s]", qos_map_type_name.c_str(), qos_object_name.c_str());
             (*(m_qos_maps[qos_map_type_name]))[qos_object_name].m_saiObjectId = sai_object;
@@ -892,7 +900,11 @@ task_process_status QosOrch::handleSchedulerTable(Consumer& consumer)
         if (SAI_STATUS_SUCCESS != sai_status)
         {
             SWSS_LOG_ERROR("Failed to remove scheduler profile. db name:%s sai object:%" PRIx64, qos_object_name.c_str(), sai_object);
-            return task_process_status::task_failed;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_SCHEDULER, sai_status);
+            if (handle_status != task_process_status::task_success)
+            {
+                return handle_status;
+            }
         }
         auto it_to_delete = (m_qos_maps[qos_map_type_name])->find(qos_object_name);
         (m_qos_maps[qos_map_type_name])->erase(it_to_delete);
@@ -1024,7 +1036,11 @@ bool QosOrch::applySchedulerToQueueSchedulerGroup(Port &port, size_t queue_ind, 
     if (SAI_STATUS_SUCCESS != sai_status)
     {
         SWSS_LOG_ERROR("Failed applying scheduler profile:0x%" PRIx64 " to scheduler group:0x%" PRIx64 ", port:%s", scheduler_profile_id, group_id, port.m_alias.c_str());
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_SCHEDULER_GROUP, sai_status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_DEBUG("port:%s, scheduler_profile_id:0x%" PRIx64 " applied to scheduler group:0x%" PRIx64, port.m_alias.c_str(), scheduler_profile_id, group_id);
@@ -1052,7 +1068,11 @@ bool QosOrch::applyWredProfileToQueue(Port &port, size_t queue_ind, sai_object_i
     if (sai_status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set queue attribute:%d", sai_status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_QUEUE, sai_status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     return true;
 }
@@ -1206,7 +1226,11 @@ bool QosOrch::applyMapToPort(Port &port, sai_attr_id_t attr_id, sai_object_id_t 
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed setting sai object:%" PRIx64 " for port:%s, status:%d", map_id, port.m_alias.c_str(), status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     return true;
 }
@@ -1326,7 +1350,11 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
             {
                 SWSS_LOG_ERROR("Failed to apply %s to port %s, rv:%d",
                                it->second.first.c_str(), port_name.c_str(), status);
-                return task_process_status::task_invalid_entry;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return task_process_status::task_invalid_entry;
+                }
             }
             SWSS_LOG_INFO("Applied %s to port %s", it->second.first.c_str(), port_name.c_str());
         }

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -933,7 +933,11 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
         if (SAI_STATUS_SUCCESS != sai_status)
         {
             SWSS_LOG_ERROR("Failed to get number of scheduler groups for port:%s", port.m_alias.c_str());
-            return SAI_NULL_OBJECT_ID;
+            task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, sai_status);
+            if (handle_status != task_process_status::task_success)
+            {
+                return SAI_NULL_OBJECT_ID;
+            }
         }
 
         /* Get total groups list on the port */
@@ -947,7 +951,11 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
         if (SAI_STATUS_SUCCESS != sai_status)
         {
             SWSS_LOG_ERROR("Failed to get scheduler group list for port:%s", port.m_alias.c_str());
-            return SAI_NULL_OBJECT_ID;
+            task_process_status handle_status = handleSaiGetStatus(SAI_API_PORT, sai_status);
+            if (handle_status != task_process_status::task_success)
+            {
+                return SAI_NULL_OBJECT_ID;
+            }
         }
 
         m_scheduler_group_port_info[port.m_port_id] = {
@@ -969,7 +977,11 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
             if (SAI_STATUS_SUCCESS != sai_status)
             {
                 SWSS_LOG_ERROR("Failed to get child count for scheduler group:0x%" PRIx64 " of port:%s", group_id, port.m_alias.c_str());
-                return SAI_NULL_OBJECT_ID;
+                task_process_status handle_status = handleSaiGetStatus(SAI_API_SCHEDULER_GROUP, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return SAI_NULL_OBJECT_ID;
+                }
             }
 
             uint32_t child_count = attr.value.u32;
@@ -988,7 +1000,11 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
             if (SAI_STATUS_SUCCESS != sai_status)
             {
                 SWSS_LOG_ERROR("Failed to get child list for scheduler group:0x%" PRIx64 " of port:%s", group_id, port.m_alias.c_str());
-                return SAI_NULL_OBJECT_ID;
+                task_process_status handle_status = handleSaiGetStatus(SAI_API_SCHEDULER_GROUP, sai_status);
+                if (handle_status != task_process_status::task_success)
+                {
+                    return SAI_NULL_OBJECT_ID;
+                }
             }
 
             m_scheduler_group_port_info[port.m_port_id].child_groups[ii] = std::move(child_groups);

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -333,7 +333,7 @@ bool RouteOrch::validnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t& 
         {
             SWSS_LOG_ERROR("Failed to add next hop member to group %" PRIx64 ": %d\n",
                            nhopgroup->second.next_hop_group_id, status);
-            return false;
+            return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
         }
 
         ++count;
@@ -373,7 +373,7 @@ bool RouteOrch::invalidnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t
         {
             SWSS_LOG_ERROR("Failed to remove next hop member %" PRIx64 " from group %" PRIx64 ": %d\n",
                            nexthop_id, nhopgroup->second.next_hop_group_id, status);
-            return false;
+            return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
         }
 
         ++count;
@@ -971,7 +971,7 @@ bool RouteOrch::createFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create next hop group rv:%d", status);
-        return false;
+        return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -989,7 +989,7 @@ bool RouteOrch::removeFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d",
                 next_hop_group_id, status);
-        return false;
+        return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -1062,7 +1062,7 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
     {
         SWSS_LOG_ERROR("Failed to create next hop group %s, rv:%d",
                        nexthops.to_string().c_str(), status);
-        return false;
+        return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     m_nextHopGroupCount ++;
@@ -1190,7 +1190,7 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
         {
             SWSS_LOG_ERROR("Failed to remove next hop group member[%zu] %" PRIx64 ", rv:%d",
                            i, next_hop_ids[i], statuses[i]);
-            return false;
+            return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, statuses[i]);
         }
 
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
@@ -1200,7 +1200,7 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d", next_hop_group_id, status);
-        return false;
+        return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
     }
 
     m_nextHopGroupCount --;
@@ -1703,7 +1703,8 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
     }
     else if (it_route == m_syncdRoutes.at(vrf_id).end())
     {
-        if (*it_status++ != SAI_STATUS_SUCCESS)
+        sai_status_t status = *it_status++;
+        if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create route %s with next hop(s) %s",
                     ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
@@ -1712,7 +1713,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 removeNextHopGroup(nextHops);
             }
-            return false;
+            return handleSaiCreateStatus(SAI_API_ROUTE, status);
         }
 
         if (ipPrefix.isV4())
@@ -1742,7 +1743,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 SWSS_LOG_ERROR("Failed to set route %s with packet action forward, %d",
                                ipPrefix.to_string().c_str(), status);
-                return false;
+                return handleSaiSetStatus(SAI_API_ROUTE, status);
             }
         }
 
@@ -1751,7 +1752,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         {
             SWSS_LOG_ERROR("Failed to set route %s with next hop(s) %s",
                     ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
-            return false;
+            return handleSaiSetStatus(SAI_API_ROUTE, status);
         }
 
         /* Increase the ref_count for the next hop (group) entry */
@@ -1881,7 +1882,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s packet action to drop, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return false;
+            return handleSaiSetStatus(SAI_API_ROUTE, status);
         }
 
         SWSS_LOG_INFO("Set route %s packet action to drop", ipPrefix.to_string().c_str());
@@ -1891,7 +1892,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s next hop ID to NULL, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return false;
+            return handleSaiSetStatus(SAI_API_ROUTE, status);
         }
 
         SWSS_LOG_INFO("Set route %s next hop ID to NULL", ipPrefix.to_string().c_str());
@@ -1902,7 +1903,7 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to remove route prefix:%s\n", ipPrefix.to_string().c_str());
-            return false;
+            return handleSaiRemoveStatus(SAI_API_ROUTE, status);
         }
 
         if (ipPrefix.isV4())

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -333,7 +333,11 @@ bool RouteOrch::validnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t& 
         {
             SWSS_LOG_ERROR("Failed to add next hop member to group %" PRIx64 ": %d\n",
                            nhopgroup->second.next_hop_group_id, status);
-            return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
+            task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         ++count;
@@ -373,7 +377,11 @@ bool RouteOrch::invalidnexthopinNextHopGroup(const NextHopKey &nexthop, uint32_t
         {
             SWSS_LOG_ERROR("Failed to remove next hop member %" PRIx64 " from group %" PRIx64 ": %d\n",
                            nexthop_id, nhopgroup->second.next_hop_group_id, status);
-            return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         ++count;
@@ -971,7 +979,11 @@ bool RouteOrch::createFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create next hop group rv:%d", status);
-        return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -989,7 +1001,11 @@ bool RouteOrch::removeFineGrainedNextHopGroup(sai_object_id_t &next_hop_group_id
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d",
                 next_hop_group_id, status);
-        return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP);
@@ -1062,7 +1078,11 @@ bool RouteOrch::addNextHopGroup(const NextHopGroupKey &nexthops)
     {
         SWSS_LOG_ERROR("Failed to create next hop group %s, rv:%d",
                        nexthops.to_string().c_str(), status);
-        return handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_NEXT_HOP_GROUP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     m_nextHopGroupCount ++;
@@ -1190,7 +1210,11 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
         {
             SWSS_LOG_ERROR("Failed to remove next hop group member[%zu] %" PRIx64 ", rv:%d",
                            i, next_hop_ids[i], statuses[i]);
-            return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, statuses[i]);
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, statuses[i]);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_NEXTHOP_GROUP_MEMBER);
@@ -1200,7 +1224,11 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove next hop group %" PRIx64 ", rv:%d", next_hop_group_id, status);
-        return handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP_GROUP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     m_nextHopGroupCount --;
@@ -1713,7 +1741,11 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 removeNextHopGroup(nextHops);
             }
-            return handleSaiCreateStatus(SAI_API_ROUTE, status);
+            task_process_status handle_status = handleSaiCreateStatus(SAI_API_ROUTE, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         if (ipPrefix.isV4())
@@ -1743,7 +1775,11 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
             {
                 SWSS_LOG_ERROR("Failed to set route %s with packet action forward, %d",
                                ipPrefix.to_string().c_str(), status);
-                return handleSaiSetStatus(SAI_API_ROUTE, status);
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_ROUTE, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
 
@@ -1752,7 +1788,11 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         {
             SWSS_LOG_ERROR("Failed to set route %s with next hop(s) %s",
                     ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
-            return handleSaiSetStatus(SAI_API_ROUTE, status);
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_ROUTE, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         /* Increase the ref_count for the next hop (group) entry */
@@ -1882,7 +1922,11 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s packet action to drop, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return handleSaiSetStatus(SAI_API_ROUTE, status);
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_ROUTE, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         SWSS_LOG_INFO("Set route %s packet action to drop", ipPrefix.to_string().c_str());
@@ -1892,7 +1936,11 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         {
             SWSS_LOG_ERROR("Failed to set route %s next hop ID to NULL, rv:%d",
                     ipPrefix.to_string().c_str(), status);
-            return handleSaiSetStatus(SAI_API_ROUTE, status);
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_ROUTE, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         SWSS_LOG_INFO("Set route %s next hop ID to NULL", ipPrefix.to_string().c_str());
@@ -1903,7 +1951,11 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to remove route prefix:%s\n", ipPrefix.to_string().c_str());
-            return handleSaiRemoveStatus(SAI_API_ROUTE, status);
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_ROUTE, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         if (ipPrefix.isV4())

--- a/orchagent/sfloworch.cpp
+++ b/orchagent/sfloworch.cpp
@@ -31,7 +31,11 @@ bool SflowOrch::sflowCreateSession(uint32_t rate, SflowSession &session)
     if (sai_rc != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create sample packet session with rate %d", rate);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_SAMPLEPACKET, sai_rc);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     session.m_sample_id = session_id;
     session.ref_count = 0;
@@ -47,7 +51,11 @@ bool SflowOrch::sflowDestroySession(SflowSession &session)
     {
         SWSS_LOG_ERROR("Failed to destroy sample packet session with id %" PRIx64 "",
                        session.m_sample_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_SAMPLEPACKET, sai_rc);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     return true;
 }
@@ -111,7 +119,11 @@ bool SflowOrch::sflowAddPort(sai_object_id_t sample_id, sai_object_id_t port_id)
     if (sai_rc != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set session %" PRIx64 " on port %" PRIx64 , sample_id, port_id);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, sai_rc);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     return true;
 }
@@ -128,7 +140,11 @@ bool SflowOrch::sflowDelPort(sai_object_id_t port_id)
     if (sai_rc != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to delete session on port %" PRIx64  , port_id);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_PORT, sai_rc);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     return true;
 }

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -205,7 +205,7 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
                 {
                     SWSS_LOG_ERROR("Failed to set switch attribute %s to %s, rv:%d",
                             attribute.c_str(), value.c_str(), status);
-                    retry = true;
+                    retry = (handleSaiSetStatus(SAI_API_SWITCH, status) == task_need_retry);
                     break;
                 }
 
@@ -306,7 +306,11 @@ bool SwitchOrch::setAgingFDB(uint32_t sec)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set switch %" PRIx64 " fdb_aging_time attribute: %d", gSwitchId, status);
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_SWITCH, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     SWSS_LOG_NOTICE("Set switch %" PRIx64 " fdb_aging_time %u sec", gSwitchId, sec);
     return true;

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -238,7 +238,11 @@ bool TunnelDecapOrch::addDecapTunnel(string key, string type, IpAddresses dst_ip
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create overlay router interface %d", status);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_ROUTER_INTERFACE, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     SWSS_LOG_NOTICE("Create overlay loopback router interface oid:%" PRIx64, overlayIfId);
@@ -314,7 +318,11 @@ bool TunnelDecapOrch::addDecapTunnel(string key, string type, IpAddresses dst_ip
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to create tunnel");
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_TUNNEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     tunnelTable[key] = { tunnel_id, overlayIfId, dst_ip, {} };
@@ -390,7 +398,11 @@ bool TunnelDecapOrch::addDecapTunnelTermEntries(string tunnelKey, IpAddresses ds
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to create tunnel entry table for ip: %s", ip.c_str());
-                return false;
+                task_process_status handle_status = handleSaiCreateStatus(SAI_API_TUNNEL, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
 
             // insert into ip to entry mapping
@@ -482,7 +494,11 @@ bool TunnelDecapOrch::setTunnelAttribute(string field, string value, sai_object_
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to set attribute %s with value %s\n", field.c_str(), value.c_str());
-        return false;
+        task_process_status handle_status = handleSaiSetStatus(SAI_API_TUNNEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     SWSS_LOG_NOTICE("Set attribute %s with value %s\n", field.c_str(), value.c_str());
     return true;
@@ -569,7 +585,11 @@ bool TunnelDecapOrch::removeDecapTunnel(string key)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove tunnel: %" PRIu64, tunnel_info->tunnel_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_TUNNEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     // delete overlay loopback interface
@@ -577,7 +597,11 @@ bool TunnelDecapOrch::removeDecapTunnel(string key)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove tunnel overlay interface: %" PRIu64, tunnel_info->overlay_intf_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_ROUTER_INTERFACE, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     tunnelTable.erase(key);
@@ -602,7 +626,11 @@ bool TunnelDecapOrch::removeDecapTunnelTermEntry(sai_object_id_t tunnel_term_id,
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove tunnel table entry: %" PRIu64, tunnel_term_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_TUNNEL, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     // making sure to remove all instances of the ip address
@@ -682,6 +710,7 @@ sai_object_id_t TunnelDecapOrch::createNextHopTunnel(std::string tunnelKey, IpAd
     {
         SWSS_LOG_ERROR("Tunnel NH create failed %s, ip %s", tunnelKey.c_str(),
                         ipAddr.to_string().c_str());
+        handleSaiCreateStatus(SAI_API_NEXT_HOP, status);
     }
     else
     {
@@ -737,7 +766,11 @@ bool TunnelDecapOrch::removeNextHopTunnel(std::string tunnelKey, IpAddress& ipAd
         {
             SWSS_LOG_ERROR("Failed to remove next hop %s on %s, rv:%d",
                             ipAddr.to_string().c_str(), tunnelKey.c_str(), status);
-            return false;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_NEXT_HOP, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
     }
     else

--- a/orchagent/vrforch.cpp
+++ b/orchagent/vrforch.cpp
@@ -89,7 +89,11 @@ bool VRFOrch::addOperation(const Request& request)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create virtual router name: %s, rv: %d", vrf_name.c_str(), status);
-            return false;
+            task_process_status handle_status = handleSaiCreateStatus(SAI_API_VIRTUAL_ROUTER, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         vrf_table_[vrf_name].vrf_id = router_id;
@@ -119,7 +123,11 @@ bool VRFOrch::addOperation(const Request& request)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to update virtual router attribute. vrf name: %s, rv: %d", vrf_name.c_str(), status);
-                return false;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_VIRTUAL_ROUTER, status);
+                if (handle_status != task_success)
+                {
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
 
@@ -156,7 +164,11 @@ bool VRFOrch::delOperation(const Request& request)
     if (status != SAI_STATUS_SUCCESS)
     {
         SWSS_LOG_ERROR("Failed to remove virtual router name: %s, rv:%d", vrf_name.c_str(), status);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_VIRTUAL_ROUTER, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
 
     vrf_table_.erase(vrf_name);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Backport SAI failure handling related commits into the 202012 branch. The following is a list of backported commits:
```
941875a Deactivate mirror session only when session status is true in updateLagMember (#1666)
be12482 Ignore ALREADY_EXIST error in FDB creation (#1815)
c9c1aa2 Add failure handling for SAI get operations (#1768)
47b4276 [BufferOrch] Don't call SAI API for BUFFER_POOL/PROFILE handling in case the op is DEL and the SAI OID is NULL (#1786)
db9238f Add failure notification for orchagent (#1665)
fc8e43f [synchronous mode] Add failure notification for SAI failures in synchronous mode (#1596)
```

**Why I did it**
202012 image needs to include failure handling mechanism for enough notification in the presence of SAI failures.

**How I verified it**

**Details if related**
