### PR TITLE
[muxorch] Handling optional attributes in muxorch

### DIFF
--- a/orchagent/muxorch.h
+++ b/orchagent/muxorch.h
@@ -131,6 +131,8 @@ const request_description_t mux_cfg_request_description = {
                 { "server_ipv4", REQ_T_IP_PREFIX },
                 { "server_ipv6", REQ_T_IP_PREFIX },
                 { "address_ipv4", REQ_T_IP },
+                { "soc_ipv4", REQ_T_IP_PREFIX },
+                { "cable_type", REQ_T_STRING },
             },
             { }
 };


### PR DESCRIPTION
What I did: Added soc_ipv4 and cable_type as optional attributes in muxorch.

Why I did it: cable_type field in MUX_CABLE table was throwing parse errors

How I did it: adding soc_ipv4 and cable_type wo mux_cfg_request_description

Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>