### PR TITLE
Retry the creation of decap tunnel if dependant QoS map is not ready

### DIFF
--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -1995,3 +1995,21 @@ sai_object_id_t QosOrch::resolveTunnelQosMap(std::string referencing_table_name,
         return SAI_NULL_OBJECT_ID;
     }
 }
+
+/**
+ * Function Description:
+ *    @brief Remove the reference from tunnel object. Called after tunnel is removed
+ *
+ * Arguments:
+ *    @param[in] referencing_table_name - The name of table that is referencing the QoS map
+ *    @param[in] tunnle_name - The name of tunnel
+ *
+ * Return Values:
+ *    @return no return
+ */
+void QosOrch::removeTunnelReference(std::string referencing_table_name, std::string tunnel_name)
+{
+    removeObject(m_qos_maps, referencing_table_name, tunnel_name);
+    SWSS_LOG_INFO("Freed QoS objects referenced by %s:%s", referencing_table_name.c_str(), tunnel_name.c_str());
+}
+

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -169,6 +169,7 @@ public:
     static type_map m_qos_maps;
 
     sai_object_id_t resolveTunnelQosMap(std::string referencing_table_name, std::string tunnel_name, std::string map_type_name, KeyOpFieldsValuesTuple& tuple);
+    void removeTunnelReference(std::string referencing_table_name, std::string tunnel_name);
 private:
     void doTask() override;
     virtual void doTask(Consumer& consumer);

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -50,13 +50,13 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
         string ecn_mode;
         string encap_ecn_mode;
         string ttl_mode;
-        sai_object_id_t dscp_to_dc_map_id = SAI_NULL_OBJECT_ID;
+        sai_object_id_t dscp_to_tc_map_id = SAI_NULL_OBJECT_ID;
         sai_object_id_t tc_to_pg_map_id = SAI_NULL_OBJECT_ID;
         // The tc_to_dscp_map_id and tc_to_queue_map_id are parsed here for muxorch to retrieve
         sai_object_id_t tc_to_dscp_map_id = SAI_NULL_OBJECT_ID;
         sai_object_id_t tc_to_queue_map_id = SAI_NULL_OBJECT_ID;
 
-        bool valid = true;
+        task_process_status task_status = task_process_status::task_success;
 
         sai_object_id_t tunnel_id = SAI_NULL_OBJECT_ID;
 
@@ -78,7 +78,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (tunnel_type != "IPINIP")
                     {
                         SWSS_LOG_ERROR("Invalid tunnel type %s", tunnel_type.c_str());
-                        valid = false;
+                        task_status = task_process_status::task_invalid_entry;
                         break;
                     }
                 }
@@ -91,7 +91,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     catch (const std::invalid_argument &e)
                     {
                         SWSS_LOG_ERROR("%s", e.what());
-                        valid = false;
+                        task_status = task_process_status::task_invalid_entry;
                         break;
                     }
                     if (exists)
@@ -109,7 +109,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     catch (const std::invalid_argument &e)
                     {
                         SWSS_LOG_ERROR("%s", e.what());
-                        valid = false;
+                        task_status = task_process_status::task_invalid_entry;
                         break;
                     }
                     if (exists)
@@ -123,7 +123,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (dscp_mode != "uniform" && dscp_mode != "pipe")
                     {
                         SWSS_LOG_ERROR("Invalid dscp mode %s\n", dscp_mode.c_str());
-                        valid = false;
+                        task_status = task_process_status::task_invalid_entry;
                         break;
                     }
                     if (exists)
@@ -138,7 +138,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (ecn_mode != "copy_from_outer" && ecn_mode != "standard")
                     {
                         SWSS_LOG_ERROR("Invalid ecn mode %s\n", ecn_mode.c_str());
-                        valid = false;
+                        task_status = task_process_status::task_invalid_entry;
                         break;
                     }
                     if (exists)
@@ -152,7 +152,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (encap_ecn_mode != "standard")
                     {
                         SWSS_LOG_ERROR("Only standard encap ecn mode is supported currently %s\n", ecn_mode.c_str());
-                        valid = false;
+                        task_status = task_process_status::task_invalid_entry;
                         break;
                     }
                     if (exists)
@@ -166,7 +166,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (ttl_mode != "uniform" && ttl_mode != "pipe")
                     {
                         SWSS_LOG_ERROR("Invalid ttl mode %s\n", ttl_mode.c_str());
-                        valid = false;
+                        task_status = task_process_status::task_invalid_entry;
                         break;
                     }
                     if (exists)
@@ -176,15 +176,27 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                 }
                 else if (fvField(i) == decap_dscp_to_tc_field_name)
                 {
-                    dscp_to_dc_map_id = gQosOrch->resolveTunnelQosMap(table_name, key, decap_dscp_to_tc_field_name, t); 
-                    if (exists && dscp_to_dc_map_id != SAI_NULL_OBJECT_ID)
+                    dscp_to_tc_map_id = gQosOrch->resolveTunnelQosMap(table_name, key, decap_dscp_to_tc_field_name, t);
+                    if (dscp_to_tc_map_id == SAI_NULL_OBJECT_ID)
                     {
-                        setTunnelAttribute(fvField(i), dscp_to_dc_map_id, tunnel_id);
+                        SWSS_LOG_NOTICE("QoS map %s is not ready yet", decap_dscp_to_tc_field_name.c_str());
+                        task_status = task_process_status::task_need_retry;
+                        break;
+                    }
+                    if (exists && dscp_to_tc_map_id != SAI_NULL_OBJECT_ID)
+                    {
+                        setTunnelAttribute(fvField(i), dscp_to_tc_map_id, tunnel_id);
                     }
                 }
                 else if (fvField(i) == decap_tc_to_pg_field_name)
                 {
-                    tc_to_pg_map_id = gQosOrch->resolveTunnelQosMap(table_name, key, decap_tc_to_pg_field_name, t); 
+                    tc_to_pg_map_id = gQosOrch->resolveTunnelQosMap(table_name, key, decap_tc_to_pg_field_name, t);
+                    if (tc_to_pg_map_id == SAI_NULL_OBJECT_ID)
+                    {
+                        SWSS_LOG_NOTICE("QoS map %s is not ready yet", decap_tc_to_pg_field_name.c_str());
+                        task_status = task_process_status::task_need_retry;
+                        break;
+                    }
                     if (exists && tc_to_pg_map_id != SAI_NULL_OBJECT_ID)
                     {
                         setTunnelAttribute(fvField(i), tc_to_pg_map_id, tunnel_id);
@@ -193,6 +205,12 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                 else if (fvField(i) == encap_tc_to_dscp_field_name)
                 {
                     tc_to_dscp_map_id = gQosOrch->resolveTunnelQosMap(table_name, key, encap_tc_to_dscp_field_name, t);
+                    if (tc_to_dscp_map_id == SAI_NULL_OBJECT_ID)
+                    {
+                        SWSS_LOG_NOTICE("QoS map %s is not ready yet", encap_tc_to_dscp_field_name.c_str());
+                        task_status = task_process_status::task_need_retry;
+                        break;
+                    }
                     if (exists)
                     {
                         // Record only
@@ -202,6 +220,12 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                 else if (fvField(i) == encap_tc_to_queue_field_name)
                 {
                     tc_to_queue_map_id = gQosOrch->resolveTunnelQosMap(table_name, key, encap_tc_to_queue_field_name, t);
+                    if (tc_to_queue_map_id == SAI_NULL_OBJECT_ID)
+                    {
+                        SWSS_LOG_NOTICE("QoS map %s is not ready yet", encap_tc_to_queue_field_name.c_str());
+                        task_status = task_process_status::task_need_retry;
+                        break;
+                    }
                     if (exists)
                     {
                         // Record only
@@ -211,11 +235,11 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
             }
 
             //create new tunnel if it doesn't exists already
-            if (valid && !exists)
+            if (task_status == task_process_status::task_success && !exists)
             {
                 
                 if (addDecapTunnel(key, tunnel_type, ip_addresses, p_src_ip, dscp_mode, ecn_mode, encap_ecn_mode, ttl_mode,
-                                    dscp_to_dc_map_id, tc_to_pg_map_id))
+                                    dscp_to_tc_map_id, tc_to_pg_map_id))
                 {
                     // Record only
                     tunnelTable[key].encap_tc_to_dscp_map_id = tc_to_dscp_map_id;
@@ -233,7 +257,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
         {
             if (exists)
             {
-                removeDecapTunnel(key);
+                removeDecapTunnel(table_name, key);
             }
             else
             {
@@ -241,7 +265,20 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
             }
         }
 
-        it = consumer.m_toSync.erase(it);
+        switch (task_status)
+        {
+            case task_process_status::task_failed:
+            case task_process_status::task_success:
+            case task_process_status::task_invalid_entry:
+                it = consumer.m_toSync.erase(it);
+                break;
+            case task_process_status::task_need_retry:
+                ++it;
+                break;
+            default:
+                it = consumer.m_toSync.erase(it);
+                break;
+        }
     }
 }
 
@@ -717,12 +754,13 @@ bool TunnelDecapOrch::setIpAttribute(string key, IpAddresses new_ip_addresses, s
  *    @brief remove decap tunnel
  *
  * Arguments:
+ *    @param[in] table_name - name of the table in APP_DB
  *    @param[in] key - key of the tunnel from APP_DB
  *
  * Return Values:
  *    @return true on success and false if there's an error
  */
-bool TunnelDecapOrch::removeDecapTunnel(string key)
+bool TunnelDecapOrch::removeDecapTunnel(string table_name, string key)
 {
     sai_status_t status;
     TunnelEntry *tunnel_info = &tunnelTable.find(key)->second;
@@ -764,6 +802,7 @@ bool TunnelDecapOrch::removeDecapTunnel(string key)
     }
 
     tunnelTable.erase(key);
+    gQosOrch->removeTunnelReference(table_name, key);
     return true;
 }
 

--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -56,6 +56,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
         sai_object_id_t tc_to_dscp_map_id = SAI_NULL_OBJECT_ID;
         sai_object_id_t tc_to_queue_map_id = SAI_NULL_OBJECT_ID;
 
+        bool valid = true;
         task_process_status task_status = task_process_status::task_success;
 
         sai_object_id_t tunnel_id = SAI_NULL_OBJECT_ID;
@@ -78,7 +79,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (tunnel_type != "IPINIP")
                     {
                         SWSS_LOG_ERROR("Invalid tunnel type %s", tunnel_type.c_str());
-                        task_status = task_process_status::task_invalid_entry;
+                        valid = false;
                         break;
                     }
                 }
@@ -91,7 +92,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     catch (const std::invalid_argument &e)
                     {
                         SWSS_LOG_ERROR("%s", e.what());
-                        task_status = task_process_status::task_invalid_entry;
+                        valid = false;
                         break;
                     }
                     if (exists)
@@ -109,7 +110,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     catch (const std::invalid_argument &e)
                     {
                         SWSS_LOG_ERROR("%s", e.what());
-                        task_status = task_process_status::task_invalid_entry;
+                        valid = false;
                         break;
                     }
                     if (exists)
@@ -123,7 +124,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (dscp_mode != "uniform" && dscp_mode != "pipe")
                     {
                         SWSS_LOG_ERROR("Invalid dscp mode %s\n", dscp_mode.c_str());
-                        task_status = task_process_status::task_invalid_entry;
+                        valid = false;
                         break;
                     }
                     if (exists)
@@ -138,7 +139,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (ecn_mode != "copy_from_outer" && ecn_mode != "standard")
                     {
                         SWSS_LOG_ERROR("Invalid ecn mode %s\n", ecn_mode.c_str());
-                        task_status = task_process_status::task_invalid_entry;
+                        valid = false;
                         break;
                     }
                     if (exists)
@@ -152,7 +153,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (encap_ecn_mode != "standard")
                     {
                         SWSS_LOG_ERROR("Only standard encap ecn mode is supported currently %s\n", ecn_mode.c_str());
-                        task_status = task_process_status::task_invalid_entry;
+                        valid = false;
                         break;
                     }
                     if (exists)
@@ -166,7 +167,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                     if (ttl_mode != "uniform" && ttl_mode != "pipe")
                     {
                         SWSS_LOG_ERROR("Invalid ttl mode %s\n", ttl_mode.c_str());
-                        task_status = task_process_status::task_invalid_entry;
+                        valid = false;
                         break;
                     }
                     if (exists)
@@ -234,8 +235,14 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                 }
             }
 
+            if (task_status == task_process_status::task_need_retry)
+            {
+                ++it;
+                continue;
+            }
+            
             //create new tunnel if it doesn't exists already
-            if (task_status == task_process_status::task_success && !exists)
+            if (valid && !exists)
             {
                 
                 if (addDecapTunnel(key, tunnel_type, ip_addresses, p_src_ip, dscp_mode, ecn_mode, encap_ecn_mode, ttl_mode,
@@ -265,20 +272,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
             }
         }
 
-        switch (task_status)
-        {
-            case task_process_status::task_failed:
-            case task_process_status::task_success:
-            case task_process_status::task_invalid_entry:
-                it = consumer.m_toSync.erase(it);
-                break;
-            case task_process_status::task_need_retry:
-                ++it;
-                break;
-            default:
-                it = consumer.m_toSync.erase(it);
-                break;
-        }
+        it = consumer.m_toSync.erase(it);
     }
 }
 

--- a/orchagent/tunneldecaporch.h
+++ b/orchagent/tunneldecaporch.h
@@ -78,7 +78,7 @@ private:
     bool addDecapTunnel(std::string key, std::string type, swss::IpAddresses dst_ip, swss::IpAddress* p_src_ip,
                         std::string dscp, std::string ecn, std::string encap_ecn, std::string ttl,
                         sai_object_id_t dscp_to_tc_map_id, sai_object_id_t tc_to_pg_map_id);
-    bool removeDecapTunnel(std::string key);
+    bool removeDecapTunnel(std::string table_name, std::string key);
 
     bool addDecapTunnelTermEntries(std::string tunnelKey, swss::IpAddress src_ip, swss::IpAddresses dst_ip, sai_object_id_t tunnel_id, TunnelTermType type);
     bool removeDecapTunnelTermEntry(sai_object_id_t tunnel_term_id, std::string ip);


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR is to add a retry logic when creating decap tunnel.
If `decap_dscp_to_tc_map`, `decap_tc_to_pg_map`, `encap_tc_to_queue_map` or `encap_tc_to_dscp_map` is set for a decap tunnel, `TunnelDecapOrch` will retry if any of the values is not ready in `QosOrch`.
This PR also fixed an issue when decap tunnel is removed, the reference count of QoS object that being referenced is not decreased.
  
**Why I did it**
We need to wait `QosOrch` to process the required QoS table in `TunnelDecapOrch`.

**How I verified it**
Verified by vs test
```
sudo pytest test_tunnel.py -v --pdb --dvsname=vs
===================================================================================================================== test session starts ======================================================================================================================
platform linux -- Python 3.7.5, pytest-7.1.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/bingwang/work/sonic/sonic-buildimage-master/src/sonic-swss/tests
collected 7 items                                                                                                                                                                                                                                              

test_tunnel.py::TestDecapTunnel::test_TunnelDecap_v4 PASSED                                                                                                                                                                                              [ 14%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_v6 PASSED                                                                                                                                                                                              [ 28%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_MuxTunnel PASSED                                                                                                                                                                                       [ 42%]
test_tunnel.py::TestDecapTunnel::test_TunnelDecap_MuxTunnel_with_retry PASSED                                                                                                                                                                            [ 57%]
test_tunnel.py::TestSymmetricTunnel::test_TunnelSymmetric_v4 PASSED                                                                                                                                                                                      [ 71%]
test_tunnel.py::TestSymmetricTunnel::test_TunnelSymmetric_v6 PASSED                                                                                                                                                                                      [ 85%]
test_tunnel.py::test_nonflaky_dummy PASSED                                                                                                                                                                                                               [100%]
```
**Details if related**
