### PR TITLE
Update netlink messages handler

### DIFF
--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -212,9 +212,8 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
-    /* If netlink for this port has master, we ignore that for now
-     * This could be the case where the port was removed from VLAN bridge
-     */
+    /* Ignore DELLINK message if port has master, this is applicable to
+     * the case where port was part of VLAN bridge or LAG */
     if (master && nlmsg_type == RTM_DELLINK)
     {
         return;

--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -4,7 +4,6 @@
 #include <sys/socket.h>
 #include <linux/if.h>
 #include <netlink/route/link.h>
-#include <netlink/route/link/bridge.h>
 #include "logger.h"
 #include "netmsg.h"
 #include "dbconnector.h"

--- a/portsyncd/linksync.cpp
+++ b/portsyncd/linksync.cpp
@@ -213,18 +213,12 @@ void LinkSync::onMsg(int nlmsg_type, struct nl_object *obj)
         return;
     }
 
-    /* Ignore netlink on interfaces belong to VLAN bridge */
-    if (master)
+    /* If netlink for this port has master, we ignore that for now
+     * This could be the case where the port was removed from VLAN bridge
+     */
+    if (master && nlmsg_type == RTM_DELLINK)
     {
-        LinkCache &linkCache = LinkCache::getInstance();
-        string masterName = linkCache.ifindexToName(master);
-        struct rtnl_link *masterLink = linkCache.getLinkByName(masterName.c_str());
-        bool isBridge = rtnl_link_is_bridge(masterLink);
-
-        if(isBridge)
-        {
-            return;
-        }
+        return;
     }
 
     /* In the event of swss restart, it is possible to get netlink messages during bridge


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Ignore netlink DELLINK messages if port has master, this is applicable to the case where port was part of VLAN bridge or LAG.

**Why I did it**
Netlink messages handler in portsyncd was ignoring all messages that had master.
Therefore we ignored messages on interfaces that belong to LAG (not only interfaces belong to bridge as intended).
The result was "netdev_oper_status" down in PORT_TABLE in state DB for port which is part of LAG although it is actually up.

**How I verified it**
Check "netdev_oper_status" in PORT_TABLE in state DB for port which is part of LAG.

**Details if related**
