### PR TITLE
[neighsync] Ignoring IPv4 link local addresses

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -79,6 +79,16 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= ":";
 
     nl_addr2str(rtnl_neigh_get_dst(neigh), ipStr, MAX_ADDR_SIZE);
+
+    /* Ignore IPv4 link-local addresses as neighbors */
+    IpAddress ipAddress(ipStr);
+    if (family == IPV4_NAME && ipAddress.getAddrScope() == IpAddress::AddrScope::LINK_SCOPE)
+    {
+        SWSS_LOG_INFO("Link Local address received, ignoring for %s", ipStr);
+        return;
+    }
+
+
     /* Ignore IPv6 link-local addresses as neighbors, if ipv6 link local mode is disabled */
     if (family == IPV6_NAME && IN6_IS_ADDR_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
     {

--- a/tests/test_neighbor.py
+++ b/tests/test_neighbor.py
@@ -413,6 +413,53 @@ class TestNeighbor(object):
         (exitcode, output) = dvs.runcmd(['sh', '-c', "supervisorctl status nbrmgrd | awk '{print $2}'"])
         assert output == "RUNNING\n"
 
+    def test_NeighborAddRemoveIpv4(self, dvs, testlog):
+        self.setup_db(dvs)
+
+        # bring up interface
+        self.set_admin_status("Ethernet8", "up")
+
+        # create interface and get rif_oid
+        rif_oid = self.create_l3_intf("Ethernet8", "")
+
+        # assign IP to interface
+        self.add_ip_address("Ethernet8", "10.0.0.1/24")
+
+        # add neighbor
+        self.add_neighbor("Ethernet8", "169.254.0.0", "00:01:02:03:04:05")
+
+        # check application database
+        tbl = swsscommon.Table(self.pdb, "NEIGH_TABLE:Ethernet8")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # check ASIC neighbor database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # remove neighbor
+        self.remove_neighbor("Ethernet8", "169.254.0.0")
+
+        # remove IP from interface
+        self.remove_ip_address("Ethernet8", "10.0.0.1/24")
+
+        # remove interface
+        self.remove_l3_intf("Ethernet8")
+
+        # bring down interface
+        self.set_admin_status("Ethernet8", "down")
+
+        # check application database
+        tbl = swsscommon.Table(self.pdb, "NEIGH_TABLE:Ethernet8")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
+        # check ASIC neighbor database
+        tbl = swsscommon.Table(self.adb, "ASIC_STATE:SAI_OBJECT_TYPE_NEIGHBOR_ENTRY")
+        intf_entries = tbl.getKeys()
+        assert len(intf_entries) == 0
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION
Skipping over writing ipv4 link local neighbors to APPL_DB.
This was causing link local neighbors to appear and led to long
switchover times during mux state change.

Tested in test_neighbor.py by adding a link local neighbor and making
sure dbs do not contain the neighbor.

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>
