### PR TITLE
[portsorch]: Prevent LAG member configuration when port has active ACL binding

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3851,6 +3851,17 @@ void PortsOrch::doLagMemberTask(Consumer &consumer)
                     continue;
                 }
 
+                if (!port.m_ingress_acl_tables_uset.empty() || !port.m_egress_acl_tables_uset.empty())
+                {
+                    SWSS_LOG_ERROR(
+                        "Failed to add member %s to LAG %s: ingress/egress ACL configuration is present",
+                        port.m_alias.c_str(),
+                        lag.m_alias.c_str()
+                    );
+                    it = consumer.m_toSync.erase(it);
+                    continue;
+                }
+
                 if (!addLagMember(lag, port, (status == "enabled")))
                 {
                     it++;


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
Add some extra validation to make sure that port can't be made a LAG member when ingress/egress ACL binding is configured.
Before moving port to LAG, user should disable active ACL binding, since LAG uses a different dedicated attributes

fixes Azure/sonic-buildimage#10233

**What I did**
* Prevent LAG member configuration when port has active ACL binding

**Why I did it**
* To fix ACL PORT/LAG config divergency

**How I verified it**
1. Deploy t0 topology
2. Create LAG interface
3. Remove arbitrary port from VLAN
4. Make port LAG member

**Details if related**
```
root@sonic:/home/admin# show acl table
Name        Type       Binding         Description    Stage
----------  ---------  --------------  -------------  -------
DATAACL     L3         PortChannel101  DATAACL        ingress
                       PortChannel102
                       PortChannel103
                       PortChannel104
EVERFLOW    MIRROR     Ethernet2       EVERFLOW       ingress
                       Ethernet4
                       Ethernet6
                       Ethernet8
                       Ethernet10
                       Ethernet12
                       Ethernet14
                       Ethernet16
                       Ethernet18
                       Ethernet20
                       Ethernet22
                       Ethernet24
                       Ethernet28
                       Ethernet32
                       Ethernet36
                       Ethernet40
                       Ethernet42
                       Ethernet44
                       Ethernet46
                       Ethernet48
                       Ethernet50
                       Ethernet52
                       Ethernet54
                       Ethernet56
                       PortChannel101
                       PortChannel102
                       PortChannel103
                       PortChannel104
EVERFLOWV6  MIRRORV6   Ethernet2       EVERFLOWV6     ingress
                       Ethernet4
                       Ethernet6
                       Ethernet8
                       Ethernet10
                       Ethernet12
                       Ethernet14
                       Ethernet16
                       Ethernet18
                       Ethernet20
                       Ethernet22
                       Ethernet24
                       Ethernet28
                       Ethernet32
                       Ethernet36
                       Ethernet40
                       Ethernet42
                       Ethernet44
                       Ethernet46
                       Ethernet48
                       Ethernet50
                       Ethernet52
                       Ethernet54
                       Ethernet56
                       PortChannel101
                       PortChannel102
                       PortChannel103
                       PortChannel104
NTP_ACL     CTRLPLANE  NTP             NTP_ACL        ingress
SNMP_ACL    CTRLPLANE  SNMP            SNMP_ACL       ingress
SSH_ONLY    CTRLPLANE  SSH             SSH_ONLY       ingress

root@sonic-vs-ut:~/sonic-swss/tests# pytest --dvsname=vs --log-cli-level=info test_acl_portchannel.py::TestAclInterfaceBinding -v
========================================================================= test session starts =========================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /root/sonic-swss/tests
plugins: flaky-3.7.0
collected 2 items

test_acl_portchannel.py::TestAclInterfaceBinding::test_AclTablePortChannelMemberBinding[ingress]
--------------------------------------------------------------------------- live log setup ----------------------------------------------------------------------------
INFO     test_acl_portchannel:test_acl_portchannel.py:18 Initialize DVS API: ACL
---------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------
INFO     test_acl_portchannel:test_acl_portchannel.py:30 Create ACL table: acl_table
INFO     test_acl_portchannel:test_acl_portchannel.py:39 Create LAG: PortChannel0001
INFO     test_acl_portchannel:test_acl_portchannel.py:43 Create LAG member: Ethernet120
INFO     test_acl_portchannel:test_acl_portchannel.py:47 Create LAG member: Ethernet124
INFO     test_acl_portchannel:test_acl_portchannel.py:55 Verify LAG member hasn't been created: Ethernet124
INFO     test_acl_portchannel:test_acl_portchannel.py:51 Remove LAG member: Ethernet124
INFO     test_acl_portchannel:test_acl_portchannel.py:55 Remove LAG member: Ethernet120
INFO     test_acl_portchannel:test_acl_portchannel.py:59 Remove LAG: PortChannel0001
INFO     test_acl_portchannel:test_acl_portchannel.py:63 Remove ACL table: acl_table
PASSED                                                                                                                                                          [ 50%]
test_acl_portchannel.py::TestAclInterfaceBinding::test_AclTablePortChannelMemberBinding[egress]
---------------------------------------------------------------------------- live log call ----------------------------------------------------------------------------
INFO     test_acl_portchannel:test_acl_portchannel.py:30 Create ACL table: acl_table
INFO     test_acl_portchannel:test_acl_portchannel.py:39 Create LAG: PortChannel0001
INFO     test_acl_portchannel:test_acl_portchannel.py:43 Create LAG member: Ethernet120
INFO     test_acl_portchannel:test_acl_portchannel.py:47 Create LAG member: Ethernet124
INFO     test_acl_portchannel:test_acl_portchannel.py:55 Verify LAG member hasn't been created: Ethernet124
INFO     test_acl_portchannel:test_acl_portchannel.py:51 Remove LAG member: Ethernet124
INFO     test_acl_portchannel:test_acl_portchannel.py:55 Remove LAG member: Ethernet120
INFO     test_acl_portchannel:test_acl_portchannel.py:59 Remove LAG: PortChannel0001
INFO     test_acl_portchannel:test_acl_portchannel.py:63 Remove ACL table: acl_table
PASSED                                                                                                                                                          [100%]
-------------------------------------------------------------------------- live log teardown --------------------------------------------------------------------------
INFO     test_acl_portchannel:test_acl_portchannel.py:21 Deinitialize DVS API: ACL


-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================== 2 passed, 8 warnings in 73.15s (0:01:13) ===============================================================
```