### PR TITLE
Cache routes for single nexthop for faster retrieval

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1317,47 +1317,87 @@ bool RouteOrch::removeNextHopGroup(const NextHopGroupKey &nexthops)
     return true;
 }
 
+void RouteOrch::addNextHopRoute(const NextHopKey& nextHop, const RouteKey& routeKey)
+{
+    auto it = m_nextHops.find((nextHop));
+
+    if (it != m_nextHops.end())
+    {
+        if (it->second.find(routeKey) != it->second.end())
+        {
+            SWSS_LOG_INFO("Route already present in nh table %s",
+                          routeKey.prefix.to_string().c_str());
+            return;
+        }
+
+        it->second.insert(routeKey);
+    }
+    else
+    {
+        set<RouteKey> routes;
+        routes.insert(routeKey);
+        m_nextHops.insert(make_pair(nextHop, routes));
+    }
+}
+
+void RouteOrch::removeNextHopRoute(const NextHopKey& nextHop, const RouteKey& routeKey)
+{
+    auto it = m_nextHops.find((nextHop));
+
+    if (it != m_nextHops.end())
+    {
+        if (it->second.find(routeKey) == it->second.end())
+        {
+            SWSS_LOG_INFO("Route not present in nh table %s",
+                          routeKey.prefix.to_string().c_str());
+            return;
+        }
+
+        it->second.erase(routeKey);
+        if (it->second.empty())
+        {
+            m_nextHops.erase(nextHop);
+        }
+    }
+}
+
 bool RouteOrch::updateNextHopRoutes(const NextHopKey& nextHop, uint32_t& numRoutes)
 {
     numRoutes = 0;
+    auto it = m_nextHops.find((nextHop));
+
+    if (it == m_nextHops.end())
+    {
+        SWSS_LOG_INFO("No routes found for NH %s", nextHop.ip_address.to_string().c_str());
+        return true;
+    }
+
     sai_route_entry_t route_entry;
     sai_attribute_t route_attr;
     sai_object_id_t next_hop_id;
 
-    for (auto rt_table : m_syncdRoutes)
+    auto rt = it->second.begin();
+    while(rt != it->second.end())
     {
-        for (auto rt_entry : rt_table.second)
+        SWSS_LOG_INFO("Updating route %s", (*rt).prefix.to_string().c_str());
+        next_hop_id = m_neighOrch->getNextHopId(nextHop);
+
+        route_entry.vr_id = (*rt).vrf_id;
+        route_entry.switch_id = gSwitchId;
+        copy(route_entry.destination, (*rt).prefix);
+
+        route_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
+        route_attr.value.oid = next_hop_id;
+
+        sai_status_t status = sai_route_api->set_route_entry_attribute(&route_entry, &route_attr);
+        if (status != SAI_STATUS_SUCCESS)
         {
-            // Skip routes with ecmp nexthops
-            if (rt_entry.second.getSize() > 1)
-            {
-                continue;
-            }
-
-            if (rt_entry.second.contains(nextHop))
-            {
-                SWSS_LOG_INFO("Updating route %s during nexthop status change",
-                               rt_entry.first.to_string().c_str());
-                next_hop_id = m_neighOrch->getNextHopId(nextHop);
-
-                route_entry.vr_id = rt_table.first;
-                route_entry.switch_id = gSwitchId;
-                copy(route_entry.destination, rt_entry.first);
-
-                route_attr.id = SAI_ROUTE_ENTRY_ATTR_NEXT_HOP_ID;
-                route_attr.value.oid = next_hop_id;
-
-                sai_status_t status = sai_route_api->set_route_entry_attribute(&route_entry, &route_attr);
-                if (status != SAI_STATUS_SUCCESS)
-                {
-                    SWSS_LOG_ERROR("Failed to update route %s, rv:%d",
-                                    rt_entry.first.to_string().c_str(), status);
-                    return false;
-                }
-
-                ++numRoutes;
-            }
+            SWSS_LOG_ERROR("Failed to update route %s, rv:%d", (*rt).prefix.to_string().c_str(), status);
+            return false;
         }
+
+        ++numRoutes;
+        ++rt;
     }
 
     return true;
@@ -1856,6 +1896,12 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
                 SWSS_LOG_NOTICE("Update overlay Nexthop %s", ol_nextHops.to_string().c_str());
                 m_bulkNhgReducedRefCnt.emplace(ol_nextHops, vrf_id);
             }
+            else if (ol_nextHops.getSize() == 1)
+            {
+                RouteKey r_key = { vrf_id, ipPrefix };
+                auto nexthop = NextHopKey(ol_nextHops.to_string());
+                removeNextHopRoute(nexthop, r_key);
+            }
         }
 
         if (blackhole)
@@ -1876,6 +1922,16 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
 
         SWSS_LOG_INFO("Post set route %s with next hop(s) %s",
                 ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
+    }
+
+    if (nextHops.getSize() == 1)
+    {
+        RouteKey r_key = { vrf_id, ipPrefix };
+        auto nexthop = NextHopKey(nextHops.to_string());
+        if (!nexthop.ip_address.isZero())
+        {
+            addNextHopRoute(nexthop, r_key);
+        }
     }
 
     m_syncdRoutes[vrf_id][ipPrefix] = nextHops;
@@ -2048,6 +2104,12 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             {
                 m_neighOrch->removeMplsNextHop(nexthop);
             }
+        }
+        else if (ol_nextHops.getSize() == 1)
+        {
+            RouteKey r_key = { vrf_id, ipPrefix };
+            auto nexthop = NextHopKey(ol_nextHops.to_string());
+            removeNextHopRoute(nexthop, r_key);
         }
     }
 

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1348,8 +1348,7 @@ void RouteOrch::removeNextHopRoute(const NextHopKey& nextHop, const RouteKey& ro
     {
         if (it->second.find(routeKey) == it->second.end())
         {
-            SWSS_LOG_INFO("Route not present in nh table %s",
-                          routeKey.prefix.to_string().c_str());
+            SWSS_LOG_INFO("Route not present in nh table %s", routeKey.prefix.to_string().c_str());
             return;
         }
 
@@ -1358,6 +1357,10 @@ void RouteOrch::removeNextHopRoute(const NextHopKey& nextHop, const RouteKey& ro
         {
             m_nextHops.erase(nextHop);
         }
+    }
+    else
+    {
+        SWSS_LOG_INFO("Nexthop %s not found in nexthop table", nextHop.to_string().c_str());
     }
 }
 
@@ -1393,7 +1396,11 @@ bool RouteOrch::updateNextHopRoutes(const NextHopKey& nextHop, uint32_t& numRout
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to update route %s, rv:%d", (*rt).prefix.to_string().c_str(), status);
-            return false;
+            task_process_status handle_status = handleSaiCreateStatus(SAI_API_ROUTE, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         ++numRoutes;

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1396,7 +1396,7 @@ bool RouteOrch::updateNextHopRoutes(const NextHopKey& nextHop, uint32_t& numRout
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to update route %s, rv:%d", (*rt).prefix.to_string().c_str(), status);
-            task_process_status handle_status = handleSaiCreateStatus(SAI_API_ROUTE, status);
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_ROUTE, status);
             if (handle_status != task_success)
             {
                 return parseHandleSaiStatusFailure(handle_status);

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1931,7 +1931,7 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
                 ipPrefix.to_string().c_str(), nextHops.to_string().c_str());
     }
 
-    if (nextHops.getSize() == 1)
+    if (nextHops.getSize() == 1 && !nextHops.is_overlay_nexthop())
     {
         RouteKey r_key = { vrf_id, ipPrefix };
         auto nexthop = NextHopKey(nextHops.to_string());

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -2111,11 +2111,8 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
             {
                 m_neighOrch->removeMplsNextHop(nexthop);
             }
-        }
-        else if (ol_nextHops.getSize() == 1)
-        {
+
             RouteKey r_key = { vrf_id, ipPrefix };
-            auto nexthop = NextHopKey(ol_nextHops.to_string());
             removeNextHopRoute(nexthop, r_key);
         }
     }

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -42,6 +42,18 @@ struct NextHopUpdate
 
 struct NextHopObserverEntry;
 
+/* Route destination key for a nexthop */
+struct RouteKey
+{
+    sai_object_id_t vrf_id;
+    IpPrefix prefix;
+
+    bool operator < (const RouteKey& rhs) const
+    {
+        return (vrf_id <= rhs.vrf_id && prefix < rhs.prefix);
+    }
+};
+
 /* NextHopGroupTable: NextHopGroupKey, NextHopGroupEntry */
 typedef std::map<NextHopGroupKey, NextHopGroupEntry> NextHopGroupTable;
 /* RouteTable: destination network, NextHopGroupKey */
@@ -56,6 +68,8 @@ typedef std::map<sai_object_id_t, LabelRouteTable> LabelRouteTables;
 typedef std::pair<sai_object_id_t, IpAddress> Host;
 /* NextHopObserverTable: Host, next hop observer entry */
 typedef std::map<Host, NextHopObserverEntry> NextHopObserverTable;
+/* Single Nexthop to Routemap */
+typedef std::map<NextHopKey, std::set<RouteKey>> NextHopRouteTable;
 
 struct NextHopObserverEntry
 {
@@ -138,6 +152,8 @@ public:
     bool addNextHopGroup(const NextHopGroupKey&);
     bool removeNextHopGroup(const NextHopGroupKey&);
 
+    void addNextHopRoute(const NextHopKey&, const RouteKey&);
+    void removeNextHopRoute(const NextHopKey&, const RouteKey&);
     bool updateNextHopRoutes(const NextHopKey&, uint32_t&);
 
     bool validnexthopinNextHopGroup(const NextHopKey&, uint32_t&);
@@ -170,6 +186,7 @@ private:
     RouteTables m_syncdRoutes;
     LabelRouteTables m_syncdLabelRoutes;
     NextHopGroupTable m_syncdNextHopGroups;
+    NextHopRouteTable m_nextHops;
 
     std::set<std::pair<NextHopGroupKey, sai_object_id_t>> m_bulkNhgReducedRefCnt;
     /* m_bulkNhgReducedRefCnt: nexthop, vrf_id */

--- a/tests/test_mux.py
+++ b/tests/test_mux.py
@@ -298,29 +298,6 @@ class TestMuxTunnelBase(object):
 
         self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
 
-        # Check route set flow and changing nexthop
-        self.set_mux_state(appdb, "Ethernet4", "active")
-
-        ps = swsscommon.ProducerStateTable(pdb.db_connection, "ROUTE_TABLE")
-        fvs = swsscommon.FieldValuePairs([("nexthop", self.SERV2_IPV4), ("ifname", "Vlan1000")])
-        ps.set(rtprefix, fvs)
-
-        # Check if route was propagated to ASIC DB
-        rtkeys = dvs_route.check_asicdb_route_entries([rtprefix])
-
-        # Change Mux status for Ethernet0 and expect no change to replaced route
-        self.set_mux_state(appdb, "Ethernet0", "standby")
-        self.check_nexthop_in_asic_db(asicdb, rtkeys[0])
-
-        self.set_mux_state(appdb, "Ethernet4", "standby")
-        self.check_nexthop_in_asic_db(asicdb, rtkeys[0], True)
-
-        # Delete the route
-        ps._del(rtprefix)
-
-        self.set_mux_state(appdb, "Ethernet4", "active")
-        dvs_route.check_asicdb_deleted_route_entries([rtprefix])
-
         # Test ECMP routes
 
         self.set_mux_state(appdb, "Ethernet0", "active")


### PR DESCRIPTION
**What I did**
Created a map to store single nexthop routes. This is for faster retrieval when you've to fetch the routes for a particular nexthop. No changes to ECMP route handling. 

This is an optimization and the existing [VS test ](https://github.com/Azure/sonic-swss/blob/master/tests/test_mux.py#L276) covers the code for add flow. Set flow is covered with new test case.  

**Why I did it**
Faster retrieval of route when a particular nexthop state changes. This avoid looping through all the routes to find a matching nexthop. 

**How I verified it**
Tested on DUT:

```
Sep 21 18:05:46.996655 NOTICE swss#orchagent: :- setState: [Ethernet4] Set MUX state from active to standby
Sep 21 18:05:46.996748 INFO swss#orchagent: :- stateStandby: Set state to Standby for Ethernet4
Sep 21 18:05:46.996798 INFO swss#orchagent: :- disable: Disabling neigh 192.168.0.10 on Vlan1000
Sep 21 18:05:46.996847 INFO swss#orchagent: :- updateNextHopRoutes: Updating route 32.1.1.1/32
Sep 21 18:05:46.998418 NOTICE swss#orchagent: :- disableNeighbor: Neighbor disable request for 192.168.0.10 
Sep 21 18:05:46.999408 NOTICE swss#orchagent: :- removeNeighbor: Removed next hop 192.168.0.10 on Vlan1000
Sep 21 18:05:47.000661 NOTICE swss#orchagent: :- removeNeighbor: Removed neighbor 00:00:11:22:33:44 on Vlan1000
Sep 21 18:05:47.000661 INFO swss#orchagent: :- addTunnelRoute: Add tunnel route DB 'Vlan1000:192.168.0.10/32'
Sep 21 18:05:47.003652 NOTICE swss#orchagent: :- create_route: Created tunnel route to 192.168.0.10/32 
Sep 21 18:05:47.003652 NOTICE swss#orchagent: :- MuxAclHandler: Binding port 1000000000003
Sep 21 18:05:47.003652 INFO swss#orchagent: :- getAclRule: Rule mux_acl_rule doesn't exist
Sep 21 18:05:47.003652 INFO swss#orchagent: :- create: Created counter for the rule mux_acl_rule in table IngressTableDrop
Sep 21 18:05:47.006407 NOTICE swss#orchagent: :- add: Successfully created ACL rule mux_acl_rule in table IngressTableDrop
Sep 21 18:05:47.007733 INFO swss#orchagent: :- setState: Changed state to standby
Sep 21 18:05:47.007960 NOTICE swss#orchagent: :- addOperation: Mux State set to standby for port Ethernet4

```


**Details if related**
