### PR TITLE
Don't initialize P4Orch code when running on a Broadcom platform

### DIFF
--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -40,7 +40,6 @@ const char state_db_key_delimiter  = '|';
 #define NPS_PLATFORM_SUBSTRING  "nephos"
 #define MRVL_PLATFORM_SUBSTRING "marvell"
 #define CISCO_8000_PLATFORM_SUBSTRING "cisco-8000"
-#define P4_PLATFORM_SUBSTRING "p4"
 
 #define CONFIGDB_KEY_SEPARATOR "|"
 #define DEFAULT_KEY_SEPARATOR  ":"

--- a/orchagent/orch.h
+++ b/orchagent/orch.h
@@ -40,6 +40,7 @@ const char state_db_key_delimiter  = '|';
 #define NPS_PLATFORM_SUBSTRING  "nephos"
 #define MRVL_PLATFORM_SUBSTRING "marvell"
 #define CISCO_8000_PLATFORM_SUBSTRING "cisco-8000"
+#define P4_PLATFORM_SUBSTRING "p4"
 
 #define CONFIGDB_KEY_SEPARATOR "|"
 #define DEFAULT_KEY_SEPARATOR  ":"

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -621,9 +621,11 @@ bool OrchDaemon::init()
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
 
-    vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
-    gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
-    m_orchList.push_back(gP4Orch);
+    if (platform == P4_PLATFORM_SUBSTRING) {
+        vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
+        gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
+        m_orchList.push_back(gP4Orch);
+    }
 
     if (WarmStart::isWarmStart())
     {

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -621,7 +621,7 @@ bool OrchDaemon::init()
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
 
-    if (platform == P4_PLATFORM_SUBSTRING)
+    if (platform != BRCM_PLATFORM_SUBSTRING)
     {
         vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
         gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -621,7 +621,8 @@ bool OrchDaemon::init()
 
     m_orchList.push_back(&CounterCheckOrch::getInstance(m_configDb));
 
-    if (platform == P4_PLATFORM_SUBSTRING) {
+    if (platform == P4_PLATFORM_SUBSTRING)
+    {
         vector<string> p4rt_tables = {APP_P4RT_TABLE_NAME};
         gP4Orch = new P4Orch(m_applDb, p4rt_tables, vrf_orch, gCoppOrch);
         m_orchList.push_back(gP4Orch);


### PR DESCRIPTION
Signed-off-by: Saikrishna Arcot <sarcot@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

The P4Orch initializer assumes that UDF is available on the platform,
which isn't available on Broadcom platforms. Therefore, for Broadcom,
don't initialize P4Orch.

**Why I did it**

On some platforms (such as Broadcom), UDF is not available, and trying to program it results in an error. This doesn't break anything during coldboot, but fails warmboot.

**How I verified it**

Tested on virtual switch and Broadcom.

**Details if related**
