### PR TITLE
[202012] [vxlan] Remove tunnel map objects on VNET tunnel removal

### DIFF
--- a/orchagent/vxlanorch.cpp
+++ b/orchagent/vxlanorch.cpp
@@ -1325,27 +1325,12 @@ bool VxlanTunnelOrch::removeVxlanTunnelMap(string tunnelName, uint32_t vni)
     tunnel_obj->vlan_vrf_vni_count--;
     if (tunnel_obj->vlan_vrf_vni_count == 0)
     {
-        auto tunnel_term_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelTermId();
-        try
-        {
-            remove_tunnel_termination(tunnel_term_id);
-        }
-        catch(const std::runtime_error& error)
-        {
-            SWSS_LOG_ERROR("Error removing tunnel term entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
-            return false;
-        }
- 
-        auto tunnel_id = vxlan_tunnel_table_[tunnelName].get()->getTunnelId();
-        try
-        {
-            remove_tunnel(tunnel_id);
-        }
-        catch(const std::runtime_error& error)
-        {
-            SWSS_LOG_ERROR("Error removing tunnel entry. Tunnel: %s. Error: %s", tunnelName.c_str(), error.what());
-            return false;
-        }
+       uint8_t mapper_list = 0;
+
+       TUNNELMAP_SET_VLAN(mapper_list);
+       TUNNELMAP_SET_VRF(mapper_list);
+
+       tunnel_obj->deleteTunnelHw(mapper_list, TUNNEL_MAP_USE_DEDICATED_ENCAP_DECAP);
     }
 
     SWSS_LOG_NOTICE("Vxlan map entry deleted for tunnel '%s' with vni '%d'", tunnelName.c_str(), vni);

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -362,6 +362,9 @@ def create_vxlan_tunnel(dvs, name, src_ip):
         attrs,
     )
 
+def delete_vxlan_tunnel(dvs, name):
+    conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
+    delete_entry_tbl(conf_db, "VXLAN_TUNNEL", name)
 
 def create_vxlan_tunnel_map(dvs, tunnel_name, tunnel_map_entry_name, vlan, vni_id):
     conf_db = swsscommon.DBConnector(swsscommon.CONFIG_DB, dvs.redis_sock, 0)
@@ -619,6 +622,18 @@ class VnetVxlanVrfTunnel(object):
         self.tunnel_term_ids.add(tunnel_term_id)
         self.tunnel_map_map[tunnel_name] = tunnel_map_id
         self.tunnel[tunnel_name] = tunnel_id
+
+    def check_del_vxlan_tunnel(self, dvs):
+        asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
+
+        old_tunnel = get_deleted_entries(asic_db, self.ASIC_TUNNEL_TABLE, self.tunnel_ids, 1)
+        check_deleted_object(asic_db, self.ASIC_TUNNEL_TABLE, old_tunnel[0])
+        self.tunnel_ids.remove(old_tunnel[0])
+
+        old_tunnel_maps = get_deleted_entries(asic_db, self.ASIC_TUNNEL_MAP, self.tunnel_map_ids, 4)
+        for old_tunnel_map in old_tunnel_maps:
+            check_deleted_object(asic_db, self.ASIC_TUNNEL_MAP, old_tunnel_map)
+            self.tunnel_map_ids.remove(old_tunnel_map)
 
     def check_vxlan_tunnel_entry(self, dvs, tunnel_name, vnet_name, vni_id):
         asic_db = swsscommon.DBConnector(swsscommon.ASIC_DB, dvs.redis_sock, 0)
@@ -1014,6 +1029,9 @@ class TestVnetOrch(object):
         delete_vnet_entry(dvs, 'Vnet_2000')
         vnet_obj.check_del_vnet_entry(dvs, 'Vnet_2000')
 
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
+
     '''
     Test 2 - Two VNets, One HSMs per VNet
     '''
@@ -1140,6 +1158,9 @@ class TestVnetOrch(object):
         delete_vnet_entry(dvs, 'Vnet_2')
         vnet_obj.check_del_vnet_entry(dvs, 'Vnet_2')
 
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
+
     '''
     Test 3 - Two VNets, One HSMs per VNet, Peering
     '''
@@ -1219,6 +1240,9 @@ class TestVnetOrch(object):
 
         delete_vnet_entry(dvs, 'Vnet_20')
         vnet_obj.check_del_vnet_entry(dvs, 'Vnet_20')
+
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
 
     '''
     Test 4 - IPv6 Vxlan tunnel test
@@ -1360,6 +1384,9 @@ class TestVnetOrch(object):
 
         delete_vnet_entry(dvs, 'Vnet3001')
         vnet_obj.check_del_vnet_entry(dvs, 'Vnet3001')
+
+        delete_vxlan_tunnel(dvs, tunnel_name)
+        vnet_obj.check_del_vxlan_tunnel(dvs)
 
     '''
     Test 5 - Default VNet test


### PR DESCRIPTION
Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

### Porting changes in PR https://github.com/Azure/sonic-swss/pull/2150 to ```202012``` branch.

**What I did**

* VxLAN tunnel map objects were not removed on VNET tunnel removal.
* It caused config lefovers which is not expected.
* If tunnel is removed then all related objects should be removed as well.
* To do so just used deleteTunnelHw() function which does proper remove.

**Why I did it**

To cleanup config leftovers after VNET tunnel removal.

**How I verified it**
* Configure 2 VNETs and then remove them one by one.
* Verify that after 1st VNET removed tunnel and all related objects still exist.
* Verify that after 2nd (last) VNET removed tunnel and all related objects are removed.

**Details if related**
N/A