### PR TITLE
[swss] Install IPv6 link local route for new VRF

### DIFF
--- a/orchagent/vrforch.cpp
+++ b/orchagent/vrforch.cpp
@@ -9,6 +9,7 @@
 #include "macaddress.h"
 #include "orch.h"
 #include "request_parser.h"
+#include "routeorch.h"
 #include "vrforch.h"
 #include "vxlanorch.h"
 #include "directory.h"
@@ -20,6 +21,7 @@ extern sai_virtual_router_api_t* sai_virtual_router_api;
 extern sai_object_id_t gSwitchId;
 extern Directory<Orch*> gDirectory;
 extern PortsOrch*       gPortsOrch;
+extern RouteOrch *gRouteOrch;
 
 bool VRFOrch::addOperation(const Request& request)
 {
@@ -115,6 +117,8 @@ bool VRFOrch::addOperation(const Request& request)
         }
         m_stateVrfObjectTable.hset(vrf_name, "state", "ok");
         SWSS_LOG_NOTICE("VRF '%s' was added", vrf_name.c_str());
+
+	gRouteOrch->addLinkLocalRouteToMe(router_id, gRouteOrch->getLinkLocalEui64Addr());
     }
     else
     {


### PR DESCRIPTION
Signed-off-by: Masaru OKI <masaru.oki@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix for issue: Azure/sonic-buildimage#8831

**Why I did it**
When created new VRF, IPv6 link local route is not installed for the VRF.
It causes BGP unnumbered (ipv4 route via ipv6 nexthop) is not working.

**How I verified it**

`Ethernet0` of DUT is connected to another switch speaking BGP (ASN 100).

Setting:
```
sudo config vrf add Vrf1
sudo config interface vrf bind Ethernet0 Vrf1
sudo config ipv6 enable link-local
vtysh \
-c "conf t" \
-c "router bgp 100 vrf Vrf1" \
-c "  router-id 1.1.1.1" \
-c "  neighbor Ethernet0 interface remote-as internal"
```

Wait for minutes, and run `vtysh -c 'show bgp vrf all summary'`

**Details if related**
