### PR TITLE
[VS] Increase test timout to 360min

### DIFF
--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: timeout
   type: number
-  default: 240
+  default: 360
 
 - name: log_artifact_name
   type: string


### PR DESCRIPTION
**What I did**
Changing the docker pool, VS test is taking slightly more than 4hrs. 

**Why I did it**

**How I verified it**

**Details if related**
