### PR TITLE
[neighsync] Ignoring IPv4 link local addresses (#2260)

### DIFF
--- a/neighsyncd/neighsync.cpp
+++ b/neighsyncd/neighsync.cpp
@@ -74,7 +74,17 @@ void NeighSync::onMsg(int nlmsg_type, struct nl_object *obj)
     key+= ":";
 
     nl_addr2str(rtnl_neigh_get_dst(neigh), ipStr, MAX_ADDR_SIZE);
-    /* Ignore IPv6 link-local addresses as neighbors */
+
+    /* Ignore IPv4 link-local addresses as neighbors */
+    IpAddress ipAddress(ipStr);
+    if (family == IPV4_NAME && ipAddress.getAddrScope() == IpAddress::AddrScope::LINK_SCOPE)
+    {
+        SWSS_LOG_INFO("Link Local address received, ignoring for %s", ipStr);
+        return;
+    }
+
+
+    /* Ignore IPv6 link-local addresses as neighbors, if ipv6 link local mode is disabled */
     if (family == IPV6_NAME && IN6_IS_ADDR_LINKLOCAL(nl_addr_get_binary_addr(rtnl_neigh_get_dst(neigh))))
         return;
     /* Ignore IPv6 multicast link-local addresses as neighbors */


### PR DESCRIPTION
[neighsync] Ignoring IPv4 link local addresses (#2260)
    
    * [neighsync] Ignoring IPv4 link local addresses
    
    Skipping over writing ipv4 link local neighbors to APPL_DB. This was causing link local neighbors to appear and led to long switchover times during mux state change.
    
    Signed-off-by: Nikola Dancejic <ndancejic@microsoft.com>


cherry-pick to 202012 version from (#2260)