### PR TITLE
[202012] [orchagent]: Support for setting switch level DSCP to TC QoS map (cherry-pick from master)

### DIFF
--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include "orch.h"
+#include "switchorch.h"
 #include "portsorch.h"
 
 const string dscp_to_tc_field_name              = "dscp_to_tc_map";
@@ -68,6 +69,8 @@ class DscpToTcMapHandler : public QosMapHandler
 public:
     bool convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes) override;
     sai_object_id_t addQosItem(const vector<sai_attribute_t> &attributes) override;
+protected:
+    void applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t sai_dscp_to_tc_map);
 };
 
 class Dot1pToTcMapHandler : public QosMapHandler

--- a/orchagent/switchorch.cpp
+++ b/orchagent/switchorch.cpp
@@ -486,3 +486,31 @@ void SwitchOrch::set_switch_capability(const std::vector<FieldValueTuple>& value
 {
      m_switchTable.set("switch", values);
 }
+
+bool SwitchOrch::querySwitchDscpToTcCapability(sai_object_type_t sai_object, sai_attr_id_t attr_id)
+{
+    SWSS_LOG_ENTER();
+
+    /* Check if SAI is capable of handling Switch level DSCP to TC QoS map */
+    vector<FieldValueTuple> fvVector;
+    sai_status_t status = SAI_STATUS_SUCCESS;
+    sai_attr_capability_t capability;
+
+    status = sai_query_attribute_capability(gSwitchId, sai_object, attr_id, &capability);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Could not query switch level DSCP to TC map %d", status);
+        return false;
+    }
+    else 
+    {
+        if (capability.set_implemented)
+        {
+            return true;
+        }
+        else 
+        {
+            return false;
+        }
+    }
+}

--- a/orchagent/switchorch.h
+++ b/orchagent/switchorch.h
@@ -25,6 +25,7 @@ public:
     void restartCheckReply(const std::string &op, const std::string &data, std::vector<swss::FieldValueTuple> &values);
     bool setAgingFDB(uint32_t sec);
     void set_switch_capability(const std::vector<swss::FieldValueTuple>& values);
+    bool querySwitchDscpToTcCapability(sai_object_type_t sai_object, sai_attr_id_t attr_id);
 private:
     void doTask(Consumer &consumer);
     void doTask(swss::SelectableTimer &timer);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
**What I did**
Added support for setting switch level DSCP to TC QoS map. cherry picked the following - 
https://github.com/Azure/sonic-swss/pull/2023

**Why I did it**
This is required to set correct DSCP -> TC QoS map for tunnels else they will point to some default QoS map (DSCP/8 = TC) which is not correct.

**How I verified it**
This needs SAI change to support this capability. Verified this to be working fine on T0 testbed with mock dual ToR topology.
 
**Details if related**