### PR TITLE
[asan]: Fix signal handler

### DIFF
--- a/cfgmgr/natmgrd.cpp
+++ b/cfgmgr/natmgrd.cpp
@@ -72,6 +72,10 @@ void sigterm_handler(int signo)
 {
     SWSS_LOG_ENTER();
 
+    if (old_sigaction.sa_handler != SIG_IGN && old_sigaction.sa_handler != SIG_DFL) {
+        old_sigaction.sa_handler(signo);
+    }
+
     gExit = 1;
 }
 
@@ -108,10 +112,6 @@ void cleanup()
 
         natmgr->cleanupMangleIpTables();
         natmgr->cleanupPoolIpTable();
-    }
-
-    if (old_sigaction.sa_handler != SIG_IGN && old_sigaction.sa_handler != SIG_DFL) {
-        old_sigaction.sa_handler(signo);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
* Fixed `natmgrd` signal handler

**Why I did it**
* To fix `swss` package compilation

**How I verified it**
1. Compile `swss` package

**Details if related**
```bash
natmgrd.cpp: In function 'void cleanup()':
natmgrd.cpp:114:34: error: 'signo' was not declared in this scope
         old_sigaction.sa_handler(signo);
                                  ^~~~~
natmgrd.cpp:114:34: note: suggested alternative: 'sig_t'
         old_sigaction.sa_handler(signo);
                                  ^~~~~
                                  sig_t
make[3]: *** [Makefile:1377: natmgrd-natmgrd.o] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/__w/1/s/cfgmgr'
make[2]: *** [Makefile:418: all-recursive] Error 1
make[2]: Leaving directory '/__w/1/s'
make[1]: *** [Makefile:350: all] Error 2
make[1]: Leaving directory '/__w/1/s'
dh_auto_build: error: make -j2 returned exit code 2
make: *** [debian/rules:22: build] Error 25
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```