### PR TITLE
[muxorch] Bind all ports to drop ACL table

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -790,9 +790,9 @@ void MuxAclHandler::createMuxAclTable(sai_object_id_t port, string strTable)
 
     acl_table.type = ACL_TABLE_DROP;
     acl_table.id = strTable;
-    acl_table.link(port);
     acl_table.stage = ACL_STAGE_INGRESS;
     gAclOrch->addAclTable(acl_table);
+    bindAllPorts(acl_table);
 }
 
 void MuxAclHandler::createMuxAclRule(shared_ptr<AclRuleMux> rule, string strTable)
@@ -815,6 +815,24 @@ void MuxAclHandler::createMuxAclRule(shared_ptr<AclRuleMux> rule, string strTabl
     rule->validateAddAction(attr_name, attr_value);
 
     gAclOrch->addAclRule(rule, strTable);
+}
+
+void MuxAclHandler::bindAllPorts(AclTable &acl_table)
+{
+    SWSS_LOG_ENTER();
+
+    auto allPorts = gPortsOrch->getAllPorts();
+    for (auto &it: allPorts)
+    {
+        Port port = it.second;
+        if (port.m_type == Port::PHY)
+        {
+            SWSS_LOG_INFO("Binding port %" PRIx64 " to ACL table %s", port.m_port_id, acl_table.id.c_str());
+
+            acl_table.link(port.m_port_id);
+            acl_table.bind(port.m_port_id);
+        }
+    }
 }
 
 sai_object_id_t MuxOrch::createNextHopTunnel(std::string tunnelKey, swss::IpAddress& ipAddr)

--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -44,6 +44,7 @@ public:
 private:
     void createMuxAclTable(sai_object_id_t port, string strTable);
     void createMuxAclRule(shared_ptr<AclRuleMux> rule, string strTable);
+    void bindAllPorts(AclTable &acl_table);
 
     // class shared dict: ACL table name -> ACL table
     static std::map<std::string, AclTable> acl_table_;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
BInd all physical ports to drop ACL table

**Why I did it**
With current implementation, ACL table is link/bind to the very first port that triggers creation of drop ACL table followed by rule creation for the same.
For subsequent ports only new rule is created.
If a port is not linked/bind to the drop ACL table, the rule is not applied for that port.

**How I verified it**
1. Verified using sairedis log and mux logs that was added with new code that all ports are linked/bind to the drop ACL table.
2. Verified that after this fix all standby ports are dropping packets as expected.

**Details if related**
