### PR TITLE
[cfgmgr/natmgrd] added disabling of NAT feature (Azure#1835)

### DIFF
--- a/cfgmgr/natmgr.h
+++ b/cfgmgr/natmgr.h
@@ -251,6 +251,7 @@ public:
     void removeStaticNatIptables(const std::string port = NONE_STRING);
     void removeStaticNaptIptables(const std::string port = NONE_STRING);
     void removeDynamicNatRules(const std::string port = NONE_STRING, const std::string ipPrefix = NONE_STRING);
+    void disableNatFeature(void);
 
 private:
     /* Declare APPL_DB, CFG_DB and STATE_DB tables */
@@ -291,7 +292,6 @@ private:
 
     /* Declare all NAT functionality member functions*/
     void enableNatFeature(void);
-    void disableNatFeature(void);
     bool warmBootingInProgress(void);
     void flushAllNatEntries(void);
     void addAllStaticConntrackEntries(void);

--- a/cfgmgr/natmgrd.cpp
+++ b/cfgmgr/natmgrd.cpp
@@ -97,6 +97,7 @@ void sigterm_handler(int signo)
 
         natmgr->cleanupMangleIpTables();
         natmgr->cleanupPoolIpTable();
+        natmgr->disableNatFeature();
     }
 }
 


### PR DESCRIPTION
Signed-off-by: KonstiantynHalushka <Konstiantyn_Halushka@jabil.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Added disabling of NAT feature
**Why I did it**
IP table rule was not removed after config reload (Azure#1835)
**How I verified it**
sudo config feature state nat enabled 
sudo config nat feature enable
sudo iptables -nL -t nat 

target     prot opt source               destination
DNAT       all  --  0.0.0.0/0            0.0.0.0/0            to:1.1.1.1 fullcone
Chain INPUT (policy ACCEPT)
target     prot opt source               destination
Chain POSTROUTING (policy ACCEPT)
target     prot opt source               destination
Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination 

sudo config reload
sudo iptables -nL -t nat 

Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination         
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         
Chain POSTROUTING (policy ACCEPT)
target     prot opt source               destination         
Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination

**Details if related**
