### PR TITLE
[MuxOrch] Mux state order change

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -394,15 +394,14 @@ void MuxCable::setState(string new_state)
     SWSS_LOG_NOTICE("[%s] Set MUX state from %s to %s", mux_name_.c_str(),
                      muxStateValToString.at(state_).c_str(), new_state.c_str());
 
-    // Update HW Mux cable state anyways
-    mux_cb_orch_->updateMuxState(mux_name_, new_state);
-
     MuxState ns = muxStateStringToVal.at(new_state);
 
     auto it = muxStateTransition.find(make_pair(state_, ns));
 
     if (it ==  muxStateTransition.end())
     {
+        // Update HW Mux cable state anyways
+        mux_cb_orch_->updateMuxState(mux_name_, new_state);
         SWSS_LOG_ERROR("State transition from %s to %s is not-handled ",
                         muxStateValToString.at(state_).c_str(), new_state.c_str());
         return;
@@ -430,6 +429,7 @@ void MuxCable::setState(string new_state)
     st_chg_failed_ = false;
     SWSS_LOG_INFO("Changed state to %s", new_state.c_str());
 
+    mux_cb_orch_->updateMuxState(mux_name_, new_state);
     return;
 }
 


### PR DESCRIPTION
**What I did**
Orchagent sometimes took >50ms to finish the state change operations. This change is to update notification to xcvrd (via APPDB) after execution is complete.  This enables xcvrd to simulate the direction change *after* orchagent has completed the state transition. 

**Why I did it**
Reduce packet drop during state transition. 

**How I verified it**


**Details if related**
