### PR TITLE
Stale rif counter db removal (fix for #2193)_

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1024,6 +1024,7 @@ bool IntfsOrch::removeRouterIntfs(Port &port)
 
     const auto id = sai_serialize_object_id(port.m_rif_id);
     removeRifFromFlexCounter(id, port.m_alias);
+    cleanUpRifFromCounterDb(id, port.m_alias);
 
     sai_status_t status = sai_router_intfs_api->remove_router_interface(port.m_rif_id);
     if (status != SAI_STATUS_SUCCESS)
@@ -1219,10 +1220,39 @@ void IntfsOrch::removeRifFromFlexCounter(const string &id, const string &name)
     SWSS_LOG_DEBUG("Unregistered interface %s from Flex counter", name.c_str());
 }
 
+void IntfsOrch::cleanUpRifFromCounterDb(const string &id, const string &name)
+{
+    SWSS_LOG_ENTER();
+    string counter_key = getRifCounterTableKey(id);
+    string rate_key = getRifRateTableKey(id);
+    string rate_init_key = getRifRateInitTableKey(id);
+    m_counter_db->del(counter_key);
+    m_counter_db->del(rate_key);
+    m_counter_db->del(rate_init_key);
+    SWSS_LOG_NOTICE("CleanUp interface %s oid %s from counter db", name.c_str(),id.c_str());
+}
+
 string IntfsOrch::getRifFlexCounterTableKey(string key)
 {
     return string(RIF_STAT_COUNTER_FLEX_COUNTER_GROUP) + ":" + key;
 }
+
+string IntfsOrch::getRifCounterTableKey(string key)
+{
+    return "COUNTERS:" + key;
+}
+
+string IntfsOrch::getRifRateTableKey(string key)
+{
+    return "RATES:" + key;
+}
+
+string IntfsOrch::getRifRateInitTableKey(string key)
+{
+    return "RATES:" + key + ":RIF";
+}
+
+
 
 void IntfsOrch::generateInterfaceMap()
 {

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -86,6 +86,10 @@ private:
     unique_ptr<ProducerTable> m_flexCounterGroupTable;
 
     std::string getRifFlexCounterTableKey(std::string s);
+    std::string getRifCounterTableKey(std::string s);
+    std::string getRifRateTableKey(std::string s);
+    std::string getRifRateInitTableKey(std::string s);
+    void cleanUpRifFromCounterDb(const string &id, const string &name);
 
     bool addRouterIntfs(sai_object_id_t vrf_id, Port &port);
     bool removeRouterIntfs(Port &port);


### PR DESCRIPTION
**What I did**
Fix for [https://github.com/Azure/sonic-swss/issues/2193](url)

To handle this , whenever RIF is deleted (removeRouterIntfs) , we ensure that these COUNTER_DB tables are deleted(handled in cleanUpRifFromCounterDb) .

**Why I did it**
In this issue , stale COUNTER_DB table/entries were present even after RIF was deleted.
So cleaning up of such stale tables are needed. 
In the absence of this , if same oid is allocated to a different RIF , we may show stale stats.
Also the COUNTER_DB will keep holding un-necessary tables and this number/used-memory keep growing if there RIFs are deleted . 

**How I verified it**
Before this fix , here is the snapshot of the stale COUNTER_DB tables.
 **a. Before fix , here the steps where problem was seen**

    1. After RIF creation derived info of oid for RIF from "COUNTERS_RIF_NAME_MAP"
          127) "Vlan100"
          128) "oid:0x6000000000ba6"

      2. Checked all the tabled in COUNTER_DB which has same OID in keys
          127.0.0.1:6379[2]> keys *6000000000ba6*
                                    1) "RATES:oid:0x6000000000ba6:RIF"
                                    2) "COUNTERS:oid:0x6000000000ba6"
                                    3) "RATES:oid:0x6000000000ba6"
        127.0.0.1:6379[2]>

      3.  Deleted the RIF by removing the ip on the intf.
      4. Checked COUNTER_DB again with same OID if there are stale entries or not. No stale entries exist now.
          127.0.0.1:6379[2]> keys *6000000000ba6*
                                    1) "RATES:oid:0x6000000000ba6:RIF"
                                    2) "COUNTERS:oid:0x6000000000ba6"
                                    3) "RATES:oid:0x6000000000ba6"
        127.0.0.1:6379[2]>

 **b. After this fix, here are the verification steps**
    
       1. After RIF creation derived info of oid for RIF from "COUNTERS_RIF_NAME_MAP"
          127) "Vlan100"
          128) "oid:0x6000000000ba6"

      2. Checked all the tabled in COUNTER_DB which has same OID in keys
          127.0.0.1:6379[2]> keys *6000000000ba6*
                                    1) "RATES:oid:0x6000000000ba6:RIF"
                                    2) "COUNTERS:oid:0x6000000000ba6"
                                    3) "RATES:oid:0x6000000000ba6"
        127.0.0.1:6379[2]>

      3.  Deleted the RIF by removing the ip on the intf.
      4. Checked COUNTER_DB again with same OID if there are stale entries or not. No stale entries exist now.
         127.0.0.1:6379[2]> keys *6000000000ba6*
                                 (empty array)
         127.0.0.1:6379[2]>

 **Check syslog too to confirm the changes to handle this issue is invoked** 

Jul 14 19:37:37.233767 sonic NOTICE swss#orchagent: :- cleanUpRifFromCounterDb: CleanUp interface Vlan100 oid oid:0x6000000000ba6 from counter db

**Details if related**
