### PR TITLE
[macsecorch]: Fix deleting MACsec bug

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -1280,7 +1280,7 @@ bool MACsecOrch::updateMACsecSCs(MACsecPort &macsec_port, std::function<bool(MAC
     auto sc = macsec_port.m_egress_scs.begin();
     while (sc != macsec_port.m_egress_scs.end())
     {
-        if (!action((sc++).second))
+        if (!action((sc++)->second))
         {
             return false;
         }
@@ -1288,7 +1288,7 @@ bool MACsecOrch::updateMACsecSCs(MACsecPort &macsec_port, std::function<bool(MAC
     sc = macsec_port.m_ingress_scs.begin();
     while (sc != macsec_port.m_ingress_scs.end())
     {
-        if (!action((sc++).second))
+        if (!action((sc++)->second))
         {
             return false;
         }
@@ -1312,7 +1312,7 @@ bool MACsecOrch::deleteMACsecPort(
     auto sc = macsec_port.m_egress_scs.begin();
     while (sc != macsec_port.m_egress_scs.end())
     {
-        const std::string port_sci = swss::join(':', port_name, sc.first);
+        const std::string port_sci = swss::join(':', port_name, sc->first);
         sc ++;
         if (deleteMACsecSC(port_sci, SAI_MACSEC_DIRECTION_EGRESS) != task_success)
         {
@@ -1322,7 +1322,7 @@ bool MACsecOrch::deleteMACsecPort(
     sc = macsec_port.m_ingress_scs.begin();
     while (sc != macsec_port.m_ingress_scs.end())
     {
-        const std::string port_sci = swss::join(':', port_name, sc.first);
+        const std::string port_sci = swss::join(':', port_name, sc->first);
         sc ++;
         if (deleteMACsecSC(port_sci, SAI_MACSEC_DIRECTION_INGRESS) != task_success)
         {
@@ -1714,7 +1714,7 @@ task_process_status MACsecOrch::deleteMACsecSC(
     auto sa = ctx.get_macsec_sc()->m_sa_ids.begin();
     while (sa != ctx.get_macsec_sc()->m_sa_ids.end())
     {
-        const std::string port_sci_an = swss::join(':', port_sci, sa.first);
+        const std::string port_sci_an = swss::join(':', port_sci, sa->first);
         sa ++;
         deleteMACsecSA(port_sci_an, direction);
     }

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -1277,16 +1277,18 @@ bool MACsecOrch::updateMACsecSCs(MACsecPort &macsec_port, std::function<bool(MAC
 {
     SWSS_LOG_ENTER();
 
-    for (auto &sc : macsec_port.m_egress_scs)
+    auto sc = macsec_port.m_egress_scs.begin();
+    while (sc != macsec_port.m_egress_scs.end())
     {
-        if (!action(sc.second))
+        if (!action((sc++).second))
         {
             return false;
         }
     }
-    for (auto &sc : macsec_port.m_ingress_scs)
+    sc = macsec_port.m_ingress_scs.begin();
+    while (sc != macsec_port.m_ingress_scs.end())
     {
-        if (!action(sc.second))
+        if (!action((sc++).second))
         {
             return false;
         }
@@ -1307,17 +1309,21 @@ bool MACsecOrch::deleteMACsecPort(
 
     bool result = true;
 
-    for (auto &sc : macsec_port.m_egress_scs)
+    auto sc = macsec_port.m_egress_scs.begin();
+    while (sc != macsec_port.m_egress_scs.end())
     {
         const std::string port_sci = swss::join(':', port_name, sc.first);
+        sc ++;
         if (deleteMACsecSC(port_sci, SAI_MACSEC_DIRECTION_EGRESS) != task_success)
         {
             result &= false;
         }
     }
-    for (auto &sc : macsec_port.m_ingress_scs)
+    sc = macsec_port.m_ingress_scs.begin();
+    while (sc != macsec_port.m_ingress_scs.end())
     {
         const std::string port_sci = swss::join(':', port_name, sc.first);
+        sc ++;
         if (deleteMACsecSC(port_sci, SAI_MACSEC_DIRECTION_INGRESS) != task_success)
         {
             result &= false;
@@ -1705,9 +1711,11 @@ task_process_status MACsecOrch::deleteMACsecSC(
 
     auto result = task_success;
 
-    for (auto &sa : ctx.get_macsec_sc()->m_sa_ids)
+    auto sa = ctx.get_macsec_sc()->m_sa_ids.begin();
+    while (sa != ctx.get_macsec_sc()->m_sa_ids.end())
     {
         const std::string port_sci_an = swss::join(':', port_sci, sa.first);
+        sa ++;
         deleteMACsecSA(port_sci_an, direction);
     }
 


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fix a segment fault in MACsec orchagent to record the next iterator before deleting the corresponding MACsec object.

**Why I did it**
The segment fault will happen if to delete the MACsec Port or MACsec SC that have MACsec SC(s) or MACsec SA(s), Because the original implementation used the for loop to iterate all MACsec sub objects, but the MACsec sub object will be delete on each iteration so that the removed iterator cannot go to the next one.

**How I verified it**
Use `appl_db_del(appl_db, "MACSEC_PORT_TABLE", ifname)` to delete a MACsec port that has MACsec SC, The segment fault shouldn't happen.
**Details if related**
