### PR TITLE
[Flex-counters] Fix the delay of flex counters flow to prevent infinite loop

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -86,9 +86,9 @@ void FlexCounterOrch::doTask(Consumer &consumer)
 
         if (op == SET_COMMAND)
         {
-            auto it = std::find(std::begin(data), std::end(data), FieldValueTuple(FLEX_COUNTER_DELAY_STATUS_FIELD, "true"));
+            auto delay_it = std::find(std::begin(data), std::end(data), FieldValueTuple(FLEX_COUNTER_DELAY_STATUS_FIELD, "true"));
 
-            if (it != data.end())
+            if (delay_it != data.end())
             {
                 consumer.m_toSync.erase(it++);
                 continue;

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -86,9 +86,9 @@ void FlexCounterOrch::doTask(Consumer &consumer)
 
         if (op == SET_COMMAND)
         {
-            auto delay_it = std::find(std::begin(data), std::end(data), FieldValueTuple(FLEX_COUNTER_DELAY_STATUS_FIELD, "true"));
+            auto itDelay = std::find(std::begin(data), std::end(data), FieldValueTuple(FLEX_COUNTER_DELAY_STATUS_FIELD, "true"));
 
-            if (delay_it != data.end())
+            if (itDelay != data.end())
             {
                 consumer.m_toSync.erase(it++);
                 continue;

--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -90,6 +90,7 @@ void FlexCounterOrch::doTask(Consumer &consumer)
 
             if (it != data.end())
             {
+                consumer.m_toSync.erase(it++);
                 continue;
             }
             for (auto valuePair:data)


### PR DESCRIPTION
Signed-off-by: Shlomi Bitton <shlomibi@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add 'consumer.m_toSync.erase(it++)' before 'continue' statement on while loop.

**Why I did it**
Running fast-reboot with a delay indicator will result in an infinite loop, following PR: https://github.com/Azure/sonic-swss/pull/1877

**How I verified it**
Run fast-reboot with this change.

**Details if related**
