### PR TITLE
[ci] Change artifact reference pipeline to common lib pipeline.

### DIFF
--- a/.azure-pipelines/build-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/build-docker-sonic-vs-template.yml
@@ -36,40 +36,47 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: 9
+      pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 12
+      pipeline: Azure.sonic-sairedis
       artifact: ${{ parameters.sairedis_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: ${{ parameters.swss_artifact_name }}
-    displayName: "Download sonic swss artifact"
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built ${{ parameters.swss_artifact_name }}"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 1
+      pipeline: Azure.sonic-buildimage.official.vs
       artifact: sonic-buildimage.vs
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
-    displayName: "Download sonic buildimage"
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: '**/target/docker-sonic-vs.gz'
+    displayName: "Download sonic-buildimage docker-sonic-vs"
   - script: |
+      set -ex
       echo $(Build.DefinitionName).$(Build.BuildNumber)
 
-      docker load < ../target/docker-sonic-vs.gz
+      docker load < $(Build.ArtifactStagingDirectory)/download/target/docker-sonic-vs.gz
+
       mkdir -p .azure-pipelines/docker-sonic-vs/debs
 
-      cp -v ../*.deb .azure-pipelines/docker-sonic-vs/debs
+      cp -v $(Build.ArtifactStagingDirectory)/download/*.deb .azure-pipelines/docker-sonic-vs/debs
 
       pushd .azure-pipelines
 
@@ -78,7 +85,8 @@ jobs:
       popd
 
       docker save docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber) | gzip -c > $(Build.ArtifactStagingDirectory)/docker-sonic-vs.gz
-
+      rm -rf $(Build.ArtifactStagingDirectory)/download
+    displayName: "Build docker-sonic-vs"
   - publish: $(Build.ArtifactStagingDirectory)/
     artifact: ${{ parameters.artifact_name }}
     displayName: "Archive sonic docker vs image"

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -113,19 +113,19 @@ jobs:
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
       path: $(Build.ArtifactStagingDirectory)/download
       patterns: |
-        target/debs/${{ parameters.debian_version }}/libnl-3-200_*.deb
-        target/debs/${{ parameters.debian_version }}/libnl-3-dev_*.deb
-        target/debs/${{ parameters.debian_version }}/libnl-genl-3-200_*.deb
-        target/debs/${{ parameters.debian_version }}/libnl-genl-3-dev_*.deb
-        target/debs/${{ parameters.debian_version }}/libnl-route-3-200_*.deb
-        target/debs/${{ parameters.debian_version }}/libnl-route-3-dev_*.deb
-        target/debs/${{ parameters.debian_version }}/libnl-nf-3-200_*.deb
-        target/debs/${{ parameters.debian_version }}/libnl-nf-3-dev_*.deb
+        target/debs/buster/libnl-3-200_*.deb
+        target/debs/buster/libnl-3-dev_*.deb
+        target/debs/buster/libnl-genl-3-200_*.deb
+        target/debs/buster/libnl-genl-3-dev_*.deb
+        target/debs/buster/libnl-route-3-200_*.deb
+        target/debs/buster/libnl-route-3-dev_*.deb
+        target/debs/buster/libnl-nf-3-200_*.deb
+        target/debs/buster/libnl-nf-3-dev_*.deb
     displayName: "Download common libs"
   - script: |
       set -ex
       cd download
-      sudo dpkg -i $(find target/debs/${{ parameters.debian_version }} -type f)
+      sudo dpkg -i $(find target/debs/buster -type f)
       sudo dpkg -i $(ls *.deb)
       cd ..
       rm -rf download

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -23,12 +23,6 @@ parameters:
 - name: sonic_slave
   type: string
 
-- name: buildimage_artifact_name
-  type: string
-
-- name: buildimage_pipeline
-  type: number
-
 - name: sairedis_artifact_name
   type: string
 
@@ -45,6 +39,9 @@ parameters:
 - name: archive_gcov
   type: boolean
   default: false
+
+- name: common_lib_artifact_name
+  type: string
 
 jobs:
 - job:
@@ -79,77 +76,63 @@ jobs:
     inputs:
       source: specific
       project: build
-      pipeline: 9
+      pipeline: Azure.sonic-swss-common
       artifact: ${{ parameters.swss_common_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: '$(Build.SourcesDirectory)/${{ parameters.swss_common_artifact_name }}'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libswsscommon_1.0.0_${{ parameters.arch }}.deb
+        libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
     displayName: "Download sonic swss common deb packages"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 12
+      pipeline: Azure.sonic-sairedis
       artifact: ${{ parameters.sairedis_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: '$(Build.SourcesDirectory)/${{ parameters.sairedis_artifact_name }}'
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        libsaivs_*.deb
+        libsaivs-dev_*.deb
+        libsairedis_*.deb
+        libsairedis-dev_*.deb
+        libsaimetadata_*.deb
+        libsaimetadata-dev_*.deb
+        syncd-vs_*.deb
     displayName: "Download sonic sairedis deb packages"
   - task: DownloadPipelineArtifact@2
-    ${{ if eq(parameters.buildimage_pipeline, 141) }}:
-      continueOnError: True
     inputs:
       source: specific
       project: build
-      pipeline: ${{ parameters.buildimage_pipeline }}
-      artifact: ${{ parameters.buildimage_artifact_name }}
+      pipeline: Azure.sonic-buildimage.common_libs
+      artifact: ${{ parameters.common_lib_artifact_name }}
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
-      path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
-    displayName: "Download sonic buildimage deb packages"
+      path: $(Build.ArtifactStagingDirectory)/download
+      patterns: |
+        target/debs/${{ parameters.debian_version }}/libnl-3-200_*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-3-dev_*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-genl-3-200_*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-genl-3-dev_*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-route-3-200_*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-route-3-dev_*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-nf-3-200_*.deb
+        target/debs/${{ parameters.debian_version }}/libnl-nf-3-dev_*.deb
+    displayName: "Download common libs"
   - script: |
-      buildimage_artifact_downloaded=n
-      [ -d "$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}/target" ] && buildimage_artifact_downloaded=y
-      echo "buildimage_artifact_downloaded=$buildimage_artifact_downloaded"
-      echo "##vso[task.setvariable variable=buildimage_artifact_downloaded]$buildimage_artifact_downloaded"
-    condition: eq(${{ parameters.buildimage_pipeline }}, 141)
-    displayName: "Check if sonic buildimage deb packages downloaded"
-  - task: DownloadPipelineArtifact@2
-    condition: and(eq(variables.buildimage_artifact_downloaded, 'n'), eq(${{ parameters.buildimage_pipeline }}, 141))
-    inputs:
-      source: specific
-      project: build
-      pipeline: ${{ parameters.buildimage_pipeline }}
-      artifact: 'sonic-buildimage.marvell-armhf1'
-      runVersion: specific
-      runId: 80637
-      path: '$(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}'
-    displayName: "Download sonic buildimage deb packages from 80637"
-  - script: |
-      cd $(Build.SourcesDirectory)/${{ parameters.buildimage_artifact_name }}
-      sudo dpkg -i target/debs/buster/libnl-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-genl-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-genl-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-route-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-route-3-dev_*.deb
-      sudo dpkg -i target/debs/buster/libnl-nf-3-200_*.deb
-      sudo dpkg -i target/debs/buster/libnl-nf-3-dev_*.deb
-      cd $(Build.SourcesDirectory)/${{ parameters.swss_common_artifact_name }}
-      sudo dpkg -i libswsscommon_1.0.0_${{ parameters.arch }}.deb
-      sudo dpkg -i libswsscommon-dev_1.0.0_${{ parameters.arch }}.deb
-      cd $(Build.SourcesDirectory)/${{ parameters.sairedis_artifact_name }}
-      sudo dpkg -i libsaivs_*.deb
-      sudo dpkg -i libsaivs-dev_*.deb
-      sudo dpkg -i libsairedis_*.deb
-      sudo dpkg -i libsairedis-dev_*.deb
-      sudo dpkg -i libsaimetadata_*.deb
-      sudo dpkg -i libsaimetadata-dev_*.deb
-      sudo dpkg -i syncd-vs_*.deb
-    workingDirectory: $(Pipeline.Workspace)
+      set -ex
+      cd download
+      sudo dpkg -i $(find target/debs/${{ parameters.debian_version }} -type f)
+      sudo dpkg -i $(ls *.deb)
+      cd ..
+      rm -rf download
+    workingDirectory: $(Build.ArtifactStagingDirectory)
     displayName: "Install libnl3, sonic swss common and sairedis"
   - script: |
-      set -x
+      set -ex
       tar czf pytest.tgz tests
       cp -r pytest.tgz $(Build.ArtifactStagingDirectory)/
       if [ '${{ parameters.archive_gcov }}' == True ]; then

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -31,25 +31,25 @@ jobs:
   - task: DownloadPipelineArtifact@2
     inputs:
       artifact: docker-sonic-vs
-    displayName: "Download docker sonic vs image"
-
+      path: $(Build.ArtifactStagingDirectory)/download
+    displayName: "Download pre-stage built docker-sonic-vs"
   - task: DownloadPipelineArtifact@2
     inputs:
       source: specific
       project: build
-      pipeline: 9
+      pipeline: Azure.sonic-swss-common
       artifact: sonic-swss-common.amd64.ubuntu20_04
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
     displayName: "Download sonic swss common deb packages"
 
   - script: |
-      set -x
+      set -ex
       sudo .azure-pipelines/build_and_install_module.sh
 
       sudo apt-get install -y libhiredis0.14
-      sudo dpkg -i --force-confask,confnew ../libswsscommon_1.0.0_amd64.deb || apt-get install -f
-      sudo dpkg -i ../python3-swsscommon_1.0.0_amd64.deb
+      sudo dpkg -i --force-confask,confnew $(Build.ArtifactStagingDirectory)/download/libswsscommon_1.0.0_amd64.deb || apt-get install -f
+      sudo dpkg -i $(Build.ArtifactStagingDirectory)/download/python3-swsscommon_1.0.0_amd64.deb
 
       # install packages for vs test
       sudo apt-get install -y net-tools bridge-utils vlan
@@ -58,8 +58,8 @@ jobs:
     displayName: "Install dependencies"
 
   - script: |
-      set -x
-      sudo docker load -i ../docker-sonic-vs.gz
+      set -ex
+      sudo docker load -i $(Build.ArtifactStagingDirectory)/download/docker-sonic-vs.gz
       docker ps
       ip netns list
       uname -a
@@ -72,6 +72,7 @@ jobs:
       else
         sudo py.test -v --force-flaky --junitxml=tr.xml --imgname=docker-sonic-vs:$(Build.DefinitionName).$(Build.BuildNumber)
       fi
+      rm -rf $(Build.ArtifactStagingDirectory)/download
     displayName: "Run vs tests"
 
   - task: PublishTestResults@2

--- a/.azure-pipelines/test-docker-sonic-vs-template.yml
+++ b/.azure-pipelines/test-docker-sonic-vs-template.yml
@@ -41,6 +41,7 @@ jobs:
       artifact: sonic-swss-common.amd64.ubuntu20_04
       runVersion: 'latestFromBranch'
       runBranch: 'refs/heads/$(BUILD_BRANCH)'
+      path: $(Build.ArtifactStagingDirectory)/download
     displayName: "Download sonic swss common deb packages"
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,7 @@ stages:
     parameters:
       arch: amd64
       sonic_slave: sonic-slave-buster
-      buildimage_artifact_name: sonic-buildimage.vs
-      buildimage_pipeline: 142
+      common_lib_artifact_name: common-lib
       swss_common_artifact_name: sonic-swss-common
       sairedis_artifact_name: sonic-sairedis
       artifact_name: sonic-swss
@@ -60,8 +59,7 @@ stages:
       timeout: 240
       pool: sonicbld-armhf
       sonic_slave: sonic-slave-buster-armhf
-      buildimage_artifact_name: sonic-buildimage.marvell-armhf
-      buildimage_pipeline: 141
+      common_lib_artifact_name: common-lib.armhf
       swss_common_artifact_name: sonic-swss-common.armhf
       sairedis_artifact_name: sonic-sairedis.armhf
       artifact_name: sonic-swss.armhf
@@ -73,9 +71,8 @@ stages:
       timeout: 240
       pool: sonicbld-arm64
       sonic_slave: sonic-slave-buster-arm64
+      common_lib_artifact_name: common-lib.arm64
       swss_common_artifact_name: sonic-swss-common.arm64
-      buildimage_artifact_name: sonic-buildimage.centec-arm64
-      buildimage_pipeline: 140
       sairedis_artifact_name: sonic-sairedis.arm64
       artifact_name: sonic-swss.arm64
       archive_gcov: false


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Use common lib pipeline instead of sonic image pipeline.
2. Use ArtifactStagingDirectory for download to avoid using old artifacts.

**Why I did it**
1. common lib pipeline has a less failure rate. Because it only builds some third-party packages.
2. ArtifactStagingDirectory will be reset before every job. It will avoid using out-of-date dependencies.

**How I verified it**

**Details if related**
