### PR TITLE
[cfgmgr] Fix for STATE_DB Port check logic in cfgmgr daemons

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -9,6 +9,7 @@
 #include "shellcmd.h"
 #include "macaddress.h"
 #include "warm_restart.h"
+#include <swss/redisutility.h>
 
 using namespace std;
 using namespace swss;
@@ -438,6 +439,11 @@ bool IntfMgr::isIntfStateOk(const string &alias)
     }
     else if (m_statePortTable.get(alias, temp))
     {
+        auto state_opt = swss::fvsGetValue(temp, "state", true);
+        if (!state_opt)
+        {
+            return false;
+        }
         SWSS_LOG_DEBUG("Port %s is ready", alias.c_str());
         return true;
     }

--- a/cfgmgr/portmgr.cpp
+++ b/cfgmgr/portmgr.cpp
@@ -6,6 +6,7 @@
 #include "portmgr.h"
 #include "exec.h"
 #include "shellcmd.h"
+#include <swss/redisutility.h>
 
 using namespace std;
 using namespace swss;
@@ -87,6 +88,12 @@ bool PortMgr::isPortStateOk(const string &alias)
 
     if (m_statePortTable.get(alias, temp))
     {
+        auto state_opt = swss::fvsGetValue(temp, "state", true);
+        if (!state_opt)
+        {
+            return false;
+        }
+
         SWSS_LOG_INFO("Port %s is ready", alias.c_str());
         return true;
     }

--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -5,6 +5,7 @@
 #include "tokenize.h"
 #include "warm_restart.h"
 #include "portmgr.h"
+#include <swss/redisutility.h>
 
 #include <algorithm>
 #include <iostream>
@@ -67,6 +68,13 @@ bool TeamMgr::isPortStateOk(const string &alias)
     vector<FieldValueTuple> temp;
 
     if (!m_statePortTable.get(alias, temp))
+    {
+        SWSS_LOG_INFO("Port %s is not ready", alias.c_str());
+        return false;
+    }
+
+    auto state_opt = swss::fvsGetValue(temp, "state", true);
+    if (!state_opt)
     {
         SWSS_LOG_INFO("Port %s is not ready", alias.c_str());
         return false;


### PR DESCRIPTION
**What I did**
Updated checks for Port entry in STATE_DB in portmgrd, teammgrd, and intfmgrd to additionally check for presence of "state" attribute.

**Why I did it**
Prior to recent commits for DPB, 3 daemons in cfgmgr (portmgrd, teammgrd, and intfmgrd) would not allow configuration to proceed for a specific PORT until portsyncd detected the presence of the kernel device (EthernetN) associated with the PORT and created the associated entry for the PORT in the STATE_DB with attribute "state" and value "ok".
With recent commits for DPB, this logic is now broken due to creation of PORT entry in the STATE_DB by PortsOrch with only "supported_speed" attribute.
The logic in the 3 cfgmgr daemons has been updated to additionally check for the "state" attribute when they detect the presence of the PORT entry in STATE_DB.

**How I verified it**
SONiC unit-tests and platform tests.

**Details if related**
N/A