### PR TITLE
[Buffer] Fix the bug that buffer configuration will cause failed logs during warm restart.

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -287,6 +287,13 @@ void BufferMgr::doBufferTableTask(Consumer &consumer, ProducerStateTable &applTa
         string op = kfvOp(t);
         if (op == SET_COMMAND)
         {
+            if (m_warmStartAppTableKeys[applTable.getTableName()].find(key) != m_warmStartAppTableKeys[applTable.getTableName()].end())
+            {
+                m_warmStartAppTableKeys[applTable.getTableName()].erase(key);
+                it = consumer.m_toSync.erase(it);
+                continue;
+            }
+
             vector<FieldValueTuple> fvVector;
 
             SWSS_LOG_INFO("Inserting entry %s from CONFIG_DB to APPL_DB", key.c_str());
@@ -349,6 +356,44 @@ void BufferMgr::doBufferMetaTask(Consumer &consumer)
 void BufferMgr::doTask(Consumer &consumer)
 {
     SWSS_LOG_ENTER();
+
+    static bool warmStartInit = false;
+
+    //
+    // Prevent the BufferMgr from processing the entries which already exist in APPL_DB during warm restart.
+    //
+    if (warmStartInit == false)
+    {
+        m_warmStartAppTableKeys[APP_BUFFER_POOL_TABLE_NAME] = {};
+        m_warmStartAppTableKeys[APP_BUFFER_PROFILE_TABLE_NAME] = {};
+
+        WarmStart::initialize("buffermgrd", "swss");
+        WarmStart::checkWarmStart("buffermgrd", "swss");
+
+        bool isWarmStart = WarmStart::isWarmStart();
+
+        if (isWarmStart)
+        {
+            DBConnector applDb("APPL_DB", 0);
+            Table applBufferPoolTable(&applDb, APP_BUFFER_POOL_TABLE_NAME);
+            Table applBufferProfileTable(&applDb, APP_BUFFER_PROFILE_TABLE_NAME);
+
+            std::vector<std::string> keys;
+            applBufferPoolTable.getKeys(keys);
+            for (const auto& key : keys)
+            {
+                m_warmStartAppTableKeys[APP_BUFFER_POOL_TABLE_NAME].insert(key);
+            }
+
+            keys.clear();
+            applBufferProfileTable.getKeys(keys);
+            for (const auto& key : keys)
+            {
+                m_warmStartAppTableKeys[APP_BUFFER_PROFILE_TABLE_NAME].insert(key);
+            }
+        }
+        warmStartInit = true;
+    }
 
     string table_name = consumer.getTableName();
 

--- a/cfgmgr/buffermgr.h
+++ b/cfgmgr/buffermgr.h
@@ -51,6 +51,8 @@ private:
     ProducerStateTable m_applBufferIngressProfileListTable;
     ProducerStateTable m_applBufferEgressProfileListTable;
 
+    std::map<std::string, std::set<std::string>> m_warmStartAppTableKeys;
+
     bool m_pgfile_processed;
     bool dynamic_buffer_model;
 


### PR DESCRIPTION
- What I do:
  Let BufferMgr not execute the entries which are already in APPL_DB after a warm restart.

- Why I did it:
  After warm start, the BufferMgr will set entries into APPL_DB which already exist.
  It will cause bufferorch to do a modification event.
  But, currently, modifying the buffer configuration is not supported in SAI, and it will print error messages.
  The error messages will cause test cases to fail.

- How I verify it:
  With this enhancement, the syslog will not appear the error messages about Buffer during a warm restart.