### PR TITLE
[voq][syncd][bcmsai] Adjusting syncd response timeout during switch create

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -81,8 +81,6 @@ int32_t gVoqMaxCores = 0;
 uint32_t gCfgSystemPorts = 0;
 string gMyHostName = "";
 string gMyAsicName = "";
-uint64_t gSyncdRespTimeoutLC = ( 5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
-uint64_t gSyncdRespTimeoutFab = ( 10 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
 
 void usage()
 {
@@ -576,10 +574,7 @@ int main(int argc, char **argv)
     attr.value.u64 = gSwitchId;
     attrs.push_back(attr);
 
-
-    char *platform = getenv("platform");
-    if (platform && strstr(platform, BRCM_PLATFORM_SUBSTRING) &&
-            (gMySwitchType == "voq" || gMySwitchType == "fabric"))
+    if (gMySwitchType == "voq" || gMySwitchType == "fabric")
     {
         /* We set this long timeout in order for orchagent to wait enough time for
          * response from syncd. It is needed since switch create takes more time
@@ -589,11 +584,11 @@ int main(int argc, char **argv)
 
         if (gMySwitchType == "voq")
         {
-            attr.value.u64 = gSyncdRespTimeoutLC;
+            attr.value.u64 = (5 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
         }
         else if (gMySwitchType == "fabric")
         {
-            attr.value.u64 = gSyncdRespTimeoutFab;
+            attr.value.u64 = (10 * SAI_REDIS_DEFAULT_SYNC_OPERATION_RESPONSE_TIMEOUT);
         }
 
         attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;
@@ -617,8 +612,7 @@ int main(int argc, char **argv)
     }
     SWSS_LOG_NOTICE("Create a switch, id:%" PRIu64, gSwitchId);
 
-    if (platform && strstr(platform, BRCM_PLATFORM_SUBSTRING) && 
-            (gMySwitchType == "voq" || gMySwitchType == "fabric"))
+    if (gMySwitchType == "voq" || gMySwitchType == "fabric")
     {
         /* Set syncd response timeout back to the default value */
         attr.id = SAI_REDIS_SWITCH_ATTR_SYNC_OPERATION_RESPONSE_TIMEOUT;


### PR DESCRIPTION
**What I did**

Fix for syncd response time out for switch create request from orchagent

**Why I did it**

In VOQ based chassis where syncd uses BCM VOQ SAI, if there are large number of front panel ports, SAI takes more than 1 minutes to complete the switch create initialization. Because of this, the switch create request sent by orchagent is not getting response within the default response wait time of 1 minute. So the orchagent declares switch create failure and crashes.

The number of ports need to be initialized by SAI depends on number of ports per asic and total number of system ports configured in the system. The total number of system ports in the system in turn depends on number of line cards supported, number of asics per line card and number of ports supported by each asic. Therefore in a fully populated system, which is an often expected scenario, this crashing will happen.

To fix this, in orchagent, the syncd response time out is set to 35 minutes before sending request for switch create and is set back to default wait time after the switch create. For now, since the problem is observed for BCM platforms, this adjustment is done only for BCM platform.

**How I verified it**

- In a VOQ based chassis that uses BCM SAI, populate the chassis with a  line card that has asics with more than 62 ports.
- Configure 192+ system ports
- Reboot the line card
- Observe that the orchagent does not crash with swith create failure
- Observe that the syncd does not show reponse time out error
- Observe that swss and syncd dockers are up and running and all the interfaces come up.

**Details if related**
