### PR TITLE
Completely remove "recirc port" code

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -44,7 +44,6 @@ extern sai_port_api_t *sai_port_api;
 
 extern sai_object_id_t  gSwitchId;
 extern PortsOrch*       gPortsOrch;
-extern string           gMySwitchType;
 
 using namespace std::rel_ops;
 
@@ -663,10 +662,6 @@ bool MirrorOrch::getNeighborInfo(const string& name, MirrorEntry& session)
 
             return true;
         }
-        case Port::SYSTEM:
-        {
-            return true;
-        }
         default:
         {
             return false;
@@ -863,21 +858,7 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
     else
     {
         attr.id = SAI_MIRROR_SESSION_ATTR_MONITOR_PORT;
-        // Set monitor port to recirc port in voq switch.
-        if (gMySwitchType == "voq")
-        {
-            Port recirc_port;
-            if (!m_portsOrch->getRecircPort(recirc_port, "Rec"))
-            {
-                SWSS_LOG_ERROR("Failed to get recirc prot");
-                return false;
-            }
-            attr.value.oid = recirc_port.m_port_id;
-        }
-        else
-        {
-            attr.value.oid = session.neighborInfo.portId;
-        }
+        attr.value.oid = session.neighborInfo.portId;
         attrs.push_back(attr);
 
         attr.id = SAI_MIRROR_SESSION_ATTR_TYPE;
@@ -939,15 +920,7 @@ bool MirrorOrch::activateSession(const string& name, MirrorEntry& session)
         attrs.push_back(attr);
 
         attr.id = SAI_MIRROR_SESSION_ATTR_DST_MAC_ADDRESS;
-        // Use router mac as mirror dst mac in voq switch.
-        if (gMySwitchType == "voq")
-        {
-            memcpy(attr.value.mac, gMacAddress.getMac(), sizeof(sai_mac_t));
-        }
-        else
-        {
-            memcpy(attr.value.mac, session.neighborInfo.mac.getMac(), sizeof(sai_mac_t));
-        }
+        memcpy(attr.value.mac, session.neighborInfo.mac.getMac(), sizeof(sai_mac_t));
         attrs.push_back(attr);
 
         attr.id = SAI_MIRROR_SESSION_ATTR_GRE_PROTOCOL_TYPE;

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2278,14 +2278,9 @@ string PortsOrch::getPriorityGroupDropPacketsFlexCounterTableKey(string key)
     return string(PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP) + ":" + key;
 }
 
-bool PortsOrch::initPort(const string &alias, const string &role, const int index, const set<int> &lane_set)
+bool PortsOrch::initPort(const string &alias, const int index, const set<int> &lane_set)
 {
     SWSS_LOG_ENTER();
-
-    if (role == "Rec" || role == "Inb")
-    {
-        return doProcessRecircPort(alias, role, lane_set, SET_COMMAND);
-    }
 
     /* Determine if the lane combination exists in switch */
     if (m_portListLaneMap.find(lane_set) != m_portListLaneMap.end())
@@ -2548,7 +2543,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
             string an_str;
             int an = -1;
             int index = -1;
-            string role;
             string adv_speeds_str;
             string interface_type_str;
             string adv_interface_types_str;
@@ -2703,18 +2697,12 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     getPortSerdesVal(fvValue(i), attr_val);
                     serdes_attr.insert(serdes_attr_pair(SAI_PORT_SERDES_ATTR_TX_FIR_ATTN, attr_val));
                 }
-
-                /* Get port role */
-                if (fvField(i) == "role")
-                {
-                    role = fvValue(i);
-                }
             }
 
             /* Collect information about all received ports */
             if (lane_set.size())
             {
-                m_lanesAliasSpeedMap[lane_set] = make_tuple(alias, speed, an, fec_mode, index, role);
+                m_lanesAliasSpeedMap[lane_set] = make_tuple(alias, speed, an, fec_mode, index);
             }
 
             // TODO:
@@ -2756,7 +2744,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         }
                     }
 
-                    if (!initPort(get<0>(it->second), get<5>(it->second), get<4>(it->second), it->first))
+                    if (!initPort(get<0>(it->second), get<4>(it->second), it->first))
                     {
                         throw runtime_error("PortsOrch initialization failure.");
                     }
@@ -2800,15 +2788,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
             }
             else
             {
-                /* Skip configuring recirc port for now because the current SAI implementation of some vendors
-                 * have limiited support for recirc port. This check can be removed once SAI implementation
-                 * is enhanced/changed in the future.
-                 */
-                if (m_recircPortRole.find(alias) != m_recircPortRole.end())
-                {
-                    it = consumer.m_toSync.erase(it);
-                    continue;
-                }
 
                 if (!an_str.empty())
                 {
@@ -6049,93 +6028,6 @@ bool PortsOrch::getSystemPorts()
     }
 
     return true;
-}
-
-bool PortsOrch::getRecircPort(Port &port, string role)
-{
-    for (auto it = m_recircPortRole.begin(); it != m_recircPortRole.end(); it++)
-    {
-        if (it->second == role)
-        {
-            return getPort(it->first, port);
-        }
-    }
-    SWSS_LOG_ERROR("Failed to find recirc port with role %s", role.c_str());
-    return false;
-}
-
-bool PortsOrch::doProcessRecircPort(string alias, string role, set<int> lane_set, string op)
-{
-    SWSS_LOG_ENTER();
-
-    if (op == SET_COMMAND)
-    {
-        if (m_recircPortRole.find(alias) != m_recircPortRole.end())
-        {
-            SWSS_LOG_DEBUG("Recirc port %s already added", alias.c_str());
-            return true;
-        }
-
-        /* Find pid of recirc port */ 
-        sai_object_id_t port_id = SAI_NULL_OBJECT_ID;
-        if (m_portListLaneMap.find(lane_set) != m_portListLaneMap.end())
-        {
-            port_id = m_portListLaneMap[lane_set];
-        }
-
-        if (port_id == SAI_NULL_OBJECT_ID)
-        {
-            SWSS_LOG_ERROR("Failed to find port id for recirc port %s", alias.c_str());
-            return false;
-        }
-
-        Port p(alias, Port::PHY);
-        p.m_port_id = port_id;
-        p.m_init = true;
-        m_recircPortRole[alias] = role;
-        setPort(alias, p);
-
-        string lane_str = "";
-        for (auto lane : lane_set)
-        {
-            lane_str += to_string(lane) + " ";
-        }
-        SWSS_LOG_NOTICE("Added recirc port %s, pid:%" PRIx64 " lanes:%s",
-                        alias.c_str(), port_id, lane_str.c_str());
-
-        /* Create host intf for recirc port */
-        if(addHostIntfs(p, p.m_alias, p.m_hif_id))
-        {
-            SWSS_LOG_NOTICE("Created host intf for recycle port %s", p.m_alias.c_str());
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Failed to Create host intf for recirc port %s", p.m_alias.c_str());
-        }
-
-        if(setHostIntfsOperStatus(p, true))
-        {
-            SWSS_LOG_NOTICE("Set host intf oper status UP for recirc port %s", p.m_alias.c_str());
-        }
-        else
-        {
-            SWSS_LOG_ERROR("Failed to set host intf oper status for recirc port %s", p.m_alias.c_str());
-        }
-
-        PortUpdate update = { p, true };
-        notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
-        return true;
-    }
-    else if (op == DEL_COMMAND)
-    {
-        SWSS_LOG_ERROR("Delete recirc port is not supported.");
-        return false;
-    }
-    else
-    {
-        SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
-        return false;
-    }
 }
 
 bool PortsOrch::addSystemPorts()

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2282,6 +2282,11 @@ bool PortsOrch::initPort(const string &alias, const string &role, const int inde
 {
     SWSS_LOG_ENTER();
 
+    if (role == "Rec" || role == "Inb")
+    {
+        return doProcessRecircPort(alias, role, lane_set, SET_COMMAND);
+    }
+
     /* Determine if the lane combination exists in switch */
     if (m_portListLaneMap.find(lane_set) != m_portListLaneMap.end())
     {
@@ -2335,11 +2340,6 @@ bool PortsOrch::initPort(const string &alias, const string &role, const int inde
                 notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
 
                 m_portList[alias].m_init = true;
-
-                if (role == "Rec" || role == "Inb")
-                {
-                    m_recircPortRole[alias] = role;
-                }
 
                 SWSS_LOG_NOTICE("Initialized port %s", alias.c_str());
             }
@@ -2800,6 +2800,16 @@ void PortsOrch::doPortTask(Consumer &consumer)
             }
             else
             {
+                /* Skip configuring recirc port for now because the current SAI implementation of some vendors
+                 * have limiited support for recirc port. This check can be removed once SAI implementation
+                 * is enhanced/changed in the future.
+                 */
+                if (m_recircPortRole.find(alias) != m_recircPortRole.end())
+                {
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
                 if (!an_str.empty())
                 {
                     if (autoneg_mode_map.find(an_str) == autoneg_mode_map.end())
@@ -6052,6 +6062,80 @@ bool PortsOrch::getRecircPort(Port &port, string role)
     }
     SWSS_LOG_ERROR("Failed to find recirc port with role %s", role.c_str());
     return false;
+}
+
+bool PortsOrch::doProcessRecircPort(string alias, string role, set<int> lane_set, string op)
+{
+    SWSS_LOG_ENTER();
+
+    if (op == SET_COMMAND)
+    {
+        if (m_recircPortRole.find(alias) != m_recircPortRole.end())
+        {
+            SWSS_LOG_DEBUG("Recirc port %s already added", alias.c_str());
+            return true;
+        }
+
+        /* Find pid of recirc port */ 
+        sai_object_id_t port_id = SAI_NULL_OBJECT_ID;
+        if (m_portListLaneMap.find(lane_set) != m_portListLaneMap.end())
+        {
+            port_id = m_portListLaneMap[lane_set];
+        }
+
+        if (port_id == SAI_NULL_OBJECT_ID)
+        {
+            SWSS_LOG_ERROR("Failed to find port id for recirc port %s", alias.c_str());
+            return false;
+        }
+
+        Port p(alias, Port::PHY);
+        p.m_port_id = port_id;
+        p.m_init = true;
+        m_recircPortRole[alias] = role;
+        setPort(alias, p);
+
+        string lane_str = "";
+        for (auto lane : lane_set)
+        {
+            lane_str += to_string(lane) + " ";
+        }
+        SWSS_LOG_NOTICE("Added recirc port %s, pid:%" PRIx64 " lanes:%s",
+                        alias.c_str(), port_id, lane_str.c_str());
+
+        /* Create host intf for recirc port */
+        if(addHostIntfs(p, p.m_alias, p.m_hif_id))
+        {
+            SWSS_LOG_NOTICE("Created host intf for recycle port %s", p.m_alias.c_str());
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to Create host intf for recirc port %s", p.m_alias.c_str());
+        }
+
+        if(setHostIntfsOperStatus(p, true))
+        {
+            SWSS_LOG_NOTICE("Set host intf oper status UP for recirc port %s", p.m_alias.c_str());
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Failed to set host intf oper status for recirc port %s", p.m_alias.c_str());
+        }
+
+        PortUpdate update = { p, true };
+        notify(SUBJECT_TYPE_PORT_CHANGE, static_cast<void *>(&update));
+        return true;
+    }
+    else if (op == DEL_COMMAND)
+    {
+        SWSS_LOG_ERROR("Delete recirc port is not supported.");
+        return false;
+    }
+    else
+    {
+        SWSS_LOG_ERROR("Unknown operation type %s", op.c_str());
+        return false;
+    }
 }
 
 bool PortsOrch::addSystemPorts()

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -324,6 +324,7 @@ private:
     bool initGearboxPort(Port &port);
 
     map<string, string> m_recircPortRole;
+    bool doProcessRecircPort(string alias, string role, set<int> laneSet, string op);
 
     //map key is tuple of <attached_switch_id, core_index, core_port_index>
     map<tuple<int, int, int>, sai_object_id_t> m_systemPortOidMap;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -150,8 +150,6 @@ public:
     bool isInbandPort(const string &alias);
     bool setVoqInbandIntf(string &alias, string &type);
 
-    bool getRecircPort(Port &p, string role);
-
 private:
     unique_ptr<Table> m_counterTable;
     unique_ptr<Table> m_counterLagTable;
@@ -214,7 +212,7 @@ private:
     port_config_state_t m_portConfigState = PORT_CONFIG_MISSING;
     sai_uint32_t m_portCount;
     map<set<int>, sai_object_id_t> m_portListLaneMap;
-    map<set<int>, tuple<string, uint32_t, int, string, int, string>> m_lanesAliasSpeedMap;
+    map<set<int>, tuple<string, uint32_t, int, string, int>> m_lanesAliasSpeedMap;
     map<string, Port> m_portList;
     unordered_map<sai_object_id_t, int> m_portOidToIndex;
     map<string, uint32_t> m_port_ref_count;
@@ -260,7 +258,7 @@ private:
 
     bool addPort(const set<int> &lane_set, uint32_t speed, int an=0, string fec="");
     sai_status_t removePort(sai_object_id_t port_id);
-    bool initPort(const string &alias, const string &role, const int index, const set<int> &lane_set);
+    bool initPort(const string &alias, const int index, const set<int> &lane_set);
     void deInitPort(string alias, sai_object_id_t port_id);
 
     bool setPortAdminStatus(Port &port, bool up);
@@ -323,9 +321,8 @@ private:
     void initGearbox();
     bool initGearboxPort(Port &port);
 
-    map<string, string> m_recircPortRole;
-    bool doProcessRecircPort(string alias, string role, set<int> laneSet, string op);
-
+    
+    
     //map key is tuple of <attached_switch_id, core_index, core_port_index>
     map<tuple<int, int, int>, sai_object_id_t> m_systemPortOidMap;
     sai_uint32_t m_systemPortCount;

--- a/tests/test_port_config.py
+++ b/tests/test_port_config.py
@@ -4,7 +4,6 @@ import os
 import pytest
 
 from swsscommon import swsscommon
-from dvslib.dvs_common import wait_for_result, PollingConfig
 
 
 @pytest.yield_fixture
@@ -155,76 +154,6 @@ class TestPortConfig(object):
             assert hw_lane_value, "Can't get hw_lane list"
             assert hw_lane_value == "1:%s" % (new_lanes[i])
 
-    def test_recirc_port(self, dvs):
-
-        # Get port config from configDB
-        cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
-        cfg_port_tbl = swsscommon.Table(cfg_db, swsscommon.CFG_PORT_TABLE_NAME)
-
-        indexes = []
-        lanes = []
-        keys = cfg_port_tbl.getKeys()
-        for port in keys:
-            (status, fvs) = cfg_port_tbl.get(port)
-            assert(status == True)
-
-            for fv in fvs:
-                if fv[0] == "index":
-                    indexes.append(int(fv[1]))
-                if fv[0] == "lanes":
-                    lanes.extend([int(lane) for lane in fv[1].split(",")])
-
-        # Stop swss before modifing the configDB
-        dvs.stop_swss()
-        time.sleep(1)
-
-        recirc_port_lane_base = max(lanes) + 1
-        recirc_port_index_base = max(indexes) + 1
-
-        # Add recirc ports to port config in configDB
-        recirc_port_lane_name_map = {}
-        for i in range(2):
-            name = alias = "Ethernet-Rec%s" % i
-            fvs = swsscommon.FieldValuePairs([("role", "Rec" if i % 2 == 0 else "Inb"),
-                                              ("alias", alias),
-                                              ("lanes", str(recirc_port_lane_base + i)),
-                                              ("speed", "10000"),
-                                              ("index", str(recirc_port_index_base + i))])
-            cfg_port_tbl.set(name, fvs)
-
-        # Start swss
-        dvs.start_swss()
-        time.sleep(5)
-
-        polling_config = PollingConfig(polling_interval=0.1, timeout=15, strict=True)
-
-        # Verify recirc ports in port table in applDB
-        for i in range(2):
-            name = alias = "Ethernet-Rec%s" % i
-            dvs.get_app_db().wait_for_field_match(swsscommon.APP_PORT_TABLE_NAME, name,
-                                                  {"role" : "Rec" if i % 2 == 0 else "Inb",
-                                                   "alias" : name,
-                                                   "lanes" : str(recirc_port_lane_base + i),
-                                                   "speed" : "10000",
-                                                   "index" : str(recirc_port_index_base + i) },
-                                                  polling_config=polling_config)
-
-        # Verify recirc port lanes in asicDB
-        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
-        asic_db_lanes_tbl = swsscommon.Table(asic_db, "LANES")
-
-        def _access_function():
-            lanes = asic_db_lanes_tbl.get('')[1]
-            if len(lanes) == 0:
-                return (False, None)
-
-            recirc_port_lanes = [recirc_port_lane_base, recirc_port_lane_base + 1]
-            for lane in lanes:
-                lane_num = int(lane[0])
-                if int(lane_num) in recirc_port_lanes:
-                    recirc_port_lanes.remove( lane_num )
-            return (not recirc_port_lanes, None)
-        wait_for_result(_access_function, polling_config=polling_config)
 
 
 


### PR DESCRIPTION
**What I did**
Completely remove "recirc port" code. The intention of 1813 is to revert 1530, but it is not complete.
Reverts below commits
```
7c7c4513 2021-07-06 | Revert recirc port change (#1813) [Song Yuan]
5ef4b382 2021-06-01 | Add support for recirc port and everflow (#1530) [Song Yuan]
```

**Why I did it**

**How I verified it**

**Details if related**
