### PR TITLE
Allow IPv4 link-local nexthops

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -671,19 +671,6 @@ void NeighOrch::doTask(Consumer &consumer)
 
         IpAddress ip_address(key.substr(found+1));
 
-        /* Verify Ipv4 LinkLocal and skip neighbor entry added for RFC5549 */
-        if ((ip_address.getAddrScope() == IpAddress::LINK_SCOPE) && (ip_address.isV4()))
-        {
-            /* Check if this prefix is not a configured ip, if so allow */
-            IpPrefix ipll_prefix(ip_address.getV4Addr(), 16);
-            if (!m_intfsOrch->isPrefixSubnet (ipll_prefix, alias))
-            {
-                SWSS_LOG_NOTICE("Skip IPv4LL neighbor %s, Intf:%s op: %s ", ip_address.to_string().c_str(), alias.c_str(), op.c_str());
-                it = consumer.m_toSync.erase(it);
-                continue;
-            }
-        }
-
         NeighborEntry neighbor_entry = { ip_address, alias };
 
         if (op == SET_COMMAND)
@@ -792,6 +779,18 @@ bool NeighOrch::addNeighbor(const NeighborEntry &neighborEntry, const MacAddress
     neighbor_attr.id = SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS;
     memcpy(neighbor_attr.value.mac, macAddress.getMac(), 6);
     neighbor_attrs.push_back(neighbor_attr);
+
+    if ((ip_address.getAddrScope() == IpAddress::LINK_SCOPE) && (ip_address.isV4()))
+    {
+        /* Check if this prefix is a configured ip, if not allow */
+        IpPrefix ipll_prefix(ip_address.getV4Addr(), 16);
+        if (!m_intfsOrch->isPrefixSubnet (ipll_prefix, alias))
+        {
+            neighbor_attr.id = SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE;
+            neighbor_attr.value.booldata = 1;
+            neighbor_attrs.push_back(neighbor_attr);
+        }
+    }
 
     MuxOrch* mux_orch = gDirectory.get<MuxOrch*>();
     bool hw_config = isHwConfigured(neighborEntry);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix for issue: https://github.com/Azure/sonic-buildimage/issues/8606

**Why I did it**
Orchagent (NeighOrch) currently ignores IPv4 link-local neighbours. Any route pointing to such a nexthop is not added to the ASIC DB. Such routes are expected and should be supported.

**How I verified it**

```
root@sonic:/home/admin# redis-cli hgetall "NEIGH_TABLE:Ethernet0:169.254.0.1"
1) "family"
2) "IPv4"
3) "neigh"
4) "00:10:94:00:00:01"
root@sonic:/home/admin#
root@sonic:/home/admin# redis-cli hgetall "ROUTE_TABLE:50.0.1.0/24"
1) "nexthop"
2) "169.254.0.1"
3) "ifname"
4) "Ethernet0"
root@sonic:/home/admin#


--- Syslog ---

Sep 10 08:51:22.177963 sonic NOTICE swss#orchagent: :- addNeighbor: Created neighbor ip 169.254.0.1, 00:10:94:00:00:01 on Ethernet0
Sep 10 08:51:22.178802 sonic NOTICE swss#orchagent: :- addNextHop: Created next hop 169.254.0.1 on Ethernet0

Sep 10 08:55:34.173418 sonic INFO swss#orchagent: :- create_entry: EntityBulker.create_entry 1, 1, 2, 1
Sep 10 08:55:34.174798 sonic INFO swss#orchagent: :- flush_creating_entries: EntityBulker.flush creating_entries 1
Sep 10 08:55:34.174798 sonic INFO swss#orchagent: :- addRoutePost: Post create route 50.0.1.0/24 with next hop(s) 169.254.0.1@Ethernet0

-------

root@sonic:/home/admin# redis-cli -n 1 keys *NEIGH*
1) "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{\"ip\":\"169.254.0.1\",\"rif\":\"oid:0x6000000000600\",\"switch_id\":\"oid:0x21000000000000\"}"
root@sonic:/home/admin#

root@sonic:/home/admin# redis-cli -n 1 keys *NEXT_HOP*
1) "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP:oid:0x4000000000621"
root@sonic:/home/admin#

root@sonic:/home/admin# redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY:{\"ip\":\"169.254.0.1\",\"rif\":\"oid:0x6000000000600\",\"switch_id\":\"oid:0x21000000000000\"}"
1) "SAI_NEIGHBOR_ENTRY_ATTR_DST_MAC_ADDRESS"
2) "00:10:94:00:00:01"
3) "SAI_NEIGHBOR_ENTRY_ATTR_NO_HOST_ROUTE"
4) "true"
root@sonic:/home/admin# 

root@sonic:/home/admin# redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_NEXT_HOP:oid:0x4000000000621"
1) "SAI_NEXT_HOP_ATTR_TYPE"
2) "SAI_NEXT_HOP_TYPE_IP"
3) "SAI_NEXT_HOP_ATTR_IP"
4) "169.254.0.1"
5) "SAI_NEXT_HOP_ATTR_ROUTER_INTERFACE_ID"
6) "oid:0x6000000000600"
root@sonic:/home/admin#

root@sonic:/home/admin# redis-cli -n 1 hgetall "ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY:{\"dest\":\"50.0.1.0/24\",\"switch_id\":\"oid:0x21000000000000\",\"vr\":\"oid:0x3000000000022\"}"
1) "SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID"
2) "oid:0x4000000000621"
root@sonic:/home/admin#
```

**Details if related**
