### PR TITLE
[portsorch] Expose supported FEC modes to STABE_DB and check whether FEC mode is supported before setting it

### DIFF
--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -209,6 +209,7 @@ private:
     unique_ptr<Table> m_gbcounterTable;
 
     std::map<sai_object_id_t, PortSupportedSpeeds> m_portSupportedSpeeds;
+    // Supported FEC modes on the system side.
     std::map<sai_object_id_t, PortSupportedFecModes> m_portSupportedFecModes;
 
     bool m_initDone = false;
@@ -315,6 +316,7 @@ private:
     bool isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
     void getPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id, PortSupportedSpeeds &supported_speeds);
     void initPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id);
+    // Get supported FEC modes on system side
     void getPortSupportedFecModes(const std::string& alias, sai_object_id_t port_id, PortSupportedFecModes &supported_fecmodes);
     void initPortSupportedFecModes(const std::string& alias, sai_object_id_t port_id);
     task_process_status setPortSpeed(Port &port, sai_uint32_t speed);

--- a/orchagent/portsorch.h
+++ b/orchagent/portsorch.h
@@ -27,6 +27,7 @@
 #define PG_DROP_STAT_COUNTER_FLEX_COUNTER_GROUP "PG_DROP_STAT_COUNTER"
 
 typedef std::vector<sai_uint32_t> PortSupportedSpeeds;
+typedef std::set<std::string> PortSupportedFecModes;
 
 static const map<sai_port_oper_status_t, string> oper_status_strings =
 {
@@ -208,6 +209,7 @@ private:
     unique_ptr<Table> m_gbcounterTable;
 
     std::map<sai_object_id_t, PortSupportedSpeeds> m_portSupportedSpeeds;
+    std::map<sai_object_id_t, PortSupportedFecModes> m_portSupportedFecModes;
 
     bool m_initDone = false;
     Port m_cpuPort;
@@ -304,7 +306,7 @@ private:
     bool setPortTpid(sai_object_id_t id, sai_uint16_t tpid);
     bool setPortPvid (Port &port, sai_uint32_t pvid);
     bool getPortPvid(Port &port, sai_uint32_t &pvid);
-    bool setPortFec(Port &port, sai_port_fec_mode_t mode);
+    bool setPortFec(Port &port, std::string &mode);
     bool setPortPfcAsym(Port &port, string pfc_asym);
     bool getDestPortId(sai_object_id_t src_port_id, dest_port_type_t port_type, sai_object_id_t &des_port_id);
 
@@ -313,6 +315,8 @@ private:
     bool isSpeedSupported(const std::string& alias, sai_object_id_t port_id, sai_uint32_t speed);
     void getPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id, PortSupportedSpeeds &supported_speeds);
     void initPortSupportedSpeeds(const std::string& alias, sai_object_id_t port_id);
+    void getPortSupportedFecModes(const std::string& alias, sai_object_id_t port_id, PortSupportedFecModes &supported_fecmodes);
+    void initPortSupportedFecModes(const std::string& alias, sai_object_id_t port_id);
     task_process_status setPortSpeed(Port &port, sai_uint32_t speed);
     bool getPortSpeed(sai_object_id_t id, sai_uint32_t &speed);
     bool setGearboxPortsAttr(Port &port, sai_port_attr_t id, void *value);


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Expose supported FEC modes to `STATE_DB.PORT_TABLE|<port>.supported_fecs`.
The orchagent calls `get_port_attribute` to get attribute `SAI_PORT_ATTR_SUPPORTED_FEC_MODE` during initialization and then records it into internal data.
   - By default, the supported FEC modes will be returned by SAI and exposed to `STATE_DB`. Eg. `rs,none` means only `rs` and `none` is supported on the port.
     - The orchagent will check whether the FEC mode is supported on the port before calling the SAI API to set it.
     - The CLI will check whether the FEC mode is in `supported_fecs` before setting FEC mode on a port to the `CONFIG_DB`
   - In case the SAI API does not support any FEC mode on the port, `N/A` will be exposed to `STATE_DB`
     - The orchagent will deny any FEC setting and prints log.
     - The CLI will deny FEC setting.
   - In case the SAI API `get_port_attribute` returns `Not implemented`
     - No check will be performed before setting a FEC mode to SAI on the port.
     - The CLI will check whether the FEC mode is defined before setting it to `CONFIG_DB`.

**Why I did it**
It is not supported to set FEC mode on some platforms. To avoid error, we need to expose the supported FEC list.

**How I verified it**
Manually test and mock test.

**Details if related**
