### PR TITLE
[202012][Mux orch] set default as standby, change mux orch priority

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -326,6 +326,9 @@ MuxCable::MuxCable(string name, IpPrefix& srv_ip4, IpPrefix& srv_ip6, IpAddress 
     state_machine_handlers_.insert(handler_pair(MUX_STATE_STANDBY_ACTIVE, &MuxCable::stateActive));
     state_machine_handlers_.insert(handler_pair(MUX_STATE_INIT_STANDBY, &MuxCable::stateStandby));
     state_machine_handlers_.insert(handler_pair(MUX_STATE_ACTIVE_STANDBY, &MuxCable::stateStandby));
+
+    /* Set initial state to "standby" */
+    stateStandby();
 }
 
 bool MuxCable::stateInitActive()

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -271,7 +271,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, qos_orch, wm_orch, policer_orch, tunnel_decap_orch, sflow_orch, debug_counter_orch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, mux_orch, mux_cb_orch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, qos_orch, wm_orch, policer_orch, tunnel_decap_orch, sflow_orch, debug_counter_orch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)
@@ -320,8 +320,6 @@ bool OrchDaemon::init()
     m_orchList.push_back(vnet_rt_orch);
     m_orchList.push_back(gNatOrch);
     m_orchList.push_back(gFgNhgOrch);
-    m_orchList.push_back(mux_orch);
-    m_orchList.push_back(mux_cb_orch);
     m_orchList.push_back(mux_st_orch);
 
     m_select = new Select();


### PR DESCRIPTION
**What I did**

1. Set default status for each mux port to standby state during init.
2. Change mux orch priority to process entries before neighbor orch

**Why I did it**

Cherry-pick PR https://github.com/Azure/sonic-swss/pull/2010

**How I verified it**

**Details if related**
