### PR TITLE
[bulk mode] Fix bulk conflict when in case there are both remove and set operations

### DIFF
--- a/orchagent/bulker.h
+++ b/orchagent/bulker.h
@@ -414,6 +414,11 @@ public:
         return creating_entries.count(entry);
     }
 
+    bool bulk_entry_pending_removal(const Te& entry) const
+    {
+        return removing_entries.find(entry) != removing_entries.end();
+    }
+
 private:
     std::unordered_map<                                     // A map of
             Te,                                             // entry ->

--- a/orchagent/mplsrouteorch.cpp
+++ b/orchagent/mplsrouteorch.cpp
@@ -599,7 +599,7 @@ bool RouteOrch::addLabelRoute(LabelRouteBulkContext& ctx, const NextHopGroupKey 
      * (group) id. The old next hop (group) is then not used and the reference
      * count will decrease by 1.
      */
-    if (it_route == m_syncdLabelRoutes.at(vrf_id).end())
+    if (it_route == m_syncdLabelRoutes.at(vrf_id).end() || gLabelRouteBulker.bulk_entry_pending_removal(inseg_entry))
     {
         vector<sai_attribute_t> inseg_attrs;
         if (blackhole)

--- a/orchagent/mplsrouteorch.cpp
+++ b/orchagent/mplsrouteorch.cpp
@@ -598,6 +598,10 @@ bool RouteOrch::addLabelRoute(LabelRouteBulkContext& ctx, const NextHopGroupKey 
      * in m_syncdLabelRoutes, then we need to update the route with a new next hop
      * (group) id. The old next hop (group) is then not used and the reference
      * count will decrease by 1.
+     *
+     * In case the entry is already pending removal in the bulk, it would be removed
+     * from m_syncdLabelRoutes during the bulk call. Therefore, such entries need to be
+     * re-created rather than set attribute.
      */
     if (it_route == m_syncdLabelRoutes.at(vrf_id).end() || gLabelRouteBulker.bulk_entry_pending_removal(inseg_entry))
     {

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1827,7 +1827,7 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
      * (group) id. The old next hop (group) is then not used and the reference
      * count will decrease by 1.
      */
-    if (it_route == m_syncdRoutes.at(vrf_id).end())
+    if (it_route == m_syncdRoutes.at(vrf_id).end() || gRouteBulker.bulk_entry_pending_removal(route_entry))
     {
         if (blackhole)
         {

--- a/orchagent/routeorch.cpp
+++ b/orchagent/routeorch.cpp
@@ -1826,6 +1826,10 @@ bool RouteOrch::addRoute(RouteBulkContext& ctx, const NextHopGroupKey &nextHops)
      * in m_syncdRoutes, then we need to update the route with a new next hop
      * (group) id. The old next hop (group) is then not used and the reference
      * count will decrease by 1.
+     *
+     * In case the entry is already pending removal in the bulk, it would be removed
+     * from m_syncdRoutes during the bulk call. Therefore, such entries need to be
+     * re-created rather than set attribute.
      */
     if (it_route == m_syncdRoutes.at(vrf_id).end() || gRouteBulker.bulk_entry_pending_removal(route_entry))
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Check if there are items pending removal in bulk before calling bulk set API.

Fixes https://github.com/Azure/sonic-buildimage/issues/9434

**Why I did it**
When there are items pending removal in bulk before calling set API, it means the item will be removed before the set and it should do create instead.

**How I verified it**

**Details if related**
