### PR TITLE
[Vxlanmgr] vnet netdev cleanup during config reload fix

### DIFF
--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -1054,21 +1054,21 @@ void VxlanMgr::getAllVxlanNetDevices()
     std::string stdout;
 
     // Get VxLan Netdev Interfaces
-    const std::string cmd = std::string("") + IP_CMD + " link show type vxlan";
+    std::string cmd = std::string("") + IP_CMD + " link show type vxlan";
     int ret = swss::exec(cmd, stdout);
     if (ret != 0)
     {
         SWSS_LOG_ERROR("Cannot get vxlan devices by command : %s", cmd.c_str());
         stdout.clear();
     }
-    auto netdevs = parseNetDev(stdout);
+    std::vector<std::string> netdevs = parseNetDev(stdout);
     for (auto netdev : netdevs){
         m_vxlanNetDevices[netdev] = VXLAN;
     }
 
     // Get VxLanIf Netdev Interfaces
-    const std::string cmd = std::string("") + IP_CMD + " link show type bridge";
-    int ret = swss::exec(cmd, stdout);
+    cmd = std::string("") + IP_CMD + " link show type bridge";
+    ret = swss::exec(cmd, stdout);
     if (ret != 0)
     {
         SWSS_LOG_ERROR("Cannot get vxlanIf devices by command : %s", cmd.c_str());

--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -1031,29 +1031,57 @@ int VxlanMgr::deleteVxlanNetdevice(std::string vxlan_dev_name)
     return swss::exec(cmd, res);
 }
 
-void VxlanMgr::getAllVxlanNetDevices()
-{
-    std::string stdout;
-    const std::string cmd = std::string("") + IP_CMD + " link show type vxlan";
-    int ret = swss::exec(cmd, stdout);
-    if (ret != 0)
-    {
-        SWSS_LOG_ERROR("Cannot get devices by command : %s", cmd.c_str());
-        return;
-    }
+std::vector<std::string> VxlanMgr::parseNetDev(const string& stdout){
+    std::vector<std::string> netdevs;
     std::regex device_name_pattern("^\\d+:\\s+([^:]+)");
     std::smatch match_result;
     auto lines = tokenize(stdout, '\n');
     for (const std::string & line : lines)
     {
-        SWSS_LOG_INFO("line : %s\n",line.c_str());
+        SWSS_LOG_DEBUG("line : %s\n",line.c_str());
         if (!std::regex_search(line, match_result, device_name_pattern))
         {
             continue;
         }
-        std::string vxlan_dev_name = match_result[1];
-        m_vxlanNetDevices[vxlan_dev_name] = vxlan_dev_name;
+        std::string dev_name = match_result[1];
+        netdevs.push_back(dev_name);
     }
+    return netdevs;
+}
+
+void VxlanMgr::getAllVxlanNetDevices()
+{
+    std::string stdout;
+
+    // Get VxLan Netdev Interfaces
+    const std::string cmd = std::string("") + IP_CMD + " link show type vxlan";
+    int ret = swss::exec(cmd, stdout);
+    if (ret != 0)
+    {
+        SWSS_LOG_ERROR("Cannot get vxlan devices by command : %s", cmd.c_str());
+        stdout.clear();
+    }
+    auto netdevs = parseNetDev(stdout);
+    for (auto netdev : netdevs){
+        m_vxlanNetDevices[netdev] = VXLAN;
+    }
+
+    // Get VxLanIf Netdev Interfaces
+    const std::string cmd = std::string("") + IP_CMD + " link show type bridge";
+    int ret = swss::exec(cmd, stdout);
+    if (ret != 0)
+    {
+        SWSS_LOG_ERROR("Cannot get vxlanIf devices by command : %s", cmd.c_str());
+        stdout.clear();
+    }
+    netdevs = parseNetDev(stdout);
+    for (auto netdev : netdevs){
+        if (netdev.find(VXLAN_IF_NAME_PREFIX) == 0)
+        {
+            m_vxlanNetDevices[netdev] = VXLAN_IF;
+        }
+    }
+
     return;
 }
 
@@ -1150,8 +1178,21 @@ void VxlanMgr::clearAllVxlanDevices()
 {
     for (auto it = m_vxlanNetDevices.begin(); it != m_vxlanNetDevices.end();)
     {
-        SWSS_LOG_INFO("Deleting Stale NetDevice vxlandevname %s\n", (it->first).c_str());
-        deleteVxlanNetdevice(it->first);
+        std::string netdev_name = it->first;
+        std::string netdev_type = it->second;
+        SWSS_LOG_INFO("Deleting Stale NetDevice %s, type: %s\n", netdev_name.c_str(), netdev_type.c_str());
+        VxlanInfo info;
+        std::string res;
+        if (netdev_type.compare(VXLAN))
+        {
+            info.m_vxlan = netdev_name;
+            cmdDeleteVxlan(info, res);
+        }
+        else if(netdev_type.compare(VXLAN_IF))
+        {
+            info.m_vxlanIf = netdev_name;
+            cmdDeleteVxlanIf(info, res);
+        }
         it = m_vxlanNetDevices.erase(it);
     }
 }

--- a/cfgmgr/vxlanmgr.cpp
+++ b/cfgmgr/vxlanmgr.cpp
@@ -1062,7 +1062,8 @@ void VxlanMgr::getAllVxlanNetDevices()
         stdout.clear();
     }
     std::vector<std::string> netdevs = parseNetDev(stdout);
-    for (auto netdev : netdevs){
+    for (auto netdev : netdevs)
+    {
         m_vxlanNetDevices[netdev] = VXLAN;
     }
 
@@ -1075,7 +1076,8 @@ void VxlanMgr::getAllVxlanNetDevices()
         stdout.clear();
     }
     netdevs = parseNetDev(stdout);
-    for (auto netdev : netdevs){
+    for (auto netdev : netdevs)
+    {
         if (netdev.find(VXLAN_IF_NAME_PREFIX) == 0)
         {
             m_vxlanNetDevices[netdev] = VXLAN_IF;

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -6,6 +6,7 @@
 #include "orch.h"
 
 #include <map>
+#include <vector>
 #include <memory>
 #include <string>
 #include <utility>
@@ -70,6 +71,7 @@ private:
     int createVxlanNetdevice(std::string vxlanTunnelName, std::string vni_id,
                              std::string src_ip, std::string dst_ip, std::string vlan_id);
     int deleteVxlanNetdevice(std::string vxlan_dev_name);
+    std::vector<std::string> parseNetDev(const string& stdout);
     void getAllVxlanNetDevices();
 
     /*

--- a/cfgmgr/vxlanmgr.h
+++ b/cfgmgr/vxlanmgr.h
@@ -71,7 +71,7 @@ private:
     int createVxlanNetdevice(std::string vxlanTunnelName, std::string vni_id,
                              std::string src_ip, std::string dst_ip, std::string vlan_id);
     int deleteVxlanNetdevice(std::string vxlan_dev_name);
-    std::vector<std::string> parseNetDev(const string& stdout);
+    std::vector<std::string> parseNetDev(const std::string& stdout);
     void getAllVxlanNetDevices();
 
     /*

--- a/tests/test_vxlan_tunnel.py
+++ b/tests/test_vxlan_tunnel.py
@@ -26,6 +26,18 @@ def create_entry_pst(db, table, separator, key, pairs):
     create_entry(tbl, key, pairs)
 
 
+def delete_entry_pst(db, table, key):
+    tbl = swsscommon.ProducerStateTable(db, table)
+    tbl._del(key)
+    time.sleep(1)
+
+
+def delete_entry_tbl(db, table, key):
+    tbl = swsscommon.Table(db, table)
+    tbl._del(key)
+    time.sleep(1)
+
+
 def how_many_entries_exist(db, table):
     tbl =  swsscommon.Table(db, table)
     return len(tbl.getKeys())
@@ -324,46 +336,66 @@ class TestVxlan(object):
         create_vxlan_tunnel_entry(dvs, 'tunnel_4', 'entry_2', tunnel_map_map, 'Vlan57', '857',
                                   tunnel_map_ids, tunnel_map_entry_ids, tunnel_ids, tunnel_term_ids)
 
-def apply_test_vnet_cfg(cfg):
+def apply_test_vnet_cfg(cfg_db):
 
     # create VXLAN Tunnel
-    tbl_tun = swsscommon.Table(cfg_db, "VXLAN_TUNNEL")
-    fvs_tun = swsscommon.FieldValuePairs([("src_ip", "1.1.1.1")])
-    tbl_tun.set("tunnel1", fvs_tun)
+    create_entry_tbl(
+        cfg_db,
+        "VXLAN_TUNNEL", '|', "tunnel1",
+        [
+            ("src_ip", "1.1.1.1")
+        ],
+    )
 
     # create VNET
-    tbl_vnet = swsscommon.Table(cfg_db, "VNET")
-    fvs_vnet = swsscommon.FieldValuePairs([("vxlan_tunnel", "tunnel1"), ("vni", "1")])
-    tbl_vnet.set("Vnet1", fvs_vnet)
+    create_entry_tbl(
+        cfg_db,
+        "VNET", '|', "tunnel1",
+        [
+            ("vxlan_tunnel", "tunnel1"),
+            ("vni", "1")
+        ],
+    )
 
-    return tbl_tun, tbl_vnet
+    return 
 
 
 @pytest.fixture
-def cfg_fixture():
+def env_setup(dvs):
     cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
-    tbl_tun, tbl_vnet = apply_test_vnet_cfg(cfg)
+    app_db = swsscommon.DBConnector(swsscommon.APPL_DB, dvs.redis_sock, 0)
+
+    create_entry_pst(
+        app_db,
+        "SWITCH_TABLE", ':', "switch",
+        [
+            ("vxlan_router_mac", "00:01:02:03:04:05")
+        ],
+    )
+
+    apply_test_vnet_cfg(cfg_db)
 
     yield 
 
-    tbl_tun.del("tunnel1")
-    tbl_vnet.del("Vnet1")
+    delete_entry_pst(app_db, "SWITCH_TABLE", "switch")
+    delete_entry_tbl(cfg_db, "VXLAN_TUNNEL", "tunnel1")
+    delete_entry_tbl(cfg_db, "VNET", "Vnet1")
 
-def test_vnet_cleanup_config_reload(dvs, cfg_fixture):
+def test_vnet_cleanup_config_reload(dvs, env_setup):
 
     # Restart vxlanmgrd Process
     dvs.runcmd(["systemctl", "restart", "vxlanmgrd"])
 
     # Reapply cfg to simulate cfg reload
     cfg_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
-    apply_test_vnet_cfg(cfg)
+    apply_test_vnet_cfg(cfg_db)
 
-    # Check if the vnet device is created as expected
-    stdout = dvs.runcmd_output(["ip", "link", "show", "type", "vxlan"])
-    
+    time.sleep(0.5)
+
+    # Check if the netdevices is created as expected
+    ret, stdout = dvs.runcmd(["ip", "link", "show"])
     assert "Vxlan1" in stdout
-
-    pass
+    assert "Brvxlan1" in stdout
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Fixes https://github.com/Azure/sonic-buildimage/issues/9709

Enhanced the Existing cleanup methods i.e. `getAllVxlanNetDevices` & `clearAllVxlanDevices` to also include any stale Brvxlan interfaces and remove them.

Added a vs-test to simulate the scenario.

**Why I did it**

Config reload with VNET and VxLAN tunnel configuration results in error in syslog "Cannot create vxlan Vxlan1"

```
Jan 6 21:07:10.858785 r-lionfish-16 WARNING swss#vxlanmgrd: :- doVxlanDeleteTask: Vxlan(Vnet Vnet1) hasn't been created
Jan 6 21:07:10.874014 r-lionfish-16 INFO swss#/supervisord: vxlanmgrd RTNETLINK answers: File exists
Jan 6 21:07:10.924868 r-lionfish-16 WARNING swss#vxlanmgrd: :- createVxlan: Fail to create vxlan interface Brvxlan1
Jan 6 21:07:10.924868 r-lionfish-16 ERR swss#vxlanmgrd: :- doVxlanCreateTask: Cannot create vxlan Vxlan1
```

**How I verified it**

```
root@r-sonic-vs-018:~/sonic-swss/tests# pytest --dvsname=vs test_vxlan_tunnel.py
================================================================== test session starts ===================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /root/sonic-swss/tests
plugins: flaky-3.7.0
collected 3 items

test_vxlan_tunnel.py ...                                                                                                                           [100%]
```


**Details if related**
