### PR TITLE
[sonic-swss] : Fix for missing lossless PG profile on certain ports

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -205,6 +205,7 @@ task_process_status BufferMgr::doSpeedUpdateTask(string port, string speed)
     fvVector.clear();
 
     fvVector.push_back(make_pair("profile", profile_ref));
+    SWSS_LOG_INFO("Setting buffer profile to PG %s", buffer_pg_key.c_str());
     m_cfgBufferPgTable.set(buffer_pg_key, fvVector);
     return task_process_status::task_success;
 }
@@ -373,10 +374,7 @@ void BufferMgr::doTask(Consumer &consumer)
                 {
                     // create/update profile for port
                     task_status = doSpeedUpdateTask(port, fvValue(i));
-                }
-                if (task_status != task_process_status::task_success)
-                {
-                    break;
+                    SWSS_LOG_DEBUG("Return code for doSpeedUpdateTask %d", task_status);
                 }
             }
         }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed the issue of missing PG lossless profile for set of ports on multiple HWSKUs.

**Why I did it**
After switch bringup, a set of ports were missing PG profile in config file. This was causing most of QoS test cases to fail.

**How I verified it**
Verified it on BRCM based HWSKU.

**Details if related**
Fix involves removing break statement from the logic. This statement was causing exiting the while loop hence no more port updates were processed (in this case PG profile) if doSpeedUpdateTask returns failure for some reason.