### PR TITLE
[macsec] Remove setting SCI to data acl entry

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -2283,14 +2283,6 @@ bool MACsecOrch::createMACsecACLDataEntry(
     attr.value.aclaction.parameter.s32 = SAI_PACKET_ACTION_DROP;
     attr.value.aclaction.enable = true;
     attrs.push_back(attr);
-    if (sci_in_sectag)
-    {
-        attr.id = SAI_ACL_ENTRY_ATTR_FIELD_MACSEC_SCI;
-        attr.value.aclfield.enable = true;
-        attr.value.aclfield.mask.u64 = 0xFFFFFFFFFFFFFFFF;
-        attr.value.aclfield.data.u64 = sci;
-        attrs.push_back(attr);
-    }
 
     sai_status_t status = sai_acl_api->create_acl_entry(
                                 &entry_id,


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
The reason for this change is SAI_ACL_ENTRY_ATTR_FIELD_MACSEC_SCI is not supported by the Credo driver. For Credo B52 chip, its classification engine does not support SCI; still the SCI field in be verified by the security engine through SAI_MACSEC_SC_ATTR_MACSEC_SCI.  
**Why I did it**

**How I verified it**

**Details if related**
