### PR TITLE
[voq] Neighbor entry impose encap index attribute deprecated

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1541,10 +1541,6 @@ bool NeighOrch::addVoqEncapIndex(string &alias, IpAddress &ip, vector<sai_attrib
             attr.value.u32 = encap_index;
             neighbor_attrs.push_back(attr);
 
-            attr.id = SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX;
-            attr.value.booldata = true;
-            neighbor_attrs.push_back(attr);
-
             attr.id = SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL;
             attr.value.booldata = false;
             neighbor_attrs.push_back(attr);

--- a/tests/test_virtual_chassis.py
+++ b/tests/test_virtual_chassis.py
@@ -381,11 +381,6 @@ class TestVirtualChassis(object):
                     assert mac == test_neigh_mac, "Encap index of remote neigh mismatch with allocated encap index"
                     
                     # Check for other mandatory attributes
-                    # For remote neighbor, encap index must be imposed. So impose_index must be "true"
-                    impose_index = remote_neigh_entry.get("SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX")
-                    assert impose_index != "", "Impose index attribute is not programmed for remote neigh in ASIC_DB"
-                    assert impose_index == "true", "Impose index attribute is false for remote neigh"
-                   
                     # For remote neighbors, is_local must be "false" 
                     is_local = remote_neigh_entry.get("SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL")
                     assert is_local != "", "is_local attribute is not programmed for remote neigh in ASIC_DB"


### PR DESCRIPTION
**What I did**

Changes done to avoid sending SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX in neighbor entry while creating neighbor records in SAI

**Why I did it**

Since neighbor entry attribute SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX is deprecated, and since the new version of SAI (version > 6.0.0.11; OCP version 1.9.1) returns error (previous versions just ignores this deprecated attribute instead of returning error), this attribute is no longer sent in the neighbor entry creation to avoid orchagent crash when syncd returns error.

**How I verified it**

- Load VOQ chassis line card with image that uses SAI version > 6.0.0.11 (OCP version 1.9.1)
- Bring up an interface and configure IP address to the interface.
- Observe that syncd has not returned any error, orchagent process is up and running.

**Details if related**
