### PR TITLE
Reduce route count for route perf test

### DIFF
--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -906,7 +906,6 @@ class TestRoutePerf(TestRouteBase):
         self.setup_db(dvs)
         self.clear_srv_config(dvs)
         numRoutes = 5000   # number of routes to add/remove
-        
 
         # generate ip prefixes of routes
         prefixes = []

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -905,7 +905,7 @@ class TestRoutePerf(TestRouteBase):
     def test_PerfAddRemoveRoute(self, dvs, testlog):
         self.setup_db(dvs)
         self.clear_srv_config(dvs)
-        numRoutes = 10000   # number of routes to add/remove
+        numRoutes = 5000   # number of routes to add/remove
 
         # generate ip prefixes of routes
         prefixes = []

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -906,6 +906,7 @@ class TestRoutePerf(TestRouteBase):
         self.setup_db(dvs)
         self.clear_srv_config(dvs)
         numRoutes = 5000   # number of routes to add/remove
+        
 
         # generate ip prefixes of routes
         prefixes = []


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Reduce route count for route perf test.

**Why I did it**
Route perf test sometimes experiences timeout failure. I measured the route creation/removal time locally and it is roughly the same as it was a year ago. As there is no performance degradation, the test failures should be false alarms caused by the test server speed. Reducing the route count to avoid blocking PR tests due to false alarms.

**How I verified it**

**Details if related**
