### PR TITLE
[202012] Update default route status to state DB (#2009)

### DIFF
--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -75,7 +75,11 @@ RouteOrch::RouteOrch(DBConnector *db, string tableName, SwitchOrch *switchOrch, 
 
     SWSS_LOG_NOTICE("Maximum number of ECMP groups supported is %d", m_maxNextHopGroupCount);
 
+    m_stateDb = shared_ptr<DBConnector>(new DBConnector("STATE_DB", 0));
+    m_stateDefaultRouteTb = unique_ptr<swss::Table>(new Table(m_stateDb.get(), STATE_ROUTE_TABLE_NAME));
+
     IpPrefix default_ip_prefix("0.0.0.0/0");
+    updateDefRouteState("0.0.0.0/0");
 
     sai_route_entry_t unicast_route_entry;
     unicast_route_entry.vr_id = gVirtualRouterId;
@@ -101,6 +105,7 @@ RouteOrch::RouteOrch(DBConnector *db, string tableName, SwitchOrch *switchOrch, 
     SWSS_LOG_NOTICE("Create IPv4 default route with packet action drop");
 
     IpPrefix v6_default_ip_prefix("::/0");
+    updateDefRouteState("::/0");
 
     copy(unicast_route_entry.destination, v6_default_ip_prefix);
     subnet(unicast_route_entry.destination, unicast_route_entry.destination);
@@ -203,6 +208,16 @@ void RouteOrch::addLinkLocalRouteToMe(sai_object_id_t vrf_id, IpPrefix linklocal
     gCrmOrch->incCrmResUsedCounter(CrmResourceType::CRM_IPV6_ROUTE);
 
     SWSS_LOG_NOTICE("Created link local ipv6 route  %s to cpu", linklocal_prefix.to_string().c_str());
+}
+
+void RouteOrch::updateDefRouteState(string ip, bool add)
+{
+    vector<FieldValueTuple> tuples;
+    string state = add?"ok":"na";
+    FieldValueTuple tuple("state", state);
+    tuples.push_back(tuple);
+
+    m_stateDefaultRouteTb->set(ip, tuples);
 }
 
 bool RouteOrch::hasNextHopGroup(const NextHopGroupKey& nexthops) const
@@ -1898,7 +1913,10 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         }
     }
 
-    m_syncdRoutes[vrf_id][ipPrefix] = nextHops;
+    if (ipPrefix.isDefaultRoute())
+    {
+        updateDefRouteState(ipPrefix.to_string(), true);
+    }
 
     notifyNextHopChangeObservers(vrf_id, ipPrefix, nextHops, true);
     return true;
@@ -2006,6 +2024,8 @@ bool RouteOrch::removeRoutePost(const RouteBulkContext& ctx)
                 return parseHandleSaiStatusFailure(handle_status);
             }
         }
+
+        updateDefRouteState(ipPrefix.to_string());
 
         SWSS_LOG_INFO("Set route %s next hop ID to NULL", ipPrefix.to_string().c_str());
     }

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1918,6 +1918,8 @@ bool RouteOrch::addRoutePost(const RouteBulkContext& ctx, const NextHopGroupKey 
         updateDefRouteState(ipPrefix.to_string(), true);
     }
 
+    m_syncdRoutes[vrf_id][ipPrefix] = nextHops;
+
     notifyNextHopChangeObservers(vrf_id, ipPrefix, nextHops, true);
     return true;
 }

--- a/orchagent/routeorch.h
+++ b/orchagent/routeorch.h
@@ -148,6 +148,9 @@ private:
     int m_maxNextHopGroupCount;
     bool m_resync;
 
+    shared_ptr<DBConnector> m_stateDb;
+    unique_ptr<swss::Table> m_stateDefaultRouteTb;
+
     RouteTables m_syncdRoutes;
     NextHopGroupTable m_syncdNextHopGroups;
     NextHopRouteTable m_nextHops;
@@ -167,6 +170,8 @@ private:
 
     std::string getLinkLocalEui64Addr(void);
     void        addLinkLocalRouteToMe(sai_object_id_t vrf_id, IpPrefix linklocal_prefix);
+
+    void updateDefRouteState(string ip, bool add=false);
 
     void doTask(Consumer& consumer);
 };


### PR DESCRIPTION
**What I did**
* Orchagent update of IPv4 and IPv6 default route status. If there is a valid default route, it shall be updated as state:ok. If there is no valid default route (with packet action drop), state db shall be updated as state:na - Schema ("ROUTE_TABLE|0.0.0.0/0")

cherry-pick PR https://github.com/Azure/sonic-swss/pull/2009

**Why I did it**

**How I verified it**

**Details if related**
