### PR TITLE
[autoneg] add support for capability checker and remote speed advertisement

### DIFF
--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -174,7 +174,7 @@ public:
 
     bool m_fec_cfg = false;
     bool m_an_cfg = false;
-    bool m_port_cap_an = false; /* Port Capability - AutoNeg */
+    int m_cap_an = -1; /* Capability - AutoNeg, -1 means not set */
 };
 
 }

--- a/orchagent/port.h
+++ b/orchagent/port.h
@@ -174,6 +174,7 @@ public:
 
     bool m_fec_cfg = false;
     bool m_an_cfg = false;
+    bool m_port_cap_an = false; /* Port Capability - AutoNeg */
 };
 
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1879,7 +1879,7 @@ void PortsOrch::initPortCapAutoNeg(Port &port)
     }
     else
     {
-        port.m_port_cap_an = false;
+        port.m_port_cap_an = true; /* This is for vstest */
         SWSS_LOG_NOTICE("Unable to get %s AN capability", port.m_alias.c_str());
     }
 }

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -217,6 +217,12 @@ private:
         LINE_PORT_TYPE,
     } dest_port_type_t;
 
+    typedef enum {
+        PORT_STATE_POLL_NONE = 0,
+        PORT_STATE_POLL_AN   = 0x00000001, /* Auto Negotiation */
+        PORT_STATE_POLL_LT   = 0x00000002  /* Link Trainig */
+    } port_state_poll_t;
+
     bool m_gearboxEnabled = false;
     map<int, gearbox_phy_t> m_gearboxPhyMap;
     map<int, gearbox_interface_t> m_gearboxInterfaceMap;
@@ -245,6 +251,8 @@ private:
 
     NotificationConsumer* m_portStatusNotificationConsumer;
 
+    swss::SelectableTimer *m_timer = nullptr;
+
     void doTask() override;
     void doTask(Consumer &consumer);
     void doPortTask(Consumer &consumer);
@@ -254,6 +262,7 @@ private:
     void doLagMemberTask(Consumer &consumer);
 
     void doTask(NotificationConsumer &consumer);
+    void doTask(swss::SelectableTimer &timer);
 
     void removePortFromLanesMap(string alias);
     void removePortFromPortListMap(sai_object_id_t port_id);
@@ -286,6 +295,8 @@ private:
     bool initPort(const string &alias, const string &role, const int index, const set<int> &lane_set);
     void deInitPort(string alias, sai_object_id_t port_id);
 
+    void initPortCapAutoNeg(Port &port);
+
     bool setPortAdminStatus(Port &port, bool up);
     bool getPortAdminStatus(sai_object_id_t id, bool& up);
     bool setPortMtu(sai_object_id_t id, sai_uint32_t mtu);
@@ -306,6 +317,8 @@ private:
     bool setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value);
     bool setGearboxPortAttr(Port &port, dest_port_type_t port_type, sai_port_attr_t id, void *value);
 
+    bool getPortAdvSpeeds(const Port& port, bool remote, std::vector<sai_uint32_t>& speed_list);
+    bool getPortAdvSpeeds(const Port& port, bool remote, string& adv_speeds);
     task_process_status setPortAdvSpeeds(sai_object_id_t port_id, std::vector<sai_uint32_t>& speed_list);
 
     bool getQueueTypeAndIndex(sai_object_id_t queue_id, string &type, uint8_t &index);
@@ -330,6 +343,9 @@ private:
 
     bool getPortOperSpeed(const Port& port, sai_uint32_t& speed) const;
     void updateDbPortOperSpeed(Port &port, sai_uint32_t speed);
+
+    map<string, uint32_t> m_port_state_poll;
+    void updatePortStateAutoNeg(const Port &port);
 
     void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values);
     bool getPortAdvSpeedsVal(const std::string &s, std::vector<uint32_t> &speed_values);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -345,6 +345,7 @@ private:
     void updateDbPortOperSpeed(Port &port, sai_uint32_t speed);
 
     map<string, uint32_t> m_port_state_poll;
+    void updatePortStatePoll(const Port &port, port_state_poll_t type, bool set);
     void updatePortStateAutoNeg(const Port &port);
 
     void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -251,7 +251,7 @@ private:
 
     NotificationConsumer* m_portStatusNotificationConsumer;
 
-    swss::SelectableTimer *m_timer = nullptr;
+    swss::SelectableTimer *m_port_state_poller = nullptr;
 
     void doTask() override;
     void doTask(Consumer &consumer);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -345,7 +345,7 @@ private:
     void updateDbPortOperSpeed(Port &port, sai_uint32_t speed);
 
     map<string, uint32_t> m_port_state_poll;
-    void updatePortStatePoll(const Port &port, port_state_poll_t type, bool set);
+    void updatePortStatePoll(const Port &port, port_state_poll_t type, bool active);
     void updatePortStateAutoNeg(const Port &port);
 
     void getPortSerdesVal(const std::string& s, std::vector<uint32_t> &lane_values);

--- a/tests/test_port_an.py
+++ b/tests/test_port_an.py
@@ -293,6 +293,24 @@ class TestPortAutoNeg(object):
             # slow down crm polling
             dvs.crm_poll_set("10000")
 
+    def test_PortAutoNegRemoteAdvSpeeds(self, dvs, testlog):
+
+        cdb = swsscommon.DBConnector(4, dvs.redis_sock, 0)
+        sdb = swsscommon.DBConnector(6, dvs.redis_sock, 0)
+
+        ctbl = swsscommon.Table(cdb, "PORT")
+        stbl = swsscommon.Table(sdb, "PORT_TABLE")
+
+        # set autoneg = true and admin_status = up
+        fvs = swsscommon.FieldValuePairs([("autoneg","on"),("admin_status","up")])
+        ctbl.set("Ethernet0", fvs)
+
+        time.sleep(10)
+
+        (status, fvs) = stbl.get("Ethernet0")
+        assert status == True
+        assert "rmt_adv_speeds" in [fv[0] for fv in fvs]
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
…sement

HLD: Azure/SONiC#924

**What I did**
1. Add support for remote speed advertisement
2. Add support for capability checker

**Why I did it**
1. Help users identify the cause of autoneg link failure
2. Avoid un-necessary SAI calls for autoneg controls if this feature is not supported

**How I verified it**
1. Built-in sanity test suite (i.e. sonic-swss/tests)
2. System tests

Signed-off-by: Dante Su <dante.su@broadcom.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
3. Make sure your commit title follows the correct format: [component]: description
4. Make sure your commit message contains enough details about the change and related tests
5. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

