### PR TITLE
portsorch: initial support for link-training and remote advertisement

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -113,6 +113,7 @@ public:
     uint32_t            m_speed = 0;    // Mbps
     std::string         m_learn_mode = "hardware";
     int                 m_autoneg = -1;  // -1 means not set, 0 = disabled, 1 = enabled
+    int                 m_link_training = -1; // -1 means not set, 0 = disabled, 1 = enabled
     bool                m_admin_state_up = false;
     bool                m_init = false;
     bool                m_l3_vni = false;
@@ -174,8 +175,14 @@ public:
     sai_object_id_t  m_system_side_id = 0;
     sai_object_id_t  m_line_side_id = 0;
 
+    /* pre-emphasis */
+    std::map<sai_port_serdes_attr_t, std::vector<uint32_t>> m_preemphasis;
+
     bool m_fec_cfg = false;
     bool m_an_cfg = false;
+
+    int m_cap_an = -1; /* Capability - AutoNeg, -1 means not set */
+    int m_cap_lt = -1; /* Capability - LinkTraining, -1 means not set */
 };
 
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -61,6 +61,8 @@ extern string gMyAsicName;
 #define DEFAULT_VLAN_ID     1
 #define MAX_VALID_VLAN_ID   4094
 
+#define PORT_SPEED_LIST_DEFAULT_SIZE                     16
+#define PORT_STATE_POLLING_SEC                            5
 #define PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS     1000
 #define PORT_BUFFER_DROP_STAT_POLLING_INTERVAL_MS     60000
 #define QUEUE_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS   10000
@@ -110,6 +112,26 @@ static map<string, int> autoneg_mode_map =
 {
     { "on", 1 },
     { "off", 0 }
+};
+
+static map<string, int> link_training_mode_map =
+{
+    { "on", 1 },
+    { "off", 0 }
+};
+
+static map<sai_port_link_training_failure_status_t, string> link_training_failure_map =
+{
+    { SAI_PORT_LINK_TRAINING_FAILURE_STATUS_NO_ERROR, "none" },
+    { SAI_PORT_LINK_TRAINING_FAILURE_STATUS_FRAME_LOCK_ERROR, "frame_lock"},
+    { SAI_PORT_LINK_TRAINING_FAILURE_STATUS_SNR_LOWER_THRESHOLD, "snr_low"},
+    { SAI_PORT_LINK_TRAINING_FAILURE_STATUS_TIME_OUT, "timeout"}
+};
+
+static map<sai_port_link_training_rx_status_t, string> link_training_rx_status_map =
+{
+    { SAI_PORT_LINK_TRAINING_RX_STATUS_NOT_TRAINED, "not_trained" },
+    { SAI_PORT_LINK_TRAINING_RX_STATUS_TRAINED, "trained"}
 };
 
 // Interface type map used for gearbox
@@ -327,7 +349,8 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
                 GBPORT_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ,
                 PORT_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
         port_buffer_drop_stat_manager(PORT_BUFFER_DROP_STAT_FLEX_COUNTER_GROUP, StatsMode::READ, PORT_BUFFER_DROP_STAT_POLLING_INTERVAL_MS, false),
-        queue_stat_manager(QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, QUEUE_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false)
+        queue_stat_manager(QUEUE_STAT_COUNTER_FLEX_COUNTER_GROUP, StatsMode::READ, QUEUE_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS, false),
+        m_port_state_poller(new SelectableTimer(timespec { .tv_sec = PORT_STATE_POLLING_SEC, .tv_nsec = 0 }))
 {
     SWSS_LOG_ENTER();
 
@@ -592,6 +615,9 @@ PortsOrch::PortsOrch(DBConnector *db, DBConnector *stateDb, vector<table_name_wi
 
         m_lagIdAllocator = unique_ptr<LagIdAllocator> (new LagIdAllocator(chassisAppDb));
     }
+
+    auto executor = new ExecutableTimer(m_port_state_poller, this, "PORT_STATE_POLLER");
+    Orch::addExecutor(executor);
 }
 
 void PortsOrch::removeDefaultVlanMembers()
@@ -1931,6 +1957,35 @@ void PortsOrch::initPortSupportedSpeeds(const std::string& alias, sai_object_id_
     m_portStateTable.set(alias, v);
 }
 
+void PortsOrch::initPortCapAutoNeg(Port &port)
+{
+    sai_status_t status;
+    sai_attribute_t attr;
+
+    attr.id = SAI_PORT_ATTR_SUPPORTED_AUTO_NEG_MODE;
+    status = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
+    if (status == SAI_STATUS_SUCCESS)
+    {
+        port.m_cap_an = attr.value.booldata ? 1 : 0;
+    }
+    else
+    {
+        // To avoid breakage on the existing platforms, AN should be 1 by default
+        port.m_cap_an = 1;
+        SWSS_LOG_WARN("Unable to get %s AN support capability",
+                      port.m_alias.c_str());
+    }
+}
+
+void PortsOrch::initPortCapLinkTraining(Port &port)
+{
+    // TODO:
+    // Add SAI_PORT_ATTR_SUPPORTED_LINK_TRAINING_MODE query when it is
+    // available in the saiport.h of SAI.
+    port.m_cap_lt = 1;
+    SWSS_LOG_WARN("Unable to get %s LT support capability", port.m_alias.c_str());
+}
+
 /*
  * If Gearbox is enabled and this is a Gearbox port then set the attributes accordingly.
  */
@@ -2085,6 +2140,45 @@ bool PortsOrch::getPortSpeed(sai_object_id_t id, sai_uint32_t &speed)
     return true;
 }
 
+bool PortsOrch::getPortAdvSpeeds(const Port& port, bool remote, std::vector<sai_uint32_t>& speed_list)
+{
+    sai_object_id_t port_id = port.m_port_id;
+    sai_object_id_t line_port_id;
+    sai_attribute_t attr;
+    sai_status_t status;
+    std::vector<sai_uint32_t> speeds(PORT_SPEED_LIST_DEFAULT_SIZE);
+
+    attr.id = remote ? SAI_PORT_ATTR_REMOTE_ADVERTISED_SPEED : SAI_PORT_ATTR_ADVERTISED_SPEED;
+    attr.value.u32list.count = static_cast<uint32_t>(speeds.size());
+    attr.value.u32list.list = speeds.data();
+
+    if (getDestPortId(port_id, LINE_PORT_TYPE, line_port_id))
+    {
+        status = sai_port_api->get_port_attribute(line_port_id, 1, &attr);
+    }
+    else
+    {
+        status = sai_port_api->get_port_attribute(port_id, 1, &attr);
+    }
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_WARN("Unable to get advertised speed for %s", port.m_alias.c_str());
+        return false;
+    }
+    speeds.resize(attr.value.u32list.count);
+    speed_list.swap(speeds);
+    return true;
+}
+
+bool PortsOrch::getPortAdvSpeeds(const Port& port, bool remote, string& adv_speeds)
+{
+    std::vector<sai_uint32_t> speed_list;
+    bool rc = getPortAdvSpeeds(port, remote, speed_list);
+
+    adv_speeds = rc ? swss::join(',', speed_list.begin(), speed_list.end()) : "";
+    return rc;
+}
+
 task_process_status PortsOrch::setPortAdvSpeeds(sai_object_id_t port_id, std::vector<sai_uint32_t>& speed_list)
 {
     SWSS_LOG_ENTER();
@@ -2196,6 +2290,32 @@ task_process_status PortsOrch::setPortAutoNeg(sai_object_id_t id, int an)
         return handleSaiSetStatus(SAI_API_PORT, status);
     }
     SWSS_LOG_INFO("Set AutoNeg %u to port pid:%" PRIx64, attr.value.booldata, id);
+    return task_success;
+}
+
+task_process_status PortsOrch::setPortLinkTraining(const Port &port, bool state)
+{
+    SWSS_LOG_ENTER();
+
+    if (port.m_type != Port::PHY)
+    {
+        return task_failed;
+    }
+
+    sai_attribute_t attr;
+    attr.id = SAI_PORT_ATTR_LINK_TRAINING_ENABLE;
+    attr.value.booldata = state;
+
+    string op = state ? "on" : "off";
+    sai_status_t status = sai_port_api->set_port_attribute(port.m_port_id, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to set LT %s to port %s", op.c_str(), port.m_alias.c_str());
+        return handleSaiSetStatus(SAI_API_PORT, status);
+    }
+
+    SWSS_LOG_INFO("Set LT %s to port %s", op.c_str(), port.m_alias.c_str());
+
     return task_success;
 }
 
@@ -2706,7 +2826,9 @@ void PortsOrch::doPortTask(Consumer &consumer)
             uint32_t speed = 0;
             string learn_mode;
             string an_str;
+            string lt_str;
             int an = -1;
+            int lt = -1;
             int index = -1;
             string role;
             string adv_speeds_str;
@@ -2796,6 +2918,11 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 else if (fvField(i) == "adv_interface_types")
                 {
                     adv_interface_types_str = fvValue(i);
+                }
+                /* Set link training */
+                else if (fvField(i) == "link_training")
+                {
+                    lt_str = fvValue(i);
                 }
                 /* Set port serdes Pre-emphasis */
                 else if (fvField(i) == "preemphasis")
@@ -2964,6 +3091,18 @@ void PortsOrch::doPortTask(Consumer &consumer)
             {
                 if (!an_str.empty())
                 {
+                    if (p.m_cap_an < 0)
+                    {
+                        initPortCapAutoNeg(p);
+                        m_portList[alias] = p;
+                    }
+                    if (p.m_cap_an < 1)
+                    {
+                        SWSS_LOG_ERROR("%s: autoneg is not supported", p.m_alias.c_str());
+                        // Invalid auto negotiation mode configured, don't retry
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
                     if (autoneg_mode_map.find(an_str) == autoneg_mode_map.end())
                     {
                         SWSS_LOG_ERROR("Failed to parse autoneg value: %s", an_str.c_str());
@@ -3006,6 +3145,62 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         SWSS_LOG_NOTICE("Set port %s AutoNeg from %d to %d", alias.c_str(), p.m_autoneg, an);
                         p.m_autoneg = an;
                         m_portList[alias] = p;
+                        m_portStateTable.hdel(p.m_alias, "rmt_adv_speeds");
+                        updatePortStatePoll(p, PORT_STATE_POLL_AN, (an > 0));
+                    }
+                }
+
+                if (!lt_str.empty() && (p.m_type == Port::PHY))
+                {
+                    if (link_training_mode_map.find(lt_str) == link_training_mode_map.end())
+                    {
+                        SWSS_LOG_ERROR("Failed to parse LT value: %s", lt_str.c_str());
+                        // Invalid link training mode configured, don't retry
+                        it = consumer.m_toSync.erase(it);
+                        continue;
+                    }
+
+                    lt = link_training_mode_map[lt_str];
+                    if (lt != p.m_link_training)
+                    {
+                        if (p.m_cap_lt < 0)
+                        {
+                            initPortCapLinkTraining(p);
+                            m_portList[alias] = p;
+                        }
+                        if (p.m_cap_lt < 1)
+                        {
+                            SWSS_LOG_WARN("%s: LT is not supported by the ASIC", alias.c_str());
+                            // Don't retry
+                            it = consumer.m_toSync.erase(it);
+                            continue;
+                        }
+
+                        auto status = setPortLinkTraining(p, lt > 0 ? true : false);
+                        if (status != task_success)
+                        {
+                            SWSS_LOG_ERROR("Failed to set port %s LT from %d to %d", alias.c_str(), p.m_link_training, lt);
+                            if (status == task_need_retry)
+                            {
+                                it++;
+                            }
+                            else
+                            {
+                                it = consumer.m_toSync.erase(it);
+                            }
+                            continue;
+                        }
+                        m_portStateTable.hset(alias, "link_training_status", lt_str);
+                        SWSS_LOG_NOTICE("Set port %s LT from %d to %d", alias.c_str(), p.m_link_training, lt);
+                        p.m_link_training = lt;
+                        m_portList[alias] = p;
+                        updatePortStatePoll(p, PORT_STATE_POLL_LT, (lt > 0));
+
+                        // Restore pre-emphasis when LT is transitioned from ON to OFF
+                        if ((p.m_link_training < 1) && (serdes_attr.size() == 0))
+                        {
+                            serdes_attr = p.m_preemphasis;
+                        }
                     }
                 }
 
@@ -3346,9 +3541,17 @@ void PortsOrch::doPortTask(Consumer &consumer)
 
                 if (serdes_attr.size() != 0)
                 {
-                    if (setPortSerdesAttribute(p.m_port_id, serdes_attr))
+                    if (p.m_link_training > 0)
                     {
-                        SWSS_LOG_NOTICE("Set port %s  preemphasis is success", alias.c_str());
+                        SWSS_LOG_NOTICE("Save port %s preemphasis for LT", alias.c_str());
+                        p.m_preemphasis = serdes_attr;
+                        m_portList[alias] = p;
+                    }
+                    else if (setPortSerdesAttribute(p.m_port_id, serdes_attr))
+                    {
+                        SWSS_LOG_NOTICE("Set port %s preemphasis is success", alias.c_str());
+                        p.m_preemphasis = serdes_attr;
+                        m_portList[alias] = p;
                     }
                     else
                     {
@@ -3356,7 +3559,6 @@ void PortsOrch::doPortTask(Consumer &consumer)
                         it++;
                         continue;
                     }
-
                 }
 
                 /* Last step set port admin status */
@@ -5835,6 +6037,18 @@ void PortsOrch::updatePortOperStatus(Port &port, sai_port_oper_status_t status)
     {
         updateDbPortOperStatus(port, status);
         updateGearboxPortOperStatus(port);
+
+        /* Refresh the port states and reschedule the poller tasks */
+        if (port.m_autoneg > 0)
+        {
+            refreshPortStateAutoNeg(port);
+            updatePortStatePoll(port, PORT_STATE_POLL_AN, !(status == SAI_PORT_OPER_STATUS_UP));
+        }
+        if (port.m_link_training > 0)
+        {
+            refreshPortStateLinkTraining(port);
+            updatePortStatePoll(port, PORT_STATE_POLL_LT, !(status == SAI_PORT_OPER_STATUS_UP));
+        }
     }
     port.m_oper_status = status;
 
@@ -5987,6 +6201,50 @@ bool PortsOrch::getPortOperSpeed(const Port& port, sai_uint32_t& speed) const
         return false;
     }
 
+    return true;
+}
+
+bool PortsOrch::getPortLinkTrainingRxStatus(const Port &port, sai_port_link_training_rx_status_t &rx_status)
+{
+    SWSS_LOG_ENTER();
+
+    if (port.m_type != Port::PHY)
+    {
+        return false;
+    }
+
+    sai_attribute_t attr;
+    attr.id = SAI_PORT_ATTR_LINK_TRAINING_RX_STATUS;
+    sai_status_t ret = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
+    if (ret != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get LT rx status for %s", port.m_alias.c_str());
+        return false;
+    }
+
+    rx_status = static_cast<sai_port_link_training_rx_status_t>(attr.value.u32);
+    return true;
+}
+
+bool PortsOrch::getPortLinkTrainingFailure(const Port &port, sai_port_link_training_failure_status_t &failure)
+{
+    SWSS_LOG_ENTER();
+
+    if (port.m_type != Port::PHY)
+    {
+        return false;
+    }
+
+    sai_attribute_t attr;
+    attr.id = SAI_PORT_ATTR_LINK_TRAINING_FAILURE_STATUS;
+    sai_status_t ret = sai_port_api->get_port_attribute(port.m_port_id, 1, &attr);
+    if (ret != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to get LT failure status for %s", port.m_alias.c_str());
+        return false;
+    }
+
+    failure = static_cast<sai_port_link_training_failure_status_t>(attr.value.u32);
     return true;
 }
 
@@ -7049,4 +7307,120 @@ bool PortsOrch::decrFdbCount(const std::string& alias, int count)
         itr->second.m_fdb_count -= count;
     }
     return true;
+}
+
+/* Refresh the per-port Auto-Negotiation operational states */
+void PortsOrch::refreshPortStateAutoNeg(const Port &port)
+{
+    SWSS_LOG_ENTER();
+
+    if (port.m_type != Port::Type::PHY)
+    {
+        return;
+    }
+
+    string adv_speeds = "N/A";
+
+    if (port.m_admin_state_up)
+    {
+        if (!getPortAdvSpeeds(port, true, adv_speeds))
+        {
+            adv_speeds = "N/A";
+            updatePortStatePoll(port, PORT_STATE_POLL_AN, false);
+        }
+    }
+
+    m_portStateTable.hset(port.m_alias, "rmt_adv_speeds", adv_speeds);
+}
+
+/* Refresh the per-port Link-Training operational states */
+void PortsOrch::refreshPortStateLinkTraining(const Port &port)
+{
+    SWSS_LOG_ENTER();
+
+    if (port.m_type != Port::Type::PHY)
+    {
+        return;
+    }
+
+    string status = "off";
+
+    if (port.m_admin_state_up && port.m_link_training > 0 && port.m_cap_lt > 0)
+    {
+        sai_port_link_training_rx_status_t rx_status;
+        sai_port_link_training_failure_status_t failure;
+
+        if (!getPortLinkTrainingRxStatus(port, rx_status))
+        {
+            status = "on"; // LT is enabled, while the rx status is unavailable
+        }
+        else if (rx_status == SAI_PORT_LINK_TRAINING_RX_STATUS_TRAINED)
+        {
+            status = link_training_rx_status_map.at(rx_status);
+        }
+        else
+        {
+            if (getPortLinkTrainingFailure(port, failure) &&
+                failure != SAI_PORT_LINK_TRAINING_FAILURE_STATUS_NO_ERROR)
+            {
+                status = link_training_failure_map.at(failure);
+            }
+            else
+            {
+                status = link_training_rx_status_map.at(rx_status);
+            }
+        }
+    }
+
+    m_portStateTable.hset(port.m_alias, "link_training_status", status);
+}
+
+/* Activate/De-activate a specific port state poller task */
+void PortsOrch::updatePortStatePoll(const Port &port, port_state_poll_t type, bool active)
+{
+    if (type == PORT_STATE_POLL_NONE)
+    {
+        return;
+    }
+    if (active)
+    {
+        m_port_state_poll[port.m_alias] |= type;
+        m_port_state_poller->start();
+    }
+    else
+    {
+        m_port_state_poll[port.m_alias] &= ~type;
+    }
+}
+
+void PortsOrch::doTask(swss::SelectableTimer &timer)
+{
+    Port port;
+
+    for (auto it = m_port_state_poll.begin(); it != m_port_state_poll.end(); )
+    {
+        if ((it->second == 0) || !getPort(it->first, port))
+        {
+            it = m_port_state_poll.erase(it);
+            continue;
+        }
+        if (!port.m_admin_state_up)
+        {
+            ++it;
+            continue;
+        }
+        if (it->second & PORT_STATE_POLL_AN)
+        {
+            refreshPortStateAutoNeg(port);
+        }
+        if (it->second & PORT_STATE_POLL_LT)
+        {
+            refreshPortStateLinkTraining(port);
+        }
+        ++it;
+    }
+    if (m_port_state_poll.size() == 0)
+    {
+        m_port_state_poller->stop();
+    }
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -259,6 +259,8 @@ private:
 
     NotificationConsumer* m_portStatusNotificationConsumer;
 
+    swss::SelectableTimer *m_port_state_poller = nullptr;
+
     void doTask() override;
     void doTask(Consumer &consumer);
     void doPortTask(Consumer &consumer);
@@ -268,6 +270,7 @@ private:
     void doLagMemberTask(Consumer &consumer);
 
     void doTask(NotificationConsumer &consumer);
+    void doTask(swss::SelectableTimer &timer);
 
     void removePortFromLanesMap(string alias);
     void removePortFromPortListMap(sai_object_id_t port_id);
@@ -300,6 +303,9 @@ private:
     bool initPort(const string &alias, const string &role, const int index, const set<int> &lane_set);
     void deInitPort(string alias, sai_object_id_t port_id);
 
+    void initPortCapAutoNeg(Port &port);
+    void initPortCapLinkTraining(Port &port);
+
     bool setPortAdminStatus(Port &port, bool up);
     bool getPortAdminStatus(sai_object_id_t id, bool& up);
     bool setPortMtu(sai_object_id_t id, sai_uint32_t mtu);
@@ -320,6 +326,8 @@ private:
     bool setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value);
     bool setGearboxPortAttr(Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value);
 
+    bool getPortAdvSpeeds(const Port& port, bool remote, std::vector<sai_uint32_t>& speed_list);
+    bool getPortAdvSpeeds(const Port& port, bool remote, string& adv_speeds);
     task_process_status setPortAdvSpeeds(sai_object_id_t port_id, std::vector<sai_uint32_t>& speed_list);
 
     bool getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index);
@@ -339,11 +347,26 @@ private:
     bool setPortFecMode(sai_object_id_t id, int fec);
     task_process_status setPortInterfaceType(sai_object_id_t id, sai_port_interface_type_t interface_type);
     task_process_status setPortAdvInterfaceTypes(sai_object_id_t id, std::vector<uint32_t> &interface_types);
+    task_process_status setPortLinkTraining(const Port& port, bool state);
 
     void updatePortOperStatus(Port &port, sai_port_oper_status_t status);
 
     bool getPortOperSpeed(const Port& port, sai_uint32_t& speed) const;
     void updateDbPortOperSpeed(Port &port, sai_uint32_t speed);
+
+    bool getPortLinkTrainingRxStatus(const Port &port, sai_port_link_training_rx_status_t &rx_status);
+    bool getPortLinkTrainingFailure(const Port &port, sai_port_link_training_failure_status_t &failure);
+
+    typedef enum {
+        PORT_STATE_POLL_NONE = 0,
+        PORT_STATE_POLL_AN   = 0x00000001, /* Auto Negotiation */
+        PORT_STATE_POLL_LT   = 0x00000002  /* Link Trainig */
+    } port_state_poll_t;
+
+    map<string, uint32_t> m_port_state_poll;
+    void updatePortStatePoll(const Port &port, port_state_poll_t type, bool active);
+    void refreshPortStateAutoNeg(const Port &port);
+    void refreshPortStateLinkTraining(const Port &port);
 
     void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values);
     bool getPortAdvSpeedsVal(const std::string &s, std::vector<uint32_t> &speed_values);

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -293,6 +293,23 @@ class TestPortAutoNeg(object):
             # slow down crm polling
             dvs.crm_poll_set("10000")
 
+    def test_PortAutoNegRemoteAdvSpeeds(self, dvs, testlog):
+
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        sdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+
+        ctbl = swsscommon.Table(cdb, "PORT")
+        stbl = swsscommon.Table(sdb, "PORT_TABLE")
+
+        # set autoneg = true and admin_status = up
+        fvs = swsscommon.FieldValuePairs([("autoneg","on"),("admin_status","up")])
+        ctbl.set("Ethernet0", fvs)
+
+        time.sleep(10)
+
+        (status, fvs) = stbl.get("Ethernet0")
+        assert status == True
+        assert "rmt_adv_speeds" in [fv[0] for fv in fvs]
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_port_lt.py
+++ b/tests/test_port_lt.py
@@ -1,0 +1,139 @@
+import time
+import os
+import pytest
+
+from swsscommon import swsscommon
+
+
+class TestPortLinkTraining(object):
+    def test_PortLinkTrainingForce(self, dvs, testlog):
+
+        db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        adb = dvs.get_asic_db()
+
+        tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+        fvs = swsscommon.FieldValuePairs([("link_training","off")])
+        tbl.set("Ethernet0", fvs)
+
+        tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+        fvs = swsscommon.FieldValuePairs([("link_training","on")])
+        tbl.set("Ethernet4", fvs)
+
+        # validate if link_training false is pushed to asic db when set first time
+        port_oid = adb.port_name_map["Ethernet0"]
+        expected_fields = {"SAI_PORT_ATTR_LINK_TRAINING_ENABLE":"false"}
+        adb.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid, expected_fields)
+
+        # validate if link_training true is pushed to asic db when set first time
+        port_oid = adb.port_name_map["Ethernet4"]
+        expected_fields = {"SAI_PORT_ATTR_LINK_TRAINING_ENABLE":"true"}
+        adb.wait_for_field_match("ASIC_STATE:SAI_OBJECT_TYPE_PORT", port_oid, expected_fields)
+
+    def test_PortLinkTrainingCold(self, dvs, testlog):
+        db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+
+        tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+
+        # set link_training = true
+        fvs = swsscommon.FieldValuePairs([("link_training","on")])
+
+        tbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+
+        atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+
+        assert "SAI_PORT_ATTR_LINK_TRAINING_ENABLE" in [fv[0] for fv in fvs]
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_LINK_TRAINING_ENABLE":
+                assert fv[1] == "true"
+
+        # change link_training to false
+        fvs = swsscommon.FieldValuePairs([("link_training","off")])
+
+        tbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+
+        assert "SAI_PORT_ATTR_LINK_TRAINING_ENABLE" in [fv[0] for fv in fvs]
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_LINK_TRAINING_ENABLE":
+                assert fv[1] == "false"
+
+    def test_PortLinkTrainingWarm(self, dvs, testlog):
+
+        db = swsscommon.DBConnector(0, dvs.redis_sock, 0)
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        sdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+
+        tbl = swsscommon.ProducerStateTable(db, "PORT_TABLE")
+        ctbl = swsscommon.Table(cdb, "PORT")
+        stbl = swsscommon.Table(sdb, "PORT_TABLE")
+
+        # set link_training = true
+        fvs = swsscommon.FieldValuePairs([("link_training","on")])
+        ctbl.set("Ethernet0", fvs)
+
+        time.sleep(1)
+
+        adb = swsscommon.DBConnector(1, dvs.redis_sock, 0)
+
+        atbl = swsscommon.Table(adb, "ASIC_STATE:SAI_OBJECT_TYPE_PORT")
+        (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+        assert status == True
+
+        assert "SAI_PORT_ATTR_LINK_TRAINING_ENABLE" in [fv[0] for fv in fvs]
+        for fv in fvs:
+            if fv[0] == "SAI_PORT_ATTR_AUTO_NEG_MODE":
+                assert fv[1] == "true"
+
+        # set admin up
+        cfvs = swsscommon.FieldValuePairs([("admin_status", "up")])
+        ctbl.set("Ethernet0", cfvs)
+
+        # enable warm restart
+        (exitcode, result) = dvs.runcmd("config warm_restart enable swss")
+        assert exitcode == 0
+
+        # freeze orchagent for warm restart
+        (exitcode, result) = dvs.runcmd("/usr/bin/orchagent_restart_check")
+        assert result == "RESTARTCHECK succeeded\n"
+        time.sleep(2)
+
+        try:
+            # restart orchagent
+            # clean port state
+            dvs.stop_swss()
+            ports = stbl.getKeys()
+            for port in ports:
+                stbl._del(port)
+            dvs.start_swss()
+            time.sleep(2)
+
+            # check ASIC DB after warm restart
+            (status, fvs) = atbl.get(dvs.asicdb.portnamemap["Ethernet0"])
+            assert status == True
+
+            assert "SAI_PORT_ATTR_LINK_TRAINING_ENABLE" in [fv[0] for fv in fvs]
+            for fv in fvs:
+                if fv[0] == "SAI_PORT_ATTR_LINK_TRAINING_ENABLE":
+                    assert fv[1] == "true"
+
+        finally:
+            # disable warm restart
+            dvs.runcmd("config warm_restart disable swss")
+            # slow down crm polling
+            dvs.runcmd("crm config polling interval 10000")
+
+
+# Add Dummy always-pass test at end as workaroud
+# for issue when Flaky fail on final test it invokes module tear-down before retrying
+def test_nonflaky_dummy():
+    pass


### PR DESCRIPTION
Signed-off-by: Dante Su <dante.su@broadcom.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Add Link-Training support to portsorch, while Gearbox is not in the scope
2. Add support for remote speed advertisement
3. Add support for capability checker

**Why I did it**
1. In the case of DAC, static pre-calibrated pre-emphasis is rarely available on SONIC, as most of the ODM are expecting this to be  done dynamically at runtime via link-training, hence we'll need this feature to improve the link quality
2. Help users identify the cause of autoneg link failure
3. Avoid un-necessary SAI calls for autoneg and link-training controls if this feature is not supported

**How I verified it**

1. Manual test
2. Ran the Unit-tests to the corresponding changes

**Details if related**

HLD: Azure/SONiC#924,  Azure/SONiC#925