### PR TITLE
[teammgr]: Waiting MACsec ready before doLagMemberTask

### DIFF
--- a/cfgmgr/teammgr.cpp
+++ b/cfgmgr/teammgr.cpp
@@ -456,7 +456,6 @@ void TeamMgr::doPortUpdateTask(Consumer &consumer)
                     SWSS_LOG_INFO("MACsec is NOT ready on the port %s", alias.c_str());
                     continue;
                 }
-                SWSS_LOG_NOTICE("MACsec is ready on the port %s", alias.c_str());
 
                 if (addLagMember(lag, alias) == task_need_retry)
                 {

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -28,7 +28,6 @@ private:
     Table m_statePortTable;
     Table m_stateLagTable;
     Table m_stateMACsecIngressSATable;
-    Table m_stateFeatureTable;
 
     ProducerStateTable m_appPortTable;
     ProducerStateTable m_appLagTable;
@@ -57,7 +56,6 @@ private:
     bool checkPortIffUp(const std::string &);
     bool isPortStateOk(const std::string&);
     bool isLagStateOk(const std::string&);
-    bool isMACsecFeatureEnabled();
     bool isMACsecAttached(const std::string &);
     bool isMACsecIngressSAOk(const std::string &);
     uint16_t generateLacpKey(const std::string&);

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -27,7 +27,7 @@ private:
     Table m_cfgLagMemberTable;
     Table m_statePortTable;
     Table m_stateLagTable;
-    Table m_stateMACsecPortTable;
+    Table m_stateMACsecIngressSATable;
     Table m_stateFeatureTable;
 
     ProducerStateTable m_appPortTable;
@@ -58,8 +58,8 @@ private:
     bool isPortStateOk(const std::string&);
     bool isLagStateOk(const std::string&);
     bool isMACsecFeatureEnabled();
-    bool isMACsecSetted(const std::string &);
-    bool isMACsecStateOk(const std::string &);
+    bool isMACsecAttached(const std::string &);
+    bool isMACsecIngressSAOk(const std::string &);
     uint16_t generateLacpKey(const std::string&);
 };
 

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -27,6 +27,7 @@ private:
     Table m_cfgLagMemberTable;
     Table m_statePortTable;
     Table m_stateLagTable;
+    Table m_stateMACsecPortTable;
 
     ProducerStateTable m_appPortTable;
     ProducerStateTable m_appLagTable;
@@ -55,6 +56,8 @@ private:
     bool checkPortIffUp(const std::string &);
     bool isPortStateOk(const std::string&);
     bool isLagStateOk(const std::string&);
+    bool isMACsecSetted(const std::string &);
+    bool isMACsecStateOk(const std::string &);
     uint16_t generateLacpKey(const std::string&);
 };
 

--- a/cfgmgr/teammgr.h
+++ b/cfgmgr/teammgr.h
@@ -28,6 +28,7 @@ private:
     Table m_statePortTable;
     Table m_stateLagTable;
     Table m_stateMACsecPortTable;
+    Table m_stateFeatureTable;
 
     ProducerStateTable m_appPortTable;
     ProducerStateTable m_appLagTable;
@@ -56,6 +57,7 @@ private:
     bool checkPortIffUp(const std::string &);
     bool isPortStateOk(const std::string&);
     bool isLagStateOk(const std::string&);
+    bool isMACsecFeatureEnabled();
     bool isMACsecSetted(const std::string &);
     bool isMACsecStateOk(const std::string &);
     uint16_t generateLacpKey(const std::string&);

--- a/tests/test_macsec.py
+++ b/tests/test_macsec.py
@@ -765,7 +765,8 @@ class TestMACsec(object):
     def test_macsec_with_portchannel(self, dvs: conftest.DockerVirtualSwitch, testlog):
 
         # Set MACsec enabled on Ethernet0
-        ConfigTable(dvs, "PORT")["Ethernet0"] = {"macsec": "test"}
+        ConfigTable(dvs, "PORT")["Ethernet0"] = {"macsec" : "test"}
+        StateDBTable(dvs, "FEATURE")["macsec"] = {"state": "enabled"}
 
         # Setup Port-channel
         ConfigTable(dvs, "PORTCHANNEL")["PortChannel001"] = {"admin": "up", "mtu": "9100", "oper_status": "up"}
@@ -830,6 +831,18 @@ class TestMACsec(object):
             peer_mac_address,
             macsec_port_identifier,
             0)
+
+        # remove port channel member
+        del ConfigTable(dvs, "PORTCHANNEL_INTERFACE")["PortChannel001"]
+        del ConfigTable(dvs, "PORTCHANNEL_INTERFACE")["PortChannel001|40.0.0.0/31"]
+        del ConfigTable(dvs, "PORTCHANNEL_MEMBER")["PortChannel001|Ethernet0"]
+
+        # remove port channel
+        del ConfigTable(dvs, "PORTCHANNEL")["PortChannel001"]
+
+        # Clear MACsec enabled on Ethernet0
+        ConfigTable(dvs, "PORT")["Ethernet0"] = {"macsec" : ""}
+
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down

--- a/tests/test_macsec.py
+++ b/tests/test_macsec.py
@@ -1,6 +1,7 @@
 from swsscommon import swsscommon
 import conftest
 
+import time
 import functools
 import typing
 import re
@@ -85,6 +86,12 @@ class StateDBTable(Table):
             str.maketrans(
                 AppDBTable.SEPARATOR,
                 StateDBTable.SEPARATOR))
+
+
+class ConfigTable(Table):
+
+    def __init__(self, dvs: conftest.DockerVirtualSwitch, table_name: str):
+        super(ConfigTable, self).__init__(dvs.get_config_db(), table_name)
 
 
 def gen_sci(macsec_system_identifier: str, macsec_port_identifier: int) -> str:
@@ -755,6 +762,74 @@ class TestMACsec(object):
             macsec_port_identifier,
             0)
 
+    def test_macsec_with_portchannel(self, dvs: conftest.DockerVirtualSwitch, testlog):
+
+        # Set MACsec enabled on Ethernet0
+        ConfigTable(dvs, "PORT")["Ethernet0"] = {"macsec": "test"}
+
+        # Setup Port-channel
+        ConfigTable(dvs, "PORTCHANNEL")["PortChannel001"] = {"admin": "up", "mtu": "9100", "oper_status": "up"}
+        time.sleep(1)
+
+        # create port channel member
+        ConfigTable(dvs, "PORTCHANNEL_MEMBER")["PortChannel001|Ethernet0"] = {"NULL": "NULL"}
+        ConfigTable(dvs, "PORTCHANNEL_INTERFACE")["PortChannel001"] = {"NULL": "NULL"}
+        ConfigTable(dvs, "PORTCHANNEL_INTERFACE")["PortChannel001|40.0.0.0/31"] = {"NULL": "NULL"}
+        time.sleep(3)
+
+        # Check Portchannel member in ASIC db that shouldn't been created before MACsec enabled
+        lagmtbl = swsscommon.Table(swsscommon.DBConnector(1, dvs.redis_sock, 0), "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER")
+        lagms = lagmtbl.getKeys()
+        assert len(lagms) == 0
+
+        # Create MACsec session
+        port_name = "Ethernet0"
+        local_mac_address = "00-15-5D-78-FF-C1"
+        peer_mac_address = "00-15-5D-78-FF-C2"
+        macsec_port_identifier = 1
+        macsec_port = "macsec_eth1"
+        sak = "0" * 32
+        auth_key = "0" * 32
+        packet_number = 1
+        ssci = 1
+        salt = "0" * 24
+
+        wpa = WPASupplicantMock(dvs)
+        inspector = MACsecInspector(dvs)
+
+        self.init_macsec(
+            wpa,
+            port_name,
+            local_mac_address,
+            macsec_port_identifier)
+        self.establish_macsec(
+            wpa,
+            port_name,
+            local_mac_address,
+            peer_mac_address,
+            macsec_port_identifier,
+            0,
+            sak,
+            packet_number,
+            auth_key,
+            ssci,
+            salt)
+        time.sleep(3)
+
+        # Check Portchannel member in ASIC db that should been created after MACsec enabled
+        lagmtbl = swsscommon.Table(swsscommon.DBConnector(1, dvs.redis_sock, 0), "ASIC_STATE:SAI_OBJECT_TYPE_LAG_MEMBER")
+        lagms = lagmtbl.getKeys()
+        assert len(lagms) == 1
+
+        self.deinit_macsec(
+            wpa,
+            inspector,
+            port_name,
+            macsec_port,
+            local_mac_address,
+            peer_mac_address,
+            macsec_port_identifier,
+            0)
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>, Judy Joseph <jujoseph@microsoft.com>

**What I did**
If a member of portchannel has macsec profile attached in config, enable MACsec on the port before it's been added as a member of portchannel.

**Why I did it**
Due to some hardware limitation, cannot enable MACsec on a member of portchannel.  
So we enable the macsec on interface first and then add it as part of portchannel.

**Note: This is a work around which will be removed when h/w supports it future releases.**

The approach taken in this PR is 

> In the teamdMgr when an interface is added as part of the LAG, we wait for the macsecPort creation done in SAI and Ingress SA creation complete (if macsec is enabled on the interface)
> The above takes care of config reload, reboot scenario's where we cannot guarantee the sequence of macsec attach to interface, add interface as part of portchannel. 

If we do a manual removal of port from portchannel, or remove macsec config from the interface, Please follow this steps 
> First remove the portchannel member out of portchannel 
> Remove the macsec profile attached to interface.


**How I verified it**

Verified with config reload, reboot with the macsec profile attached to portchannel member interfaces.
Verified case when SAK rekey is enabled on macsec on portchannel members
Verified case when member interface link flaps 

**Details if related**
