### PR TITLE
Fix issues in dynamic buffer in rare scenario after "config qos clear"

### DIFF
--- a/cfgmgr/buffermgrdyn.h
+++ b/cfgmgr/buffermgrdyn.h
@@ -71,6 +71,7 @@ typedef struct {
     std::string xon_offset;
     std::string xoff;
     std::string threshold;
+    std::string threshold_mode;
     std::string pool_name;
     // port_pgs - stores pgs referencing this profile
     // An element will be added or removed when a PG added or removed


### PR DESCRIPTION
1. Do not generate dynamic lossless buffer profiles in case default_dynamic_th is not ready.
2. For non-dynamic lossless buffer profiles
  - record threshold mode from CONFIG_DB
  - do not apply if the threshold mode doesn't aligh with buffer pool
3. Remove an item from m_toSync on failure

Signed-off-by: Stephen Sun <stephens@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

**Why I did it**

**How I verified it**

**Details if related**
