### PR TITLE
Remove redundant calls to get child scheduler group during initialization

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -991,7 +991,7 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
             if (scheduler_group_port_info.group_has_been_initialized[ii])
             {
                 // skip this iteration if it has been initialized which means there're no children in this group
-                SWSS_LOG_INFO("No child group for port %s group %lx, skip", port.m_alias.c_str(), group_id);
+                SWSS_LOG_INFO("No child group for port %s group 0x%" PRIx64 ", skip", port.m_alias.c_str(), group_id);
                 continue;
             }
 
@@ -1009,13 +1009,13 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
 
             uint32_t child_count = attr.value.u32;
 
-            SWSS_LOG_INFO("Port %s group %lx has been initialized with %u child group(s)", port.m_alias.c_str(), group_id, child_count);
+            SWSS_LOG_INFO("Port %s group 0x%" PRIx64 " has been initialized with %u child group(s)", port.m_alias.c_str(), group_id, child_count);
             scheduler_group_port_info.group_has_been_initialized[ii] = true;
 
             // skip this iteration if there're no children in this group
             if (child_count == 0)
             {
-                SWSS_LOG_INFO("No child group for port %s group %lx, skip", port.m_alias.c_str(), group_id);
+                SWSS_LOG_INFO("No child group for port %s group 0x%" PRIx64 ", skip", port.m_alias.c_str(), group_id);
                 continue;
             }
 
@@ -1039,10 +1039,8 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
 
         for (const auto& child_group_id: child_groups_per_group)
         {
-            SWSS_LOG_INFO("Check child group %lx for port %s group %lx", child_group_id, port.m_alias.c_str(), group_id);
             if (child_group_id == queue_id)
             {
-                SWSS_LOG_INFO("Found group id %lx for port %s queue %lx", group_id, port.m_alias.c_str(), queue_id);
                 return group_id;
             }
         }

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -972,18 +972,29 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
 
         m_scheduler_group_port_info[port.m_port_id] = {
             .groups = std::move(groups),
-            .child_groups = std::vector<std::vector<sai_object_id_t>>(groups_count)
+            .child_groups = std::vector<std::vector<sai_object_id_t>>(groups_count),
+            .group_has_been_initialized = std::vector<bool>(groups_count)
         };
-     }
+
+        SWSS_LOG_INFO("Port %s has been initialized with %u group(s)", port.m_alias.c_str(), groups_count);
+    }
 
     /* Lookup groups to which queue belongs */
-    const auto& groups = m_scheduler_group_port_info[port.m_port_id].groups;
+    auto& scheduler_group_port_info = m_scheduler_group_port_info[port.m_port_id];
+    const auto& groups = scheduler_group_port_info.groups;
     for (uint32_t ii = 0; ii < groups.size() ; ii++)
     {
         const auto& group_id = groups[ii];
-        const auto& child_groups_per_group = m_scheduler_group_port_info[port.m_port_id].child_groups[ii];
+        const auto& child_groups_per_group = scheduler_group_port_info.child_groups[ii];
         if (child_groups_per_group.empty())
         {
+            if (scheduler_group_port_info.group_has_been_initialized[ii])
+            {
+                // skip this iteration if it has been initialized which means there're no children in this group
+                SWSS_LOG_INFO("No child group for port %s group %lx, skip", port.m_alias.c_str(), group_id);
+                continue;
+            }
+
             attr.id = SAI_SCHEDULER_GROUP_ATTR_CHILD_COUNT;//Number of queues/groups childs added to scheduler group
             sai_status = sai_scheduler_group_api->get_scheduler_group_attribute(group_id, 1, &attr);
             if (SAI_STATUS_SUCCESS != sai_status)
@@ -997,14 +1008,18 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
             }
 
             uint32_t child_count = attr.value.u32;
-            vector<sai_object_id_t> child_groups(child_count);
+
+            SWSS_LOG_INFO("Port %s group %lx has been initialized with %u child group(s)", port.m_alias.c_str(), group_id, child_count);
+            scheduler_group_port_info.group_has_been_initialized[ii] = true;
 
             // skip this iteration if there're no children in this group
             if (child_count == 0)
             {
+                SWSS_LOG_INFO("No child group for port %s group %lx, skip", port.m_alias.c_str(), group_id);
                 continue;
             }
 
+            vector<sai_object_id_t> child_groups(child_count);
             attr.id = SAI_SCHEDULER_GROUP_ATTR_CHILD_LIST;
             attr.value.objlist.list = child_groups.data();
             attr.value.objlist.count = child_count;
@@ -1019,13 +1034,15 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
                 }
             }
 
-            m_scheduler_group_port_info[port.m_port_id].child_groups[ii] = std::move(child_groups);
+            scheduler_group_port_info.child_groups[ii] = std::move(child_groups);
         }
 
         for (const auto& child_group_id: child_groups_per_group)
         {
+            SWSS_LOG_INFO("Check child group %lx for port %s group %lx", child_group_id, port.m_alias.c_str(), group_id);
             if (child_group_id == queue_id)
             {
+                SWSS_LOG_INFO("Found group id %lx for port %s queue %lx", group_id, port.m_alias.c_str(), queue_id);
                 return group_id;
             }
         }

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1015,7 +1015,6 @@ sai_object_id_t QosOrch::getSchedulerGroup(const Port &port, const sai_object_id
             // skip this iteration if there're no children in this group
             if (child_count == 0)
             {
-                SWSS_LOG_INFO("No child group for port %s group 0x%" PRIx64 ", skip", port.m_alias.c_str(), group_id);
                 continue;
             }
 

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -162,6 +162,7 @@ private:
     {
         std::vector<sai_object_id_t> groups;
         std::vector<std::vector<sai_object_id_t>> child_groups;
+        std::vector<bool> group_has_been_initialized;
     };
 
     std::unordered_map<sai_object_id_t, SchedulerGroupPortInfo_t> m_scheduler_group_port_info;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

The QoS orchagent calls SAI APIs to get the number of child scheduler groups and then initialize them.
After that, the size of the child scheduler groups vector will be non-zero, which indicates the child scheduler groups have been initialized and prevents QoS orchagent from calling SAI get APIs again.
However, on some platforms, it may be that some of the scheduler groups don't have child groups, leaving size of child scheduler groups always being zero. It causes QoS orchagent to call the SAI get API each time the scheduler group is handled, which wastes a lot of time, especially during fast reboot.

An extra flag indicating whether the child groups have been initialized is introduced to avoid redundant calls.

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**

To optimize QoS orchagent performance during initialization especially for fast reboot.

**How I verified it**

It can be covered by the existing regression test.

**Details if related**

I did a pair of tests, comparing the time to handle scheduler and child scheduler groups between the old and the new (optimized) version. Dump and sairedis.record attached. 

|           |     Start       |      Finish     | Number of Calls | Duration |FR longest down time|
|-----------|-----------------|-----------------|-----------------|----------|--------------------|
|Old version| 14:01:45.548761 | 14:01:48.337098 |      3950       | 2.788337 |     28.804206      |
|New version| 14:26:14.613581 | 14:26:16.016768 |      1598       | 1.403187 |     27.643941      |
|Difference |                 |                 |     -2352       | -1.38515 |     -1.160265      |

[sairedis.rec.old.log](https://github.com/Azure/sonic-swss/files/7475781/sairedis.rec.old.log)
[sairedis.rec.new.log](https://github.com/Azure/sonic-swss/files/7475783/sairedis.rec.new.log)
[sonic_dump_mtbc-sonic-03-2700_20211104_145113.tar.gz](https://github.com/Azure/sonic-swss/files/7475790/sonic_dump_mtbc-sonic-03-2700_20211104_145113.tar.gz)


