### PR TITLE
[vstest]: Increase PollingConfig default timeout

### DIFF
--- a/tests/dvslib/dvs_common.py
+++ b/tests/dvslib/dvs_common.py
@@ -17,7 +17,7 @@ class PollingConfig:
     """
 
     polling_interval: float = 0.01
-    timeout: float = 5.00
+    timeout: float = 20.00
     strict: bool = True
 
     def iterations(self) -> int:


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Increase the default timeout for PollingConfig to 20 seconds

**Why I did it**
Many VS tests are flaky due to DB entries not being populated quickly enough.

**How I verified it**

**Details if related**
