### PR TITLE
Add initial value for weight in overlay nexthops

### DIFF
--- a/orchagent/nexthopkey.h
+++ b/orchagent/nexthopkey.h
@@ -102,7 +102,7 @@ struct NextHopKey
         }
     }
 
-    NextHopKey(const IpAddress &ip, const MacAddress &mac, const uint32_t &vni, bool overlay_nh) : ip_address(ip), alias(""), vni(vni), mac_address(mac){}
+    NextHopKey(const IpAddress &ip, const MacAddress &mac, const uint32_t &vni, bool overlay_nh) : ip_address(ip), alias(""), vni(vni), mac_address(mac), weight(0){}
 
     const std::string to_string() const
     {


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Add initial value for weight in overlay nexthops.

**Why I did it**
Without initializing the weight variable, it may be initialized as non-zero values. This PR aims to prevent it from happening.

**How I verified it**

**Details if related**
