### PR TITLE
Orchagent changes for synchronizing npu/phy device Tx in the data path before enabling transceiver<CMIS compliant> Tx.

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1032,7 +1032,7 @@ void PortsOrch::getCpuPort(Port &port)
     port = m_cpuPort;
 }
 
-bool PortsOrch::initHostTxReadyState(Port &port)
+void PortsOrch::initHostTxReadyState(Port &port)
 {
     SWSS_LOG_ENTER();
 
@@ -1058,8 +1058,6 @@ bool PortsOrch::initHostTxReadyState(Port &port)
         SWSS_LOG_INFO("initalize hostTxReady %s with status %s", 
                 port.m_alias.c_str(), hostTxReady.c_str());
     }
-
- return true;
 }
 
 bool PortsOrch::setPortAdminStatus(Port &port, bool state)
@@ -1090,7 +1088,7 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
     }
 
     bool gbstatus = setGearboxPortsAttr(port, SAI_PORT_ATTR_ADMIN_STATE, &state);
-    if(gbstatus != true)
+    if (gbstatus != true)
     {
         SWSS_LOG_ERROR("Failed to set admin status on PHY %s to port pid:%" PRIx64,
                        state ? "UP" : "DOWN", port.m_port_id);
@@ -3414,11 +3412,10 @@ void PortsOrch::doPortTask(Consumer &consumer)
                     }
 
                 }
-
-                if (!initHostTxReadyState(p)) {
-                        SWSS_LOG_ERROR("Failed to initialize host_tx_ready for  port %s ", alias.c_str());
-                }
-
+                
+                /* create host_tx_ready field in state-db */
+                initHostTxReadyState(p)
+                
                 /* Last step set port admin status */
                 if (!admin_status.empty() && (p.m_admin_state_up != (admin_status == "up")))
                 {

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1094,6 +1094,10 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
     }
 
     bool gbstatus = setGearboxPortsAttr(port, SAI_PORT_ATTR_ADMIN_STATE, &state);
+    if (gbstatus != true)
+    {
+        m_portStateTable.hset(port.m_alias, "host_tx_ready", "false");
+    }
    
     /* Update the state table for host_tx_ready*/
     if (state && (gbstatus == true) && (status == SAI_STATUS_SUCCESS) )
@@ -1102,12 +1106,6 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
         SWSS_LOG_INFO("Set admin status UP host_tx_ready to true to port pid:%" PRIx64,
                 port.m_port_id);
     } 
-    else
-    {
-        m_portStateTable.hset(port.m_alias, "host_tx_ready", "false");
-        SWSS_LOG_INFO("Set admin status %s host_tx_ready to false to port pid:%" PRIx64,
-                    state ? "UP" : "DOWN", port.m_port_id);
-    }
 
     return true;
 }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -1032,6 +1032,11 @@ void PortsOrch::getCpuPort(Port &port)
     port = m_cpuPort;
 }
 
+/* 
+ * Create host_tx_ready field in PORT_TABLE of STATE-DB 
+ * and set the field to false by default for the 
+ * front<Ethernet> port.
+ */
 void PortsOrch::initHostTxReadyState(Port &port)
 {
     SWSS_LOG_ENTER();
@@ -1051,7 +1056,6 @@ void PortsOrch::initHostTxReadyState(Port &port)
         }
     }
 
-     /* Create host_tx_ready field in state-DB and set it to false by default. */
     if (hostTxReady.empty())
     {
         m_portStateTable.hset(port.m_alias, "host_tx_ready", "false");
@@ -1092,7 +1096,7 @@ bool PortsOrch::setPortAdminStatus(Port &port, bool state)
     {
         SWSS_LOG_ERROR("Failed to set admin status on PHY %s to port pid:%" PRIx64,
                        state ? "UP" : "DOWN", port.m_port_id);
-     /* add task handler to recover/take action on this failure */
+        /* TODO add task handler to recover/take action on this failure */
     }
    
     /* Update the state table for 'host_tx_ready'*/

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -3418,7 +3418,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 }
                 
                 /* create host_tx_ready field in state-db */
-                initHostTxReadyState(p)
+                initHostTxReadyState(p);
                 
                 /* Last step set port admin status */
                 if (!admin_status.empty() && (p.m_admin_state_up != (admin_status == "up")))

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -95,7 +95,7 @@ public:
     bool getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port);
     void setPort(string alias, Port port);
     void getCpuPort(Port &port);
-    bool initHostTxReadyState(Port &port);
+    void initHostTxReadyState(Port &port);
     bool getInbandPort(Port &port);
     bool getVlanByVlanId(sai_vlan_id_t vlan_id, Port &vlan);
 

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -95,6 +95,7 @@ public:
     bool getPortByBridgePortId(sai_object_id_t bridge_port_id, Port &port);
     void setPort(string alias, Port port);
     void getCpuPort(Port &port);
+    bool initHostTxReadyState(Port &port);
     bool getInbandPort(Port &port);
     bool getVlanByVlanId(sai_vlan_id_t vlan_id, Port &vlan);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
3. Make sure your commit title follows the correct format: [component]: description
4. Make sure your commit message contains enough details about the change and related tests
5. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Orchagent changes for https://github.com/sonic-net/SONiC/pull/916

1. Create host_tx_ready field in state-db during OA init.
2. Set the host_tx_ready to true in STATE-DB PORT_TABLE when both NPU and PHY device Tx is enabled successfully <PHY device status will be ignored for platform without PHY device>. 
3. Set the field 'host_tx_ready' to false in STATE-DB PORT_TABLE when NPU and PHY line side Tx gets muted/disabled which happens during admin shutdown configuration is committed.

**Why I did it**
xcvrd will be handling "host_tx_ready" change of value event for CMIS complaint modules to bring it to appropriate CMIS state on the CMIS complaint modules.

**How I verified it**
UT logs attached.

**Details if related**
