### PR TITLE
[202012] Skip bfd notification during switch create

### DIFF
--- a/orchagent/main.cpp
+++ b/orchagent/main.cpp
@@ -297,10 +297,6 @@ int main(int argc, char **argv)
     attr.value.ptr = (void *)on_port_state_change;
     attrs.push_back(attr);
 
-    attr.id = SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY;
-    attr.value.ptr = (void *)on_bfd_session_state_change;
-    attrs.push_back(attr);
-
     attr.id = SAI_SWITCH_ATTR_SHUTDOWN_REQUEST_NOTIFY;
     attr.value.ptr = (void *)on_switch_shutdown_request;
     attrs.push_back(attr);


### PR DESCRIPTION
**What I did**
Do not register for BFD notification during switch create for all platforms

**Why I did it**
Some platforms are failing switch create with the following logs:

```
/var/log/syslog:Feb 8 17:20:25.726339 str2-7215-acs-1 NOTICE swss#orchagent: :- notifySyncd: sending syncd: INIT_VIEW
/var/log/syslog:Feb 8 17:20:25.727724 str2-7215-acs-1 NOTICE syncd#syncd: :- processNotifySyncd: very first run is TRUE, op = INIT_VIEW
/var/log/syslog:Feb 8 17:20:25.728156 str2-7215-acs-1 NOTICE syncd#syncd: :- clearTempView: clearing current TEMP VIEW
/var/log/syslog:Feb 8 17:20:25.728697 str2-7215-acs-1 NOTICE syncd#syncd: :- clearTempView: clear temp view took 0.000314 sec
/var/log/syslog:Feb 8 17:20:25.745185 str2-7215-acs-1 NOTICE swss#orchagent: :- sai_redis_notify_syncd: switched ASIC to INIT VIEW
/var/log/syslog:Feb 8 17:20:25.746611 str2-7215-acs-1 NOTICE swss#orchagent: :- sai_redis_notify_syncd: clearing current local state since init view is called on initialized switch
/var/log/syslog:Feb 8 17:20:25.750903 str2-7215-acs-1 NOTICE swss#orchagent: :- initSaiRedis: Notify syncd INIT_VIEW
/var/log/syslog:Feb 8 17:20:25.782006 str2-7215-acs-1 NOTICE syncd#syncd: :- processOidCreate: creating switch number 1
/var/log/syslog:Feb 8 17:20:25.787457 str2-7215-acs-1 INFO syncd#/supervisord: syncd 17:20:25 SAI: ERROR SWITCH xpSaiSwitch.c:5082 : Specified attribute 136 couldn't be set during switch create
/var/log/syslog:Feb 8 17:20:25.788623 str2-7215-acs-1 INFO syncd#/supervisord: syncd 17:20:25 SAI: ERROR SWITCH xpSaiSwitch.c:5417 : Validation of input parameters failed
/var/log/syslog:Feb 8 17:20:25.789076 str2-7215-acs-1 ERR syncd#syncd: :- sendApiResponse: api SAI_COMMON_API_CREATE failed in syncd mode: SAI_STATUS_NOT_SUPPORTED
/var/log/syslog:Feb 8 17:20:25.790044 str2-7215-acs-1 ERR syncd#syncd: :- processQuadEvent: attr: SAI_SWITCH_ATTR_INIT_SWITCH: true
/var/log/syslog:Feb 8 17:20:25.790485 str2-7215-acs-1 ERR syncd#syncd: :- processQuadEvent: attr: SAI_SWITCH_ATTR_FDB_EVENT_NOTIFY: 0x485495
/var/log/syslog:Feb 8 17:20:25.790830 str2-7215-acs-1 ERR syncd#syncd: :- processQuadEvent: attr: SAI_SWITCH_ATTR_PORT_STATE_CHANGE_NOTIFY: 0x485499
/var/log/syslog:Feb 8 17:20:25.791162 str2-7215-acs-1 ERR syncd#syncd: :- processQuadEvent: attr: SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY: 0x48549d
/var/log/syslog:Feb 8 17:20:25.791481 str2-7215-acs-1 ERR syncd#syncd: :- processQuadEvent: attr: SAI_SWITCH_ATTR_SWITCH_SHUTDOWN_REQUEST_NOTIFY: 0x4854a1
/var/log/syslog:Feb 8 17:20:25.792205 str2-7215-acs-1 ERR syncd#syncd: :- processQuadEvent: attr: SAI_SWITCH_ATTR_SRC_MAC_ADDRESS: 50:E0:EF:7A:F1:D1
/var/log/syslog:Feb 8 17:20:26.367971 str2-7215-acs-1 INFO teamd#supervisord 2022-02-08 17:20:26,366 INFO success: teamsyncd entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
/var/log/syslog:Feb 8 17:20:27.828204 str2-7215-acs-1 INFO swss#supervisord 2022-02-08 17:20:27,816 INFO waiting for dependent-startup, supervisor-proc-exit-listener, rsyslogd, portsyncd, swssconfig, coppmgrd to die
```

**How I verified it**

**Details if related**
