### PR TITLE
[Mellanox] '_8lane' not added to Mellanox 5xxx models with 800G

### DIFF
--- a/cfgmgr/buffermgrdyn.cpp
+++ b/cfgmgr/buffermgrdyn.cpp
@@ -22,7 +22,6 @@
  *        In internal maps: table name removed from the index
  * 2. Maintain maps for pools, profiles and PGs in CONFIG_DB and APPL_DB
  * 3. Keys of maps in this file don't contain the TABLE_NAME
- * 3. 
  */
 using namespace std;
 using namespace swss;
@@ -37,6 +36,7 @@ BufferMgrDynamic::BufferMgrDynamic(DBConnector *cfgDb, DBConnector *stateDb, DBC
         m_zeroProfilesLoaded(false),
         m_supportRemoving(true),
         m_cfgDefaultLosslessBufferParam(cfgDb, CFG_DEFAULT_LOSSLESS_BUFFER_PARAMETER),
+        m_cfgDeviceMetaDataTable(cfgDb, CFG_DEVICE_METADATA_TABLE_NAME),
         m_applBufferPoolTable(applDb, APP_BUFFER_POOL_TABLE_NAME),
         m_applBufferProfileTable(applDb, APP_BUFFER_PROFILE_TABLE_NAME),
         m_applBufferObjectTables({ProducerStateTable(applDb, APP_BUFFER_PG_TABLE_NAME), ProducerStateTable(applDb, APP_BUFFER_QUEUE_TABLE_NAME)}),
@@ -73,6 +73,30 @@ BufferMgrDynamic::BufferMgrDynamic(DBConnector *cfgDb, DBConnector *stateDb, DBC
     string checkHeadroomPluginName = "buffer_check_headroom_" + platform + ".lua";
 
     m_platform = platform;
+    m_specific_platform = platform;     // default for non-Mellanox
+    m_model_number = 0;
+
+    // Retrieve the type of mellanox platform
+    if (m_platform == "mellanox")
+    {
+        m_cfgDeviceMetaDataTable.hget("localhost", "platform", m_specific_platform);
+        if (!m_specific_platform.empty())
+        {
+            // Mellanox model number follows "sn" in the platform name and is 4 digits long
+            std::size_t sn_pos = m_specific_platform.find("sn");
+            if (sn_pos != std::string::npos)
+            {
+                std::string model_number = m_specific_platform.substr (sn_pos + 2, 4);
+                if (!model_number.empty())
+                {
+                    m_model_number = atoi(model_number.c_str());
+                }
+            }
+        }
+        if (!m_model_number) {
+            SWSS_LOG_ERROR("Failed to retrieve Mellanox model number");
+        }
+    }
 
     try
     {
@@ -471,7 +495,9 @@ string BufferMgrDynamic::getDynamicProfileName(const string &speed, const string
 
     if (m_platform == "mellanox")
     {
-        if ((speed != "400000") && (lane_count == 8))
+        if ((lane_count == 8) &&
+            (((m_model_number / 1000 == 4) && (speed != "400000")) ||
+             ((m_model_number / 1000 == 5) && (speed != "800000"))))
         {
             // On Mellanox platform, ports with 8 lanes have different(double) xon value then other ports
             // For ports at speed other than 400G can have
@@ -482,7 +508,8 @@ string BufferMgrDynamic::getDynamicProfileName(const string &speed, const string
             // Eg.
             // - A 100G port with 8 lanes will use buffer profile "pg_profile_100000_5m_8lane_profile"
             // - A 100G port with 4 lanes will use buffer profile "pg_profile_100000_5m_profile"
-            // Currently, 400G ports can only have 8 lanes. So we don't add this to the profile
+            // Currently, for 4xxx models, 400G ports can only have 8 lanes,
+            // and for 5xxx models, 800G ports can only have 8 lanes. So we don't add this to the profile.
             buffer_profile_key = buffer_profile_key + "_8lane";
         }
     }

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -150,7 +150,10 @@ public:
     using Orch::doTask;
 
 private:
-    std::string m_platform;
+    std::string     m_platform;             // vendor, e.g. "mellanox"
+    std::string     m_specific_platform;    // name of platform, e.g. "x86_64-mlnx_msn3420-r0"
+    unsigned int    m_model_number;         // model number extracted from specific platform, e.g. 3420
+
     std::vector<buffer_direction_t> m_bufferDirections;
     const std::string m_bufferObjectNames[BUFFER_DIR_MAX];
     const std::string m_bufferDirectionNames[BUFFER_DIR_MAX];
@@ -158,10 +161,6 @@ private:
     typedef task_process_status (BufferMgrDynamic::*buffer_table_handler)(KeyOpFieldsValuesTuple &t);
     typedef std::map<std::string, buffer_table_handler> buffer_table_handler_map;
     typedef std::pair<std::string, buffer_table_handler> buffer_handler_pair;
-
-    std::string     m_platform;             // vendor, e.g. "mellanox"
-    std::string     m_specific_platform;    // name of platform, e.g. "x86_64-mlnx_msn3420-r0"
-    unsigned int    m_model_number;         // model number extracted from specific platform, e.g. 3420
 
     buffer_table_handler_map m_bufferTableHandlerMap;
 

--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -159,6 +159,10 @@ private:
     typedef std::map<std::string, buffer_table_handler> buffer_table_handler_map;
     typedef std::pair<std::string, buffer_table_handler> buffer_handler_pair;
 
+    std::string     m_platform;             // vendor, e.g. "mellanox"
+    std::string     m_specific_platform;    // name of platform, e.g. "x86_64-mlnx_msn3420-r0"
+    unsigned int    m_model_number;         // model number extracted from specific platform, e.g. 3420
+
     buffer_table_handler_map m_bufferTableHandlerMap;
 
     typedef task_process_status (BufferMgrDynamic::*buffer_single_item_handler)(const std::string &key, const std::string &port, const KeyOpFieldsValuesTuple &tuple);
@@ -234,7 +238,7 @@ private:
 
     // Other tables
     Table m_cfgDefaultLosslessBufferParam;
-
+    Table m_cfgDeviceMetaDataTable;
     Table m_stateBufferMaximumTable;
 
     Table m_applPortTable;


### PR DESCRIPTION

**What I did**

Previously, 400G buffer profiles for Mellanox 4xxx switches did not add '_8lane' to the profile name, because there is no other possibility. Now, the condition also applies to 800G buffer profiles for 5xxx switches. The work includes code that other vendors could use in buffermgrdyn if they need to distinguish between models.

**Why I did it**

No need for '_8lane' in profile name when there is no other possibility.

**How I verified it**

buffershow -l

**Details if related**
