### PR TITLE
Fix key generation in removeDecapTunnel

### DIFF
--- a/orchagent/tunneldecaporch.cpp
+++ b/orchagent/tunneldecaporch.cpp
@@ -67,7 +67,7 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
         {
             tunnel_id = tunnelTable[key].tunnel_id;
         }
-        
+
         if (op == SET_COMMAND)
         {
 
@@ -240,11 +240,11 @@ void TunnelDecapOrch::doTask(Consumer& consumer)
                 ++it;
                 continue;
             }
-            
+
             //create new tunnel if it doesn't exists already
             if (valid && !exists)
             {
-                
+
                 if (addDecapTunnel(key, tunnel_type, ip_addresses, p_src_ip, dscp_mode, ecn_mode, encap_ecn_mode, ttl_mode,
                                     dscp_to_tc_map_id, tc_to_pg_map_id))
                 {
@@ -427,7 +427,7 @@ bool TunnelDecapOrch::addDecapTunnel(
         attr.value.oid = tc_to_pg_map_id;
         tunnel_attrs.push_back(attr);
     }
-    
+
     // write attributes to ASIC_DB
     sai_object_id_t tunnel_id;
     status = sai_tunnel_api->create_tunnel(&tunnel_id, gSwitchId, (uint32_t)tunnel_attrs.size(), tunnel_attrs.data());
@@ -669,8 +669,8 @@ bool TunnelDecapOrch::setTunnelAttribute(string field, sai_object_id_t value, sa
     {
         // TC remapping.
         attr.id = SAI_TUNNEL_ATTR_DECAP_QOS_DSCP_TO_TC_MAP;
-        attr.value.oid = value; 
-        
+        attr.value.oid = value;
+
     }
     else if (field == decap_tc_to_pg_field_name)
     {
@@ -763,7 +763,16 @@ bool TunnelDecapOrch::removeDecapTunnel(string table_name, string key)
     for (auto it = tunnel_info->tunnel_term_info.begin(); it != tunnel_info->tunnel_term_info.end(); ++it)
     {
         TunnelTermEntry tunnel_entry_info = *it;
-        string term_key = tunnel_entry_info.src_ip + '-' + tunnel_entry_info.dst_ip;
+        string term_key;
+        swss::IpAddress src_ip(tunnel_entry_info.src_ip);
+        if (!src_ip.isZero())
+        {
+            term_key = src_ip.to_string() + '-' + tunnel_entry_info.dst_ip;
+        }
+        else
+        {
+            term_key = tunnel_entry_info.dst_ip;
+        }
         if (!removeDecapTunnelTermEntry(tunnel_entry_info.tunnel_term_id, term_key))
         {
             return false;


### PR DESCRIPTION
Signed-off-by: Myron Sosyak <myronx.sosyak@intel.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->
After the latest changes in this PR https://github.com/Azure/sonic-swss/pull/2190 an issue was introduced. When the tunnel was deleted the TunnelTermEntries were deleted from ASIC but not from the OA cache. Due to that then the same tunnel is created the TunnelTermEntries are not created as OA has it in local cache.

**What I did**
Fix key generation in removeDecapTunnel

**Why I did it**
To fix the issue described above.

**How I verified it**
On SONiC testbed after deployment of t1/t0 topology
```
docker exec -ti swss bash
cp /etc/swss/config.d/ipinip.json deltun.json
sed -i 's/SET/DEL/g' deltun.json
swssconfig deltun.json
swssconfig /etc/swss/config.d/ipinip.json 
```
Check in logs that entries were removed and then created.
```
Jun 10 08:45:39.973461 igk-6-dut NOTICE swss#orchagent: :- removeDecapTunnelTermEntry: Removed decap tunnel term entry with ip address: 192.168.0.1
Jun 10 08:45:39.974420 igk-6-dut NOTICE swss#orchagent: :- removeDecapTunnelTermEntry: Removed decap tunnel term entry with ip address: 10.1.0.32
Jun 10 08:45:39.975411 igk-6-dut NOTICE swss#orchagent: :- removeDecapTunnelTermEntry: Removed decap tunnel term entry with ip address: 10.0.0.56
Jun 10 08:45:39.976601 igk-6-dut NOTICE swss#orchagent: :- removeDecapTunnelTermEntry: Removed decap tunnel term entry with ip address: 10.0.0.58
Jun 10 08:45:39.977533 igk-6-dut NOTICE swss#orchagent: :- removeDecapTunnelTermEntry: Removed decap tunnel term entry with ip address: 10.0.0.60
Jun 10 08:45:39.978469 igk-6-dut NOTICE swss#orchagent: :- removeDecapTunnelTermEntry: Removed decap tunnel term entry with ip address: 10.0.0.62Jun 10 08:45:55.653637 igk-6-dut NOTICE swss#swssconfig: :- main: Loading config from JSON file:/etc/swss/config.d/ipinip.json...
Jun 10 08:45:55.659735 igk-6-dut NOTICE swss#orchagent: :- addDecapTunnel: Create overlay loopback router interface oid:6000000000740
Jun 10 08:45:55.664682 igk-6-dut NOTICE swss#orchagent: :- addDecapTunnelTermEntries: Created tunnel entry for ip: 192.168.0.1
Jun 10 08:45:55.667057 igk-6-dut NOTICE swss#orchagent: :- addDecapTunnelTermEntries: Created tunnel entry for ip: 10.1.0.32
Jun 10 08:45:55.669582 igk-6-dut NOTICE swss#orchagent: :- addDecapTunnelTermEntries: Created tunnel entry for ip: 10.0.0.56
Jun 10 08:45:55.671794 igk-6-dut NOTICE swss#orchagent: :- addDecapTunnelTermEntries: Created tunnel entry for ip: 10.0.0.58
Jun 10 08:45:55.673442 igk-6-dut NOTICE swss#orchagent: :- addDecapTunnelTermEntries: Created tunnel entry for ip: 10.0.0.60
Jun 10 08:45:55.675260 igk-6-dut NOTICE swss#orchagent: :- addDecapTunnelTermEntries: Created tunnel entry for ip: 10.0.0.62

```

**Details if related**
