### PR TITLE
[mirrororch] Implement HW resources availability validation

### DIFF
--- a/orchagent/mirrororch.cpp
+++ b/orchagent/mirrororch.cpp
@@ -344,6 +344,27 @@ bool MirrorOrch::validateSrcPortList(const string& srcPortList)
     return true;
 }
 
+bool MirrorOrch::isHwResourcesAvailable()
+{
+    uint64_t availCount = 0;
+
+    sai_status_t status = sai_object_type_get_availability(
+        gSwitchId, SAI_OBJECT_TYPE_MIRROR_SESSION, 0, nullptr, &availCount
+    );
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        if (status == SAI_STATUS_NOT_SUPPORTED)
+        {
+            SWSS_LOG_WARN("Mirror session resource availability monitoring is not supported. Skipping ...");
+            return true;
+        }
+
+        return parseHandleSaiStatusFailure(handleSaiGetStatus(SAI_API_MIRROR, status));
+    }
+
+    return availCount > 0;
+}
+
 task_process_status MirrorOrch::createEntry(const string& key, const vector<FieldValueTuple>& data)
 {
     SWSS_LOG_ENTER();
@@ -351,8 +372,7 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
     auto session = m_syncdMirrors.find(key);
     if (session != m_syncdMirrors.end())
     {
-        SWSS_LOG_NOTICE("Failed to create session, session %s already exists",
-                key.c_str());
+        SWSS_LOG_NOTICE("Failed to create session %s: object already exists", key.c_str());
         return task_process_status::task_duplicated;
     }
 
@@ -463,10 +483,13 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
         }
     }
 
+    if (!isHwResourcesAvailable())
+    {
+        SWSS_LOG_ERROR("Failed to create session %s: HW resources are not available", key.c_str());
+        return task_process_status::task_failed;
+    }
+
     m_syncdMirrors.emplace(key, entry);
-
-    SWSS_LOG_NOTICE("Created mirror session %s", key.c_str());
-
     setSessionState(key, entry);
 
     if (entry.type == MIRROR_SESSION_SPAN && !entry.dst_port.empty())
@@ -479,6 +502,8 @@ task_process_status MirrorOrch::createEntry(const string& key, const vector<Fiel
         // Attach the destination IP to the routeOrch
         m_routeOrch->attach(this, entry.dstIp);
     }
+
+    SWSS_LOG_NOTICE("Created mirror session %s", key.c_str());
 
     return task_process_status::task_success;
 }

--- a/orchagent/mirrororch.h
+++ b/orchagent/mirrororch.h
@@ -104,6 +104,8 @@ private:
     // session_name -> VLAN | monitor_port_alias | next_hop_ip
     map<string, string> m_recoverySessionMap;
 
+    bool isHwResourcesAvailable();
+
     task_process_status createEntry(const string&, const vector<FieldValueTuple>&);
     task_process_status deleteEntry(const string&);
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
* Added a validation to prevent mirror session configuration if there is no available HW resources

**Why I did it**
* To prevent system from unexpected reboots
* To add some debuggability information to the system journal

**How I verified it**
1. Configure mirror sessions
```bash
config mirror_session span add TEST1 Ethernet0 Ethernet4
config mirror_session span add TEST2 Ethernet8 Ethernet12
config mirror_session span add TEST3 Ethernet16 Ethernet20
config mirror_session span add TEST4 Ethernet24 Ethernet28
config mirror_session span add TEST5 Ethernet32 Ethernet36
config mirror_session span add TEST6 Ethernet40 Ethernet44
config mirror_session span add TEST7 Ethernet48 Ethernet52
config mirror_session span add TEST8 Ethernet56 Ethernet60
```

**Details if related**
* CLI
```bash
root@sonic:/home/admin# show mirror_session
ERSPAN Sessions
Name    Status    SRC IP    DST IP    GRE    DSCP    TTL    Queue    Policer    Monitor Port    SRC Port    Direction
------  --------  --------  --------  -----  ------  -----  -------  ---------  --------------  ----------  -----------

SPAN Sessions
Name    Status    DST Port    SRC Port    Direction    Queue    Policer
------  --------  ----------  ----------  -----------  -------  ---------
TEST1   active    Ethernet0   Ethernet4   both
TEST2   active    Ethernet8   Ethernet12  both
TEST3   active    Ethernet16  Ethernet20  both
TEST4   active    Ethernet24  Ethernet28  both
TEST5   active    Ethernet32  Ethernet36  both
TEST6   active    Ethernet40  Ethernet44  both
TEST7   active    Ethernet48  Ethernet52  both
TEST8   error     Ethernet56  Ethernet60  both
```

* Log
```bash
Mar 16 10:05:26.236210 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[221]- sai_object_type_get_availability: Querying SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list
Mar 16 10:05:26.236478 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[242]- sai_object_type_get_availability: Got SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list: 7
Mar 16 10:05:26.238214 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2191]- mlnx_check_mirror_attribute_on_create: Create mirror, #0 MONITOR_PORT=PORT,(0:0),10069,0000,0 #1 TYPE=LOCAL
Mar 16 10:05:26.241129 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2808]- mlnx_create_mirror_session: Created sdk mirror obj id: 1
Mar 16 10:05:26.241222 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2847]- mlnx_create_mirror_session: Created SAI mirror obj id: 10000000e
Mar 16 10:05:26.242355 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set INGRESS_MIRROR_SESSION, key:port 1006a, val:1 : [ 10000000e]
Mar 16 10:05:26.243616 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set EGRESS_MIRROR_SESSION, key:port 1006a, val:1 : [ 10000000e]
Mar 16 10:05:26.244686 sonic NOTICE swss#orchagent: :- activateSession: Activated mirror session TEST1
Mar 16 10:05:26.244686 sonic NOTICE swss#orchagent: :- createEntry: Created mirror session TEST1
Mar 16 10:05:26.732414 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[221]- sai_object_type_get_availability: Querying SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list
Mar 16 10:05:26.733007 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[242]- sai_object_type_get_availability: Got SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list: 6
Mar 16 10:05:26.734711 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2191]- mlnx_check_mirror_attribute_on_create: Create mirror, #0 MONITOR_PORT=PORT,(0:0),10031,0000,0 #1 TYPE=LOCAL
Mar 16 10:05:26.736280 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2808]- mlnx_create_mirror_session: Created sdk mirror obj id: 2
Mar 16 10:05:26.736395 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2847]- mlnx_create_mirror_session: Created SAI mirror obj id: 20000000e
Mar 16 10:05:26.738465 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set INGRESS_MIRROR_SESSION, key:port 10071, val:1 : [ 20000000e]
Mar 16 10:05:26.740891 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set EGRESS_MIRROR_SESSION, key:port 10071, val:1 : [ 20000000e]
Mar 16 10:05:26.742509 sonic NOTICE swss#orchagent: :- activateSession: Activated mirror session TEST2
Mar 16 10:05:26.742509 sonic NOTICE swss#orchagent: :- createEntry: Created mirror session TEST2
Mar 16 10:05:27.270144 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[221]- sai_object_type_get_availability: Querying SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list
Mar 16 10:05:27.270256 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[242]- sai_object_type_get_availability: Got SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list: 5
Mar 16 10:05:27.271919 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2191]- mlnx_check_mirror_attribute_on_create: Create mirror, #0 MONITOR_PORT=PORT,(0:0),10072,0000,0 #1 TYPE=LOCAL
Mar 16 10:05:27.272975 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2808]- mlnx_create_mirror_session: Created sdk mirror obj id: 3
Mar 16 10:05:27.272975 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2847]- mlnx_create_mirror_session: Created SAI mirror obj id: 30000000e
Mar 16 10:05:27.274545 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set INGRESS_MIRROR_SESSION, key:port 10032, val:1 : [ 30000000e]
Mar 16 10:05:27.276311 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set EGRESS_MIRROR_SESSION, key:port 10032, val:1 : [ 30000000e]
Mar 16 10:05:27.277404 sonic NOTICE swss#orchagent: :- activateSession: Activated mirror session TEST3
Mar 16 10:05:27.277404 sonic NOTICE swss#orchagent: :- createEntry: Created mirror session TEST3
Mar 16 10:05:27.745178 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[221]- sai_object_type_get_availability: Querying SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list
Mar 16 10:05:27.745329 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[242]- sai_object_type_get_availability: Got SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list: 4
Mar 16 10:05:27.746975 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2191]- mlnx_check_mirror_attribute_on_create: Create mirror, #0 MONITOR_PORT=PORT,(0:0),10073,0000,0 #1 TYPE=LOCAL
Mar 16 10:05:27.748498 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2808]- mlnx_create_mirror_session: Created sdk mirror obj id: 4
Mar 16 10:05:27.748498 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2847]- mlnx_create_mirror_session: Created SAI mirror obj id: 40000000e
Mar 16 10:05:27.750200 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set INGRESS_MIRROR_SESSION, key:port 10074, val:1 : [ 40000000e]
Mar 16 10:05:27.752326 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set EGRESS_MIRROR_SESSION, key:port 10074, val:1 : [ 40000000e]
Mar 16 10:05:27.754113 sonic NOTICE swss#orchagent: :- activateSession: Activated mirror session TEST4
Mar 16 10:05:27.754113 sonic NOTICE swss#orchagent: :- createEntry: Created mirror session TEST4
Mar 16 10:05:28.245222 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[221]- sai_object_type_get_availability: Querying SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list
Mar 16 10:05:28.245222 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[242]- sai_object_type_get_availability: Got SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list: 3
Mar 16 10:05:28.246993 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2191]- mlnx_check_mirror_attribute_on_create: Create mirror, #0 MONITOR_PORT=PORT,(0:0),10029,0000,0 #1 TYPE=LOCAL
Mar 16 10:05:28.248750 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2808]- mlnx_create_mirror_session: Created sdk mirror obj id: 5
Mar 16 10:05:28.248891 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2847]- mlnx_create_mirror_session: Created SAI mirror obj id: 50000000e
Mar 16 10:05:28.250655 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set INGRESS_MIRROR_SESSION, key:port 10079, val:1 : [ 50000000e]
Mar 16 10:05:28.252470 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set EGRESS_MIRROR_SESSION, key:port 10079, val:1 : [ 50000000e]
Mar 16 10:05:28.253899 sonic NOTICE swss#orchagent: :- activateSession: Activated mirror session TEST5
Mar 16 10:05:28.253899 sonic NOTICE swss#orchagent: :- createEntry: Created mirror session TEST5
Mar 16 10:05:28.718214 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[221]- sai_object_type_get_availability: Querying SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list
Mar 16 10:05:28.718441 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[242]- sai_object_type_get_availability: Got SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list: 2
Mar 16 10:05:28.720524 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2191]- mlnx_check_mirror_attribute_on_create: Create mirror, #0 MONITOR_PORT=PORT,(0:0),1007a,0000,0 #1 TYPE=LOCAL
Mar 16 10:05:28.722119 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2808]- mlnx_create_mirror_session: Created sdk mirror obj id: 6
Mar 16 10:05:28.722119 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2847]- mlnx_create_mirror_session: Created SAI mirror obj id: 60000000e
Mar 16 10:05:28.724054 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set INGRESS_MIRROR_SESSION, key:port 1002a, val:1 : [ 60000000e]
Mar 16 10:05:28.726880 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set EGRESS_MIRROR_SESSION, key:port 1002a, val:1 : [ 60000000e]
Mar 16 10:05:28.728886 sonic NOTICE swss#orchagent: :- activateSession: Activated mirror session TEST6
Mar 16 10:05:28.728886 sonic NOTICE swss#orchagent: :- createEntry: Created mirror session TEST6
Mar 16 10:05:29.190097 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[221]- sai_object_type_get_availability: Querying SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list
Mar 16 10:05:29.190485 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[242]- sai_object_type_get_availability: Got SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list: 1
Mar 16 10:05:29.192498 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2191]- mlnx_check_mirror_attribute_on_create: Create mirror, #0 MONITOR_PORT=PORT,(0:0),1007b,0000,0 #1 TYPE=LOCAL
Mar 16 10:05:29.194013 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2808]- mlnx_create_mirror_session: Created sdk mirror obj id: 7
Mar 16 10:05:29.194243 sonic NOTICE syncd#SDK: [SAI_MIRROR.NOTICE] mlnx_sai_mirror.c[2847]- mlnx_create_mirror_session: Created SAI mirror obj id: 70000000e
Mar 16 10:05:29.196196 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set INGRESS_MIRROR_SESSION, key:port 1007c, val:1 : [ 70000000e]
Mar 16 10:05:29.198516 sonic NOTICE syncd#SDK: [SAI_UTILS.NOTICE] mlnx_sai_utils.c[1833]- set_dispatch_attrib_handler: Set EGRESS_MIRROR_SESSION, key:port 1007c, val:1 : [ 70000000e]
Mar 16 10:05:29.200503 sonic NOTICE swss#orchagent: :- activateSession: Activated mirror session TEST7
Mar 16 10:05:29.200503 sonic NOTICE swss#orchagent: :- createEntry: Created mirror session TEST7
Mar 16 10:05:29.637004 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[221]- sai_object_type_get_availability: Querying SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list
Mar 16 10:05:29.637004 sonic NOTICE syncd#SDK: [SAI_OBJECT.NOTICE] mlnx_sai_object.c[242]- sai_object_type_get_availability: Got SAI_OBJECT_TYPE_MIRROR_SESSION availability, empty list: 0
Mar 16 10:05:29.637543 sonic ERR swss#orchagent: :- createEntry: Failed to create session TEST8: HW resources are not available
```