### PR TITLE
[portsorch] Add an extra check before setting oper speed to APPL_DB

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -5252,8 +5252,22 @@ void PortsOrch::doTask(NotificationConsumer &consumer)
                 sai_uint32_t speed;
                 if (getPortOperSpeed(port, speed))
                 {
-                    SWSS_LOG_NOTICE("%s oper speed is %d", port.m_alias.c_str(), speed);
-                    updateDbPortOperSpeed(port, speed);
+                    if (speed != 0) 
+                    {
+                        SWSS_LOG_NOTICE("%s oper speed is %d", port.m_alias.c_str(), speed);
+                        updateDbPortOperSpeed(port, speed);
+                    }
+                    else 
+                    {
+                        // Port operational status is up, but operational speed is 0. It could be a valid case because
+                        // port UP event is an aync event, the valid flow could be:
+                        //    1. port UP event comes
+                        //    2. SONiC gets the UP event and starts to process the event
+                        //    3. port goes down due to any reason
+                        //    4. SONiC reads the oper speed, and gets a 0 because oper_state is down.
+                        // And it could also be a bug. So, we log a warning here.
+                        SWSS_LOG_WARN("Port %s operational speed is 0 when operational status is up", port.m_alias.c_str());
+                    }
                 }
             }
 
@@ -5362,8 +5376,21 @@ void PortsOrch::refreshPortStatus()
             sai_uint32_t speed;
             if (getPortOperSpeed(port, speed))
             {
-                SWSS_LOG_INFO("%s oper speed is %d", port.m_alias.c_str(), speed);
-                updateDbPortOperSpeed(port, speed);
+                if (speed != 0)
+                {
+                    SWSS_LOG_INFO("%s oper speed is %d", port.m_alias.c_str(), speed);
+                    updateDbPortOperSpeed(port, speed);
+                }
+                else
+                {
+                    // Port operational status is up, but operational speed is 0. It could be a valid case because
+                    // port state can change during two SAI calls:
+                    //    1. getPortOperStatus returns UP
+                    //    2. port goes down due to any reason
+                    //    3. getPortOperSpeed gets speed value 0
+                    // And it could also be a bug. So, we log a warning here.
+                    SWSS_LOG_WARN("Port %s operational speed is 0 when operational status is up", port.m_alias.c_str());
+                }
             }
         }
     }

--- a/tests/mock_tests/mock_hiredis.cpp
+++ b/tests/mock_tests/mock_hiredis.cpp
@@ -1,10 +1,21 @@
 #include <stdlib.h>
 #include <hiredis/hiredis.h>
+#include <iostream>
+
+// Add a global redisReply for user to mock
+redisReply *mockReply = nullptr;
 
 int redisGetReply(redisContext *c, void **reply)
 {
-    *reply = calloc(sizeof(redisReply), 1);
-    ((redisReply *)*reply)->type = 3;
+    if (mockReply == nullptr)
+    {
+        *reply = calloc(sizeof(redisReply), 1);
+        ((redisReply *)*reply)->type = 3;
+    }
+    else
+    {
+        *reply = mockReply;
+    }
     return 0;
 }
 
@@ -19,6 +30,11 @@ int redisvAppendCommand(redisContext *c, const char *format, va_list ap)
 }
 
 int redisAppendCommand(redisContext *c, const char *format, ...)
+{
+    return 0;
+}
+
+int redisGetReplyFromReader(redisContext *c, void **reply)
 {
     return 0;
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

If port operational status is up and port operational speed is 0, don't save it to APPL_DB

**Why I did it**

Avoid put speed 0 to APPL_DB.

Port operational status is up, but operational speed is 0. It could be a valid case because
port UP event is an aync event, the valid flow could be:
   1. port UP event comes
   2. SONiC gets the UP event and starts to process the event
   3. port goes down due to any reason
   4. SONiC reads the oper speed, and gets a 0 because oper_state is down.
And it could also be a bug. So, we log a warning here.

**How I verified it**

Run sonic-mgmt regression test cases

**Details if related**
