### PR TITLE
Removing Vnet with scope default

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -309,7 +309,7 @@ VNetVrfObject::~VNetVrfObject()
     set<sai_object_id_t> vr_ent = getVRids();
     for (auto it : vr_ent)
     {
-        if it != gVirtualRouterId {
+        if (it != gVirtualRouterId) {
             sai_status_t status = sai_virtual_router_api->remove_virtual_router(it);
             if (status != SAI_STATUS_SUCCESS)
             {

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -309,7 +309,8 @@ VNetVrfObject::~VNetVrfObject()
     set<sai_object_id_t> vr_ent = getVRids();
     for (auto it : vr_ent)
     {
-        if (it != gVirtualRouterId) {
+        if (it != gVirtualRouterId) 
+        {
             sai_status_t status = sai_virtual_router_api->remove_virtual_router(it);
             if (status != SAI_STATUS_SUCCESS)
             {

--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -309,11 +309,13 @@ VNetVrfObject::~VNetVrfObject()
     set<sai_object_id_t> vr_ent = getVRids();
     for (auto it : vr_ent)
     {
-        sai_status_t status = sai_virtual_router_api->remove_virtual_router(it);
-        if (status != SAI_STATUS_SUCCESS)
-        {
-            SWSS_LOG_ERROR("Failed to remove virtual router name: %s, rv:%d",
-                            vnet_name_.c_str(), status);
+        if it != gVirtualRouterId {
+            sai_status_t status = sai_virtual_router_api->remove_virtual_router(it);
+            if (status != SAI_STATUS_SUCCESS)
+            {
+                SWSS_LOG_ERROR("Failed to remove virtual router name: %s, rv:%d",
+                                vnet_name_.c_str(), status);
+            }
         }
     }
 

--- a/tests/test_vnet.py
+++ b/tests/test_vnet.py
@@ -1439,6 +1439,9 @@ class TestVnetOrch(object):
         vnet_obj.check_default_vnet_entry(dvs, 'Vnet_5')
         vnet_obj.check_vxlan_tunnel_entry(dvs, tunnel_name, 'Vnet_5', '4789')
 
+        delete_vnet_entry(dvs, 'Vnet_5')
+        vnet_obj.check_default_vnet_entry(dvs, 'Vnet_5')
+
     '''
     Test 6 - Test VxLAN tunnel with multiple maps
     '''


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
If VirtualRouter ID is the default value, then don' remove it.  
**Why I did it**
When removing Vnet with scope `default`, we need not remove the Vrf object if it is of default value.
**How I verified it**
Added tests to verify it
**Details if related**
