### PR TITLE
Ensure route perf test starts when route table is stable

### DIFF
--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -930,12 +930,14 @@ class TestRoutePerf(TestRouteBase):
 
         dvs.servers[1].runcmd("ip address add 10.0.0.3/31 dev eth0")
         dvs.servers[1].runcmd("ip route add default via 10.0.0.2")
+        time.sleep(2)
 
         fieldValues = [{"nexthop": "10.0.0.1", "ifname": "Ethernet0"}, {"nexthop": "10.0.0.3", "ifname": "Ethernet4"}]
 
         # get neighbor and arp entry
         dvs.servers[0].runcmd("ping -c 1 10.0.0.3")
         dvs.servers[1].runcmd("ping -c 1 10.0.0.1")
+        time.sleep(2)
 
         # get number of routes before adding new routes
         startNumRoutes = len(self.adb.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY"))


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add sleep in route perf test to ensure the test starts when route table is stable.

**Why I did it**
This PR aims to fix the PR checker failure due to route perf test failures.

**How I verified it**

**Details if related**
