### PR TITLE
[acl]Update acl type check logic

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3403,6 +3403,11 @@ bool AclOrch::processAclTablePorts(string portList, AclTable &aclTable)
 
 bool AclOrch::isAclTableTypeUpdated(acl_table_type_t table_type, AclTable &t)
 {
+    if (m_isCombinedMirrorV6Table && (table_type == ACL_TABLE_MIRROR || table_type == ACL_TABLE_MIRRORV6))
+    {
+        // ACL_TABLE_MIRRORV6 and ACL_TABLE_MIRROR should be treated as same type in combined scenario
+        return !(t.type == ACL_TABLE_MIRROR || t.type == ACL_TABLE_MIRRORV6);
+    }
     return (table_type != t.type);
 }
 


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR is to fix https://github.com/Azure/sonic-buildimage/issues/8585

**Why I did it**
Updating ```ACL_TABLE:EVERFLOW``` and ```ACL_TABLE:EVERFLOWV6``` separately will cause the EVERFLOW table being recreated rather than being updated. 
The root cause for this issue is a minor logic error in https://github.com/Azure/sonic-swss/blob/12f0ee7888be5efac5b4213e92d77a030832c40b/orchagent/aclorch.cpp#L3164-L3170

The MIRROR and MIRRORV6 should be treated as the same type on Broadcom platform.

**How I verified it**
Verified by replacing ```orchagent``` with the updated one, and update ```ACL_TABLE|EVERFLOWV6``` table by ```redis-cli```, and then check syslog.
Before this update, the ```ACL_TABLE|EVERFLOW``` table will be removed and ```ACL_TABLE|EVERFLOWV6``` will be created.
After this update, the ```ACL_TABLE|EVERFLOW``` table will be updated.

**Details if related**
No.