### PR TITLE
[vlanmgrd] fix use-after-free memory issue

### DIFF
--- a/cfgmgr/vlanmgr.cpp
+++ b/cfgmgr/vlanmgr.cpp
@@ -330,10 +330,10 @@ void VlanMgr::doVlanTask(Consumer &consumer)
              */
             if (isVlanStateOk(key) && m_vlans.find(key) == m_vlans.end())
             {
+                SWSS_LOG_DEBUG("%s already created", kfvKey(t).c_str());
                 m_vlans.insert(key);
                 m_vlanReplay.erase(kfvKey(t));
                 it = consumer.m_toSync.erase(it);
-                SWSS_LOG_DEBUG("%s already created", kfvKey(t).c_str());
                 continue;
             }
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Reordered the code so the reference to a deleted object (t) is not used
This was found via ASAN<details><summary>ASAN log</summary>
```
=================================================================
==1269==ERROR: AddressSanitizer: heap-use-after-free on address 0x60e000000518 at pc 0x5557cf441fb8 bp 0x7ffdfbd0fea0 sp 0x7ffdfbd0fe98
READ of size 8 at 0x60e000000518 thread T0
    #0 0x5557cf441fb7 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::c_str() const /usr/include/c++/8/bits/basic_string.h:2291
    #1 0x5557cf441fb7 in swss::VlanMgr::doVlanTask(Consumer&) cfgmgr/vlanmgr.cpp:336
    #2 0x5557cf4456c6 in swss::VlanMgr::doTask(Consumer&) cfgmgr/vlanmgr.cpp:686
    #3 0x5557cf4b4e76 in Consumer::execute() ../orchagent/orch.cpp:235
    #4 0x5557cf421e1d in main cfgmgr/vlanmgrd.cpp:132
    #5 0x7f6d5203109a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)
    #6 0x5557cf427b49  (/usr/bin/vlanmgrd+0x2ab49)

0x60e000000518 is located 120 bytes inside of 152-byte region [0x60e0000004a0,0x60e000000538)
freed by thread T0 here:
    #0 0x7f6d52aa0aa0 in operator delete(void*) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xebaa0)
    #1 0x5557cf449782 in __gnu_cxx::new_allocator<std::_Rb_tree_node<) /usr/include/c++/8/ext/new_allocator.h:125
    #2 0x5557cf449782 in std::allocator_traits<std::allocator<std::_Rb_tree_node<) /usr/include/c++/8/bits/alloc_traits.h:462
    #3 0x5557cf449782 in std::_Rb_tree<std::__cxx11::basic_string<char, ) /usr/include/c++/8/bits/stl_tree.h:603
    #4 0x5557cf449782 in std::_Rb_tree<std::__cxx11::basic_string<char, ) /usr/include/c++/8/bits/stl_tree.h:670
    #5 0x5557cf449782 in std::_Rb_tree<std::__cxx11::basic_string<char, ) /usr/include/c++/8/bits/stl_tree.h:2493
    #6 0x5557cf449782 in std::_Rb_tree<std::__cxx11::basic_string<char, ) /usr/include/c++/8/bits/stl_tree.h:1141
    #7 0x5557cf4413ad in std::multimap<std::__cxx11::basic_string<char, ) /usr/include/c++/8/bits/stl_multimap.h:707
    #8 0x5557cf4413ad in swss::VlanMgr::doVlanTask(Consumer&) cfgmgr/vlanmgr.cpp:335
    #9 0x5557cf4456c6 in swss::VlanMgr::doTask(Consumer&) cfgmgr/vlanmgr.cpp:686
    #10 0x5557cf4b4e76 in Consumer::execute() ../orchagent/orch.cpp:235
    #11 0x5557cf421e1d in main cfgmgr/vlanmgrd.cpp:132
    #12 0x7f6d5203109a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

previously allocated by thread T0 here:
    #0 0x7f6d52a9fd30 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xead30)
    #1 0x5557cf4ca9d3 in __gnu_cxx::new_allocator<std::_Rb_tree_node<std::pair<) /usr/include/c++/8/ext/new_allocator.h:111
    #2 0x5557cf4ca9d3 in std::allocator_traits<std::allocator<std::_Rb_tree_node<) /usr/include/c++/8/bits/alloc_traits.h:436
    #3 0x5557cf4ca9d3 in std::_Rb_tree<std::__cxx11::basic_string<>::_M_get_node() /usr/include/c++/8/bits/stl_tree.h:599
    #4 0x5557cf4ca9d3 in std::_Rb_tree_node<std::pair<> const&) /usr/include/c++/8/bits/stl_tree.h:653
    #5 0x5557cf4ca9d3 in std::_Rb_tree_iterator<std::pair<&) /usr/include/c++/8/bits/stl_tree.h:2393
    #6 0x5557cf4b03e3 in std::_Rb_tree_iterator<std::pair<> const&) /usr/include/c++/8/bits/stl_multimap.h:490
    #7 0x5557cf4b03e3 in Consumer::addToSync(std::tuple<> const&) ../orchagent/orch.cpp:96
    #8 0x5557cf4b1acf in Consumer::addToSync(std::deque<>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>...) ../orchagent/orch.cpp:166
    #9 0x5557cf4b4471 in Consumer::execute() ../orchagent/orch.cpp:232
    #10 0x5557cf421e1d in main cfgmgr/vlanmgrd.cpp:132
    #11 0x7f6d5203109a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)

SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/c++/8/bits/basic_string.h:2291 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::c_str() const
Shadow bytes around the buggy address:
  0x0c1c7fff8050: fd fd fd fd fa fa fa fa fa fa fa fa 00 00 00 00
  0x0c1c7fff8060: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 fa
  0x0c1c7fff8070: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x0c1c7fff8080: 00 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fa
  0x0c1c7fff8090: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
=>0x0c1c7fff80a0: fd fd fd[fd]fd fd fd fa fa fa fa fa fa fa fa fa
  0x0c1c7fff80b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1c7fff80c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1c7fff80d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1c7fff80e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c1c7fff80f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1269==ABORTING

```
</details>

**Why I did it**
To fix the "use-after-free" memory usage issue

**How I verified it**
Run a test that was used to find the issue and checked the ASAN report

**Details if related**
Depends on: https://github.com/Azure/sonic-swss/pull/2186