### PR TITLE
Fix for 2053, Fix IPv6 BGP multipath-relax peer-type.

### DIFF
--- a/cfgmgr/intfmgr.h
+++ b/cfgmgr/intfmgr.h
@@ -37,6 +37,7 @@ private:
     std::set<std::string> m_loopbackIntfList;
     std::set<std::string> m_pendingReplayIntfList;
     std::set<std::string> m_ipv6LinkLocalModeList;
+    std::string mySwitchType;
 
     void setIntfIp(const std::string &alias, const std::string &opCmd, const IpPrefix &ipPrefix);
     void setIntfVrf(const std::string &alias, const std::string &vrfName);

--- a/cfgmgr/nbrmgr.cpp
+++ b/cfgmgr/nbrmgr.cpp
@@ -509,7 +509,12 @@ bool NbrMgr::addKernelRoute(string odev, IpAddress ip_addr)
     }
     else
     {
-        cmd = string("") + IP_CMD + " -6 route add " + ip_str + "/128 dev " + odev;
+        // In voq system, We need the static route to the remote neighbor and connected
+        // route to have the same metric to enable BGP to choose paths from routes learned
+        // via eBGP and iBGP over the internal inband port be part of same ecmp group.
+        // For v4 both the metrics (connected and static) are default 0 so we do not need
+        // to set the metric explicitly.
+        cmd = string("") + IP_CMD + " -6 route add " + ip_str + "/128 dev " + odev + " metric 256";
         SWSS_LOG_NOTICE("IPv6 Route Add cmd: %s",cmd.c_str());
     }
 


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
By default the metric for ipv6 static route is 1024. This makes it the
routes learned via the internal bgp sessions inferior to the Ebgp
routes. So make the metric 256 which make the static route metric same
as connected route metric.

**Why I did it**
To fix IPv6 BGP multipath-relax peer-type.

**How I verified it**

Verified voq chassis can learn a route which ecmps routes advertised by internal ibgp neighbor and ebgp neighbor.

