### PR TITLE
[p4rt-test] Bind response consumer to appl_state_db

### DIFF
--- a/tests/p4rt/test_l3.py
+++ b/tests/p4rt/test_l3.py
@@ -23,7 +23,7 @@ class TestP4RTL3(object):
         self._p4rt_route_obj.set_up_databases(dvs)
         self._p4rt_wcmp_group_obj.set_up_databases(dvs)
         self.response_consumer = swsscommon.NotificationConsumer(
-            self._p4rt_route_obj.appl_db, "APPL_DB_P4RT_TABLE_RESPONSE_CHANNEL")
+            self._p4rt_route_obj.appl_state_db, "APPL_DB_P4RT_TABLE_RESPONSE_CHANNEL")
 
     def _set_vrf(self, dvs):
         # Create VRF.

--- a/tests/p4rt/test_p4rt_acl.py
+++ b/tests/p4rt/test_p4rt_acl.py
@@ -63,7 +63,7 @@ class TestP4RTAcl(object):
         self._p4rt_udf_obj.set_up_databases(dvs)
 
         self.response_consumer = swsscommon.NotificationConsumer(
-            self._p4rt_acl_table_definition_obj.appl_db, "APPL_DB_P4RT_TABLE_RESPONSE_CHANNEL"
+            self._p4rt_acl_table_definition_obj.appl_state_db, "APPL_DB_P4RT_TABLE_RESPONSE_CHANNEL"
         )
 
     @pytest.mark.skip(reason="p4orch is not enabled")

--- a/tests/p4rt/test_p4rt_mirror.py
+++ b/tests/p4rt/test_p4rt_mirror.py
@@ -42,7 +42,7 @@ class TestP4RTMirror(object):
         self._p4rt_mirror_session_wrapper = P4RtMirrorSessionWrapper()
         self._p4rt_mirror_session_wrapper.set_up_databases(dvs)
         self._response_consumer = swsscommon.NotificationConsumer(
-            self._p4rt_mirror_session_wrapper.appl_db, "APPL_DB_P4RT_TABLE_RESPONSE_CHANNEL")
+            self._p4rt_mirror_session_wrapper.appl_state_db, "APPL_DB_P4RT_TABLE_RESPONSE_CHANNEL")
 
     def test_MirrorSessionAddModifyAndDelete(self, dvs, testlog):
         # Initialize database connectors


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
In p4rt test scripts, bind response consumer to appl_state_db for consistency.

**Why I did it**
In p4orch, the relating notification producer for table `P4RT_TABLE` is on database `appl state db`

**How I verified it**
Run vstest

**Details if related**
notification channel name would be tagged `dbId` - https://github.com/Azure/sonic-swss-common/pull/568