### PR TITLE
Don't handle buffer pool watermark during warm reboot reconciling

### DIFF
--- a/orchagent/flexcounterorch.cpp
+++ b/orchagent/flexcounterorch.cpp
@@ -177,3 +177,16 @@ bool FlexCounterOrch::getPortBufferDropCountersState() const
 {
     return m_port_buffer_drop_counter_enabled;
 }
+
+bool FlexCounterOrch::bake()
+{
+    /*
+     * bake is called during warmreboot reconciling procedure.
+     * By default, it should fetch items from the tables the sub agents listen to,
+     * and then push them into m_toSync of each sub agent.
+     * The motivation is to make sub agents handle the saved entries first and then handle the upcoming entries.
+     */
+
+    SWSS_LOG_NOTICE("FlexCounterOrch: Do not handle any FLEX_COUNTER table update during reconciling");
+    return true;
+}

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -4,6 +4,7 @@
 #include "orch.h"
 #include "port.h"
 #include "producertable.h"
+#include "table.h"
 
 extern "C" {
 #include "sai.h"
@@ -24,6 +25,7 @@ private:
     std::shared_ptr<swss::ProducerTable> m_flexCounterGroupTable = nullptr;
     bool m_port_counter_enabled = false;
     bool m_port_buffer_drop_counter_enabled = false;
+    Table m_flexCounterConfigTable;
 };
 
 #endif

--- a/orchagent/flexcounterorch.h
+++ b/orchagent/flexcounterorch.h
@@ -17,6 +17,7 @@ public:
     virtual ~FlexCounterOrch(void);
     bool getPortCountersState() const;
     bool getPortBufferDropCountersState() const;
+    bool bake() override;
  
 private:
     std::shared_ptr<swss::DBConnector> m_flexCounterDb = nullptr;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Don't handle buffer pool watermark during warm reboot reconciling

**Why I did it**
This is to fix the community issue Azure/sonic-sairedis#862 and Azure/sonic-buildimage#8722

**How I verified it**
Perform a warm reboot. Check whether
- buffer pool watermark handling is skipped during reconciling and handled after it.
- other watermark handling is handled during reconciling as it was before.

**Details if related**
The warm reboot flow is like this:
1. System starts. Orchagent fetches the items from database stored before warm reboot and pushes them into `m_toSync` of all orchagents. This is done by `bake`, which can be overridden by sub orchagent.
2. All sub orchagents handle the items in `m_toSync`. At this point, any notification from redis-db is blocked.
3. Warm reboot converges.
4. Orchagent starts to handle notifications from redis-db.

The fix is like this: in FlexCounterOrch::bake. the buffer pool watermark handling is skipped.