### PR TITLE
[fpmsyncd] don't manipulate route weight

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -1208,7 +1208,7 @@ string RouteSync::getNextHopWt(struct rtnl_route *route_obj)
         uint8_t weight = rtnl_route_nh_get_weight(nexthop);
         if (weight)
         {
-            result += to_string(weight + 1);
+            result += to_string(weight);
         }
         else
         {


### PR DESCRIPTION
**What I did**
Return the next hop weight obtained from kernel as-is.

Sample next hop weight:

> admin@svcstr-7050-acs-4:~$ ip route show 193.11.248.128/25
> 193.11.248.128/25 nhid 1452 proto bgp src 10.1.0.33 metric 20 
>         nexthop via 10.0.1.61 dev PortChannel103 weight 1 
>         nexthop via 10.0.1.63 dev PortChannel104 weight 1 
>         nexthop via 10.0.1.59 dev PortChannel102 weight 1 
>         nexthop via 10.0.1.57 dev PortChannel101 weight 1 
> 

**Why I did it**
Some platforms have issue dealing with arbitrary next hop weight values.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
