### PR TITLE
Don't pass attr SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX in SAI neighbor call

### DIFF
--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1541,10 +1541,6 @@ bool NeighOrch::addVoqEncapIndex(string &alias, IpAddress &ip, vector<sai_attrib
             attr.value.u32 = encap_index;
             neighbor_attrs.push_back(attr);
 
-            attr.id = SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX;
-            attr.value.booldata = true;
-            neighbor_attrs.push_back(attr);
-
             attr.id = SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL;
             attr.value.booldata = false;
             neighbor_attrs.push_back(attr);


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Don't pass attr SAI_NEIGHBOR_ENTRY_ATTR_ENCAP_IMPOSE_INDEX in SAI neighbor call.

**Why I did it**
SAI 6.0.0.13 does not support the SAI attr anymore and this results in orchagent to be terminated because of failing to create neighbor.

**How I verified it**
Verified neighbor was successfully created with the fix.

**Details if related**
