### PR TITLE
Comment add for rif counters cleanup (fix for #2270)

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -1427,6 +1427,11 @@ void IntfsOrch::removeRifFromFlexCounter(const string &id, const string &name)
     SWSS_LOG_DEBUG("Unregistered interface %s from Flex counter", name.c_str());
 }
 
+/*
+   TODO A race condition can exist when swss removes the counter from COUNTERS DB
+   and at the same time syncd is inserting a new entry in COUNTERS DB. Therefore
+   all the rif counters cleanup code should move to syncd
+*/
 void IntfsOrch::cleanUpRifFromCounterDb(const string &id, const string &name)
 {
     SWSS_LOG_ENTER();


### PR DESCRIPTION
**What I did**
Fix for [https://github.com/Azure/sonic-swss/issues/2270](https://github.com/Azure/sonic-swss/pull/url)

Added a comment for TODO . This comment is for reminding existence of a race condition and moving the cleanup code to syncd .

**Why I did it**
This is done in follow-up to fix in https://github.com/Azure/sonic-swss/pull/2199
The comment is added as TODO - in future the cleanup for rif counters should move to syncd.

**How I verified it**
No explicit verification is needed for this.

