### PR TITLE
Routed subinterface enhancements

### DIFF
--- a/lib/subintf.cpp
+++ b/lib/subintf.cpp
@@ -9,68 +9,68 @@ using namespace swss;
 subIntf::subIntf(const std::string &ifName)
 {
     alias = ifName;
-	size_t found = alias.find(VLAN_SUB_INTERFACE_SEPARATOR);
-	if (found != std::string::npos)
-	{
-		parentIf = alias.substr(0, found);
-		if (!parentIf.compare(0, strlen("Eth"), "Eth"))
-		{
+    size_t found = alias.find(VLAN_SUB_INTERFACE_SEPARATOR);
+    if (found != std::string::npos)
+    {
+        parentIf = alias.substr(0, found);
+        if (!parentIf.compare(0, strlen("Eth"), "Eth"))
+        {
             std::string parentIfName;
-			if (!parentIf.compare(0, strlen("Ethernet"), "Ethernet"))
-			{
-		        parentIfShortName = "Eth" + parentIf.substr(strlen("Ethernet"));
-			    isCompressed = false;
-			    parentIfName = "Ethernet" + parentIf.substr(strlen("Ethernet"));
-			}
-			else
-			{
-		        parentIfShortName = "Eth" + parentIf.substr(strlen("Eth"));
-				isCompressed = true;
-			    parentIfName = "Ethernet" + parentIf.substr(strlen("Eth"));
-			}
+            if (!parentIf.compare(0, strlen("Ethernet"), "Ethernet"))
+            {
+                parentIfShortName = "Eth" + parentIf.substr(strlen("Ethernet"));
+                isCompressed = false;
+                parentIfName = "Ethernet" + parentIf.substr(strlen("Ethernet"));
+            }
+            else
+            {
+                parentIfShortName = "Eth" + parentIf.substr(strlen("Eth"));
+                isCompressed = true;
+                parentIfName = "Ethernet" + parentIf.substr(strlen("Eth"));
+            }
             parentIf = parentIfName;
-		    subIfIdx = alias.substr(found + 1);
-		}
-		else if (!parentIf.compare(0, strlen("Po"), "Po"))
-		{
-			if (!parentIf.compare(0, strlen("PortChannel"), "PortChannel"))
-			{
-				isCompressed = false;
-		        parentIfShortName = "Po" + parentIf.substr(strlen("PortChannel"));
-			    parentIf = "PortChannel" + parentIf.substr(strlen("PortChannel"));
-			}
-			else
-			{
-				isCompressed = true;
-		        parentIfShortName = "Po" + parentIf.substr(strlen("Po"));
-			    parentIf = "PortChannel" + parentIf.substr(strlen("Po"));
-			}
-		    subIfIdx = alias.substr(found + 1);
-		}
-		else
-		{
-			subIfIdx = "";
-		}
-	}
+            subIfIdx = alias.substr(found + 1);
+        }
+        else if (!parentIf.compare(0, strlen("Po"), "Po"))
+        {
+            if (!parentIf.compare(0, strlen("PortChannel"), "PortChannel"))
+            {
+                isCompressed = false;
+                parentIfShortName = "Po" + parentIf.substr(strlen("PortChannel"));
+                parentIf = "PortChannel" + parentIf.substr(strlen("PortChannel"));
+            }
+            else
+            {
+                isCompressed = true;
+                parentIfShortName = "Po" + parentIf.substr(strlen("Po"));
+                parentIf = "PortChannel" + parentIf.substr(strlen("Po"));
+            }
+            subIfIdx = alias.substr(found + 1);
+        }
+        else
+        {
+            subIfIdx = "";
+        }
+    }
 }
 
 bool subIntf::isValid() const
 {
-	if (subIfIdx == "")
+    if (subIfIdx == "")
     {
-		return false;
+        return false;
     }
     else if (alias.length() >= IFNAMSIZ)
     {
         return false;
     }
 
-	return true;
+    return true;
 }
 
 std::string subIntf::parentIntf() const
 {
-	return parentIf;
+    return parentIf;
 }
 
 int subIntf::subIntfIdx() const
@@ -88,23 +88,23 @@ int subIntf::subIntfIdx() const
     {
         return -1;
     }
-	return id;
+    return id;
 }
 
 std::string subIntf::longName() const
 {
-	if (isValid() == false)
-		return "";
+    if (isValid() == false)
+        return "";
 
-	return (parentIf + VLAN_SUB_INTERFACE_SEPARATOR + subIfIdx);
+    return (parentIf + VLAN_SUB_INTERFACE_SEPARATOR + subIfIdx);
 }
 
 std::string subIntf::shortName() const
 {
-	if (isValid() == false)
-		return "";
+    if (isValid() == false)
+        return "";
 
-	return (parentIfShortName + VLAN_SUB_INTERFACE_SEPARATOR + subIfIdx);
+    return (parentIfShortName + VLAN_SUB_INTERFACE_SEPARATOR + subIfIdx);
 }
 
 bool subIntf::isShortName() const

--- a/lib/subintf.cpp
+++ b/lib/subintf.cpp
@@ -1,0 +1,113 @@
+#include <cerrno>
+#include <cstring>
+#include <array>
+#include <net/if.h>
+#include "subintf.h"
+
+using namespace swss;
+
+subIntf::subIntf(const std::string &ifName)
+{
+    alias = ifName;
+	size_t found = alias.find(VLAN_SUB_INTERFACE_SEPARATOR);
+	if (found != std::string::npos)
+	{
+		parentIf = alias.substr(0, found);
+		if (!parentIf.compare(0, strlen("Eth"), "Eth"))
+		{
+            std::string parentIfName;
+			if (!parentIf.compare(0, strlen("Ethernet"), "Ethernet"))
+			{
+		        parentIfShortName = "Eth" + parentIf.substr(strlen("Ethernet"));
+			    isCompressed = false;
+			    parentIfName = "Ethernet" + parentIf.substr(strlen("Ethernet"));
+			}
+			else
+			{
+		        parentIfShortName = "Eth" + parentIf.substr(strlen("Eth"));
+				isCompressed = true;
+			    parentIfName = "Ethernet" + parentIf.substr(strlen("Eth"));
+			}
+            parentIf = parentIfName;
+		    subIfIdx = alias.substr(found + 1);
+		}
+		else if (!parentIf.compare(0, strlen("Po"), "Po"))
+		{
+			if (!parentIf.compare(0, strlen("PortChannel"), "PortChannel"))
+			{
+				isCompressed = false;
+		        parentIfShortName = "Po" + parentIf.substr(strlen("PortChannel"));
+			    parentIf = "PortChannel" + parentIf.substr(strlen("PortChannel"));
+			}
+			else
+			{
+				isCompressed = true;
+		        parentIfShortName = "Po" + parentIf.substr(strlen("Po"));
+			    parentIf = "PortChannel" + parentIf.substr(strlen("Po"));
+			}
+		    subIfIdx = alias.substr(found + 1);
+		}
+		else
+		{
+			subIfIdx = "";
+		}
+	}
+}
+
+bool subIntf::isValid() const
+{
+	if (subIfIdx == "")
+    {
+		return false;
+    }
+    else if (alias.length() >= IFNAMSIZ)
+    {
+        return false;
+    }
+
+	return true;
+}
+
+std::string subIntf::parentIntf() const
+{
+	return parentIf;
+}
+
+int subIntf::subIntfIdx() const
+{
+    uint16_t id;
+    try
+    {
+        id = static_cast<uint16_t>(stoul(subIfIdx));
+    }
+    catch (const std::invalid_argument &e)
+    {
+        return -1;
+    }
+    catch (const std::out_of_range &e)
+    {
+        return -1;
+    }
+	return id;
+}
+
+std::string subIntf::longName() const
+{
+	if (isValid() == false)
+		return "";
+
+	return (parentIf + VLAN_SUB_INTERFACE_SEPARATOR + subIfIdx);
+}
+
+std::string subIntf::shortName() const
+{
+	if (isValid() == false)
+		return "";
+
+	return (parentIfShortName + VLAN_SUB_INTERFACE_SEPARATOR + subIfIdx);
+}
+
+bool subIntf::isShortName() const
+{
+    return ((isCompressed == true) ? true : false);
+}

--- a/lib/subintf.h
+++ b/lib/subintf.h
@@ -14,7 +14,7 @@ namespace swss {
 			bool isShortName() const;
 
         private:
-            std::string alias;
+			std::string alias;
 			std::string subIfIdx;
 			std::string parentIf;
 			std::string parentIfShortName;

--- a/lib/subintf.h
+++ b/lib/subintf.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#define VLAN_SUB_INTERFACE_SEPARATOR   "."
+namespace swss {
+	class subIntf
+	{
+		public:
+			subIntf(const std::string &ifName);
+			bool isValid() const;
+			std::string parentIntf() const;
+			int subIntfIdx() const;
+			std::string longName() const;
+			std::string shortName() const;
+			bool isShortName() const;
+
+        private:
+            std::string alias;
+			std::string subIfIdx;
+			std::string parentIf;
+			std::string parentIfShortName;
+			bool isCompressed = false;
+	};
+}


### PR DESCRIPTION
Moving swss-common subinterface library(PR [#529](https://github.com/Azure/sonic-swss-common/pull/529)) to swss library as per subinterface enhancement HLD update.
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Routed subinterfae enhancements HLD [#833](https://github.com/Azure/SONiC/pull/833)
Add support for long name and short name routed subinterfaces.
Add support for long name and short name routed subinterfaces.
This swss common library provides APIS for:
- Subinterface validation checks
- Get parent interface corresponding to subinterface(short/long name)
- Get subinterface index
 
**Why I did it**
Routed subinterface feature was broken for physical and portchannel subinterfaces for subinterface name exceeding 15 characters due to kernel limitation of netdev name length of 15.

**How I verified it**
Routed subinterface Unit tests