### PR TITLE
[202012] [cherry-pick] Apply `DSCP_TO_TC_MAP` from `PORT_QOS_MAP|global` to switch level

### DIFF
--- a/cfgmgr/buffermgr.cpp
+++ b/cfgmgr/buffermgr.cpp
@@ -16,6 +16,8 @@
 using namespace std;
 using namespace swss;
 
+#define PORT_NAME_GLOBAL "global"
+
 BufferMgr::BufferMgr(DBConnector *cfgDb, DBConnector *applDb, string pg_lookup_file, const vector<string> &tableNames) :
         Orch(cfgDb, tableNames),
         m_cfgPortTable(cfgDb, CFG_PORT_TABLE_NAME),
@@ -455,6 +457,12 @@ void BufferMgr::doPortQosTableTask(Consumer &consumer)
     {
         KeyOpFieldsValuesTuple tuple = it->second;
         string port_name = kfvKey(tuple);
+        if (port_name == PORT_NAME_GLOBAL)
+        {
+            // Ignore the entry for global level
+            it = consumer.m_toSync.erase(it);
+            continue;
+        }
         string op = kfvOp(tuple);
         if (op == SET_COMMAND)
         {

--- a/orchagent/qosorch.h
+++ b/orchagent/qosorch.h
@@ -74,8 +74,7 @@ class DscpToTcMapHandler : public QosMapHandler
 public:
     bool convertFieldValuesToAttributes(KeyOpFieldsValuesTuple &tuple, vector<sai_attribute_t> &attributes) override;
     sai_object_id_t addQosItem(const vector<sai_attribute_t> &attributes) override;
-protected:
-    void applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t sai_dscp_to_tc_map);
+    bool removeQosItem(sai_object_id_t sai_object);
 };
 
 class Dot1pToTcMapHandler : public QosMapHandler
@@ -167,11 +166,14 @@ private:
     task_process_status handleWredProfileTable(Consumer& consumer);
     task_process_status handleTcToDscpTable(Consumer& consumer);
 
+    task_process_status handleGlobalQosMap(const string &op, KeyOpFieldsValuesTuple &tuple);
+
     sai_object_id_t getSchedulerGroup(const Port &port, const sai_object_id_t queue_id);
 
     bool applyMapToPort(Port &port, sai_attr_id_t attr_id, sai_object_id_t sai_dscp_to_tc_map);
     bool applySchedulerToQueueSchedulerGroup(Port &port, size_t queue_ind, sai_object_id_t scheduler_profile_id);
     bool applyWredProfileToQueue(Port &port, size_t queue_ind, sai_object_id_t sai_wred_profile);
+    bool applyDscpToTcMapToSwitch(sai_attr_id_t attr_id, sai_object_id_t sai_dscp_to_tc_map);
     task_process_status ResolveMapAndApplyToPort(Port &port,sai_port_attr_t port_attr,
                                                  string field_name, KeyOpFieldsValuesTuple &tuple, string op);
 

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -23,7 +23,7 @@ CFG_PORT_QOS_MAP_FIELD = "dot1p_to_tc_map"
 CFG_PORT_TABLE_NAME = "PORT"
 
 
-class aaTestDot1p(object):
+class TestDot1p(object):
     def connect_dbs(self, dvs):
         self.asic_db = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         self.config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
@@ -152,9 +152,6 @@ class TestDscpToTcMap(object):
                         dscp_to_tc_map_id = id
                         break
             switch_oid = dvs.getSwitchOid()
-            # Check switch level DSCP_TO_TC_MAP doesn't before PORT_QOS_MAP|global is created
-            fvs = self.asic_db.get_entry(self.ASIC_SWITCH_STR, switch_oid)
-            assert("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP" not in fvs)
 
             # Insert switch level map entry 
             self.port_qos_table.set("global", [("dscp_to_tc_map", "[DSCP_TO_TC_MAP|AZURE]")])

--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -23,7 +23,7 @@ CFG_PORT_QOS_MAP_FIELD = "dot1p_to_tc_map"
 CFG_PORT_TABLE_NAME = "PORT"
 
 
-class TestDot1p(object):
+class aaTestDot1p(object):
     def connect_dbs(self, dvs):
         self.asic_db = swsscommon.DBConnector(1, dvs.redis_sock, 0)
         self.config_db = swsscommon.DBConnector(4, dvs.redis_sock, 0)
@@ -105,6 +105,75 @@ class TestDot1p(object):
         port_cnt = len(swsscommon.Table(self.config_db, CFG_PORT_TABLE_NAME).getKeys())
         assert port_cnt == cnt
 
+class TestDscpToTcMap(object):
+    ASIC_QOS_MAP_STR = "ASIC_STATE:SAI_OBJECT_TYPE_QOS_MAP"
+    ASIC_PORT_STR = "ASIC_STATE:SAI_OBJECT_TYPE_PORT"
+    ASIC_SWITCH_STR = "ASIC_STATE:SAI_OBJECT_TYPE_SWITCH"
+
+    def init_test(self, dvs):
+        dvs.setup_db()
+        self.asic_db = dvs.get_asic_db()
+        self.config_db = dvs.get_config_db()
+        self.asic_qos_map_ids = self.asic_db.get_keys(self.ASIC_QOS_MAP_STR)
+        self.asic_qos_map_count = len(self.asic_qos_map_ids)
+        self.dscp_to_tc_table = swsscommon.Table(self.config_db.db_connection, swsscommon.CFG_DSCP_TO_TC_MAP_TABLE_NAME)
+        self.port_qos_table = swsscommon.Table(self.config_db.db_connection, swsscommon.CFG_PORT_QOS_MAP_TABLE_NAME)
+
+    def get_qos_id(self):
+        diff = set(self.asic_db.get_keys(self.ASIC_QOS_MAP_STR)) - set(self.asic_qos_map_ids)
+        assert len(diff) <= 1
+        return None if len(diff) == 0 else diff.pop()
+
+    def test_dscp_to_tc_map_applied_to_switch(self, dvs):
+        self.init_test(dvs)
+        dscp_to_tc_map_id = None
+        created_new_map = False
+        try:
+            existing_map = self.dscp_to_tc_table.getKeys()
+            if "AZURE" not in existing_map: 
+                # Create a DSCP_TO_TC map
+                dscp_to_tc_map = [(str(i), str(i)) for i in range(0, 63)]
+                self.dscp_to_tc_table.set("AZURE", swsscommon.FieldValuePairs(dscp_to_tc_map))
+
+                self.asic_db.wait_for_n_keys(self.ASIC_QOS_MAP_STR, self.asic_qos_map_count + 1)
+
+                # Get the DSCP_TO_TC map ID
+                dscp_to_tc_map_id = self.get_qos_id()
+                assert(dscp_to_tc_map_id is not None)
+
+                # Assert the expected values
+                fvs = self.asic_db.get_entry(self.ASIC_QOS_MAP_STR, dscp_to_tc_map_id)
+                assert(fvs.get("SAI_QOS_MAP_ATTR_TYPE") == "SAI_QOS_MAP_TYPE_DSCP_TO_TC")
+                created_new_map = True
+            else:
+                for id in self.asic_qos_map_ids:
+                    fvs = self.asic_db.get_entry(self.ASIC_QOS_MAP_STR, id)
+                    if fvs.get("SAI_QOS_MAP_ATTR_TYPE") == "SAI_QOS_MAP_TYPE_DSCP_TO_TC":
+                        dscp_to_tc_map_id = id
+                        break
+            switch_oid = dvs.getSwitchOid()
+            # Check switch level DSCP_TO_TC_MAP doesn't before PORT_QOS_MAP|global is created
+            fvs = self.asic_db.get_entry(self.ASIC_SWITCH_STR, switch_oid)
+            assert("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP" not in fvs)
+
+            # Insert switch level map entry 
+            self.port_qos_table.set("global", [("dscp_to_tc_map", "[DSCP_TO_TC_MAP|AZURE]")])
+            time.sleep(1)
+
+            # Check the switch level DSCP_TO_TC_MAP is applied
+            fvs = self.asic_db.get_entry(self.ASIC_SWITCH_STR, switch_oid)
+            assert(fvs.get("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP") == dscp_to_tc_map_id)
+
+            # Remove the global level DSCP_TO_TC_MAP
+            self.port_qos_table._del("global")
+            time.sleep(1)
+
+            # Check the global level DSCP_TO_TC_MAP is set to SAI_
+            fvs = self.asic_db.get_entry(self.ASIC_SWITCH_STR, switch_oid)
+            assert(fvs.get("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP") == "oid:0x0")
+        finally:
+            if created_new_map:
+                self.dscp_to_tc_table._del("AZURE")
 
 # Add Dummy always-pass test at end as workaroud
 # for issue when Flaky fail on final test it invokes module tear-down before retrying


### PR DESCRIPTION

**What I did**
This PR is to cherry-pick https://github.com/Azure/sonic-swss/pull/2314 to `202012` branch after resolving conflicts.

This PR is to update the code for applying switch level `DSCP_TO_TC_MAP`.
After PR https://github.com/Azure/sonic-buildimage/pull/10565, there will be two DSCP_TO_TC_MAP

- DSCP_TO_TC_MAP|AZURE is the default map, which is used at port level and switch level
- DSCP_TO_TC_MAP|AZURE_TUNNEL is used to remap the priority of tunnel traffic in dualtor deployment

To address the issue, an entry `PORT_QOS_MAP|global` will be added into `config_db`
```
"PORT_QOS_MAP": {
        "global": {
            "dscp_to_tc_map": "[DSCP_TO_TC_MAP|AZURE]"
        }
}
```
The entry will be consumed by `qosorch`, and the specified map will be applied to switch.

**Why I did it**
This change is to ensure the correct `DSCP_TO_TC_MAP` is applied to switch level.

**How I verified it**
Verified by a new test case `test_dscp_to_tc_map_applied_to_switch`
```
collected 2 items                                                                                                                                                                                     

test_qos_map.py::TestDscpToTcMap::test_dscp_to_tc_map_applied_to_switch PASSED                                                                                                                  [ 50%]
test_qos_map.py::test_nonflaky_dummy PASSED                                                                                                                                                     [100%]
```
**Details if related**
