### PR TITLE
[vxlan] Remove tunnel map objects on VNET tunnel removal

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1542,28 +1542,12 @@ bool VxlanTunnelOrch::removeVxlanTunnelMap(string tunnelName, uint32_t vni)
     tunnel_obj->vlan_vrf_vni_count--;
     if (tunnel_obj->vlan_vrf_vni_count == 0)
     {
-        auto tunnel_term_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelTermId();
-        try
-        {
-            remove_tunnel_termination(tunnel_term_id);
-        }
-        catch(const std::runtime_error& error)
-        {
-            SWSS_LOG_ERROR("Error removing tunnel term entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
-            return false;
-        }
- 
-        auto tunnel_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelId();
-        try
-        {
-            removeTunnelFromFlexCounter(tunnel_id, tunnelName);
-            remove_tunnel(tunnel_id);
-        }
-        catch(const std::runtime_error& error)
-        {
-            SWSS_LOG_ERROR("Error removing tunnel entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
-            return false;
-        }
+       uint8_t mapper_list = 0;
+
+       TUNNELMAP_SET_VLAN(mapper_list);
+       TUNNELMAP_SET_VRF(mapper_list);
+
+       tunnel_obj->deleteTunnelHw(mapper_list, TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
     }
 
     SWSS_LOG_NOTICE("Vxlan map entry deleted for tunnel '%s' with vni '%d'", tunnelName.c_str(), vni);


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

* VxLAN tunnel map objects were not removed on VNET tunnel removal.
* It caused config lefovers which is not expected.
* If tunnel is removed then all related objects should be removed as well.
* To do so just used deleteTunnelHw() function which does proper remove.

**Why I did it**

To cleanup config leftovers after VNET tunnel removal.

**How I verified it**
* Configure 2 VNETs and then remove them one by one.
* Verify that after 1st VNET removed tunnel and all related objects still exist.
* Verify that after 2nd (last) VNET removed tunnel and all related objects are removed.

**Details if related**
N/A