### PR TITLE
[macsec] Wait cipher setting done before create sc

### DIFF
--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -1051,6 +1051,7 @@ bool MACsecOrch::createMACsecPort(
     macsec_port.m_sci_in_sectag = DEFAULT_SCI_IN_SECTAG;
     macsec_port.m_cipher_suite = DEFAULT_CIPHER_SUITE;
     macsec_port.m_enable = false;
+    macsec_port.m_cipher_suite_ready = false;
 
     // If hardware matches SCI in ACL, the macsec_flow maps to an IEEE 802.1ae SecY object.
     // Multiple SCs can be associated with such a macsec_flow.
@@ -1229,18 +1230,22 @@ bool MACsecOrch::updateMACsecPort(MACsecPort &macsec_port, const TaskArgs &port_
         if (cipher_suite == "GCM-AES-128")
         {
             macsec_port.m_cipher_suite = SAI_MACSEC_CIPHER_SUITE_GCM_AES_128;
+            macsec_port.m_cipher_suite_ready = true;
         }
         else if (cipher_suite == "GCM-AES-256")
         {
             macsec_port.m_cipher_suite = SAI_MACSEC_CIPHER_SUITE_GCM_AES_256;
+            macsec_port.m_cipher_suite_ready = true;
         }
         else if (cipher_suite == "GCM-AES-XPN-128")
         {
             macsec_port.m_cipher_suite = SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_128;
+            macsec_port.m_cipher_suite_ready = true;
         }
         else if (cipher_suite == "GCM-AES-XPN-256")
         {
             macsec_port.m_cipher_suite = SAI_MACSEC_CIPHER_SUITE_GCM_AES_XPN_256;
+            macsec_port.m_cipher_suite_ready = true;
         }
         else
         {
@@ -1503,6 +1508,11 @@ task_process_status MACsecOrch::updateMACsecSC(
     {
         SWSS_LOG_ERROR("Cannot find switch id at the port %s.", port_name.c_str());
         return task_failed;
+    }
+
+    if (!ctx.get_macsec_port()->m_cipher_suite_ready)
+    {
+        return task_need_retry;
     }
 
     if (ctx.get_macsec_sc() == nullptr)

--- a/orchagent/macsecorch.h
+++ b/orchagent/macsecorch.h
@@ -102,6 +102,7 @@ private:
         bool                                m_enable_encrypt;
         bool                                m_sci_in_sectag;
         bool                                m_enable;
+        bool                                m_cipher_suite_ready;
         uint32_t                            m_original_ipg;
     };
     struct MACsecObject


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
The change is to ensure cipher setting done explicitly and avoid using the default one. If the cipher is not ready in the task of create_sc, the task is set to be retried. We also need this change https://github.com/Azure/sonic-wpa-supplicant/pull/50 to avoid a default but not desired cipher set by sonic_wpa_supplicant.
**Why I did it**
We noticed that for the existing code, occasionally, create sc is executed before the desired cipher has been set. This is an example of log.
2022-04-18.23:18:19.342399|MACSEC_PORT_TABLE:Ethernet56|SET|enable:false|cipher_suite:GCM-AES-128|send_sci:false                                                                                                                                                              **2022-04-18.23:18:22.170470|MACSEC_EGRESS_SC_TABLE:Ethernet56:72110620299941568|SET|encoding_an:0**
zz2022-04-18.23:18:22.265174|MACSEC_PORT_TABLE:Ethernet56|SET|enable:false|cipher_suite:GCM-AES-XPN-256|send_sci:false|enable_protect:true|enable_encrypt:true|enable_replay_protect:false|replay_window:0                                                                      2022-04-18.23:18:24.645027|MACSEC_INGRESS_SC_TABLE:Ethernet56:4972220524630562496|SET|Null:Nulzl
**How I verified it**
We checked that the issue is not reproduced after the fix
**Details if related**
