### PR TITLE
Revert "[debugcounterorch] check if counter type is supported 

### DIFF
--- a/orchagent/debug_counter/drop_counter.h
+++ b/orchagent/debug_counter/drop_counter.h
@@ -34,7 +34,6 @@ class DropCounter : public DebugCounter
 
         static std::unordered_set<std::string> getSupportedDropReasons(sai_debug_counter_attr_t drop_reason_type);
         static std::string serializeSupportedDropReasons(std::unordered_set<std::string> drop_reasons);
-        static std::unordered_set<std::string> getSupportedCounterTypes();
         static uint64_t getSupportedDebugCounterAmounts(sai_debug_counter_type_t counter_type);
 
     private:

--- a/orchagent/debugcounterorch.cpp
+++ b/orchagent/debugcounterorch.cpp
@@ -183,7 +183,6 @@ void DebugCounterOrch::publishDropCounterCapabilities()
 {
     supported_ingress_drop_reasons = DropCounter::getSupportedDropReasons(SAI_DEBUG_COUNTER_ATTR_IN_DROP_REASON_LIST);
     supported_egress_drop_reasons  = DropCounter::getSupportedDropReasons(SAI_DEBUG_COUNTER_ATTR_OUT_DROP_REASON_LIST);
-    supported_counter_types        = DropCounter::getSupportedCounterTypes();
 
     string ingress_drop_reason_str = DropCounter::serializeSupportedDropReasons(supported_ingress_drop_reasons);
     string egress_drop_reason_str = DropCounter::serializeSupportedDropReasons(supported_egress_drop_reasons);
@@ -191,12 +190,6 @@ void DebugCounterOrch::publishDropCounterCapabilities()
     for (auto const &counter_type : DebugCounter::getDebugCounterTypeLookup())
     {
         string drop_reasons;
-
-        if (!supported_counter_types.count(counter_type.first))
-        {
-            continue;
-        }
-
         if (counter_type.first == PORT_INGRESS_DROPS || counter_type.first == SWITCH_INGRESS_DROPS)
         {
             drop_reasons = ingress_drop_reason_str;
@@ -219,6 +212,8 @@ void DebugCounterOrch::publishDropCounterCapabilities()
         {
             continue;
         }
+
+        supported_counter_types.emplace(counter_type.first);
 
         vector<FieldValueTuple> fieldValues;
         fieldValues.push_back(FieldValueTuple("count", num_counters));


### PR DESCRIPTION
This reverts commit 04105a4bb029041f01192f2ed5935a0daf9f4ec2.

**What I did**
Revert PR https://github.com/Azure/sonic-swss/pull/1789 from 202012 branch. 

**Why I did it**
Fix issue - https://github.com/Azure/sonic-buildimage/issues/8538 in 202012 branch. 

**How I verified it**

**Details if related**
