### PR TITLE
Update default route status to state DB

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -326,6 +326,9 @@ MuxCable::MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress 
     state_machine_handlers_.insert(handler_pair(MUX_STATE_STANDBY_ACTIVE, &MuxCable::stateActive));
     state_machine_handlers_.insert(handler_pair(MUX_STATE_INIT_STANDBY, &MuxCable::stateStandby));
     state_machine_handlers_.insert(handler_pair(MUX_STATE_ACTIVE_STANDBY, &MuxCable::stateStandby));
+
+    /* Set initial state to "standby" */
+    stateStandby();
 }
 
 bool MuxCable::stateInitActive()

--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -326,9 +326,6 @@ MuxCable::MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress 
     state_machine_handlers_.insert(handler_pair(MUX_STATE_STANDBY_ACTIVE, &MuxCable::stateActive));
     state_machine_handlers_.insert(handler_pair(MUX_STATE_INIT_STANDBY, &MuxCable::stateStandby));
     state_machine_handlers_.insert(handler_pair(MUX_STATE_ACTIVE_STANDBY, &MuxCable::stateStandby));
-
-    /* Set initial state to "standby" */
-    stateStandby();
 }
 
 bool MuxCable::stateInitActive()

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -78,7 +78,7 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
     SWSS_LOG_NOTICE("Maximum number of ECMP groups supported is %d", m_maxNextHopGroupCount);
 
     m_stateDb = shared_ptr<DBConnector>(new DBConnector("STATE_DB", 0));
-    m_stateDefaultRouteTb = unique_ptr<swss::Table>(new Table(m_stateDb.get(), STATE_DEFAULT_ROUTE_TABLE_NAME));
+    m_stateDefaultRouteTb = unique_ptr<swss::Table>(new Table(m_stateDb.get(), STATE_ROUTE_TABLE_NAME));
 
     IpPrefix default_ip_prefix("0.0.0.0/0");
     updateDefRouteState("0.0.0.0/0");

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -77,7 +77,12 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
 
     SWSS_LOG_NOTICE("Maximum number of ECMP groups supported is %d", m_maxNextHopGroupCount);
 
+    m_stateDb = shared_ptr<DBConnector>(new DBConnector("STATE_DB", 0));
+    m_stateDefaultRouteTb = unique_ptr<swss::Table>(new Table(m_stateDb.get(), STATE_DEFAULT_ROUTE_TABLE_NAME));
+
+
     IpPrefix default_ip_prefix("0.0.0.0/0");
+    updateDefRouteState("0.0.0.0/0");
 
     sai_route_entry_t unicast_route_entry;
     unicast_route_entry.vr_id = gVirtualRouterId;
@@ -103,6 +108,7 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
     SWSS_LOG_NOTICE("Create IPv4 default route with packet action drop");
 
     IpPrefix v6_default_ip_prefix("::/0");
+    updateDefRouteState("::/0");
 
     copy(unicast_route_entry.destination, v6_default_ip_prefix);
     subnet(unicast_route_entry.destination, unicast_route_entry.destination);
@@ -226,6 +232,16 @@ void RouteOrch::delLinkLocalRouteToMe(sai_object_id_t vrf_id, IpPrefix linklocal
     gCrmOrch->decCrmResUsedCounter(CrmResourceType::CRM_IPV6_ROUTE);
 
     SWSS_LOG_NOTICE("Deleted link local ipv6 route  %s to cpu", linklocal_prefix.to_string().c_str());
+}
+
+void RouteOrch::updateDefRouteState(string ip, bool add)
+{
+    vector<FieldValueTuple> tuples;
+    string state = add?"ok":"na";
+    FieldValueTuple tuple("state", state);
+    tuples.push_back(tuple);
+
+    m_stateDefaultRouteTb->set(ip, tuples);
 }
 
 bool RouteOrch::hasNextHopGroup(const NextHopGroupKey& nexthops) const
@@ -2048,6 +2064,11 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         }
     }
 
+    if (ipPrefix.isDefaultRoute())
+    {
+        updateDefRouteState(ipPrefix.to_string(), true);
+    }
+
     m_syncdRoutes[vrf_id][ipPrefix] = RouteNhg(nextHops, ctx.nhg_index);
 
     notifyNextHopChangeObservers(vrf_id, ipPrefix, nextHops, true);
@@ -2162,6 +2183,8 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
                 return parseHandleSaiStatusFailure(handle_status);
             }
         }
+
+        updateDefRouteState(ipPrefix.to_string());
 
         SWSS_LOG_INFO("Set route %s next hop ID to NULL", ipPrefix.to_string().c_str());
     }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -80,7 +80,6 @@ RouteOrch::RouteOrch(DBConnector *db, vector<table_name_with_pri_t> &tableNames,
     m_stateDb = shared_ptr<DBConnector>(new DBConnector("STATE_DB", 0));
     m_stateDefaultRouteTb = unique_ptr<swss::Table>(new Table(m_stateDb.get(), STATE_DEFAULT_ROUTE_TABLE_NAME));
 
-
     IpPrefix default_ip_prefix("0.0.0.0/0");
     updateDefRouteState("0.0.0.0/0");
 

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -206,6 +206,8 @@ public:
     unsigned int getNhgCount() { return m_nextHopGroupCount; }
     unsigned int getMaxNhgCount() { return m_maxNextHopGroupCount; }
 
+    void updateDefRouteState(string ip, bool add=false);
+
 private:
     SwitchOrch *m_switchOrch;
     NeighOrch *m_neighOrch;
@@ -216,6 +218,9 @@ private:
     unsigned int m_nextHopGroupCount;
     unsigned int m_maxNextHopGroupCount;
     bool m_resync;
+
+    shared_ptr<DBConnector> m_stateDb;
+    unique_ptr<swss::Table> m_stateDefaultRouteTb;
 
     RouteTables m_syncdRoutes;
     LabelRouteTables m_syncdLabelRoutes;

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -206,7 +206,6 @@ public:
     unsigned int getNhgCount() { return m_nextHopGroupCount; }
     unsigned int getMaxNhgCount() { return m_maxNextHopGroupCount; }
 
-
 private:
     SwitchOrch *m_switchOrch;
     NeighOrch *m_neighOrch;

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -206,7 +206,6 @@ public:
     unsigned int getNhgCount() { return m_nextHopGroupCount; }
     unsigned int getMaxNhgCount() { return m_maxNextHopGroupCount; }
 
-    void updateDefRouteState(string ip, bool add=false);
 
 private:
     SwitchOrch *m_switchOrch;
@@ -247,6 +246,8 @@ private:
     bool removeLabelRoute(LabelRouteBulkContext& ctx);
     bool addLabelRoutePost(const LabelRouteBulkContext& ctx, const NextHopGroupKey &nextHops);
     bool removeLabelRoutePost(const LabelRouteBulkContext& ctx);
+
+    void updateDefRouteState(string ip, bool add=false);
 
     void doTask(Consumer& consumer);
     void doLabelTask(Consumer& consumer);

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -164,6 +164,7 @@ class TestRoute(TestRouteBase):
 
         # add route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"ip route 2.2.2.0/24 10.0.0.1\"")
+        dvs.runcmd("vtysh -c \"configure terminal\" -c \"ip route 0.0.0.0/0 10.0.0.1\"")
 
         # check application database
         self.pdb.wait_for_entry("ROUTE_TABLE", "2.2.2.0/24")
@@ -176,6 +177,7 @@ class TestRoute(TestRouteBase):
 
         # remove route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ip route 2.2.2.0/24 10.0.0.1\"")
+        dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ip route 0.0.0.0/0 10.0.0.1\"")
 
         # check application database
         self.pdb.wait_for_deleted_entry("ROUTE_TABLE", "2.2.2.0/24")
@@ -236,6 +238,7 @@ class TestRoute(TestRouteBase):
 
         # add route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"ipv6 route 3000::0/64 2000::2\"")
+        dvs.runcmd("vtysh -c \"configure terminal\" -c \"ipv6 route ::/0 2000::2\"")
 
         # check application database
         self.pdb.wait_for_entry("ROUTE_TABLE", "3000::/64")
@@ -248,6 +251,7 @@ class TestRoute(TestRouteBase):
 
         # remove route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ipv6 route 3000::0/64 2000::2\"")
+        dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ipv6 route ::/0 2000::2\"")
 
         # check application database
         self.pdb.wait_for_deleted_entry("ROUTE_TABLE", "3000::/64")

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -164,7 +164,10 @@ class TestRoute(TestRouteBase):
 
         # add route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"ip route 2.2.2.0/24 10.0.0.1\"")
-        dvs.runcmd("vtysh -c \"configure terminal\" -c \"ip route 0.0.0.0/0 10.0.0.1\"")
+
+        # add default route entry
+        fieldValues = {"nexthop": "10.0.0.1", "ifname": "Ethernet0"}
+        self.create_route_entry("0.0.0.0/0", fieldValues)
 
         # check application database
         self.pdb.wait_for_entry("ROUTE_TABLE", "2.2.2.0/24")
@@ -177,7 +180,9 @@ class TestRoute(TestRouteBase):
 
         # remove route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ip route 2.2.2.0/24 10.0.0.1\"")
-        dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ip route 0.0.0.0/0 10.0.0.1\"")
+
+        # remove default route entry
+        self.remove_route_entry("0.0.0.0/0")
 
         # check application database
         self.pdb.wait_for_deleted_entry("ROUTE_TABLE", "2.2.2.0/24")
@@ -238,7 +243,10 @@ class TestRoute(TestRouteBase):
 
         # add route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"ipv6 route 3000::0/64 2000::2\"")
-        dvs.runcmd("vtysh -c \"configure terminal\" -c \"ipv6 route ::/0 2000::2\"")
+
+        # add default route entry
+        fieldValues = {"nexthop": "2000::2", "ifname": "Ethernet0"}
+        self.create_route_entry("::/0", fieldValues)
 
         # check application database
         self.pdb.wait_for_entry("ROUTE_TABLE", "3000::/64")
@@ -251,7 +259,9 @@ class TestRoute(TestRouteBase):
 
         # remove route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ipv6 route 3000::0/64 2000::2\"")
-        dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ipv6 route ::/0 2000::2\"")
+
+        # remove default route entry
+        self.remove_route_entry("::/0")
 
         # check application database
         self.pdb.wait_for_deleted_entry("ROUTE_TABLE", "3000::/64")

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -12,6 +12,7 @@ class TestRouteBase(object):
         self.pdb = dvs.get_app_db()
         self.adb = dvs.get_asic_db()
         self.cdb = dvs.get_config_db()
+        self.sdb = dvs.get_state_db()
 
     def set_admin_status(self, interface, status):
         self.cdb.update_entry("PORT", interface, {"admin_status": status})
@@ -61,6 +62,23 @@ class TestRouteBase(object):
             return (all(destination in route_destinations for destination in destinations), None)
 
         wait_for_result(_access_function)
+
+    def check_route_state(self, prefix, value):
+        found = False
+
+        route_entries = self.sdb.get_keys("ROUTE_TABLE")
+        for key in route_entries:
+            if key != prefix:
+                continue
+            found = True
+            fvs = self.sdb.get_entry("ROUTE_TABLE", key)
+
+            assert fvs != {}
+
+            for f,v in fvs.items():
+                if f == "state":
+                    assert v == value
+        assert found
 
     def get_asic_db_key(self, destination):
         route_entries = self.adb.get_keys("ASIC_STATE:SAI_OBJECT_TYPE_ROUTE_ENTRY")
@@ -123,6 +141,9 @@ class TestRoute(TestRouteBase):
         self.create_l3_intf("Ethernet0", "")
         self.create_l3_intf("Ethernet4", "")
 
+        # check STATE route database, initial state shall be "na"
+        self.check_route_state("0.0.0.0/0", "na")
+
         # set ip address
         self.add_ip_address("Ethernet0", "10.0.0.0/31")
         self.add_ip_address("Ethernet4", "10.0.0.2/31")
@@ -150,6 +171,9 @@ class TestRoute(TestRouteBase):
         # check ASIC route database
         self.check_route_entries(["2.2.2.0/24"])
 
+        # check STATE route database
+        self.check_route_state("0.0.0.0/0", "ok")
+
         # remove route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ip route 2.2.2.0/24 10.0.0.1\"")
 
@@ -170,6 +194,9 @@ class TestRoute(TestRouteBase):
         self.set_admin_status("Ethernet0", "down")
         self.set_admin_status("Ethernet4", "down")
 
+        # check STATE route database, state set to "na" after deleting the default route
+        self.check_route_state("0.0.0.0/0", "na")
+
         # remove ip address and default route
         dvs.servers[0].runcmd("ip route del default dev eth0")
         dvs.servers[0].runcmd("ip address del 10.0.0.1/31 dev eth0")
@@ -183,6 +210,9 @@ class TestRoute(TestRouteBase):
         # create l3 interface
         self.create_l3_intf("Ethernet0", "")
         self.create_l3_intf("Ethernet4", "")
+
+        # check STATE route database, initial state shall be "na"
+        self.check_route_state("::/0", "na")
 
         # bring up interface
         self.set_admin_status("Ethernet0", "up")
@@ -213,6 +243,9 @@ class TestRoute(TestRouteBase):
         # check ASIC route database
         self.check_route_entries(["3000::/64"])
 
+        # check STATE route database
+        self.check_route_state("::/0", "ok")
+
         # remove route entry
         dvs.runcmd("vtysh -c \"configure terminal\" -c \"no ipv6 route 3000::0/64 2000::2\"")
 
@@ -232,6 +265,9 @@ class TestRoute(TestRouteBase):
 
         self.set_admin_status("Ethernet0", "down")
         self.set_admin_status("Ethernet4", "down")
+
+        # check STATE route database, state set to "na" after deleting the default route
+        self.check_route_state("::/0", "na")
 
         # remove ip address and default route
         dvs.servers[0].runcmd("ip -6 route del default dev eth0")


### PR DESCRIPTION
**What I did**
Orchagent update of IPv4 and IPv6 default route status. If there is a valid default route, it shall be updated as `state:ok`. If there is no valid default route (with packet action drop), state db shall be updated as `state:na`

**Why I did it**
Default route state in state_db can be used as a signal for application to determine if there is a valid default route learned via BGP is available in orchagent

**How I verified it**

**Details if related**
```
redis-cli -n 6
127.0.0.1:6379[6]> KEYS *ROUTE*
1) "ROUTE_TABLE|::/0"
2) "ROUTE_TABLE|0.0.0.0/0"
127.0.0.1:6379[6]> HGETALL "ROUTE_TABLE|0.0.0.0/0"
1) "state"
2) "na"
```

