### PR TITLE
[DualToR] Handle race condition between tunnel_decap and mux orchestr…

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1219,8 +1219,6 @@ bool MuxOrch::handlePeerSwitch(const Request& request)
 
     if (op == SET_COMMAND)
     {
-        mux_peer_switch_ = peer_ip;
-
         // Create P2P tunnel when peer_ip is available.
         IpAddresses dst_ips = decap_orch_->getDstIpAddresses(MUX_TUNNEL);
         if (!dst_ips.getSize())
@@ -1233,6 +1231,7 @@ bool MuxOrch::handlePeerSwitch(const Request& request)
         auto it =  dst_ips.getIpAddresses().begin();
         const IpAddress& dst_ip = *it;
         mux_tunnel_id_ = create_tunnel(&peer_ip, &dst_ip);
+        mux_peer_switch_ = peer_ip;
         SWSS_LOG_NOTICE("Mux peer ip '%s' was added, peer name '%s'",
                          peer_ip.to_string().c_str(), peer_name.c_str());
     }

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -271,7 +271,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, mux_orch, mux_cb_orch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, qos_orch, wm_orch, policer_orch, tunnel_decap_orch, sflow_orch, debug_counter_orch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gIntfsOrch, gNeighOrch, gRouteOrch, copp_orch, qos_orch, wm_orch, policer_orch, tunnel_decap_orch, sflow_orch, debug_counter_orch, mux_orch, mux_cb_orch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)


### PR DESCRIPTION
This is double commit of #2113 into 202012 branch
**What I did**
Change orch list to make sure mux_orch and mux_cb_orch are placed after tunnel_decap_orch

**Why I did it**
handlePeerSwitch returns false because mux tunnel not yet created, and that results in create_nh_tunnel failure.
This moves ports into error state.

**How I verified it**
Verified that after changing the order ports don't move to error state.

**Details if related**
