### PR TITLE
 Add possibility to compile applications with address sanitizer. 

### DIFF
--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -51,7 +51,7 @@ buffermgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 vrfmgrd_SOURCES = vrfmgrd.cpp vrfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
 vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
 vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
-vrfmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS) $(LDFLAGS_ASAN)
+vrfmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 nbrmgrd_SOURCES = nbrmgrd.cpp nbrmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
 nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CFLAGS) $(CFLAGS_ASAN)

--- a/cfgmgr/Makefile.am
+++ b/cfgmgr/Makefile.am
@@ -24,69 +24,69 @@ DBGFLAGS = -g
 endif
 
 vlanmgrd_SOURCES = vlanmgrd.cpp vlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vlanmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+vlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vlanmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 teammgrd_SOURCES = teammgrd.cpp teammgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-teammgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+teammgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+teammgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+teammgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 portmgrd_SOURCES = portmgrd.cpp portmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-portmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-portmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-portmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+portmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+portmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+portmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 intfmgrd_SOURCES = intfmgrd.cpp intfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/lib/subintf.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-intfmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+intfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+intfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+intfmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 buffermgrd_SOURCES = buffermgrd.cpp buffermgr.cpp buffermgrdyn.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-buffermgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-buffermgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-buffermgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+buffermgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+buffermgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+buffermgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 vrfmgrd_SOURCES = vrfmgrd.cpp vrfmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vrfmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+vrfmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vrfmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vrfmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS) $(LDFLAGS_ASAN)
 
 nbrmgrd_SOURCES = nbrmgrd.cpp nbrmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CFLAGS)
-nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CPPFLAGS)
-nbrmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS) $(LIBNL_LIBS)
+nbrmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CFLAGS) $(CFLAGS_ASAN)
+nbrmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(LIBNL_CPPFLAGS) $(CFLAGS_ASAN)
+nbrmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS) $(LIBNL_LIBS)
 
 vxlanmgrd_SOURCES = vxlanmgrd.cpp vxlanmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-vxlanmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+vxlanmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vxlanmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+vxlanmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 sflowmgrd_SOURCES = sflowmgrd.cpp sflowmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-sflowmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-sflowmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-sflowmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+sflowmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+sflowmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+sflowmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 natmgrd_SOURCES = natmgrd.cpp natmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-natmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-natmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-natmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+natmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+natmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+natmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 coppmgrd_SOURCES = coppmgrd.cpp coppmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-coppmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-coppmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-coppmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+coppmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+coppmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+coppmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 tunnelmgrd_SOURCES = tunnelmgrd.cpp tunnelmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-tunnelmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-tunnelmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-tunnelmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+tunnelmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+tunnelmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+tunnelmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 macsecmgrd_SOURCES = macsecmgrd.cpp macsecmgr.cpp $(top_srcdir)/orchagent/orch.cpp $(top_srcdir)/orchagent/request_parser.cpp $(top_srcdir)/orchagent/response_publisher.cpp shellcmd.h
-macsecmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-macsecmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-macsecmgrd_LDADD = $(COMMON_LIBS) $(SAIMETA_LIBS)
+macsecmgrd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+macsecmgrd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+macsecmgrd_LDADD = $(LDFLAGS_ASAN) $(COMMON_LIBS) $(SAIMETA_LIBS)
 
 if GCOV_ENABLED
 vlanmgrd_LDADD += -lgcovpreload

--- a/cfgmgr/coppmgrd.cpp
+++ b/cfgmgr/coppmgrd.cpp
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <unistd.h>
 #include <vector>
+#include <signal.h>
 
 #include "exec.h"
 #include "coppmgr.h"
@@ -24,6 +25,7 @@ using namespace swss;
  * Once Orch class refactoring is done, these global variables
  * should be removed from here.
  */
+bool gExit = false;
 int gBatchSize = 0;
 bool gSwssRecord = false;
 bool gLogRotate = false;
@@ -36,8 +38,19 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+void sigterm_handler(int signo)
+{
+    gExit = true;
+}
+
 int main(int argc, char **argv)
 {
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+
     Logger::linkToDbNative("coppmgrd");
     SWSS_LOG_ENTER();
 
@@ -68,7 +81,7 @@ int main(int argc, char **argv)
             s.addSelectables(o->getSelectables());
         }
 
-        while (true)
+        while (!gExit)
         {
             Selectable *sel;
             int ret;
@@ -92,6 +105,7 @@ int main(int argc, char **argv)
     catch (const exception &e)
     {
         SWSS_LOG_ERROR("Runtime error: %s", e.what());
+        return 1;
     }
-    return -1;
+    return 0;
 }

--- a/cfgmgr/nbrmgrd.cpp
+++ b/cfgmgr/nbrmgrd.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <chrono>
+#include <signal.h>
 
 #include "select.h"
 #include "exec.h"
@@ -28,6 +29,7 @@ using namespace swss;
  * Once Orch class refactoring is done, these global variables
  * should be removed from here.
  */
+bool gExit = false;
 int gBatchSize = 0;
 bool gSwssRecord = false;
 bool gLogRotate = false;
@@ -40,8 +42,19 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+void sigterm_handler(int signo)
+{
+    gExit = true;
+}
+
 int main(int argc, char **argv)
 {
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+
     Logger::linkToDbNative("nbrmgrd");
     SWSS_LOG_ENTER();
 
@@ -89,7 +102,7 @@ int main(int argc, char **argv)
         }
 
         SWSS_LOG_NOTICE("starting main loop");
-        while (true)
+        while (!gExit)
         {
             Selectable *sel;
             int ret;
@@ -113,6 +126,7 @@ int main(int argc, char **argv)
     catch(const std::exception &e)
     {
         SWSS_LOG_ERROR("Runtime error: %s", e.what());
+        return -1;
     }
-    return -1;
+    return 0;
 }

--- a/cfgmgr/portmgrd.cpp
+++ b/cfgmgr/portmgrd.cpp
@@ -3,6 +3,7 @@
 #include <mutex>
 #include <unistd.h>
 #include <vector>
+#include <signal.h>
 
 #include "exec.h"
 #include "portmgr.h"
@@ -23,6 +24,7 @@ using namespace swss;
  * Once Orch class refactoring is done, these global variables
  * should be removed from here.
  */
+bool gExit = false;
 int gBatchSize = 0;
 bool gSwssRecord = false;
 bool gLogRotate = false;
@@ -35,8 +37,19 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+void sigterm_handler(int signo)
+{
+    gExit = true;
+}
+
 int main(int argc, char **argv)
 {
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+
     Logger::linkToDbNative("portmgrd");
     SWSS_LOG_ENTER();
 
@@ -63,7 +76,7 @@ int main(int argc, char **argv)
             s.addSelectables(o->getSelectables());
         }
 
-        while (true)
+        while (!gExit)
         {
             Selectable *sel;
             int ret;
@@ -87,6 +100,7 @@ int main(int argc, char **argv)
     catch (const exception &e)
     {
         SWSS_LOG_ERROR("Runtime error: %s", e.what());
+        return -1;
     }
-    return -1;
+    return 0;
 }

--- a/cfgmgr/vlanmgrd.cpp
+++ b/cfgmgr/vlanmgrd.cpp
@@ -5,6 +5,8 @@
 #include <iostream>
 #include <mutex>
 #include <algorithm>
+#include <signal.h>
+
 #include "dbconnector.h"
 #include "select.h"
 #include "exec.h"
@@ -31,6 +33,7 @@ MacAddress gMacAddress;
  * Once Orch class refactoring is done, these global variables
  * should be removed from here.
  */
+bool gExit = false;
 int gBatchSize = 0;
 bool gSwssRecord = false;
 bool gLogRotate = false;
@@ -43,8 +46,19 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+void sigterm_handler(int signo)
+{
+    gExit = true;
+}
+
 int main(int argc, char **argv)
 {
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+
     Logger::linkToDbNative("vlanmgrd");
     SWSS_LOG_ENTER();
 
@@ -89,7 +103,7 @@ int main(int argc, char **argv)
         }
 
         SWSS_LOG_NOTICE("starting main loop");
-        while (true)
+        while (!gExit)
         {
             Selectable *sel;
             int ret;
@@ -113,6 +127,7 @@ int main(int argc, char **argv)
     catch(const std::exception &e)
     {
         SWSS_LOG_ERROR("Runtime error: %s", e.what());
+        return -1;
     }
-    return -1;
+    return 0;
 }

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -1,6 +1,8 @@
 #include <unistd.h>
 #include <vector>
 #include <mutex>
+#include <signal.h>
+
 #include "dbconnector.h"
 #include "select.h"
 #include "exec.h"
@@ -24,6 +26,7 @@ using namespace swss;
  * Once Orch class refactoring is done, these global variables
  * should be removed from here.
  */
+bool gExit = false;
 int gBatchSize = 0;
 bool gSwssRecord = false;
 bool gLogRotate = false;
@@ -36,8 +39,19 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+void sigterm_handler(int signo)
+{
+    gExit = true;
+}
+
 int main(int argc, char **argv)
 {
+    if (signal(SIGTERM, sigterm_handler) == SIG_ERR)
+    {
+        SWSS_LOG_ERROR("failed to setup SIGTERM action");
+        exit(1);
+    }
+
     Logger::linkToDbNative("vrfmgrd");
     bool isWarmStart = false;
     SWSS_LOG_ENTER();
@@ -74,7 +88,7 @@ int main(int argc, char **argv)
         }
 
         SWSS_LOG_NOTICE("starting main loop");
-        while (true)
+        while (!gExit)
         {
             Selectable *sel;
             static bool firstReadTimeout = true;
@@ -107,6 +121,7 @@ int main(int argc, char **argv)
     catch(const std::exception &e)
     {
         SWSS_LOG_ERROR("Runtime error: %s", e.what());
+        return -1;
     }
-    return -1;
+    return 0;
 }

--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,26 @@ fi
 AM_CONDITIONAL(GCOV_ENABLED, test x$enable_gcov = xyes)
 AC_MSG_RESULT($enable_gcov)
 
+AC_ARG_ENABLE(asan,
+[  --enable-asan      Compile with address sanitizer],
+[case "${enableval}" in
+	yes) asan_enabled=true ;;
+	no)  asan_enabled=false ;;
+	*) AC_MSG_ERROR(bad value ${enableval} for --enable-asan) ;;
+esac],[asan_enabled=false])
+
+if test "x$asan_enabled" = "xtrue"; then
+    CFLAGS_ASAN+=" -fsanitize=address"
+    CFLAGS_ASAN+=" -DASAN_ENABLED"
+    CFLAGS_ASAN+=" -ggdb"
+    AC_SUBST(CFLAGS_ASAN)
+
+    LDFLAGS_ASAN+=" -lasan"
+    AC_SUBST(LDFLAGS_ASAN)
+fi
+
+AM_CONDITIONAL(ASAN_ENABLED, test x$asan_enabled = xtrue)
+
 AC_SUBST(CFLAGS_COMMON)
 
 AC_CONFIG_FILES([

--- a/debian/rules
+++ b/debian/rules
@@ -27,10 +27,18 @@ include /usr/share/dpkg/default.mk
 #	dh_auto_configure -- \
 #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
 
-ifeq ($(ENABLE_GCOV), y)
-override_dh_auto_configure:
-	dh_auto_configure -- --enable-gcov
+configure_opts =
+ifeq ($(ENABLE_ASAN), y)
+	configure_opts += --enable-asan
 endif
+
+ifeq ($(ENABLE_GCOV), y)
+	configure_opts += --enable-gcov
+endif
+
+override_dh_auto_configure:
+	$(info "override_dh_auto_configure called")
+	dh_auto_configure -- $(configure_opts)
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/swss

--- a/fdbsyncd/Makefile.am
+++ b/fdbsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 fdbsyncd_SOURCES = fdbsyncd.cpp fdbsync.cpp $(top_srcdir)/warmrestart/warmRestartAssist.cpp
 
-fdbsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS)
-fdbsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS)
-fdbsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS)
+fdbsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(CFLAGS_ASAN)
+fdbsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(CFLAGS_ASAN)
+fdbsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS)
 
 if GCOV_ENABLED
 fdbsyncd_LDADD += -lgcovpreload

--- a/fpmsyncd/Makefile.am
+++ b/fpmsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 fpmsyncd_SOURCES = fpmsyncd.cpp fpmlink.cpp routesync.cpp $(top_srcdir)/warmrestart/warmRestartHelper.cpp
 
-fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-fpmsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+fpmsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+fpmsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+fpmsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 fpmsyncd_LDADD += -lgcovpreload

--- a/gearsyncd/Makefile.am
+++ b/gearsyncd/Makefile.am
@@ -12,7 +12,7 @@ gearsyncd_SOURCES = $(top_srcdir)/lib/gearboxutils.cpp gearsyncd.cpp gearparserb
 
 gearsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(CFLAGS_ASAN)
 
-gearsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS) $(LDFLAGS_ASAN)
+gearsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS)
 
 if GCOV_ENABLED
 gearsyncd_LDADD += -lgcovpreload

--- a/gearsyncd/Makefile.am
+++ b/gearsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 gearsyncd_SOURCES = $(top_srcdir)/lib/gearboxutils.cpp gearsyncd.cpp gearparserbase.cpp gearboxparser.cpp phyparser.cpp $(top_srcdir)/cfgmgr/shellcmd.h 
 
-gearsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(ASAN_CFLAGS)
+gearsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(COV_CFLAGS) $(CFLAGS_ASAN)
 
-gearsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS) $(ASAN_LDFLAGS)
+gearsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon $(COV_LDFLAGS) $(LDFLAGS_ASAN)
 
 if GCOV_ENABLED
 gearsyncd_LDADD += -lgcovpreload

--- a/mclagsyncd/Makefile.am
+++ b/mclagsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 mclagsyncd_SOURCES = mclagsyncd.cpp mclaglink.cpp
 
-mclagsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-mclagsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-mclagsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+mclagsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+mclagsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+mclagsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 mclagsyncd_LDADD += -lgcovpreload

--- a/natsyncd/Makefile.am
+++ b/natsyncd/Makefile.am
@@ -12,7 +12,7 @@ natsyncd_SOURCES = natsyncd.cpp natsync.cpp $(top_srcdir)/warmrestart/warmRestar
 
 natsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
 natsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
-natsyncd_LDADD = -lnl-3 -lnl-route-3 -lnl-nf-3 -lswsscommon $(LDFLAGS_ASAN)
+natsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lnl-nf-3 -lswsscommon
 
 if GCOV_ENABLED
 natsyncd_LDADD += -lgcovpreload

--- a/natsyncd/Makefile.am
+++ b/natsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 natsyncd_SOURCES = natsyncd.cpp natsync.cpp $(top_srcdir)/warmrestart/warmRestartAssist.cpp
 
-natsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-natsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-natsyncd_LDADD = -lnl-3 -lnl-route-3 -lnl-nf-3 -lswsscommon
+natsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+natsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+natsyncd_LDADD = -lnl-3 -lnl-route-3 -lnl-nf-3 -lswsscommon $(LDFLAGS_ASAN)
 
 if GCOV_ENABLED
 natsyncd_LDADD += -lgcovpreload

--- a/neighsyncd/Makefile.am
+++ b/neighsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 neighsyncd_SOURCES = neighsyncd.cpp neighsync.cpp $(top_srcdir)/warmrestart/warmRestartAssist.cpp
 
-neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-neighsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+neighsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+neighsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+neighsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 neighsyncd_LDADD += -lgcovpreload

--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -109,18 +109,18 @@ orchagent_SOURCES += p4orch/p4orch.cpp \
 		     p4orch/wcmp_manager.cpp \
 		     p4orch/mirror_session_manager.cpp
 
-orchagent_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-orchagent_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI)
-orchagent_LDADD = -lnl-3 -lnl-route-3 -lpthread -lsairedis -lsaimeta -lsaimetadata -lswsscommon -lzmq
+orchagent_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+orchagent_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_SAI) $(CFLAGS_ASAN)
+orchagent_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lpthread -lsairedis -lsaimeta -lsaimetadata -lswsscommon -lzmq
 
 routeresync_SOURCES = routeresync.cpp
-routeresync_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-routeresync_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-routeresync_LDADD = -lswsscommon
+routeresync_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+routeresync_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+routeresync_LDADD = $(LDFLAGS_ASAN) -lswsscommon
 
 orchagent_restart_check_SOURCES = orchagent_restart_check.cpp
-orchagent_restart_check_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON)
-orchagent_restart_check_LDADD = -lhiredis -lswsscommon -lpthread
+orchagent_restart_check_CPPFLAGS = $(DBGFLAGS) $(AM_CPPFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+orchagent_restart_check_LDADD = $(LDFLAGS_ASAN) -lhiredis -lswsscommon -lpthread
 
 if GCOV_ENABLED
 orchagent_LDADD += -lgcovpreload

--- a/orchagent/bfdorch.cpp
+++ b/orchagent/bfdorch.cpp
@@ -53,7 +53,7 @@ BfdOrch::BfdOrch(DBConnector *db, string tableName, TableConnector stateDbBfdSes
 {
     SWSS_LOG_ENTER();
 
-    DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
+    shared_ptr<DBConnector> notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
     m_bfdStateNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
     auto bfdStateNotificatier = new Notifier(m_bfdStateNotificationConsumer, this, "BFD_STATE_NOTIFICATIONS");
     Orch::addExecutor(bfdStateNotificatier);

--- a/orchagent/bufferorch.cpp
+++ b/orchagent/bufferorch.cpp
@@ -28,12 +28,12 @@ static const vector<sai_buffer_pool_stat_t> bufferPoolWatermarkStatIds =
 };
 
 type_map BufferOrch::m_buffer_type_maps = {
-    {APP_BUFFER_POOL_TABLE_NAME, new object_reference_map()},
-    {APP_BUFFER_PROFILE_TABLE_NAME, new object_reference_map()},
-    {APP_BUFFER_QUEUE_TABLE_NAME, new object_reference_map()},
-    {APP_BUFFER_PG_TABLE_NAME, new object_reference_map()},
-    {APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME, new object_reference_map()},
-    {APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME, new object_reference_map()}
+    {APP_BUFFER_POOL_TABLE_NAME, make_shared<object_reference_map>()},
+    {APP_BUFFER_PROFILE_TABLE_NAME, make_shared<object_reference_map>()},
+    {APP_BUFFER_QUEUE_TABLE_NAME, make_shared<object_reference_map>()},
+    {APP_BUFFER_PG_TABLE_NAME, make_shared<object_reference_map>()},
+    {APP_BUFFER_PORT_INGRESS_PROFILE_LIST_NAME, make_shared<object_reference_map>()},
+    {APP_BUFFER_PORT_EGRESS_PROFILE_LIST_NAME, make_shared<object_reference_map>()}
 };
 
 map<string, string> buffer_to_ref_table_map = {

--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <utility>
 #include <inttypes.h>
+#include <memory>
 
 #include "logger.h"
 #include "tokenize.h"
@@ -34,7 +35,7 @@ FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> app
 {
     for(auto it: appFdbTables)
     {
-        m_appTables.push_back(new Table(applDbConnector, it.first));
+        m_appTables.push_back(make_shared<Table>(applDbConnector, it.first));
     }
 
     m_portsOrch->attach(this);
@@ -43,7 +44,7 @@ FdbOrch::FdbOrch(DBConnector* applDbConnector, vector<table_name_with_pri_t> app
     Orch::addExecutor(flushNotifier);
 
     /* Add FDB notifications support from ASIC */
-    DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
+    shared_ptr<DBConnector> notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
     m_fdbNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
     auto fdbNotifier = new Notifier(m_fdbNotificationConsumer, this, "FDB_NOTIFICATIONS");
     Orch::addExecutor(fdbNotifier);

--- a/orchagent/fdborch.h
+++ b/orchagent/fdborch.h
@@ -105,7 +105,7 @@ private:
     PortsOrch *m_portsOrch;
     map<FdbEntry, FdbData> m_entries;
     fdb_entries_by_port_t saved_fdb_entries;
-    vector<Table*> m_appTables;
+    vector<shared_ptr<Table>> m_appTables;
     Table m_fdbStateTable;
     Table m_mclagFdbStateTable;
     NotificationConsumer* m_flushNotificationsConsumer;

--- a/orchagent/flex_counter/flex_counter_manager.cpp
+++ b/orchagent/flex_counter/flex_counter_manager.cpp
@@ -48,7 +48,7 @@ const unordered_map<CounterType, string> FlexCounterManager::counter_id_field_lo
 
 FlexManagerDirectory g_FlexManagerDirectory;
 
-FlexCounterManager *FlexManagerDirectory::createFlexCounterManager(const string& group_name,
+shared_ptr<FlexCounterManager> FlexManagerDirectory::createFlexCounterManager(const string& group_name,
                                                                    const StatsMode stats_mode,
                                                                    const uint polling_interval,
                                                                    const bool enabled,
@@ -76,7 +76,7 @@ FlexCounterManager *FlexManagerDirectory::createFlexCounterManager(const string&
         }
         return m_managers[group_name];
     }
-    FlexCounterManager *fc_manager = new FlexCounterManager(group_name, stats_mode, polling_interval,
+    shared_ptr<FlexCounterManager> fc_manager = make_shared<FlexCounterManager>(group_name, stats_mode, polling_interval,
                                                             enabled, fv_plugin);
     m_managers[group_name] = fc_manager;
     return fc_manager;

--- a/orchagent/flex_counter/flex_counter_manager.h
+++ b/orchagent/flex_counter/flex_counter_manager.h
@@ -5,6 +5,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <utility>
+#include <memory>
 #include "dbconnector.h"
 #include "producertable.h"
 #include "table.h"
@@ -114,11 +115,11 @@ class FlexCounterManager
 class FlexManagerDirectory
 {
     public:
-        FlexCounterManager* createFlexCounterManager(const std::string& group_name, const StatsMode stats_mode,
+        std::shared_ptr<FlexCounterManager> createFlexCounterManager(const std::string& group_name, const StatsMode stats_mode,
                                                      const uint polling_interval, const bool enabled,
                                                      swss::FieldValueTuple fv_plugin = std::make_pair("",""));
     private:
-        std::unordered_map<std::string, FlexCounterManager*>  m_managers;
+        std::unordered_map<std::string, std::shared_ptr<FlexCounterManager>>  m_managers;
 };
 
 #endif // ORCHAGENT_FLEX_COUNTER_MANAGER_H

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -68,7 +68,7 @@ typedef struct
 } referenced_object;
 
 typedef std::map<std::string, referenced_object> object_reference_map;
-typedef std::map<std::string, object_reference_map*> type_map;
+typedef std::map<std::string, std::shared_ptr<object_reference_map>> type_map;
 
 typedef std::map<std::string, sai_object_id_t> object_map;
 typedef std::pair<std::string, sai_object_id_t> object_map_pair;

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -326,7 +326,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, mux_orch, mux_cb_orch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, qos_orch, wm_orch, policer_orch, tunnel_decap_orch, sflow_orch, debug_counter_orch, gMacsecOrch, gBfdOrch, gSrv6Orch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, mux_orch, mux_cb_orch, gFdbOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, qos_orch, wm_orch, policer_orch, tunnel_decap_orch, sflow_orch, debug_counter_orch, gMacsecOrch, gBfdOrch, gSrv6Orch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)
@@ -393,7 +393,6 @@ bool OrchDaemon::init()
 
     gPbhOrch = new PbhOrch(pbhTableConnectorList, gAclOrch, gPortsOrch);
 
-    m_orchList.push_back(gFdbOrch);
     m_orchList.push_back(gMirrorOrch);
     m_orchList.push_back(gAclOrch);
     m_orchList.push_back(gPbhOrch);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -21,6 +21,7 @@ using namespace swss;
 extern sai_switch_api_t*           sai_switch_api;
 extern sai_object_id_t             gSwitchId;
 extern bool                        gSaiRedisLogRotate;
+extern bool                        gExit;
 
 extern void syncd_apply_view();
 /*
@@ -661,7 +662,7 @@ void OrchDaemon::start()
 
     auto tstart = std::chrono::high_resolution_clock::now();
 
-    while (true)
+    while (!gExit)
     {
         Selectable *s;
         int ret;

--- a/orchagent/p4orch/p4orch.cpp
+++ b/orchagent/p4orch/p4orch.cpp
@@ -62,8 +62,8 @@ P4Orch::P4Orch(swss::DBConnector *db, std::vector<std::string> tableNames, VRFOr
     m_aclCounterStatsTimer->start();
 
     // Add port state change notification handling support
-    swss::DBConnector notificationsDb("ASIC_DB", 0);
-    m_portStatusNotificationConsumer = new swss::NotificationConsumer(&notificationsDb, "NOTIFICATIONS");
+    shared_ptr<swss::DBConnector> notificationsDb = make_shared<swss::DBConnector>("ASIC_DB", 0);
+    m_portStatusNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
     auto portStatusNotifier = new Notifier(m_portStatusNotificationConsumer, this, "PORT_STATUS_NOTIFICATIONS");
     Orch::addExecutor(portStatusNotifier);
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -543,7 +543,7 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
     removeDefaultBridgePorts();
 
     /* Add port oper status notification support */
-    DBConnector *notificationsDb = new DBConnector("ASIC_DB", 0);
+    shared_ptr<DBConnector> notificationsDb = make_shared<DBConnector>("ASIC_DB", 0);
     m_portStatusNotificationConsumer = new swss::NotificationConsumer(notificationsDb, "NOTIFICATIONS");
     auto portStatusNotificatier = new Notifier(m_portStatusNotificationConsumer, this, "PORT_STATUS_NOTIFICATIONS");
     Orch::addExecutor(portStatusNotificatier);

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -65,19 +65,19 @@ map<string, sai_meter_type_t> scheduler_meter_map = {
 };
 
 type_map QosOrch::m_qos_maps = {
-    {CFG_DSCP_TO_TC_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_MPLS_TC_TO_TC_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_DOT1P_TO_TC_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_TC_TO_QUEUE_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_SCHEDULER_TABLE_NAME, new object_reference_map()},
-    {CFG_WRED_PROFILE_TABLE_NAME, new object_reference_map()},
-    {CFG_PORT_QOS_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_QUEUE_TABLE_NAME, new object_reference_map()},
-    {CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_DSCP_TO_FC_MAP_TABLE_NAME, new object_reference_map()},
-    {CFG_EXP_TO_FC_MAP_TABLE_NAME, new object_reference_map()},
+    {CFG_DSCP_TO_TC_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_MPLS_TC_TO_TC_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_DOT1P_TO_TC_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_TC_TO_QUEUE_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_SCHEDULER_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_WRED_PROFILE_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_PORT_QOS_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_QUEUE_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_TC_TO_PRIORITY_GROUP_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_PFC_PRIORITY_TO_PRIORITY_GROUP_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_PFC_PRIORITY_TO_QUEUE_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_DSCP_TO_FC_MAP_TABLE_NAME, make_shared<object_reference_map>()},
+    {CFG_EXP_TO_FC_MAP_TABLE_NAME, make_shared<object_reference_map>()}
 };
 
 map<string, string> qos_to_ref_table_map = {

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -373,7 +373,6 @@ private:
     VTEPTable vtep_table_;
     Table m_stateVxlanTable;
     std::map<sai_object_id_t, std::string> m_pendingAddToFlexCntr;
-    FlexCounterManager vxlan_tunnel_stat_manager;
     bool m_isTunnelCounterMapGenerated = false;
     FlexCounterManager *tunnel_stat_manager;
     unique_ptr<Table> m_tunnelNameTable;

--- a/orchagent/vxlanorch.h
+++ b/orchagent/vxlanorch.h
@@ -374,7 +374,7 @@ private:
     Table m_stateVxlanTable;
     std::map<sai_object_id_t, std::string> m_pendingAddToFlexCntr;
     bool m_isTunnelCounterMapGenerated = false;
-    FlexCounterManager *tunnel_stat_manager;
+    std::shared_ptr<FlexCounterManager> tunnel_stat_manager;
     unique_ptr<Table> m_tunnelNameTable;
     unique_ptr<Table> m_tunnelTypeTable;
     unique_ptr<Table> m_vidToRidTable;

--- a/portsyncd/Makefile.am
+++ b/portsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 portsyncd_SOURCES = $(top_srcdir)/lib/gearboxutils.cpp portsyncd.cpp linksync.cpp  $(top_srcdir)/cfgmgr/shellcmd.h
 
-portsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-portsyncd_LDADD = -lnl-3 -lnl-route-3 -lswsscommon
+portsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+portsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+portsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lswsscommon
 
 if GCOV_ENABLED
 portsyncd_LDADD += -lgcovpreload

--- a/swssconfig/Makefile.am
+++ b/swssconfig/Makefile.am
@@ -10,15 +10,15 @@ endif
 
 swssconfig_SOURCES = swssconfig.cpp
 
-swssconfig_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssconfig_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssconfig_LDADD = -lswsscommon
+swssconfig_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+swssconfig_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+swssconfig_LDADD = $(LDFLAGS_ASAN) -lswsscommon
 
 swssplayer_SOURCES = swssplayer.cpp
 
-swssplayer_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssplayer_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-swssplayer_LDADD = -lswsscommon
+swssplayer_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+swssplayer_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+swssplayer_LDADD = $(LDFLAGS_ASAN) -lswsscommon
 
 if GCOV_ENABLED
 swssconfig_LDADD += -lgcovpreload

--- a/teamsyncd/Makefile.am
+++ b/teamsyncd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 teamsyncd_SOURCES = teamsyncd.cpp teamsync.cpp
 
-teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-teamsyncd_LDADD = -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam
+teamsyncd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+teamsyncd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+teamsyncd_LDADD = $(LDFLAGS_ASAN) -lnl-3 -lnl-route-3 -lhiredis -lswsscommon -lteam
 
 if GCOV_ENABLED
 teamsyncd_LDADD += -lgcovpreload

--- a/tests/mock_tests/mock_orchagent_main.cpp
+++ b/tests/mock_tests/mock_orchagent_main.cpp
@@ -25,6 +25,7 @@ string gMySwitchType = "switch";
 int32_t gVoqMySwitchId = 0;
 string gMyHostName = "Linecard1";
 string gMyAsicName = "Asic0";
+bool gExit = false;
 
 VRFOrch *gVrfOrch;
 

--- a/tlm_teamd/Makefile.am
+++ b/tlm_teamd/Makefile.am
@@ -10,9 +10,9 @@ endif
 
 tlm_teamd_SOURCES = main.cpp teamdctl_mgr.cpp values_store.cpp
 
-tlm_teamd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON)
-tlm_teamd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(JANSSON_CFLAGS)
-tlm_teamd_LDADD = -lhiredis -lswsscommon -lteamdctl $(JANSSON_LIBS)
+tlm_teamd_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_ASAN)
+tlm_teamd_CPPFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(JANSSON_CFLAGS) $(CFLAGS_ASAN)
+tlm_teamd_LDADD = $(LDFLAGS_ASAN) -lhiredis -lswsscommon -lteamdctl $(JANSSON_LIBS)
 
 if GCOV_ENABLED
 tlm_teamd_LDADD += -lgcovpreload


### PR DESCRIPTION
Add SIGTERM handling as a trigger to exit to all applications.
Fix "memory usage after free" error reported by ASAN.
Fix "SEGV on unknown address" error reported by ASAN.
Fix orchagent memory leaks reported by ASAN.
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
To add a possibility to compile SONiC applications with address sanitizer (ASAN).

> ASAN is a memory error detector for C/C++. It finds:
> - Use after free (dangling pointer dereference)
> - Heap buffer overflow
> - Stack buffer overflow
> - Global buffer overflow
> - Use after return
> - Use after the scope
> - Initialization order bugs
> - Memory leaks

Add SIGTERM handling as a trigger to exit to all applications. The correct shutdown of applications is needed to allow ASAN to generate a report. 

**Why I did it**
To add a possibility to detect memory errors in applications.

**How I verified it**
Compile SWSS with **--enable-asan** option. Install applications to DUT. Run tests that trigger different kinds of memory usage inside of applications. Stop applications with **SIGTERM** signal to trigger ASAN report generation. Reports will be placed in **/var/log/asan/** directory.

**Details if related**
Depends on:
https://github.com/Azure/sonic-buildimage/pull/9857
https://github.com/Azure/sonic-swss-common/pull/579