### PR TITLE
Update linkmgr cable table name

### DIFF
--- a/orchagent/muxorch.cpp
+++ b/orchagent/muxorch.cpp
@@ -1156,7 +1156,7 @@ MuxOrch::MuxOrch(DBConnector *db, const std::vector<std::string> &tables,
          neigh_orch_(neighOrch),
          fdb_orch_(fdbOrch)
 {
-    handler_map_.insert(handler_pair(CFG_MUX_CABLE_TABLE_NAME, &MuxOrch::handleMuxCfg));
+    handler_map_.insert(handler_pair(CFG_LINKMGR_CABLE_TABLE_NAME, &MuxOrch::handleMuxCfg));
     handler_map_.insert(handler_pair(CFG_PEER_SWITCH_TABLE_NAME, &MuxOrch::handlePeerSwitch));
 
     neigh_orch_->attach(this);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -293,7 +293,7 @@ bool OrchDaemon::init()
     gNatOrch = new NatOrch(m_applDb, m_stateDb, nat_tables, gRouteOrch, gNeighOrch);
 
     vector<string> mux_tables = {
-        CFG_MUX_CABLE_TABLE_NAME,
+        CFG_LINKMGR_CABLE_TABLE_NAME,
         CFG_PEER_SWITCH_TABLE_NAME
     };
     MuxOrch *mux_orch = new MuxOrch(m_configDb, mux_tables, tunnel_decap_orch, gNeighOrch, gFdbOrch);

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -209,7 +209,7 @@ namespace routeorch_test
 
             TunnelDecapOrch *tunnel_decap_orch = new TunnelDecapOrch(m_app_db.get(), APP_TUNNEL_DECAP_TABLE_NAME);
             vector<string> mux_tables = {
-                CFG_MUX_CABLE_TABLE_NAME,
+                CFG_LINKMGR_CABLE_TABLE_NAME,
                 CFG_PEER_SWITCH_TABLE_NAME
             };
             MuxOrch *mux_orch = new MuxOrch(m_config_db.get(), mux_tables, tunnel_decap_orch, gNeighOrch, gFdbOrch);


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Update the dualtor cable table name in config db
from `CFG_MUX_CABLE_TABLE_NAME` to `CFG_LINKMGR_CABLE_TABLE_NAME`

**Why I did it**
To use the new name introduced by PR: https://github.com/Azure/sonic-swss-common/pull/580

**How I verified it**

**Details if related**
