### PR TITLE
Reverted skipped test_buffer_dynamic test cases

### DIFF
--- a/orchagent/orch.cpp
+++ b/orchagent/orch.cpp
@@ -330,42 +330,7 @@ bool Orch::parseReference(type_map &type_maps, string &ref_in, const string &typ
     if ((ref_in[0] == ref_start) || (ref_in[ref_in.size()-1] == ref_end))
     {
         SWSS_LOG_ERROR("malformed reference:%s. Must not be surrounded by [ ]\n", ref_in.c_str());
-        /* 
-         * Accepting old format until sonic-buildimage changes merged, swss tests depends on
-         * generate qos configs which are with old format. If we skip the old format 
-         * isPortAllReady() will fail whcih is set ready by checking buffer config exists in CONFIG_DB are
-         * applied to ASIC_DB or not. 
-         * Due to this All swss test cases are failing.
-         * This to avoid test case failures until merge happens.
-         * 
-         */
-        if (ref_in.size() == 2)
-        {
-            // value set by user is "[]"
-            // Deem it as a valid format
-            // clear both type_name and object_name
-            // as an indication to the caller that
-            // such a case has been encountered
-            //      type_name.clear();
-            object_name.clear();
-            return true;
-        }
-        string ref_content = ref_in.substr(1, ref_in.size() - 2);
-        vector<string> tokens;
-        tokens = tokenize(ref_content, delimiter);
-        if (tokens.size() != 2)
-        {
-            tokens = tokenize(ref_content, config_db_key_delimiter);
-            if (tokens.size() != 2)
-            {
-                SWSS_LOG_ERROR("malformed reference:%s. Must contain 2 tokens\n", ref_content.c_str());
-                return false;
-            }
-        }
-        object_name = tokens[1];
-        SWSS_LOG_ERROR("parsed: type_name:%s, object_name:%s", type_name.c_str(), object_name.c_str());
-
-        return true;
+        return false;
     }
     auto type_it = type_maps.find(type_name);
     if (type_it == type_maps.end())

--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -141,7 +141,6 @@ class TestBufferMgrDyn(object):
         cable_lengths['Ethernet0'] = cable_length
         self.config_db.update_entry('CABLE_LENGTH', 'AZURE', cable_lengths)
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_changeSpeed(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -193,7 +192,6 @@ class TestBufferMgrDyn(object):
         # Shutdown interface
         dvs.runcmd('config interface shutdown Ethernet0')
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_changeCableLen(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -244,7 +242,6 @@ class TestBufferMgrDyn(object):
         # Shutdown interface
         dvs.runcmd('config interface shutdown Ethernet0')
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_MultipleLosslessPg(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -292,7 +289,6 @@ class TestBufferMgrDyn(object):
         # Shutdown interface
         dvs.runcmd('config interface shutdown Ethernet0')
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_headroomOverride(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -376,7 +372,6 @@ class TestBufferMgrDyn(object):
         # Shutdown interface
         dvs.runcmd('config interface shutdown Ethernet0')
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_mtuUpdate(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -411,7 +406,6 @@ class TestBufferMgrDyn(object):
         # Shutdown interface
         dvs.runcmd('config interface shutdown Ethernet0')
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_nonDefaultAlpha(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -454,7 +448,6 @@ class TestBufferMgrDyn(object):
         # Shutdown interface
         dvs.runcmd('config interface shutdown Ethernet0')
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_sharedHeadroomPool(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -553,7 +546,6 @@ class TestBufferMgrDyn(object):
         # Shutdown interface
         dvs.runcmd('config interface shutdown Ethernet0')
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_shutdownPort(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -597,7 +589,6 @@ class TestBufferMgrDyn(object):
         # Shutdown interface
         dvs.runcmd("config interface shutdown Ethernet0")
 
-    @pytest.mark.skip("Skip to be removed after sonic-buildimage changes get merged")
     def test_autoNegPort(self, dvs, testlog):
         self.setup_db(dvs)
 
@@ -623,11 +614,11 @@ class TestBufferMgrDyn(object):
         self.app_db.wait_for_entry("BUFFER_PG_TABLE", "Ethernet0:3-4")
         self.app_db.wait_for_entry("BUFFER_PROFILE_TABLE", expectedProfile)
         self.check_new_profile_in_asic_db(dvs, expectedProfile)
-        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:{}]".format(expectedProfile)})
+        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": expectedProfile})
 
         # Configure another lossless PG on the interface
         self.config_db.update_entry('BUFFER_PG', 'Ethernet0|6', {'profile': 'NULL'})
-        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": "[BUFFER_PROFILE_TABLE:{}]".format(expectedProfile)})
+        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": expectedProfile})
 
         # Disable port auto negotiation
         dvs.runcmd('config interface autoneg Ethernet0 disabled')
@@ -636,8 +627,8 @@ class TestBufferMgrDyn(object):
         expectedProfile = self.make_lossless_profile_name(self.originalSpeed, self.originalCableLen)
         self.app_db.wait_for_entry("BUFFER_PROFILE_TABLE", expectedProfile)
         self.check_new_profile_in_asic_db(dvs, expectedProfile)
-        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": "[BUFFER_PROFILE_TABLE:{}]".format(expectedProfile)})
-        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": "[BUFFER_PROFILE_TABLE:{}]".format(expectedProfile)})
+        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:3-4", {"profile": expectedProfile})
+        self.app_db.wait_for_field_match("BUFFER_PG_TABLE", "Ethernet0:6", {"profile": expectedProfile})
 
         # Remove lossless PGs on the interface
         self.config_db.delete_entry('BUFFER_PG', 'Ethernet0|3-4')


### PR DESCRIPTION
**What I did**
Reverted skipped test_buffer_dynamic as part of https://github.com/Azure/sonic-swss/pull/1754

**Why I did it**

**How I verified it** sudo pytest --dvsname=vs --forcedvs -sv --keeptb test_buffer_dynamic.py
======================================================= test session starts ========================================================
platform linux -- Python 3.6.9, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/ashokd/swss-vs/ashok-swss/sonic-swss/tests
plugins: flaky-3.7.0
collected 9 items

test_buffer_dynamic.py::TestBufferMgrDyn::test_changeSpeed remove extra link dummy PASSED
test_buffer_dynamic.py::TestBufferMgrDyn::test_changeCableLen PASSED
test_buffer_dynamic.py::TestBufferMgrDyn::test_MultipleLosslessPg PASSED
test_buffer_dynamic.py::TestBufferMgrDyn::test_headroomOverride PASSED
test_buffer_dynamic.py::TestBufferMgrDyn::test_mtuUpdate PASSED
test_buffer_dynamic.py::TestBufferMgrDyn::test_nonDefaultAlpha PASSED
test_buffer_dynamic.py::TestBufferMgrDyn::test_sharedHeadroomPool PASSED
test_buffer_dynamic.py::TestBufferMgrDyn::test_shutdownPort PASSED
test_buffer_dynamic.py::TestBufferMgrDyn::test_autoNegPort PASSED
**Details if related**
