### PR TITLE
[pfcwd] Fix the polling interval time granularity

### DIFF
--- a/orchagent/pfc_detect_barefoot.lua
+++ b/orchagent/pfc_detect_barefoot.lua
@@ -1,12 +1,12 @@
 -- KEYS - queue IDs
 -- ARGV[1] - counters db index
 -- ARGV[2] - counters table name
--- ARGV[3] - poll time interval
+-- ARGV[3] - poll time interval (milliseconds)
 -- return queue Ids that satisfy criteria
 
 local counters_db = ARGV[1]
 local counters_table_name = ARGV[2]
-local poll_time = tonumber(ARGV[3])
+local poll_time = tonumber(ARGV[3]) * 1000
 
 local rets = {}
 

--- a/orchagent/pfc_detect_broadcom.lua
+++ b/orchagent/pfc_detect_broadcom.lua
@@ -1,12 +1,12 @@
 -- KEYS - queue IDs
 -- ARGV[1] - counters db index
 -- ARGV[2] - counters table name
--- ARGV[3] - poll time interval
+-- ARGV[3] - poll time interval (milliseconds)
 -- return queue Ids that satisfy criteria
 
 local counters_db = ARGV[1]
 local counters_table_name = ARGV[2]
-local poll_time = tonumber(ARGV[3])
+local poll_time = tonumber(ARGV[3]) * 1000
 
 local rets = {}
 

--- a/orchagent/pfc_detect_innovium.lua
+++ b/orchagent/pfc_detect_innovium.lua
@@ -1,12 +1,12 @@
 -- KEYS - queue IDs
 -- ARGV[1] - counters db index
 -- ARGV[2] - counters table name
--- ARGV[3] - poll time interval
+-- ARGV[3] - poll time interval (milliseconds)
 -- return queue Ids that satisfy criteria
 
 local counters_db = ARGV[1]
 local counters_table_name = ARGV[2]
-local poll_time = tonumber(ARGV[3])
+local poll_time = tonumber(ARGV[3]) * 1000
 
 local rets = {}
 

--- a/orchagent/pfc_detect_nephos.lua
+++ b/orchagent/pfc_detect_nephos.lua
@@ -1,12 +1,12 @@
 -- KEYS - queue IDs
 -- ARGV[1] - counters db index
 -- ARGV[2] - counters table name
--- ARGV[3] - poll time interval
+-- ARGV[3] - poll time interval (milliseconds)
 -- return queue Ids that satisfy criteria
 
 local counters_db = ARGV[1]
 local counters_table_name = ARGV[2]
-local poll_time = tonumber(ARGV[3])
+local poll_time = tonumber(ARGV[3]) * 1000
 
 local rets = {}
 


### PR DESCRIPTION
Signed-off-by: Neetha John <nejo@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Fixes Azure/sonic-buildimage#8773
Pfcwd regressions were observed due to the changes in the PR Azure/sonic-sairedis#878. Hence aligning the polling interval in lua script to use microseconds

**How I verified it**
Ran pfcwd tests that were failing prior to this change and they passed
