### PR TITLE
[202012][pfcwd] Convert polling interval from ms to us in LUA scripts

### DIFF
--- a/orchagent/pfc_detect_mellanox.lua
+++ b/orchagent/pfc_detect_mellanox.lua
@@ -1,12 +1,12 @@
 -- KEYS - queue IDs
 -- ARGV[1] - counters db index
 -- ARGV[2] - counters table name
--- ARGV[3] - poll time interval
+-- ARGV[3] - poll time interval (milliseconds)
 -- return queue Ids that satisfy criteria
 
 local counters_db = ARGV[1]
 local counters_table_name = ARGV[2]
-local poll_time = tonumber(ARGV[3])
+local poll_time = tonumber(ARGV[3]) * 1000
 
 local rets = {}
 

--- a/orchagent/pfc_restore.lua
+++ b/orchagent/pfc_restore.lua
@@ -1,12 +1,12 @@
 -- KEYS - queue IDs
 -- ARGV[1] - counters db index
 -- ARGV[2] - counters table name
--- ARGV[3] - poll time interval
+-- ARGV[3] - poll time interval (milliseconds)
 -- return queue Ids that satisfy criteria
 
 local counters_db = ARGV[1]
 local counters_table_name = ARGV[2]
-local poll_time = tonumber(ARGV[3])
+local poll_time = tonumber(ARGV[3]) * 1000
 
 local rets = {}
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Converted polling interval from milliseconds to microseconds in PFCWD LUA scripts.
Same as PR https://github.com/Azure/sonic-swss/pull/1908 but created directly against ```202012``` release branch

**Why I did it**
PFCWD storm detection and restoration LUA scripts require values in microseconds.
Due to recent changes polling interval is now passed in milliseconds by "FlexCounter".
* Azure/sonic-sairedis#878

So need to convert values to microseconds (as it was before) in order to make PFCWD working,

**How I verified it**
Ran PFCWD tests from sonic-mgmt.

**Details if related**
N/A