### PR TITLE
[macsecorch]: Support for non-default sa per sc

### DIFF
--- a/orchagent/macsecorch.h
+++ b/orchagent/macsecorch.h
@@ -110,6 +110,7 @@ private:
         sai_object_id_t                                 m_ingress_id;
         map<std::string, std::shared_ptr<MACsecPort> >  m_macsec_ports;
         bool                                            m_sci_in_ingress_macsec_acl;
+        sai_uint8_t                                     m_max_sa_per_sc;
     };
     map<sai_object_id_t, MACsecObject>              m_macsec_objs;
     map<std::string, std::shared_ptr<MACsecPort> >  m_macsec_ports;


### PR DESCRIPTION
**What I did**
Taught MacsecOrch to use the SAI_MACSEC_ATTR_MAX_SECURE_ASSOCIATIONS_PER_SC attribute added in
https://github.com/opencomputeproject/SAI/pull/1420

**Why I did it**
To support SAI_MACSEC_ATTR_MAX_SECURE_ASSOCIATIONS_PER_SC in MacsecOrch.

**How I verified it**
The changes have no impact until SAI_MACSEC_ATTR_MAX_SECURE_ASSOCIATIONS_PER_SC is supported by the platform.

**Details**
Cache the the result of SAI_MACSEC_ATTR_MAX_SECURE_ASSOCIATIONS_PER_SC in MACsecObject.m_max_sa_per_sc.
Set STATE_DB MACSEC_PORT_TABLE's max_sa_per_sc to the value cached in MACsecObject.m_max_sa_per_sc in createMACsecPort.
