### PR TITLE
Fix the unsafe usage of strncpy in portsorch.cpp

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2174,8 +2174,7 @@ bool PortsOrch::createVlanHostIntf(Port& vl, string hostif_name)
     attr.id = SAI_HOSTIF_ATTR_NAME;
     if (hostif_name.length() >= SAI_HOSTIF_NAME_SIZE)
     {
-        SWSS_LOG_ERROR("Host interface name is too long");
-        return false;
+        SWSS_LOG_WARN("Host interface name %s is too long and will be truncated to %d bytes", hostif_name.c_str(), SAI_HOSTIF_NAME_SIZE - 1);
     }
     strncpy(attr.value.chardata, hostif_name.c_str(), SAI_HOSTIF_NAME_SIZE);
     attr.value.chardata[SAI_HOSTIF_NAME_SIZE - 1] = '\0';
@@ -4192,6 +4191,11 @@ bool PortsOrch::addHostIntfs(Port &port, string alias, sai_object_id_t &host_int
 
     attr.id = SAI_HOSTIF_ATTR_NAME;
     strncpy((char *)&attr.value.chardata, alias.c_str(), SAI_HOSTIF_NAME_SIZE);
+    if (alias.length() >= SAI_HOSTIF_NAME_SIZE)
+    {
+        SWSS_LOG_WARN("Host interface name %s is too long and will be truncated to %d bytes", alias.c_str(), SAI_HOSTIF_NAME_SIZE - 1);
+    }
+    attr.value.chardata[SAI_HOSTIF_NAME_SIZE - 1] = '\0';
     attrs.push_back(attr);
 
     sai_status_t status = sai_hostif_api->create_hostif(&host_intfs_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2172,7 +2172,13 @@ bool PortsOrch::createVlanHostIntf(Port& vl, string hostif_name)
     attrs.push_back(attr);
 
     attr.id = SAI_HOSTIF_ATTR_NAME;
-    strncpy(attr.value.chardata, hostif_name.c_str(), sizeof(attr.value.chardata));
+    if (hostif_name.length() >= SAI_HOSTIF_NAME_SIZE)
+    {
+        SWSS_LOG_ERROR("Host interface name is too long");
+        return false;
+    }
+    strncpy(attr.value.chardata, hostif_name.c_str(), SAI_HOSTIF_NAME_SIZE);
+    attr.value.chardata[SAI_HOSTIF_NAME_SIZE - 1] = '\0';
     attrs.push_back(attr);
 
     sai_status_t status = sai_hostif_api->create_hostif(&vl.m_vlan_info.host_intf_id, gSwitchId, (uint32_t)attrs.size(), attrs.data());


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix unsafe usage of `strncpy` in portsorch.cpp.
The following errors occurred when sonic-swss is being build inside slave docker:
```
portsorch.cpp: In member function 'bool PortsOrch::createVlanHostIntf(swss::Port&, std::__cxx11::string)':
portsorch.cpp:2180:12: error: 'char* strncpy(char*, const char*, size_t)' specified bound 32 equals destination size [-Werror=stringop-truncation]
     strncpy(attr.value.chardata, hostif_name.c_str(), sizeof(attr.value.chardata));//SAI_HOSTIF_NAME_SIZE);
     ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make: *** [Makefile:942: orchagent-portsorch.o] Error 1
```

Signed-off-by: Stephen Sun <stephens@nvidia.com>

**Why I did it**
Originally, `strncpy` is used in the following way:
```
strncpy(attr.value.chardata, src_string, sizeof(attr.value.chardata));
```
where `attr.value.chardata` is a char array.

However, this is not safe in case `strlen(src_string)` >= `sizeof(attr.value.chardata)` because there will no space in `attr.value.chardata` to store the terminating character.
It will leave the string `attr.value.chardata` open, the receiver of attr cannot determine the end of the string and suffer buffer overflow.

According to SAI API definition, the actually length of `SAI_HOSTIF_ATTR_NAME` should be `SAI_HOSTIF_NAME_SIZE - 1` which is less than sizeof(attr.value.chardata)`. So a safe way to do it should be:
```
strncpy(attr.value.chardata, src_string, SAI_HOSTIF_NAME_SIZE);
attr.value.chardata[SAI_HOSTIF_NAME_SIZE - 1] = '\0'
```

**How I verified it**

**Details if related**
