### PR TITLE
[macsec] Fix setting network_id in macsec

### DIFF
--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -148,7 +148,7 @@ static void wpa_cli_commands(
     }
     if (!network_id.empty())
     {
-        wpa_cli_commands(ostream, "set_network", port_name);
+        wpa_cli_commands(ostream, "set_network", network_id);
     }
     wpa_cli_commands(ostream, args...);
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
It looks like we should use network_id in set_network, although I didn't find a related issue in running macsec before this change.
**Why I did it**

**How I verified it**

**Details if related**
