### PR TITLE
[switchorch] Implement VXLAN src port range feature 

### DIFF
--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -26,6 +26,12 @@ const map<string, sai_switch_attr_t> switch_attribute_map =
     {"vxlan_router_mac",                    SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC}
 };
 
+const map<string, sai_switch_tunnel_attr_t> switch_tunnel_attribute_map =
+{
+    {"vxlan_sport", SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT},
+    {"vxlan_mask",  SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK}
+};
+
 const map<string, sai_packet_action_t> packet_action_map =
 {
     {"drop",    SAI_PACKET_ACTION_DROP},
@@ -49,6 +55,29 @@ SwitchOrch::SwitchOrch(DBConnector *db, vector<TableConnector>& connectors, Tabl
     querySwitchTpidCapability();
     auto executorT = new ExecutableTimer(m_sensorsPollerTimer, this, "ASIC_SENSORS_POLL_TIMER");
     Orch::addExecutor(executorT);
+
+    vector<sai_attribute_t> attrs;
+    sai_attribute_t attr;
+    sai_status_t status;
+
+    attr.id = SAI_SWITCH_TUNNEL_ATTR_TUNNEL_TYPE;
+    attr.value.s32 = SAI_TUNNEL_TYPE_VXLAN;
+    attrs.push_back(attr);
+    attr.id = SAI_SWITCH_TUNNEL_ATTR_TUNNEL_VXLAN_UDP_SPORT_MODE;
+    attr.value.s32 = SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_EPHEMERAL;
+    attrs.push_back(attr);
+
+    status = sai_switch_api->create_switch_tunnel(&switch_tunnel_id, gSwitchId, static_cast<uint32_t>(attrs.size()), attrs.data());
+
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to create switch_tunnel object");
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_SWITCH, status);
+        if (handle_status != task_success)
+        {
+            throw runtime_error("SwitchOrch initialization failure");
+        }
+    }
 }
 
 void SwitchOrch::doCfgSensorsTableTask(Consumer &consumer)
@@ -127,6 +156,55 @@ void SwitchOrch::doCfgSensorsTableTask(Consumer &consumer)
     }
 }
 
+
+sai_status_t SwitchOrch::setSwitchTunnelVxlanParams(swss::FieldValueTuple &val)
+{
+    auto attribute = fvField(val);
+    auto value = fvValue(val);
+    sai_attribute_t attr;
+    sai_status_t status;
+
+    if (!m_vxlanSportUserModeEnabled)
+    {
+        // Enable Vxlan src port range feauture
+        attr.id = SAI_SWITCH_TUNNEL_ATTR_TUNNEL_VXLAN_UDP_SPORT_MODE;
+        attr.value.s32 = SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED;
+        status = sai_switch_api->set_switch_tunnel_attribute(switch_tunnel_id, &attr);
+
+        if (status != SAI_STATUS_SUCCESS)
+        {
+            SWSS_LOG_ERROR("Failed to set SAI_TUNNEL_VXLAN_UDP_SPORT_MODE_USER_DEFINED  src port mode rv:%d",  status);
+            return status;
+        }
+
+        m_vxlanSportUserModeEnabled = true;
+    }
+
+    attr.id = switch_tunnel_attribute_map.at(attribute);
+    switch (attr.id)
+    {
+        case SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT:
+            attr.value.u16 = to_uint<uint16_t>(value);
+            break;
+        case SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK:
+            attr.value.u8 = to_uint<uint8_t>(value);
+            break;
+        default:
+            SWSS_LOG_ERROR("Invalid switch tunnel attribute id %d", attr.id);
+            return SAI_STATUS_SUCCESS;
+    }
+
+    status  = sai_switch_api->set_switch_tunnel_attribute(switch_tunnel_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set tunnnel switch attribute %s to %s, rv:%d", attribute.c_str(), value.c_str(), status);
+        return status;
+    }
+
+    SWSS_LOG_NOTICE("Set switch attribute %s to %s", attribute.c_str(), value.c_str());
+    return SAI_STATUS_SUCCESS;
+}
+
 void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
@@ -136,19 +214,31 @@ void SwitchOrch::doAppSwitchTableTask(Consumer &consumer)
     {
         auto t = it->second;
         auto op = kfvOp(t);
+        bool retry = false;
 
         if (op == SET_COMMAND)
         {
-            bool retry = false;
-
             for (auto i : kfvFieldsValues(t))
             {
                 auto attribute = fvField(i);
 
                 if (switch_attribute_map.find(attribute) == switch_attribute_map.end())
                 {
-                    SWSS_LOG_ERROR("Unsupported switch attribute %s", attribute.c_str());
-                    break;
+                    // Check additionally 'switch_tunnel_attribute_map' for Switch Tunnel
+                    if (switch_tunnel_attribute_map.find(attribute) == switch_tunnel_attribute_map.end())
+                    {
+                        SWSS_LOG_ERROR("Unsupported switch attribute %s", attribute.c_str());
+                        break;
+                    }
+
+                    auto status = setSwitchTunnelVxlanParams(i);
+                    if ((status != SAI_STATUS_SUCCESS) && (handleSaiSetStatus(SAI_API_SWITCH, status) == task_need_retry))
+                    {
+                        retry = true;
+                        break;
+                    }
+
+                    continue;
                 }
 
                 auto value = fvValue(i);

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -35,11 +35,13 @@ private:
     void doAppSwitchTableTask(Consumer &consumer);
     void initSensorsTable();
     void querySwitchTpidCapability();
+    sai_status_t setSwitchTunnelVxlanParams(swss::FieldValueTuple &val);
 
     swss::NotificationConsumer* m_restartCheckNotificationConsumer;
     void doTask(swss::NotificationConsumer& consumer);
     swss::DBConnector *m_db;
     swss::Table m_switchTable;
+    sai_object_id_t switch_tunnel_id;
 
     // ASIC temperature sensors
     std::shared_ptr<swss::DBConnector> m_stateDb = nullptr;
@@ -52,6 +54,7 @@ private:
     bool m_numTempSensorsInitialized = false;
     bool m_sensorsMaxTempSupported = true;
     bool m_sensorsAvgTempSupported = true;
+    bool m_vxlanSportUserModeEnabled = false;
 
     // Information contained in the request from
     // external program for orchagent pre-shutdown state check

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -41,7 +41,7 @@ private:
     void doTask(swss::NotificationConsumer& consumer);
     swss::DBConnector *m_db;
     swss::Table m_switchTable;
-    sai_object_id_t switch_tunnel_id;
+    sai_object_id_t m_switchTunnelId;
 
     // ASIC temperature sensors
     std::shared_ptr<swss::DBConnector> m_stateDb = nullptr;

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -40,14 +40,16 @@ def check_object(db, table, key, expected_attributes):
                                                (value, name, expected_attributes[name])
 
 
-def vxlan_switch_test(dvs, oid, port, mac):
+def vxlan_switch_test(dvs, oid, port, mac, mask, sport):
     app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
     create_entry_pst(
         app_db,
         "SWITCH_TABLE", ':', "switch",
         [
             ("vxlan_port", port),
-            ("vxlan_router_mac", mac)
+            ("vxlan_router_mac", mac),
+            ("vxlan_mask", mask),
+            ("vxlan_sport", sport),
         ],
     )
     time.sleep(2)
@@ -57,6 +59,8 @@ def vxlan_switch_test(dvs, oid, port, mac):
         {
             'SAI_SWITCH_ATTR_VXLAN_DEFAULT_PORT': port,
             'SAI_SWITCH_ATTR_VXLAN_DEFAULT_ROUTER_MAC': mac,
+            'SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK': mask,
+            'SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT': sport,
         }
     )
 
@@ -67,10 +71,9 @@ class TestSwitch(object):
     '''
     def test_switch_attribute(self, dvs, testlog):
         switch_oid = get_exist_entry(dvs, "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH")
+        vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05", "20", "54321")
 
-        vxlan_switch_test(dvs, switch_oid, "12345", "00:01:02:03:04:05")
-
-        vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E")
+        vxlan_switch_test(dvs, switch_oid, "56789", "00:0A:0B:0C:0D:0E", "15", "56789")
 
 
 # Add Dummy always-pass test at end as workaroud


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added ability to configure UDP VXLAN src port range with help of new added parameters (vxlan_sport and vxlan_mask)
Сorresponding SAI attributes: SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT and SAI_SWITCH_TUNNEL_ATTR_VXLAN_UDP_SPORT_MASK

**Why I did it**
Implemented configuration of  VXLAN src port feature according to requirements

**How I verified it**
Use appropriate VS test

`sudo pytest --dvsname=vs tests/test_switch.py::TestSwitch::test_switch_attribute -v -s`

Create json file with params.
Use swssconfig to enable feature and write config params to APP_DB : swssconfig /etc/swss/config.d/switch.json
**Details if related**
```
switch.json:
[
    {
        "SWITCH_TABLE:switch": {
			"vxlan_sport": "0xFFA0",
			"vxlan_mask": "3"
        },
        "OP": "SET"
    }
]
```
