### PR TITLE
Fix for handling broadcom DNX ASIC to have ipv4 and ipv6 ACL rules in separate tables.

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -2645,6 +2645,7 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
     // Broadcom and Mellanox. Virtual switch is also supported for testing
     // purposes.
     string platform = getenv("platform") ? getenv("platform") : "";
+    string sub_platform = getenv("sub_platform") ? getenv("sub_platform") : "";
     if (platform == BRCM_PLATFORM_SUBSTRING ||
             platform == CISCO_8000_PLATFORM_SUBSTRING ||
             platform == MLNX_PLATFORM_SUBSTRING ||
@@ -2676,9 +2677,11 @@ void AclOrch::init(vector<TableConnector>& connectors, PortsOrch *portOrch, Mirr
             m_mirrorTableCapabilities[TABLE_TYPE_MIRRORV6] ? "yes" : "no");
 
     // In Mellanox platform, V4 and V6 rules are stored in different tables
+    // In Broadcom DNX platform also, V4 and V6 rules are stored in different tables
     if (platform == MLNX_PLATFORM_SUBSTRING ||
         platform == CISCO_8000_PLATFORM_SUBSTRING ||
-        platform == MRVL_PLATFORM_SUBSTRING)
+        platform == MRVL_PLATFORM_SUBSTRING ||
+        (platform == BRCM_PLATFORM_SUBSTRING && sub_platform == BRCM_DNX_PLATFORM_SUBSTRING))
     {
         m_isCombinedMirrorV6Table = false;
     }

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -34,6 +34,7 @@ const char state_db_key_delimiter  = '|';
 #define INVM_PLATFORM_SUBSTRING "innovium"
 #define MLNX_PLATFORM_SUBSTRING "mellanox"
 #define BRCM_PLATFORM_SUBSTRING "broadcom"
+#define BRCM_DNX_PLATFORM_SUBSTRING "broadcom-dnx"
 #define BFN_PLATFORM_SUBSTRING  "barefoot"
 #define VS_PLATFORM_SUBSTRING   "vs"
 #define NPS_PLATFORM_SUBSTRING  "nephos"


### PR DESCRIPTION
**What I did**
Fix for handling broadcom DNX ASIC to have ipv4 and ipv6 ACL rules in separate tables.
Related PR : https://github.com/Azure/sonic-buildimage/pull/10235

**Why I did it**
Broadcom DNX ASIC need to have ipv4 and ipv6 ACL rules in separate tables.

**How I verified it**
Verified the SWSS_VARS is updated and sub_platfom populated with 'broadcom-dnx'

**Details if related**
