### PR TITLE
[portsorch] Allow user to set none value for interface type

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -127,6 +127,7 @@ static map<string, sai_port_interface_type_t> interface_type_map =
 // Interface type map used for auto negotiation
 static map<string, sai_port_interface_type_t> interface_type_map_for_an =
 {
+    { "none", SAI_PORT_INTERFACE_TYPE_NONE },
     { "cr", SAI_PORT_INTERFACE_TYPE_CR },
     { "cr2", SAI_PORT_INTERFACE_TYPE_CR2 },
     { "cr4", SAI_PORT_INTERFACE_TYPE_CR4 },


### PR DESCRIPTION
Depends on https://github.com/Azure/sonic-buildimage/pull/9098
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Allow user to set none value for interface type

**Why I did it**

Say user has speed=50G, interface_type=CR2, and user wants to change it to 10G and CR. Currently, there is no CLI can support it, because:

1. If you change the interface type to CR first, SAI will get 50G and CR, SAI will report error because not supported
2. If you change the speed to 10G first, SAI will get 10G and CR2, also not supported

The only way for now is to manually change the CONFIG_DB and do a config reload, this is not user friendly.

This PR allow user to set none value to interface type. So there is a way to achieve the goal via CLI:

1. config interface type XXX none
2. config interface speed XXX 10000
3. config interface type XXX CR

**How I verified it**

Manual test

**Details if related**
