### PR TITLE
[sonic-swss]:enable unconfiguring PFC on last TC on a port

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1392,7 +1392,12 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
             SWSS_LOG_INFO("Applied %s to port %s", it->second.first.c_str(), port_name.c_str());
         }
 
-        if (pfc_enable)
+        sai_uint8_t old_pfc_enable = 0;
+        if (!gPortsOrch->getPortPfc(port.m_port_id, &old_pfc_enable)) {
+            SWSS_LOG_ERROR("Failed to retrieve PFC bits on port %s", port_name.c_str());
+        }
+
+        if (pfc_enable || old_pfc_enable)
         {
             if (!gPortsOrch->setPortPfc(port.m_port_id, pfc_enable))
             {

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1393,7 +1393,8 @@ task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer)
         }
 
         sai_uint8_t old_pfc_enable = 0;
-        if (!gPortsOrch->getPortPfc(port.m_port_id, &old_pfc_enable)) {
+        if (!gPortsOrch->getPortPfc(port.m_port_id, &old_pfc_enable)) 
+        {
             SWSS_LOG_ERROR("Failed to retrieve PFC bits on port %s", port_name.c_str());
         }
 

--- a/tests/test_pfc.py
+++ b/tests/test_pfc.py
@@ -101,7 +101,34 @@ class TestPfc(object):
         pfc = getPortAttr(dvs, port_oid, 'SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL')
         assert pfc == pfc_tx
 
+    def test_PfcUnconfig(self, dvs, testlog):
 
+        port_name = 'Ethernet0'
+        pfc_queues = [ 3, 4 ]
+
+        # Configure default PFC
+        setPortPfc(dvs, port_name, pfc_queues)
+
+        # Get SAI object ID for the interface
+        port_oid = getPortOid(dvs, port_name)
+
+        # Verify default PFC is set to configured value
+        pfc = getPortAttr(dvs, port_oid, 'SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL')
+        assert pfc == getBitMaskStr(pfc_queues)
+
+        # Configure PFC on single TC
+        pfc_queues = [ 3 ]
+        setPortPfc(dvs, port_name, pfc_queues)
+        # Verify default PFC is set to configured value
+        pfc = getPortAttr(dvs, port_oid, 'SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL')
+        assert pfc == getBitMaskStr(pfc_queues)
+
+        # Disable PFC on last TC
+        pfc_queues = [ ]
+        setPortPfc(dvs, port_name, pfc_queues)
+        # Verify default PFC is set to configured value
+        pfc = getPortAttr(dvs, port_oid, 'SAI_PORT_ATTR_PRIORITY_FLOW_CONTROL')
+        assert pfc == getBitMaskStr(pfc_queues)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
Signed-off-by: Alpesh S Patel <alpesh@cisco.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added code to enable disabling PFC from the single TC that is configured on a port.

**Why I did it**
Currently if a single TC is configured on a port, it cannot be unconfigured by setting the pfc bitmask to 0.
The if (pfc_enable) check skips as pfc_enable bit pattern is 0

This code change adds ability to unconfigure PFC on a single TC that's configured on a port.

**How I verified it**
tested it on a cisco-8000 router running sonic image.

**Details if related**

Note to committer: This also needs to go into 202012 version of the branch. 
