### PR TITLE
Change DBConnector("CONFIG_DB") to const type

### DIFF
--- a/cfgmgr/buffermgrd.cpp
+++ b/cfgmgr/buffermgrd.cpp
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
         shared_ptr<vector<KeyOpFieldsValuesTuple>> peripherial_table_ptr = nullptr;
         shared_ptr<vector<KeyOpFieldsValuesTuple>> zero_profiles_ptr = nullptr;
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
         DBConnector applDb("APPL_DB", 0);
 

--- a/cfgmgr/coppmgrd.cpp
+++ b/cfgmgr/coppmgrd.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
         WarmStart::initialize("coppmgrd", "swss");
         WarmStart::checkWarmStart("coppmgrd", "swss");
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/cfgmgr/intfmgrd.cpp
+++ b/cfgmgr/intfmgrd.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
             CFG_VOQ_INBAND_INTERFACE_TABLE_NAME,
         };
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/cfgmgr/macsecmgrd.cpp
+++ b/cfgmgr/macsecmgrd.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv)
         Logger::linkToDbNative("macsecmgrd");
         SWSS_LOG_NOTICE("--- Starting macsecmgrd ---");
 
-        swss::DBConnector cfgDb("CONFIG_DB", 0);
+        const swss::DBConnector cfgDb("CONFIG_DB", 0);
         swss::DBConnector stateDb("STATE_DB", 0);
 
         std::vector<std::string> cfg_macsec_tables = {

--- a/cfgmgr/natmgrd.cpp
+++ b/cfgmgr/natmgrd.cpp
@@ -123,7 +123,7 @@ int main(int argc, char **argv)
             CFG_ACL_RULE_TABLE_NAME
         };
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/cfgmgr/nbrmgrd.cpp
+++ b/cfgmgr/nbrmgrd.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
             CFG_NEIGH_TABLE_NAME,
         };
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/cfgmgr/portmgrd.cpp
+++ b/cfgmgr/portmgrd.cpp
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
             CFG_PORT_TABLE_NAME,
         };
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/cfgmgr/sflowmgrd.cpp
+++ b/cfgmgr/sflowmgrd.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
             CFG_PORT_TABLE_NAME
         };
 
-        conts DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
 
         SflowMgr sflowmgr(&cfgDb, &appDb, cfg_sflow_tables);

--- a/cfgmgr/sflowmgrd.cpp
+++ b/cfgmgr/sflowmgrd.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv)
             CFG_PORT_TABLE_NAME
         };
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        conts DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
 
         SflowMgr sflowmgr(&cfgDb, &appDb, cfg_sflow_tables);

--- a/cfgmgr/tunnelmgrd.cpp
+++ b/cfgmgr/tunnelmgrd.cpp
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
             CFG_LOOPBACK_INTERFACE_TABLE_NAME
         };
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
 
         WarmStart::initialize("tunnelmgrd", "swss");

--- a/cfgmgr/vlanmgrd.cpp
+++ b/cfgmgr/vlanmgrd.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
             CFG_VLAN_MEMBER_TABLE_NAME,
         };
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
             CFG_MGMT_VRF_CONFIG_TABLE_NAME
         };
 
-        conts DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/cfgmgr/vrfmgrd.cpp
+++ b/cfgmgr/vrfmgrd.cpp
@@ -53,7 +53,7 @@ int main(int argc, char **argv)
             CFG_MGMT_VRF_CONFIG_TABLE_NAME
         };
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        conts DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/cfgmgr/vxlanmgrd.cpp
+++ b/cfgmgr/vxlanmgrd.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
     try
     {
 
-        DBConnector cfgDb("CONFIG_DB", 0);
+        const DBConnector cfgDb("CONFIG_DB", 0);
         DBConnector appDb("APPL_DB", 0);
         DBConnector stateDb("STATE_DB", 0);
 

--- a/gearsyncd/gearsyncd.cpp
+++ b/gearsyncd/gearsyncd.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
         }
     }
 
-    DBConnector cfgDb(CONFIG_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
+    const DBConnector cfgDb(CONFIG_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     DBConnector applDb(APPL_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
     ProducerStateTable producerStateTable(&applDb, APP_GEARBOX_TABLE_NAME);
 

--- a/neighsyncd/neighsyncd.cpp
+++ b/neighsyncd/neighsyncd.cpp
@@ -18,7 +18,7 @@ int main(int argc, char **argv)
     DBConnector appDb("APPL_DB", 0);
     RedisPipeline pipelineAppDB(&appDb);
     DBConnector stateDb("STATE_DB", 0);
-    DBConnector cfgDb("CONFIG_DB", 0);
+    const DBConnector cfgDb("CONFIG_DB", 0);
 
     NeighSync sync(&pipelineAppDB, &stateDb, &cfgDb);
 

--- a/portsyncd/portsyncd.cpp
+++ b/portsyncd/portsyncd.cpp
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
         }
     }
 
-    DBConnector cfgDb("CONFIG_DB", 0);
+    const DBConnector cfgDb("CONFIG_DB", 0);
     DBConnector appl_db("APPL_DB", 0);
     DBConnector state_db("STATE_DB", 0);
     ProducerStateTable p(&appl_db, APP_PORT_TABLE_NAME);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Change DBConnector("CONFIG_DB") to const type
**Why I did it**
Ensure that C++ only has read only operations to CONFIG_DB.
Ensuring C++ has no write operations to CONFIG_DB helps define the project scope for YANG config db validation, so we can ensure that all relevant write operations to CONFIG_DB are in python
**How I verified it**

**Details if related**
