### PR TITLE
[FdbOrch] SAI_FDB_EVENT_MOVE generates update with empty update.entry.port_name

### DIFF
--- a/orchagent/fdborch.cpp
+++ b/orchagent/fdborch.cpp
@@ -345,6 +345,7 @@ void FdbOrch::update(sai_fdb_event_t        type,
         }
 
         update.add = true;
+	update.entry.port_name = update.port.m_alias;
         if (!port_old.m_alias.empty())
         {
             port_old.m_fdb_count--;


### PR DESCRIPTION

It causes incorrect neighbor processing by MuxOrch and results in test_orchagent_mac_move failure.

**What I did**
Assigned port.m_alias to entry.port_name 

**Why I did it**
In MuxOrch::updateFdb, there are decisions and assignments done based on this field.

**How I verified it**
test_orchagent_mac_move that was failing without this change, started passing

**Details if related**
