### PR TITLE
Fix armhf buildimage artifacts not found issue

### DIFF
--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -107,8 +107,14 @@ jobs:
       runBranch: 'refs/heads/master'
       path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
     displayName: "Download sonic buildimage deb packages"
+  - script: |
+      buildimage_artifact_downloaded=n
+      [ -d "$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}/target" ] && buildimage_artifact_downloaded=y
+      echo "##vso[task.setvariable variable=buildimage_artifact_downloaded]$buildimage_artifact_downloaded"
+    condition: eq('${{ parameters.buildimage_pipeline }}', '141')
+    displayName: "Check if sonic buildimage deb packages downloaded"
   - task: DownloadPipelineArtifact@2
-    condition: and(failed(), eq('${{ parameters.buildimage_pipeline }}', '141'))
+    condition: and(eq('$(buildimage_artifact_downloaded)', 'n'), eq('${{ parameters.buildimage_pipeline }}', '141'))
     inputs:
       source: specific
       project: build

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -121,6 +121,7 @@ jobs:
       project: build
       pipeline: ${{ parameters.buildimage_pipeline }}
       artifact: 'sonic-buildimage.marvell-armhf1'
+      runVersion: specific
       runId: 63911
       path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
     displayName: "Download sonic buildimage deb packages from 63911"

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -96,7 +96,7 @@ jobs:
       path: '$(Build.SourcesDirectory)/${{ parameters.sairedis_artifact_name }}'
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
-    continueOnError: eq(${{ parameters.buildimage_pipeline }}, 141)
+    continueOnError: eq('${{ parameters.buildimage_pipeline }}', '141')
     inputs:
       source: specific
       project: build
@@ -107,7 +107,7 @@ jobs:
       path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
     displayName: "Download sonic buildimage deb packages"
   - task: DownloadPipelineArtifact@2
-    condition: and(failed(), eq(${{ parameters.buildimage_pipeline }}, 141))
+    condition: and(failed(), eq('${{ parameters.buildimage_pipeline }}', '141'))
     inputs:
       source: specific
       project: build

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -110,11 +110,12 @@ jobs:
   - script: |
       buildimage_artifact_downloaded=n
       [ -d "$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}/target" ] && buildimage_artifact_downloaded=y
+      echo "buildimage_artifact_downloaded=$buildimage_artifact_downloaded"
       echo "##vso[task.setvariable variable=buildimage_artifact_downloaded]$buildimage_artifact_downloaded"
-    condition: eq('${{ parameters.buildimage_pipeline }}', '141')
+    condition: eq(${{ parameters.buildimage_pipeline }}, 141)
     displayName: "Check if sonic buildimage deb packages downloaded"
   - task: DownloadPipelineArtifact@2
-    condition: and(eq('$(buildimage_artifact_downloaded)', 'n'), eq('${{ parameters.buildimage_pipeline }}', '141'))
+    condition: and(eq(variables.buildimage_artifact_downloaded, 'n'), eq(${{ parameters.buildimage_pipeline }}, 141))
     inputs:
       source: specific
       project: build

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -96,7 +96,8 @@ jobs:
       path: '$(Build.SourcesDirectory)/${{ parameters.sairedis_artifact_name }}'
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
-    continueOnError: eq('${{ parameters.buildimage_pipeline }}', '141')
+    ${{ if eq(parameters.buildimage_pipeline, 141) }}:
+      continueOnError: True
     inputs:
       source: specific
       project: build

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -96,6 +96,7 @@ jobs:
       path: '$(Build.SourcesDirectory)/${{ parameters.sairedis_artifact_name }}'
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
+    continueOnError: eq(${{ parameters.buildimage_pipeline }}, 141)
     inputs:
       source: specific
       project: build
@@ -105,6 +106,16 @@ jobs:
       runBranch: 'refs/heads/master'
       path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
     displayName: "Download sonic buildimage deb packages"
+  - task: DownloadPipelineArtifact@2
+    condition: and(failed(), eq(${{ parameters.buildimage_pipeline }}, 141))
+    inputs:
+      source: specific
+      project: build
+      pipeline: ${{ parameters.buildimage_pipeline }}
+      artifact: 'sonic-buildimage.marvell-armhf1'
+      runId: 63911
+      path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
+    displayName: "Download sonic buildimage deb packages from 63911"
   - script: |
       cd $(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}
       sudo dpkg -i target/debs/buster/libnl-3-200_*.deb


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
The armhf sonic-buildimage build is not ready yet, it provides a workaround to download the depended packaged from the failed build 63911.
The armhf build only depends on some of the debian packages of sonic-buildimage, target/debs/buster/libnl-*.deb, although the build 63911 was failed, but the depended packages were good.
The build 63911 is retained, see https://dev.azure.com/mssonic/build/_build/results?buildId=63911&view=results

**Why I did it**

**How I verified it**

**Details if related**
