### PR TITLE
[teammgrd]: Handle LAGs cleanup gracefully on Warm/Fast reboot

### DIFF
--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -132,23 +132,44 @@ void TeamMgr::cleanTeamProcesses()
         std::string res;
         pid_t pid;
 
+        try
         {
             std::stringstream cmd;
             cmd << "cat " << shellquote("/var/run/teamd/" + alias + ".pid");
             EXEC_WITH_ERROR_THROW(cmd.str(), res);
+        }
+        catch (const std::exception &e)
+        {
+            // Handle Warm/Fast reboot scenario
+            SWSS_LOG_NOTICE("Skipping non-existent port channel %s pid...", alias.c_str());
+            continue;
+        }
 
+        try
+        {
             pid = static_cast<pid_t>(std::stoul(res, nullptr, 10));
             aliasPidMap[alias] = pid;
 
             SWSS_LOG_INFO("Read port channel %s pid %d", alias.c_str(), pid);
         }
+        catch (const std::exception &e)
+        {
+            SWSS_LOG_ERROR("Failed to read port channel %s pid: %s", alias.c_str(), e.what());
+            continue;
+        }
 
+        try
         {
             std::stringstream cmd;
             cmd << "kill -TERM " << pid;
             EXEC_WITH_ERROR_THROW(cmd.str(), res);
 
-            SWSS_LOG_INFO("Sent SIGTERM to port channel %s pid %d", alias.c_str(), pid);
+            SWSS_LOG_NOTICE("Sent SIGTERM to port channel %s pid %d", alias.c_str(), pid);
+        }
+        catch (const std::exception &e)
+        {
+            SWSS_LOG_ERROR("Failed to send SIGTERM to port channel %s pid %d: %s", alias.c_str(), pid, e.what());
+            aliasPidMap.erase(alias);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

Warm/Fast reboot requires `USR1`/`USR2` signals to be sent to all LAG pids before `teamd` is stopped.
This automatically triggers graceful LAG pids shutdown and when the `teammgrd` receives `TERM` signal, there is nothing to cleanup.

**What I did**
* Fixed LAGs cleanup on Warm/Fast reboot:
```bash
Sep 28 16:51:21.650824 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Cleaning up LAGs during shutdown...
Sep 28 16:51:21.654356 sonic INFO teamd#/supervisord: teammgrd cat: /var/run/teamd/PortChannel0001.pid: No such file or directory
Sep 28 16:51:21.655125 sonic ERR teamd#teammgrd: :- main: Runtime error: cat "/var/run/teamd/PortChannel0001.pid" :
Sep 28 16:51:22.376959 sonic INFO teamd#supervisord 2021-09-28 16:51:22,376 INFO stopped: teammgrd (exit status 1)
```

**Why I did it**
* N/A

**How I verified it**
* N/A

#### Which release branch to backport (provide reason below if selected)
<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [X] 202012
- [x] 202106

**Details if related**

**SONiC LAG configuration:**
```bash
root@sonic:/home/admin# show interfaces portchannel
Flags: A - active, I - inactive, Up - up, Dw - Down, N/A - not available,
       S - selected, D - deselected, * - not synced
  No.  Team Dev         Protocol     Ports
-----  ---------------  -----------  --------------
 0001  PortChannel0001  LACP(A)(Dw)  Ethernet224(D)
 0002  PortChannel0002  LACP(A)(Dw)  Ethernet232(D)
 0003  PortChannel0003  LACP(A)(Dw)  Ethernet240(D)
 0004  PortChannel0004  LACP(A)(Dw)  Ethernet248(D)
```

**Before:**
```bash
Sep 28 16:51:15.545568 sonic NOTICE admin: Stopping teamd ...
Sep 28 16:51:15.551695 sonic INFO systemd[1]: Stopping TEAMD container...
Sep 28 16:51:15.557599 sonic NOTICE admin: Stopping teamd service...
Sep 28 16:51:15.766858 sonic NOTICE admin: Warm boot flag: teamd true.
Sep 28 16:51:15.772815 sonic NOTICE admin: Fast boot flag: teamd false.
Sep 28 16:51:16.162061 sonic DEBUG /container: container_stop: BEGIN
Sep 28 16:51:16.162382 sonic DEBUG /container: read_data: config:True feature:teamd fields:[('set_owner', 'local'), ('no_fallback_to_local', False)] val:['local', False]
Sep 28 16:51:16.162622 sonic DEBUG /container: read_data: config:False feature:teamd fields:[('current_owner', 'none'), ('remote_state', 'none'), ('container_id', '')] val:['none', 'none', '']
Sep 28 16:51:16.163256 sonic DEBUG /container: container_stop: teamd: set_owner:local current_owner:none remote_state:none docker_id:teamd
Sep 28 16:51:16.555227 sonic INFO teamd#supervisord 2021-09-28 16:51:16,553 INFO reaped unknown pid 26 (exit status 0)
Sep 28 16:51:16.555227 sonic INFO teamd#supervisord 2021-09-28 16:51:16,553 INFO reaped unknown pid 34 (exit status 0)
Sep 28 16:51:16.555227 sonic INFO teamd#supervisord 2021-09-28 16:51:16,553 INFO reaped unknown pid 42 (exit status 0)
Sep 28 16:51:16.555227 sonic INFO teamd#supervisord 2021-09-28 16:51:16,554 INFO reaped unknown pid 50 (exit status 0)
Sep 28 16:51:17.556152 sonic INFO teamd#supervisord 2021-09-28 16:51:17,555 WARN received SIGTERM indicating exit request
Sep 28 16:51:17.556994 sonic INFO teamd#supervisord 2021-09-28 16:51:17,556 INFO waiting for supervisor-proc-exit-listener, rsyslogd, teammgrd, teamsyncd, tlm_teamd to die
Sep 28 16:51:18.557319 sonic NOTICE teamd#tlm_teamd: :- main: Exiting
Sep 28 16:51:19.372962 sonic INFO teamd#supervisord 2021-09-28 16:51:19,372 INFO stopped: tlm_teamd (exit status 0)
Sep 28 16:51:20.374201 sonic NOTICE teamd#teamsyncd: :- cleanTeamSync: Cleaning up LAG teamd resources ...
Sep 28 16:51:20.375673 sonic NOTICE teamd#teamsyncd: :- main: Received SIGTERM Exiting
Sep 28 16:51:20.649657 sonic INFO teamd#supervisord 2021-09-28 16:51:20,649 INFO stopped: teamsyncd (exit status 0)
Sep 28 16:51:20.650467 sonic INFO teamd#supervisord 2021-09-28 16:51:20,649 INFO waiting for supervisor-proc-exit-listener, rsyslogd, teammgrd to die
Sep 28 16:51:21.650824 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Cleaning up LAGs during shutdown...
Sep 28 16:51:21.654356 sonic INFO teamd#/supervisord: teammgrd cat: /var/run/teamd/PortChannel0001.pid: No such file or directory
Sep 28 16:51:21.655125 sonic ERR teamd#teammgrd: :- main: Runtime error: cat "/var/run/teamd/PortChannel0001.pid" :
Sep 28 16:51:22.376959 sonic INFO teamd#supervisord 2021-09-28 16:51:22,376 INFO stopped: teammgrd (exit status 1)
Sep 28 16:51:23.537076 sonic INFO containerd[484]: time="2021-09-28T16:51:23.534793071Z" level=info msg="shim reaped" id=1d88a45dee63d4c34950faa467293ec60d23f08a128532763a65bfc6e993a66e
Sep 28 16:51:23.546292 sonic INFO dockerd[690]: time="2021-09-28T16:51:23.545203824Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Sep 28 16:51:23.557016 sonic INFO systemd[1]: var-lib-docker-containers-1d88a45dee63d4c34950faa467293ec60d23f08a128532763a65bfc6e993a66e-mounts-shm.mount: Succeeded.
Sep 28 16:51:23.583459 sonic INFO systemd[1]: var-lib-docker-overlay2-fa2396b0b45dae5a02a0ed1d29ee5e9c3b61ac97ec887f714008a20215573df4-merged.mount: Succeeded.
Sep 28 16:51:23.628191 sonic INFO /container: docker cmd: wait for teamd
Sep 28 16:51:23.629904 sonic INFO /container: docker cmd: stop for teamd
Sep 28 16:51:23.630214 sonic DEBUG /container: container_stop: END
Sep 28 16:51:23.661672 sonic NOTICE admin: Stopped teamd service...
Sep 28 16:51:23.665107 sonic INFO systemd[1]: teamd.service: Succeeded.
Sep 28 16:51:23.665900 sonic INFO systemd[1]: Stopped TEAMD container.
Sep 28 16:51:23.670589 sonic NOTICE admin: Stopped  teamd ...
```

**After:**
```bash
Sep 28 16:44:14.329140 sonic NOTICE admin: Stopping teamd ...
Sep 28 16:44:14.339179 sonic INFO systemd[1]: Stopping TEAMD container...
Sep 28 16:44:14.345031 sonic NOTICE admin: Stopping teamd service...
Sep 28 16:44:14.560968 sonic NOTICE admin: Warm boot flag: teamd true.
Sep 28 16:44:14.566178 sonic NOTICE admin: Fast boot flag: teamd false.
Sep 28 16:44:14.918994 sonic DEBUG /container: container_stop: BEGIN
Sep 28 16:44:14.919376 sonic DEBUG /container: read_data: config:True feature:teamd fields:[('set_owner', 'local'), ('no_fallback_to_local', False)] val:['local', False]
Sep 28 16:44:14.919703 sonic DEBUG /container: read_data: config:False feature:teamd fields:[('current_owner', 'none'), ('remote_state', 'none'), ('container_id', '')] val:['none', 'none', '']
Sep 28 16:44:14.919972 sonic DEBUG /container: container_stop: teamd: set_owner:local current_owner:none remote_state:none docker_id:teamd
Sep 28 16:44:15.230287 sonic INFO teamd#supervisord 2021-09-28 16:44:15,228 INFO reaped unknown pid 25 (exit status 0)
Sep 28 16:44:15.230287 sonic INFO teamd#supervisord 2021-09-28 16:44:15,228 INFO reaped unknown pid 34 (exit status 0)
Sep 28 16:44:15.230287 sonic INFO teamd#supervisord 2021-09-28 16:44:15,228 INFO reaped unknown pid 42 (exit status 0)
Sep 28 16:44:15.230287 sonic INFO teamd#supervisord 2021-09-28 16:44:15,229 INFO reaped unknown pid 50 (exit status 0)
Sep 28 16:44:16.231226 sonic INFO teamd#supervisord 2021-09-28 16:44:16,230 WARN received SIGTERM indicating exit request
Sep 28 16:44:16.232136 sonic INFO teamd#supervisord 2021-09-28 16:44:16,231 INFO waiting for supervisor-proc-exit-listener, rsyslogd, teammgrd, teamsyncd, tlm_teamd to die
Sep 28 16:44:17.232363 sonic NOTICE teamd#tlm_teamd: :- main: Exiting
Sep 28 16:44:17.943403 sonic INFO teamd#supervisord 2021-09-28 16:44:17,942 INFO stopped: tlm_teamd (exit status 0)
Sep 28 16:44:18.944618 sonic NOTICE teamd#teamsyncd: :- cleanTeamSync: Cleaning up LAG teamd resources ...
Sep 28 16:44:18.945869 sonic NOTICE teamd#teamsyncd: :- main: Received SIGTERM Exiting
Sep 28 16:44:19.140428 sonic INFO teamd#supervisord 2021-09-28 16:44:19,139 INFO stopped: teamsyncd (exit status 0)
Sep 28 16:44:20.141507 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Cleaning up LAGs during shutdown...
Sep 28 16:44:20.142260 sonic INFO teamd#supervisord 2021-09-28 16:44:20,141 INFO waiting for supervisor-proc-exit-listener, rsyslogd, teammgrd to die
Sep 28 16:44:20.145069 sonic INFO teamd#/supervisord: teammgrd cat: /var/run/teamd/PortChannel0001.pid: No such file or directory
Sep 28 16:44:20.145525 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Skipping non-existent port channel PortChannel0001 pid...
Sep 28 16:44:20.148788 sonic INFO teamd#/supervisord: teammgrd cat: /var/run/teamd/PortChannel0002.pid: No such file or directory
Sep 28 16:44:20.149172 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Skipping non-existent port channel PortChannel0002 pid...
Sep 28 16:44:20.152335 sonic INFO teamd#/supervisord: teammgrd cat: /var/run/teamd/PortChannel0003.pid: No such file or directory
Sep 28 16:44:20.152707 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Skipping non-existent port channel PortChannel0003 pid...
Sep 28 16:44:20.155176 sonic INFO teamd#/supervisord: teammgrd cat: /var/run/teamd/PortChannel0004.pid: No such file or directory
Sep 28 16:44:20.155387 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: Skipping non-existent port channel PortChannel0004 pid...
Sep 28 16:44:20.155387 sonic NOTICE teamd#teammgrd: :- cleanTeamProcesses: LAGs cleanup is done
Sep 28 16:44:20.155387 sonic NOTICE teamd#teammgrd: :- main: Exiting
Sep 28 16:44:20.917446 sonic INFO teamd#supervisord 2021-09-28 16:44:20,916 INFO stopped: teammgrd (exit status 0)
Sep 28 16:44:22.083418 sonic INFO containerd[480]: time="2021-09-28T16:44:22.081309410Z" level=info msg="shim reaped" id=90f942c9e7be6991ae0ce30bc71738de51f1f599773106caf1c70860cb87731a
Sep 28 16:44:22.093578 sonic INFO dockerd[661]: time="2021-09-28T16:44:22.091504449Z" level=info msg="ignoring event" module=libcontainerd namespace=moby topic=/tasks/delete type="*events.TaskDelete"
Sep 28 16:44:22.103586 sonic INFO systemd[1]: var-lib-docker-containers-90f942c9e7be6991ae0ce30bc71738de51f1f599773106caf1c70860cb87731a-mounts-shm.mount: Succeeded.
Sep 28 16:44:22.137059 sonic INFO systemd[1]: var-lib-docker-overlay2-06a63c38bf0b38196702d168ba789fed9969900a0ac534ea6836a280b3b643d5-merged.mount: Succeeded.
Sep 28 16:44:22.171661 sonic INFO /container: docker cmd: wait for teamd
Sep 28 16:44:22.172828 sonic INFO /container: docker cmd: stop for teamd
Sep 28 16:44:22.173053 sonic DEBUG /container: container_stop: END
Sep 28 16:44:22.205342 sonic NOTICE admin: Stopped teamd service...
Sep 28 16:44:22.208335 sonic INFO systemd[1]: teamd.service: Succeeded.
Sep 28 16:44:22.208939 sonic INFO systemd[1]: Stopped TEAMD container.
Sep 28 16:44:22.212795 sonic NOTICE admin: Stopped  teamd ...
```