### PR TITLE
[202012][teammgrd]: Improve LAGs cleanup on shutdown

### DIFF
--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -32,7 +32,6 @@ private:
     ProducerStateTable m_appLagTable;
 
     std::set<std::string> m_lagList;
-    std::map<std::string, pid_t> m_lagPIDList;
 
     MacAddress m_mac;
 
@@ -49,7 +48,6 @@ private:
     bool setLagAdminStatus(const std::string &alias, const std::string &admin_status);
     bool setLagMtu(const std::string &alias, const std::string &mtu);
     bool setLagLearnMode(const std::string &alias, const std::string &learn_mode);
- 
 
     bool isPortEnslaved(const std::string &);
     bool findPortMaster(std::string &, const std::string &);

--- a/cfgmgr/teammgrd.cpp
+++ b/cfgmgr/teammgrd.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
         }
 
         while (!received_sigterm)
-        {            
+        {
             Selectable *sel;
             int ret;
 
@@ -91,7 +91,8 @@ int main(int argc, char **argv)
     catch (const exception &e)
     {
         SWSS_LOG_ERROR("Runtime error: %s", e.what());
+        return EXIT_FAILURE;
     }
 
-    return -1;
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn nazariig@nvidia.com

This PR is intended to fix LAGs cleanup degradation caused by python2.7 -> python3 migration.
The approach is to replace `teamd -k -t` call with the raw `SIGTERM` and add PID alive check.
This will make sure the `teammgrd` is stopped only after all managed processes are being killed.

resolves: https://github.com/Azure/sonic-buildimage/issues/8071

**What I did**
* Replaced `teamd -k -t` call with raw `SIGTERM`
* Added PID alive check

**Why I did it**
* To fix LAGs cleanup timeout issue caused by python2.7 -> python3 upgrade

**How I verified it**
1. Configure 64 LAG RIFs
2. Reload config

**Details if related**
* N/A