### PR TITLE
Apply `DSCP_TO_TC_MAP` from `PORT_QOS_MAP|global` to switch level

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -15,6 +15,8 @@
 using namespace std;
 using namespace swss;
 
+#define PORT_NAME_GLOBAL "global"
+
 BufferMgr::BufferMgr(DBConnector *cfgDb, DBConnector *applDb, string pg_lookup_file, const vector<string> &tableNames) :
         Orch(cfgDb, tableNames),
         m_cfgPortTable(cfgDb, CFG_PORT_TABLE_NAME),
@@ -391,6 +393,11 @@ void BufferMgr::doPortQosTableTask(Consumer &consumer)
     {
         KeyOpFieldsValuesTuple tuple = it->second;
         string port_name = kfvKey(tuple);
+        if (port_name == PORT_NAME_GLOBAL)
+        {
+            // Ignore the entry for global level 
+            continue;
+        }
         string op = kfvOp(tuple);
         if (op == SET_COMMAND)
         {

--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -395,7 +395,8 @@ void BufferMgr::doPortQosTableTask(Consumer &consumer)
         string port_name = kfvKey(tuple);
         if (port_name == PORT_NAME_GLOBAL)
         {
-            // Ignore the entry for global level 
+            // Ignore the entry for global level
+            it = consumer.m_toSync.erase(it);
             continue;
         }
         string op = kfvOp(tuple);

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -104,7 +104,7 @@ map<string, string> qos_to_ref_table_map = {
 #define DSCP_MAX_VAL 63
 #define EXP_MAX_VAL 7
 
-#define DEFAULT_DSCP_TO_TC_MAP_NAME "AZURE"
+#define PORT_NAME_GLOBAL "global"
 
 task_process_status QosMapHandler::processWorkItem(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
@@ -150,16 +150,6 @@ task_process_status QosMapHandler::processWorkItem(Consumer& consumer, KeyOpFiel
                 freeAttribResources(attributes);
                 return task_process_status::task_failed;
             }
-            if ((qos_map_type_name == CFG_DSCP_TO_TC_MAP_TABLE_NAME) && (qos_object_name == DEFAULT_DSCP_TO_TC_MAP_NAME))
-            {
-                DscpToTcMapHandler *handler = dynamic_cast<DscpToTcMapHandler*>(this);
-                if (handler)
-                {
-                    handler->applyDscpToTcMapToSwitch(SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP, sai_object);
-                    SWSS_LOG_NOTICE("Applied DSCP_TO_TC_MAP %s to switch level", DEFAULT_DSCP_TO_TC_MAP_NAME);
-                }
-            }
-
             (*(QosOrch::getTypeMap()[qos_map_type_name]))[qos_object_name].m_saiObjectId = sai_object;
             (*(QosOrch::getTypeMap()[qos_map_type_name]))[qos_object_name].m_pendingRemove = false;
             SWSS_LOG_NOTICE("Created [%s:%s]", qos_map_type_name.c_str(), qos_object_name.c_str());
@@ -248,37 +238,6 @@ bool DscpToTcMapHandler::convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &
     return true;
 }
 
-void DscpToTcMapHandler::applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t map_id)
-{
-    SWSS_LOG_ENTER();
-    bool rv = true;
-
-    /* Query DSCP_TO_TC QoS map at switch capability */
-    rv = gSwitchOrch->querySwitchDscpToTcCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP);
-    if (rv == false)
-    {
-        SWSS_LOG_ERROR("Switch level DSCP to TC QoS map configuration is not supported");
-        return;
-    }
-
-    /* Apply DSCP_TO_TC QoS map at switch */
-    sai_attribute_t attr;
-    attr.id = attr_id;
-    attr.value.oid = map_id;
-
-    sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
-        SWSS_LOG_ERROR("Failed to apply DSCP_TO_TC QoS map to switch rv:%d", status);
-        return;
-    }
-
-    if (map_id != gQosOrch->m_globalDscpToTcMap)
-        gQosOrch->m_globalDscpToTcMap = map_id;
-
-    SWSS_LOG_NOTICE("Applied DSCP_TO_TC QoS map to switch successfully");
-}
-
 sai_object_id_t DscpToTcMapHandler::addQosItem(const vector<sai_attribute_t> &attributes)
 {
     SWSS_LOG_ENTER();
@@ -313,23 +272,9 @@ bool DscpToTcMapHandler::removeQosItem(sai_object_id_t sai_object)
 
     if (sai_object == gQosOrch->m_globalDscpToTcMap)
     {
-        // The current global dscp to tc map is about to be removed.
-        // Find another one to set to the switch or NULL in case this is the last one
-        const auto &dscpToTcObjects = (*QosOrch::getTypeMap()[CFG_DSCP_TO_TC_MAP_TABLE_NAME]);
-        bool found = false;
-        for (const auto &ref : dscpToTcObjects)
-        {
-            if (ref.second.m_saiObjectId == sai_object)
-                continue;
-            SWSS_LOG_NOTICE("Current global dscp_to_tc map is about to be removed, set it to %s %" PRIx64, ref.first.c_str(), ref.second.m_saiObjectId);
-            applyDscpToTcMapToSwitch(SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP, ref.second.m_saiObjectId);
-            found = true;
-            break;
-        }
-        if (!found)
-        {
-            applyDscpToTcMapToSwitch(SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP, SAI_NULL_OBJECT_ID);
-        }
+        // The current global dscp to tc map is still referenced
+        SWSS_LOG_NOTICE("Current global dscp_to_tc map is still being referenced %" PRIx64, sai_object);
+        return false;
     }
 
     SWSS_LOG_DEBUG("Removing DscpToTcMap object:%" PRIx64, sai_object);
@@ -1727,12 +1672,90 @@ task_process_status QosOrch::handleQueueTable(Consumer& consumer, KeyOpFieldsVal
     return task_process_status::task_success;
 }
 
+bool QosOrch::applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t map_id)
+{
+    SWSS_LOG_ENTER();
+
+    /* Query DSCP_TO_TC QoS map at switch capability */
+    bool rv = gSwitchOrch->querySwitchDscpToTcCapability(SAI_OBJECT_TYPE_SWITCH, SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP);
+    if (rv == false)
+    {
+        SWSS_LOG_ERROR("Switch level DSCP to TC QoS map configuration is not supported");
+        return true;
+    }
+
+    /* Apply DSCP_TO_TC QoS map at switch */
+    sai_attribute_t attr;
+    attr.id = attr_id;
+    attr.value.oid = map_id;
+
+    sai_status_t status = sai_switch_api->set_switch_attribute(gSwitchId, &attr);
+    if (status != SAI_STATUS_SUCCESS)
+    {
+        SWSS_LOG_ERROR("Failed to apply DSCP_TO_TC QoS map to switch rv:%d", status);
+        return false;
+    }
+
+    if (map_id != gQosOrch->m_globalDscpToTcMap)
+        gQosOrch->m_globalDscpToTcMap = map_id;
+
+    SWSS_LOG_NOTICE("Applied DSCP_TO_TC QoS map to switch successfully");
+    return true;
+}
+
+task_process_status QosOrch::handleGlobalQosMap(const string &OP, KeyOpFieldsValuesTuple &tuple)
+{
+    task_process_status task_status = task_process_status::task_success;
+    if (OP == DEL_COMMAND)
+    {
+        // Ignore the DEL operation for switch level mapping
+        SWSS_LOG_NOTICE("Ignore DEL operation for global qos map");
+        return task_status;
+    }
+    
+    for (auto it = kfvFieldsValues(tuple).begin(); it != kfvFieldsValues(tuple).end(); it++)
+    {
+        string map_type_name = fvField(*it);
+        string map_name = fvValue(*it);
+        if (map_type_name != dscp_to_tc_field_name)
+        {
+            SWSS_LOG_WARN("Qos map %s is not supported at global level", map_type_name.c_str());
+            continue;
+        }
+        if (qos_to_attr_map.find(map_type_name) != qos_to_attr_map.end())
+        {
+            sai_object_id_t id;
+            string object_name;
+            ref_resolve_status status = resolveFieldRefValue(m_qos_maps, map_type_name, qos_to_ref_table_map.at(map_type_name), tuple, id, object_name);
+
+            if (status != ref_resolve_status::success)
+            {
+                SWSS_LOG_INFO("Global QoS map %s is not yet created", map_name.c_str());
+                task_status = task_process_status::task_need_retry;
+            }
+
+            if (applyDscpToTcMapToSwitch(SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP, id))
+            {
+                task_status = task_process_status::task_success;
+            }
+            setObjectReference(m_qos_maps, CFG_PORT_QOS_MAP_TABLE_NAME, PORT_NAME_GLOBAL, map_type_name, object_name);
+        }
+    }
+    return task_status;
+}
+
 task_process_status QosOrch::handlePortQosMapTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple)
 {
     SWSS_LOG_ENTER();
 
     string key = kfvKey(tuple);
     string op = kfvOp(tuple);
+
+    if (key == PORT_NAME_GLOBAL)
+    {
+        return handleGlobalQosMap(op, tuple);
+    }
+
     vector<string> port_names = tokenize(key, list_item_delimiter);
 
     if (op == DEL_COMMAND)

--- a/orchagent/qosorch.cpp
+++ b/orchagent/qosorch.cpp
@@ -270,13 +270,6 @@ bool DscpToTcMapHandler::removeQosItem(sai_object_id_t sai_object)
 {
     SWSS_LOG_ENTER();
 
-    if (sai_object == gQosOrch->m_globalDscpToTcMap)
-    {
-        // The current global dscp to tc map is still referenced
-        SWSS_LOG_NOTICE("Current global dscp_to_tc map is still being referenced %" PRIx64, sai_object);
-        return false;
-    }
-
     SWSS_LOG_DEBUG("Removing DscpToTcMap object:%" PRIx64, sai_object);
     sai_status_t sai_status = sai_qos_map_api->remove_qos_map(sai_object);
     if (SAI_STATUS_SUCCESS != sai_status)
@@ -1695,9 +1688,6 @@ bool QosOrch::applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t ma
         SWSS_LOG_ERROR("Failed to apply DSCP_TO_TC QoS map to switch rv:%d", status);
         return false;
     }
-
-    if (map_id != gQosOrch->m_globalDscpToTcMap)
-        gQosOrch->m_globalDscpToTcMap = map_id;
 
     SWSS_LOG_NOTICE("Applied DSCP_TO_TC QoS map to switch successfully");
     return true;

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -212,9 +212,6 @@ private:
 
     std::unordered_map<sai_object_id_t, SchedulerGroupPortInfo_t> m_scheduler_group_port_info;
 
-    // SAI OID of the global dscp to tc map
-    sai_object_id_t m_globalDscpToTcMap;
-
     friend QosMapHandler;
     friend DscpToTcMapHandler;
 };

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -78,8 +78,6 @@ public:
     bool convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes) override;
     sai_object_id_t addQosItem(const vector<sai_attribute_t> &attributes) override;
     bool removeQosItem(sai_object_id_t sai_object);
-
-    void applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t sai_dscp_to_tc_map);
 };
 
 class MplsTcToTcMapHandler : public QosMapHandler
@@ -195,11 +193,13 @@ private:
     task_process_status handleExpToFcTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
     task_process_status handleTcToDscpTable(Consumer& consumer, KeyOpFieldsValuesTuple &tuple);
 
+    task_process_status handleGlobalQosMap(const string &op, KeyOpFieldsValuesTuple &tuple);
+
     sai_object_id_t getSchedulerGroup(const Port &port, const sai_object_id_t queue_id);
 
     bool applySchedulerToQueueSchedulerGroup(Port &port, size_t queue_ind, sai_object_id_t scheduler_profile_id);
     bool applyWredProfileToQueue(Port &port, size_t queue_ind, sai_object_id_t sai_wred_profile);
-
+    bool applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t sai_dscp_to_tc_map);
 private:
     qos_table_handler_map m_qos_handler_map;
 

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -78,7 +78,7 @@ public:
     bool convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes) override;
     sai_object_id_t addQosItem(const vector<sai_attribute_t> &attributes) override;
     bool removeQosItem(sai_object_id_t sai_object);
-protected:
+
     void applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t sai_dscp_to_tc_map);
 };
 

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -947,7 +947,8 @@ namespace qosorch_test
         entries.clear();
         // Drain DSCP_TO_TC_MAP table
         static_cast<Orch *>(gQosOrch)->doTask();
-        ASSERT_EQ((*QosOrch::getTypeMap()[CFG_DSCP_TO_TC_MAP_TABLE_NAME])["AZURE_1"].m_saiObjectId, switch_dscp_to_tc_map_id);
+        // As we hardcode the default map name to AZURE, pushing AZURE_1 makes no change
+        ASSERT_EQ((*QosOrch::getTypeMap()[CFG_DSCP_TO_TC_MAP_TABLE_NAME])["AZURE"].m_saiObjectId, switch_dscp_to_tc_map_id);
 
         entries.push_back({"AZURE_1", "DEL", {}});
         consumer->addToSync(entries);

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -370,6 +370,61 @@ class TestMplsTc(object):
         port_cnt = len(swsscommon.Table(self.config_db, CFG_PORT_TABLE_NAME).getKeys())
         assert port_cnt == cnt
 
+class TestDscpToTcMap(object):
+    ASIC_QOS_MAP_STR = "ASIC_STATE:SAI_OBJECT_TYPE_QOS_MAP"
+    ASIC_PORT_STR = "ASIC_STATE:SAI_OBJECT_TYPE_PORT"
+    ASIC_SWITCH_STR = "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH"
+
+    def init_test(self, dvs):
+        dvs.setup_db()
+        self.asic_db = dvs.get_asic_db()
+        self.config_db = dvs.get_config_db()
+        self.asic_qos_map_ids = self.asic_db.get_keys(self.ASIC_QOS_MAP_STR)
+        self.asic_qos_map_count = len(self.asic_qos_map_ids)
+        self.dscp_to_tc_table = swsscommon.Table(self.config_db.db_connection, swsscommon.CFG_DSCP_TO_TC_MAP_TABLE_NAME)
+
+    def get_qos_id(self):
+        diff = set(self.asic_db.get_keys(self.ASIC_QOS_MAP_STR)) - set(self.asic_qos_map_ids)
+        assert len(diff) <= 1
+        return None if len(diff) == 0 else diff.pop()
+    
+    def test_dscp_to_tc_map_applied_to_switch(self, dvs):
+        self.init_test(dvs)
+        dscp_to_tc_map_id = None
+        created_new_map = False
+        try:
+            existing_map = self.dscp_to_tc_table.getKeys()
+            if "AZURE" not in existing_map: 
+                # Create a DSCP_TO_TC map
+                dscp_to_tc_map = [(str(i), str(i)) for i in range(0, 63)]
+                self.dscp_to_tc_table.set("AZURE", swsscommon.FieldValuePairs(dscp_to_tc_map))
+
+                self.asic_db.wait_for_n_keys(self.ASIC_QOS_MAP_STR, self.asic_qos_map_count + 1)
+
+                # Get the DSCP_TO_TC map ID
+                dscp_to_tc_map_id = self.get_qos_id()
+                assert(dscp_to_tc_map_id is not None)
+
+                # Assert the expected values
+                fvs = self.asic_db.get_entry(self.ASIC_QOS_MAP_STR, dscp_to_tc_map_id)
+                assert(fvs.get("SAI_QOS_MAP_ATTR_TYPE") == "SAI_QOS_MAP_TYPE_DSCP_TO_TC")
+                created_new_map = True
+            else:
+                for id in self.asic_qos_map_ids:
+                    fvs = self.asic_db.get_entry(self.ASIC_QOS_MAP_STR, id)
+                    if fvs.get("SAI_QOS_MAP_ATTR_TYPE") == "SAI_QOS_MAP_TYPE_DSCP_TO_TC":
+                        dscp_to_tc_map_id = id
+                        break
+
+            # Check the switch level DSCP_TO_TC_MAP is applied
+            switch_oid = dvs.getSwitchOid()
+            fvs = self.asic_db.get_entry(self.ASIC_SWITCH_STR, switch_oid)
+            assert(fvs.get("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP") == dscp_to_tc_map_id)
+
+        finally:
+            if created_new_map:
+                self.dscp_to_tc_table._del("AZURE")
+        
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -429,6 +429,13 @@ class TestDscpToTcMap(object):
             fvs = self.asic_db.get_entry(self.ASIC_SWITCH_STR, switch_oid)
             assert(fvs.get("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP") == dscp_to_tc_map_id)
 
+            # Remove the global level DSCP_TO_TC_MAP
+            self.port_qos_table._del("global")
+            time.sleep(1)
+
+            # Check the global level DSCP_TO_TC_MAP is set to SAI_
+            fvs = self.asic_db.get_entry(self.ASIC_SWITCH_STR, switch_oid)
+            assert(fvs.get("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP") == "oid:0x0")
         finally:
             if created_new_map:
                 self.dscp_to_tc_table._del("AZURE")


### PR DESCRIPTION
Signed-off-by: bingwang <wang.bing@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR is to update the code for applying switch level `DSCP_TO_TC_MAP`.
After PR https://github.com/Azure/sonic-buildimage/pull/10565, there will be two DSCP_TO_TC_MAP

- DSCP_TO_TC_MAP|AZURE is the default map, which is used at port level and switch level
- DSCP_TO_TC_MAP|AZURE_TUNNEL is used to remap the priority of tunnel traffic in dualtor deployment

To address the issue, an entry `PORT_QOS_MAP|global` will be added into `config_db`
```
"PORT_QOS_MAP": {
        "global": {
            "dscp_to_tc_map": "AZURE"
        }
}
```
The entry will be consumed by `qosorch`, and the specified map will be applied to switch.

**Why I did it**
This change is to ensure the correct `DSCP_TO_TC_MAP` is applied to switch level.

**How I verified it**
Verified by a new test case `test_dscp_to_tc_map_applied_to_switch`
```
collected 9 items                                                                                                                                                                                     

test_qos_map.py::TestDot1p::test_dot1p_cfg PASSED                                                                                                                                               [ 11%]
test_qos_map.py::TestDot1p::test_port_dot1p PASSED                                                                                                                                              [ 22%]
test_qos_map.py::TestCbf::test_dscp_to_fc PASSED                                                                                                                                                [ 33%]
test_qos_map.py::TestCbf::test_exp_to_fc PASSED                                                                                                                                                 [ 44%]
test_qos_map.py::TestCbf::test_per_port_cbf_binding PASSED                                                                                                                                      [ 55%]
test_qos_map.py::TestMplsTc::test_mpls_tc_cfg PASSED                                                                                                                                            [ 66%]
test_qos_map.py::TestMplsTc::test_port_mpls_tc PASSED                                                                                                                                           [ 77%]
test_qos_map.py::TestDscpToTcMap::test_dscp_to_tc_map_applied_to_switch PASSED                                                                                                                  [ 88%]
test_qos_map.py::test_nonflaky_dummy PASSED                                                                                                                                                     [100%]
```
**Details if related**
