### PR TITLE
patch for issue #1971 - enable Rx Drop handling for cisco-8000

### DIFF
--- a/orchagent/pfc_restore_cisco-8000.lua
+++ b/orchagent/pfc_restore_cisco-8000.lua
@@ -44,7 +44,7 @@ for i = n, 1, -1 do
         and (debug_storm ~= "enabled")
         -- DEBUG CODE END.
         then
-            if time_left <= 0 then
+            if time_left <= poll_time then
                 redis.call('PUBLISH', 'PFC_WD_ACTION', '["' .. KEYS[i] .. '","restore"]')
                 time_left = restoration_time
             else

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -221,7 +221,7 @@ void PfcWdActionHandler::updateWdCounters(const string& queueIdStr, const PfcWdQ
 
 PfcWdSaiDlrInitHandler::PfcWdSaiDlrInitHandler(sai_object_id_t port, sai_object_id_t queue,
                                                uint8_t queueId, shared_ptr<Table> countersTable):
-    PfcWdActionHandler(port, queue, queueId, countersTable)
+    PfcWdZeroBufferHandler(port, queue, queueId, countersTable)
 {
     SWSS_LOG_ENTER();
 
@@ -260,39 +260,6 @@ PfcWdSaiDlrInitHandler::~PfcWdSaiDlrInitHandler(void)
                        " queueId %d : %d", port, queue, queueId, status);
         return;
     }
-}
-
-bool PfcWdSaiDlrInitHandler::getHwCounters(PfcWdHwStats& counters)
-{
-    SWSS_LOG_ENTER();
-
-    static const vector<sai_stat_id_t> queueStatIds =
-    {
-        SAI_QUEUE_STAT_PACKETS,
-        SAI_QUEUE_STAT_DROPPED_PACKETS,
-    };
-
-    vector<uint64_t> queueStats;
-    queueStats.resize(queueStatIds.size());
-
-    sai_status_t status = sai_queue_api->get_queue_stats(
-            getQueue(),
-            static_cast<uint32_t>(queueStatIds.size()),
-            queueStatIds.data(),
-            queueStats.data());
-
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to fetch queue 0x%" PRIx64 " stats: %d", getQueue(), status);
-        return false;
-    }
-
-    counters.txPkt = queueStats[0];
-    counters.txDropPkt = queueStats[1];
-    counters.rxPkt = 0;
-    counters.rxDropPkt = 0;
-
-    return true;
 }
 
 PfcWdAclHandler::PfcWdAclHandler(sai_object_id_t port, sai_object_id_t queue,
@@ -469,6 +436,15 @@ PfcWdLossyHandler::PfcWdLossyHandler(sai_object_id_t port, sai_object_id_t queue
 {
     SWSS_LOG_ENTER();
 
+    string platform(getenv("platform"));
+
+    if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+    {
+        SWSS_LOG_DEBUG("Skipping in constructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
+                       platform.c_str(), port);
+        return;
+    }
+
     uint8_t pfcMask = 0;
 
     if (!gPortsOrch->getPortPfc(port, &pfcMask))
@@ -487,6 +463,15 @@ PfcWdLossyHandler::PfcWdLossyHandler(sai_object_id_t port, sai_object_id_t queue
 PfcWdLossyHandler::~PfcWdLossyHandler(void)
 {
     SWSS_LOG_ENTER();
+
+    string platform(getenv("platform"));
+
+    if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+    {
+        SWSS_LOG_DEBUG("Skipping in destructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
+                       platform.c_str(), getPort());
+        return;
+    }
 
     uint8_t pfcMask = 0;
 

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -436,13 +436,20 @@ PfcWdLossyHandler::PfcWdLossyHandler(sai_object_id_t port, sai_object_id_t queue
 {
     SWSS_LOG_ENTER();
 
-    string platform(getenv("platform"));
-
-    if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+    const char *env_plat = getenv("platform");
+    if (env_plat == nullptr) 
     {
-        SWSS_LOG_DEBUG("Skipping in constructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
-                       platform.c_str(), port);
-        return;
+        string platform("");
+    }
+    else
+    {
+        string platform(env_plat);
+        if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+        {
+            SWSS_LOG_DEBUG("Skipping in constructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
+                           platform.c_str(), port);
+            return;
+        }
     }
 
     uint8_t pfcMask = 0;
@@ -464,13 +471,20 @@ PfcWdLossyHandler::~PfcWdLossyHandler(void)
 {
     SWSS_LOG_ENTER();
 
-    string platform(getenv("platform"));
-
-    if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+    const char *env_plat = getenv("platform");
+    if (env_plat == nullptr) 
     {
-        SWSS_LOG_DEBUG("Skipping in destructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
+        string platform("");
+    }
+    else
+    {
+        string platform(env_plat);
+        if (platform == CISCO_8000_PLATFORM_SUBSTRING)
+        {
+            SWSS_LOG_DEBUG("Skipping in destructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
                        platform.c_str(), getPort());
-        return;
+            return;
+        }
     }
 
     uint8_t pfcMask = 0;

--- a/orchagent/pfcactionhandler.cpp
+++ b/orchagent/pfcactionhandler.cpp
@@ -436,20 +436,12 @@ PfcWdLossyHandler::PfcWdLossyHandler(sai_object_id_t port, sai_object_id_t queue
 {
     SWSS_LOG_ENTER();
 
-    const char *env_plat = getenv("platform");
-    if (env_plat == nullptr) 
+    string platform = getenv("platform") ? getenv("platform") : "";
+    if (platform == CISCO_8000_PLATFORM_SUBSTRING)
     {
-        string platform("");
-    }
-    else
-    {
-        string platform(env_plat);
-        if (platform == CISCO_8000_PLATFORM_SUBSTRING)
-        {
-            SWSS_LOG_DEBUG("Skipping in constructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
-                           platform.c_str(), port);
-            return;
-        }
+        SWSS_LOG_DEBUG("Skipping in constructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
+                       platform.c_str(), port);
+        return;
     }
 
     uint8_t pfcMask = 0;
@@ -471,20 +463,12 @@ PfcWdLossyHandler::~PfcWdLossyHandler(void)
 {
     SWSS_LOG_ENTER();
 
-    const char *env_plat = getenv("platform");
-    if (env_plat == nullptr) 
+    string platform = getenv("platform") ? getenv("platform") : "";
+    if (platform == CISCO_8000_PLATFORM_SUBSTRING)
     {
-        string platform("");
-    }
-    else
-    {
-        string platform(env_plat);
-        if (platform == CISCO_8000_PLATFORM_SUBSTRING)
-        {
-            SWSS_LOG_DEBUG("Skipping in destructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
+        SWSS_LOG_DEBUG("Skipping in destructor PfcWdLossyHandler for platform %s on port 0x%" PRIx64,
                        platform.c_str(), getPort());
-            return;
-        }
+        return;
     }
 
     uint8_t pfcMask = 0;

--- a/orchagent/pfcactionhandler.h
+++ b/orchagent/pfcactionhandler.h
@@ -165,13 +165,12 @@ class PfcWdZeroBufferHandler: public PfcWdLossyHandler
 
 // PFC queue that implements drop action by draining queue via SAI
 // attribute SAI_QUEUE_ATTR_PFC_DLR_INIT.
-class PfcWdSaiDlrInitHandler: public PfcWdActionHandler
+class PfcWdSaiDlrInitHandler: public PfcWdZeroBufferHandler
 {
     public:
         PfcWdSaiDlrInitHandler(sai_object_id_t port, sai_object_id_t queue,
                 uint8_t queueId, shared_ptr<Table> countersTable);
         virtual ~PfcWdSaiDlrInitHandler(void);
-        virtual bool getHwCounters(PfcWdHwStats& counters);
 };
 
 #endif


### PR DESCRIPTION
Signed-off-by: Alpesh S Patel <alpesh@cisco.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

1. Enables support for Rx traffic drop for a port/tc by applying the zero buffer profile
2. Changed class hierarchy so that default getHwCounters() function is used (since the Rx counter support is enabled)
3. Fixes a pfc-wd off by 1 detection in case of PFC-WD detection without traffic

**Why I did it**
1. enabling a missing functionality
2. leveraging sonic code as our sdk now implements the missing counter
3. fixes a bug 

**How I verified it**
on a cisco-8000 router:
1. detected pfc-wd detection and restore happens within the (detection/restore-time + 1 poll interval) duration and that the changeset passes MSFT tests
2. Verified that when PFC-WD is detected, both Rx and Tx traffic for a port/tc is dropped and no forwarding happens

**Details if related**

this patch will need to be double committed to the 202012 branch along with #1942 , #1748 and #1962 
