### PR TITLE
[p4orch] Fix handlePortStatusChangeNotification operstatus deserialize

### DIFF
--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -171,9 +171,9 @@ void P4Orch::handlePortStatusChangeNotification(const std::string &op, const std
             {
                 m_wcmpManager->pruneNextHops(port.m_alias);
             }
-
-            sai_deserialize_free_port_oper_status_ntf(count, port_oper_status);
         }
+
+        sai_deserialize_free_port_oper_status_ntf(count, port_oper_status);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Volodymyr Boyko <volodymyrx.boiko@intel.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Moved sai_deserialize_free_port_oper_status_ntf(count, port_oper_status); call outside the loop iterating port_oper_status array.

**Why I did it**
Calling sai_deserialize_free_port_oper_status_ntf(count, port_oper_status); in loop causes double-free.

```
Program terminated with signal SIGABRT, Aborted.
#0  0x00007f66568ed7bb in raise () from /lib/x86_64-linux-gnu/libc.so.6
[Current thread is 1 (Thread 0x7f6656507bc0 (LWP 39))]
(gdb) bt
#0  0x00007f66568ed7bb in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f66568d8535 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f665692f508 in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007f6656935c1a in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#4  0x00007f66569376fd in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#5  0x00007f665721ab4d in sai_deserialize_free_port_oper_status_ntf(unsigned int, _sai_port_oper_status_notification_t*) ()
   from /usr/lib/x86_64-linux-gnu/libsaimeta.so.0
#6  0x000055c90aec135c in P4Orch::handlePortStatusChangeNotification (this=0x55c90bbc1320, op=..., data=...) at p4orch/p4orch.cpp:175
#7  0x000055c90aec1b6e in P4Orch::doTask (this=0x55c90bbc1320, consumer=...) at p4orch/p4orch.cpp:196
#8  0x000055c90acaac77 in OrchDaemon::start (this=this@entry=0x55c90bad3b70) at orchdaemon.cpp:700
#9  0x000055c90ac5c2f1 in main (argc=<optimized out>, argv=<optimized out>) at main.cpp:692
```
```
swss#/supervisord: orchagent free(): double free detected in tcache 2
```
**How I verified it**
sudo fast-reboot
ls /var/core/orchagent*

**Details if related**