### PR TITLE
[test_nhg.py] Cleanup test resources at the end

### DIFF
--- a/tests/test_nhg.py
+++ b/tests/test_nhg.py
@@ -1875,6 +1875,9 @@ class TestCbfNextHopGroup(TestNextHopGroupBase):
             time.sleep(1)
             assert(not self.nhg_exists('cbfgroup3'))
 
+            # Cleanup
+            self.cbf_nhg_ps._del('cbfgroup3')
+
         self.init_test(dvs, 4)
 
         mainline_cbf_nhg_test()


### PR DESCRIPTION
**What I did**
Removed some leftover state from a previous test case that was sometimes messing up with a following test case.

**Why I did it**
VS test pipelines fail from time to time because of this.

**How I verified it**
Tried to repro the crash running the test file.

**Details if related**
