### PR TITLE
[macsec] Wait for port up before enabling macsec

### DIFF
--- a/cfgmgr/macsecmgr.cpp
+++ b/cfgmgr/macsecmgr.cpp
@@ -547,10 +547,13 @@ bool MACsecMgr::isPortStateOk(const std::string & port_name)
 
     std::vector<FieldValueTuple> temp;
     std::string state;
+    std::string oper_status;
 
     if (m_statePortTable.get(port_name, temp)
         && get_value(temp, "state", state)
-        && state == "ok")
+        && state == "ok"
+        && get_value(temp, "netdev_oper_status", oper_status)
+        && oper_status == "up")
     {
         SWSS_LOG_DEBUG("Port '%s' is ready", port_name.c_str());
         return true;


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Change the prerequisite of enabling macsec to port up

**Why I did it**
The macsec-related API calls have to be executed after the API calls for gearbox port setup have been done. For that reason, before this change, enabling macsec through config_db.json after reboot cannot succeed.  To fix it by this change, the API calls for enabling macsec are executed only after the port is up.

**How I verified it**

**Details if related**
