### PR TITLE
[orchagent] Init field of supported speeds while port initialization, refactoring

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1783,23 +1783,6 @@ bool PortsOrch::setHostIntfsStripTag(Port &port, sai_hostif_vlan_tag_t strip)
     return true;
 }
 
-bool PortsOrch::isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed)
-{
-    // This method will return false iff we get a list of supported speeds and the requested speed
-    // is not supported
-    // Otherwise the method will return true (even if we received errors)
-    initPortSupportedSpeeds(alias, port_id);
-
-    const auto &supp_speeds = m_portSupportedSpeeds[port_id];
-    if (supp_speeds.empty())
-    {
-        // we don't have the list for this port, so return true to change speed anyway
-        return true;
-    }
-
-    return std::find(supp_speeds.begin(), supp_speeds.end(), speed) != supp_speeds.end();
-}
-
 void PortsOrch::getPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id, PortSupportedSpeeds &supported_speeds)
 {
     sai_attribute_t attr;
@@ -1857,6 +1840,24 @@ void PortsOrch::getPortSupportedSpeeds(const std::string& alias, sai_object_id_t
     }
 }
 
+const PortSupportedSpeeds& PortsOrch::getSupportedSpeed(const std::string& alias, sai_object_id_t port_id)
+{
+    // This method will return vector of supported speeds for the port
+    // The method will return empty vector if there was something wrong during method execution.
+
+    // "Lazy" query of supported speeds for given port
+    // Once received the list will be stored in m_portSupportedSpeeds
+
+    if (!m_portSupportedSpeeds.count(port_id))
+    {
+    	PortSupportedSpeeds supported_speeds;
+    	getPortSupportedSpeeds(alias, port_id, &supported_speeds);
+    	m_portSupportedSpeeds[port_id] = supported_speeds;
+    }
+
+    return m_portSupportedSpeeds[port_id];
+}
+
 void PortsOrch::initPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id)
 {
     // If port supported speeds map already contains the information, save the SAI call
@@ -1871,6 +1872,22 @@ void PortsOrch::initPortSupportedSpeeds(const std::string& alias, sai_object_id_
     std::string supported_speeds_str = swss::join(',', supported_speeds.begin(), supported_speeds.end());
     v.emplace_back(std::make_pair("supported_speeds", supported_speeds_str));
     m_portStateTable.set(alias, v);
+}
+
+bool PortsOrch::isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed)
+{
+    // This method will return false if we get a list of supported speeds and the requested speed
+    // is not supported
+    // Otherwise the method will return true (even if did not receive list of supported speed)
+
+    const PortSupportedSpeeds &supp_speeds = getSupportedSpeed(alias, port_id);
+    if (supp_speeds.size() == 0)
+    {
+        // we don't have the list for this port, so return true to change speed anyway
+        return true;
+    }
+
+    return std::find(supp_speeds.begin(), supp_speeds.end(), speed) != supp_speeds.end();
 }
 
 /*
@@ -4165,6 +4182,28 @@ bool PortsOrch::initializePort(Port &port)
         SWSS_LOG_WARN("Failed to set operation status %s to host interface %s",
                       operStatus.c_str(), port.m_alias.c_str());
         return false;
+    }
+
+    /* 
+     * initialize field with supported speeds of the port.
+     */
+    auto supp_speed_temp = getSupportedSpeed(port.m_alias, port.m_port_id);
+    /* Copy the vector to be able to modify it */
+    auto supp_speed(supp_speed_temp);
+    if (supp_speed.size() > 0)
+    {
+        sort(supp_speed.begin(), supp_speed.end());
+
+        string tmp_supp_speed_str = "";
+        /* Add (count - 1) elements to the string with separator*/
+        for (auto iter = supp_speed.begin(); iter < prev(supp_speed.end()); iter++)
+        {
+            tmp_supp_speed_str += to_string(*iter) + ",";
+        }
+        /* Add the last element w/o separator*/
+        tmp_supp_speed_str += to_string(supp_speed.back());
+
+        m_portTable->hset(port.m_alias, "supp_speed", tmp_supp_speed_str);
     }
 
     return true;

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -289,9 +289,10 @@ private:
 
     bool setBridgePortAdminStatus(sai_object_id_t id, bool up);
 
-    bool isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
     void getPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id, PortSupportedSpeeds &supported_speeds);
+    const PortSupportedSpeeds& getSupportedSpeed(const std::string& alias, sai_object_id_t port_id);
     void initPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id);
+    bool isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
     task_process_status setPortSpeed(Port &port, sai_uint32_t speed);
     bool getPortSpeed(sai_object_id_t id, sai_uint32_t &speed);
     bool setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value);


### PR DESCRIPTION
Reading of supported speed list from the ASIC and saving it inside
PORT_TABLE:EthernetXX table in APPL_DB to be able to check supported
speeds while changing a current speed through CLI commands.
Signed-off-by: Konstiantyn Halushka Konstiantyn_Halushkai@jabil.com

What I did
Made changes in the source code regarding code duplication

Why I did it
https://github.com/Azure/sonic-swss/pull/1622#discussion_r735260692

Details if related
Related PRs:
Azure/sonic-swss#1622