### PR TITLE
set remote vtep the netdev down before delete.

### DIFF
--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -70,6 +70,7 @@ private:
     void delAppDBTunnelMapTable(std::string vxlanTunnelMapName);
     int createVxlanNetdevice(std::string vxlanTunnelName, std::string vni_id,
                              std::string src_ip, std::string dst_ip, std::string vlan_id);
+    int downVxlanNetdevice(std::string vxlan_dev_name);
     int deleteVxlanNetdevice(std::string vxlan_dev_name);
     std::vector<std::string> parseNetDev(const std::string& stdout);
     void getAllVxlanNetDevices();


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
set vtep-xxx the netdev down before delete vtep-xxx .
**Why I did it**
the vxlan netdev will be only delete only when remove vxlan tunnel map,
but the FRR doesn't remove IMET route entirely after receiving the delete event.
Therefore, add to set netdev down before delete the netdev to trigger FRR to remove related IMET route.

**How I verified it**
using t0 topology config
and flow the cmmand

redis-cli -n 4 -c DEL "VLAN_MEMBER|Vlan1000|Ethernet4"
sudo config interface ip add Ethernet4 10.0.0.64/31
vtysh
configure
ip route 100.0.0.65/31 10.0.0.65
exit
exit

sudo config vxlan add vtep 10.1.0.32
sudo config vxlan evpn_nvo add evpnnvo1 vtep
sudo config vxlan map add vtep 1000 10000

vtysh
configure
router bgp 65100
neighbor 10.0.0.65 remote-as 65200
address-family l2vpn evpn
neighbor 10.0.0.65 activate
advertise-all-vni
exit
exit
exit
exit

neighbor:
setting bgp and type 3 and typ2 packet 

**Details if related**
