### PR TITLE
[intfmgr]: Set proxy_arp kernel param

### DIFF
--- a/cfgmgr/intfmgr.cpp
+++ b/cfgmgr/intfmgr.cpp
@@ -566,15 +566,15 @@ bool IntfMgr::setIntfProxyArp(const string &alias, const string &proxy_arp)
 {
     stringstream cmd;
     string res;
-    string proxy_arp_pvlan;
+    string proxy_arp_status;
 
     if (proxy_arp == "enabled")
     {
-        proxy_arp_pvlan = "1";
+        proxy_arp_status = "1";
     }
     else if (proxy_arp == "disabled")
     {
-        proxy_arp_pvlan = "0";
+        proxy_arp_status = "0";
     }
     else
     {
@@ -582,7 +582,13 @@ bool IntfMgr::setIntfProxyArp(const string &alias, const string &proxy_arp)
         return false;
     }
 
-    cmd << ECHO_CMD << " " << proxy_arp_pvlan << " > /proc/sys/net/ipv4/conf/" << alias << "/proxy_arp_pvlan";
+    cmd << ECHO_CMD << " " << proxy_arp_status << " > /proc/sys/net/ipv4/conf/" << alias << "/proxy_arp_pvlan";
+    EXEC_WITH_ERROR_THROW(cmd.str(), res);
+
+    cmd.clear();
+    cmd.str(std::string());
+
+    cmd << ECHO_CMD << " " << proxy_arp_status << " > /proc/sys/net/ipv4/conf/" << alias << "/proxy_arp";
     EXEC_WITH_ERROR_THROW(cmd.str(), res);
 
     SWSS_LOG_INFO("Proxy ARP set to \"%s\" on interface \"%s\"", proxy_arp.c_str(), alias.c_str());


### PR DESCRIPTION
Signed-off-by: Lawrence Lee <lawlee@microsoft.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When proxy_arp is enabled for a VLAN interface in config DB, set the `proxy_arp` kernel parameter in addtion to the `proxy_arp_pvlan` parameter which is already set

**Why I did it**
If an ARP request target IP has a kernel route that does not point to a VLAN member, setting only `proxy_arp_pvlan` is insufficient to enable proxy ARP functionality.

**How I verified it**

**Details if related**
