### PR TITLE
[202205][fpmsyncd] don't manipulate route weight

### DIFF
--- a/fpmsyncd/routesync.cpp
+++ b/fpmsyncd/routesync.cpp
@@ -1208,7 +1208,7 @@ string RouteSync::getNextHopWt(struct rtnl_route *route_obj)
         uint8_t weight = rtnl_route_nh_get_weight(nexthop);
         if (weight)
         {
-            result += to_string(weight + 1);
+            result += to_string(weight);
         }
         else
         {


### PR DESCRIPTION
**What I did**
This is a cherry-pick PR for #2320.

**Why I did it**
We don't necessarily think it is the right solution, but before we can make Zebra behavior consistent. This change will unblock SONiC tests.

It will be a temporary solution until we converge with FRR/Zebra changes.

Signed-off-by: Ying Xie <ying.xie@microsoft.com>
