### PR TITLE
[FEC] Enable FEC statistics collection for Ethernet ports

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -229,7 +229,10 @@ const vector<sai_port_stat_t> port_stat_ids =
     SAI_PORT_STAT_ETHER_STATS_JABBERS,
     SAI_PORT_STAT_ETHER_STATS_FRAGMENTS,
     SAI_PORT_STAT_ETHER_STATS_UNDERSIZE_PKTS,
-    SAI_PORT_STAT_IP_IN_RECEIVES
+    SAI_PORT_STAT_IP_IN_RECEIVES,
+    SAI_PORT_STAT_IF_IN_FEC_CORRECTABLE_FRAMES,
+    SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES,
+    SAI_PORT_STAT_IF_IN_FEC_SYMBOL_ERRORS
 };
 
 const vector<sai_port_stat_t> port_buffer_drop_stat_ids =
@@ -4655,7 +4658,7 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
     if (vlan.m_vlan_info.l2mc_group_id == SAI_NULL_OBJECT_ID)
     {
         status = sai_l2mc_group_api->create_l2mc_group(&l2mc_group_id, gSwitchId, 0, NULL);
-        if (status != SAI_STATUS_SUCCESS) 
+        if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create l2mc flood group");
             return false;
@@ -4669,7 +4672,7 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
             status = sai_vlan_api->set_vlan_attribute(vlan.m_vlan_info.vlan_oid, &attr);
             if (status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_ERROR("Failed to set l2mc group %" PRIx64 
+                SWSS_LOG_ERROR("Failed to set l2mc group %" PRIx64
                                " to vlan %hu for unknown unicast flooding",
                                l2mc_group_id, vlan.m_vlan_info.vlan_id);
                 return false;
@@ -4684,7 +4687,7 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to set l2mc group %" PRIx64
-                               " to vlan %hu for broadcast flooding", 
+                               " to vlan %hu for broadcast flooding",
                                l2mc_group_id, vlan.m_vlan_info.vlan_id);
                 return false;
             }
@@ -4692,7 +4695,7 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
         vlan.m_vlan_info.l2mc_group_id = l2mc_group_id;
         m_portList[vlan.m_alias] = vlan;
     }
-        
+
     vector<sai_attribute_t> attrs;
     attr.id = SAI_L2MC_GROUP_MEMBER_ATTR_L2MC_GROUP_ID;
     attr.value.oid = vlan.m_vlan_info.l2mc_group_id;
@@ -4740,10 +4743,10 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
     SWSS_LOG_ENTER();
 
     sai_status_t status;
-    
+
     if(vlan.m_vlan_info.l2mc_members.find(end_point_ip) == vlan.m_vlan_info.l2mc_members.end())
     {
-        SWSS_LOG_NOTICE("End point ip %s is not part of vlan %hu", 
+        SWSS_LOG_NOTICE("End point ip %s is not part of vlan %hu",
                         end_point_ip.c_str(), vlan.m_vlan_info.vlan_id);
         return true;
     }
@@ -4759,7 +4762,7 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
     vlan.m_vlan_info.l2mc_members.erase(end_point_ip);
     sai_object_id_t l2mc_group_id = SAI_NULL_OBJECT_ID;
     sai_attribute_t attr;
-     
+
     if (vlan.m_vlan_info.l2mc_members.empty())
     {
         if (vlan.m_vlan_info.uuc_flood_type == SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED)
@@ -4770,7 +4773,7 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
             status = sai_vlan_api->set_vlan_attribute(vlan.m_vlan_info.vlan_oid, &attr);
             if (status != SAI_STATUS_SUCCESS)
             {
-                SWSS_LOG_ERROR("Failed to set null l2mc group "  
+                SWSS_LOG_ERROR("Failed to set null l2mc group "
                                " to vlan %hu for unknown unicast flooding",
                                vlan.m_vlan_info.vlan_id);
                 return false;
@@ -4796,7 +4799,7 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
             if (status != SAI_STATUS_SUCCESS)
             {
                 SWSS_LOG_ERROR("Failed to set null l2mc group "
-                               " to vlan %hu for broadcast flooding", 
+                               " to vlan %hu for broadcast flooding",
                                vlan.m_vlan_info.vlan_id);
                 return false;
             }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added FEC correctable, uncorrectable and symbol errors to the list of statistics collected for a port by the flex counter.

**Why I did it**
To added CLI support to show fec related counters. Currently, Broadcom has enabled fec counters in their SDK.

**How I verified it**
Ensured the FEC counters are present in counter table:-

```
root@str-s6000-acs-01:~# redis-cli -n 2 hgetall "COUNTERS:oid:0x1000000000002" | grep FEC
SAI_PORT_STAT_IF_IN_FEC_CORRECTABLE_FRAMES
SAI_PORT_STAT_IF_IN_FEC_NOT_CORRECTABLE_FRAMES
root@str-s6000-acs-01:~#
```

