### PR TITLE
[VS] Skip consistently failing test cases

### DIFF
--- a/tests/test_buffer_dynamic.py
+++ b/tests/test_buffer_dynamic.py
@@ -214,6 +214,7 @@ class TestBufferMgrDyn(object):
 
         self.cleanup_db(dvs)
 
+    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_changeCableLen(self, dvs, testlog):
         self.setup_db(dvs)
 

--- a/tests/test_nat.py
+++ b/tests/test_nat.py
@@ -1,4 +1,5 @@
 import time
+import pytest
 
 from dvslib.dvs_common import wait_for_result
 
@@ -175,6 +176,7 @@ class TestNat(object):
         #check the entry is not there in asic db
         self.asic_db.wait_for_n_keys("ASIC_STATE:SAI_OBJECT_TYPE_NAT_ENTRY", 0)
 
+    @pytest.mark.skip(reason="Failing. Under investigation")
     def test_AddTwiceNatEntry(self, dvs, testlog):
         # initialize
         self.setup_db(dvs)


### PR DESCRIPTION
**What I did**
The following two tests are consistently failing. Skipping for investigation:

```
test_changeCableLen
test_AddTwiceNatEntry
```

**Why I did it**

**How I verified it**

**Details if related**
