### PR TITLE
fix the type for SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE

### DIFF
--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -708,7 +708,7 @@ void PfcWdZeroBufferHandler::ZeroBufferProfile::createZeroBufferProfile(bool ing
     attribs.push_back(attr);
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE;
-    attr.value.u32 = 0;
+    attr.value.u64 = 0;
     attribs.push_back(attr);
 
     attr.id = SAI_BUFFER_PROFILE_ATTR_SHARED_DYNAMIC_TH;


### PR DESCRIPTION
Fixing the type for SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE

It is incorrectly set to u32 and is not clearing the higher 32 bits in the union

Sample code:

    attr.id = SAI_BUFFER_PROFILE_ATTR_POOL_ID;
    attr.value.oid = getPool(ingress); <<<<-- the higher order 32 bits were retrieved for  BUFFER_PROFILE_ATTR_BUFFER_SIZE
    attribs.push_back(attr);

    attr.id = SAI_BUFFER_PROFILE_ATTR_THRESHOLD_MODE;
    attr.value.u32 = SAI_BUFFER_PROFILE_THRESHOLD_MODE_DYNAMIC;
    attribs.push_back(attr);

    attr.id = SAI_BUFFER_PROFILE_ATTR_BUFFER_SIZE;
    attr.value.u64 = 0;      <<<<-------------------------------- This was u32 earlier
    attribs.push_back(attr);

Signed-off-by: Alpesh S Patel <alpesh@cisco.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
