### PR TITLE
[orchagent]: srv6orch support for uSID

### DIFF
--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -20,6 +20,38 @@ extern sai_next_hop_api_t* sai_next_hop_api;
 extern RouteOrch *gRouteOrch;
 extern CrmOrch *gCrmOrch;
 
+const map<string, sai_my_sid_entry_endpoint_behavior_t> end_behavior_map =
+{
+    {"end",                SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_E},
+    {"end.x",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_X},
+    {"end.t",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_T},
+    {"end.dx6",            SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6},
+    {"end.dx4",            SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4},
+    {"end.dt4",            SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4},
+    {"end.dt6",            SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6},
+    {"end.dt46",           SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46},
+    {"end.b6.encaps",      SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS},
+    {"end.b6.encaps.red",  SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS_RED},
+    {"end.b6.insert",      SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT},
+    {"end.b6.insert.red",  SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT_RED},
+    {"udx6",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6},
+    {"udx4",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4},
+    {"udt6",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6},
+    {"udt4",               SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4},
+    {"udt46",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46},
+    {"un",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN},
+    {"ua",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA}
+};
+
+const map<string, sai_my_sid_entry_endpoint_behavior_flavor_t> end_flavor_map =
+{
+    {"end",                SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"end.x",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"end.t",              SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"un",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD},
+    {"ua",                 SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD}
+};
+
 void Srv6Orch::srv6TunnelUpdateNexthops(const string srv6_source, const NextHopKey nhkey, bool insert)
 {
     if (insert)
@@ -372,92 +404,18 @@ bool Srv6Orch::mySidExists(string my_sid_string)
 bool Srv6Orch::sidEntryEndpointBehavior(string action, sai_my_sid_entry_endpoint_behavior_t &end_behavior,
                                         sai_my_sid_entry_endpoint_behavior_flavor_t &end_flavor)
 {
-    if (action == "end")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_E;
-        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
-    }
-    else if (action == "end.x")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_X;
-        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
-    }
-    else if (action == "end.t")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_T;
-        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
-    }
-    else if (action == "end.dx6")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6;
-    }
-    else if (action == "end.dx4")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4;
-    }
-    else if (action == "end.dt4")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4;
-    }
-    else if (action == "end.dt6")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6;
-    }
-    else if (action == "end.dt46")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46;
-    }
-    else if (action == "end.b6.encaps")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS;
-    }
-    else if (action == "end.b6.encaps.red")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_ENCAPS_RED;
-    }
-    else if (action == "end.b6.insert")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT;
-    }
-    else if (action == "end.b6.insert.red")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT_RED;
-    }
-    else if (action == "udx6")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6;
-    }
-    else if (action == "udx4")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4;
-    }
-    else if (action == "udt4")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4;
-    }
-    else if (action == "udt6")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6;
-    }
-    else if (action == "udt46")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46;
-    }
-    else if (action == "un")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN;
-        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
-    }
-    else if (action == "ua")
-    {
-        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA;
-        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
-    }
-    else
+    if (end_behavior_map.find(action) == end_behavior_map.end())
     {
         SWSS_LOG_ERROR("Invalid endpoint behavior function");
         return false;
     }
+    end_behavior = end_behavior_map.at(action);
+
+    if (end_flavor_map.find(action) != end_flavor_map.end())
+    {
+        end_flavor = end_flavor_map.at(action);
+    }
+
     return true;
 }
 

--- a/orchagent/srv6orch.cpp
+++ b/orchagent/srv6orch.cpp
@@ -423,9 +423,39 @@ bool Srv6Orch::sidEntryEndpointBehavior(string action, sai_my_sid_entry_endpoint
     {
         end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_B6_INSERT_RED;
     }
+    else if (action == "udx6")
+    {
+        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX6;
+    }
+    else if (action == "udx4")
+    {
+        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DX4;
+    }
+    else if (action == "udt4")
+    {
+        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT4;
+    }
+    else if (action == "udt6")
+    {
+        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT6;
+    }
+    else if (action == "udt46")
+    {
+        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46;
+    }
+    else if (action == "un")
+    {
+        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN;
+        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
+    }
+    else if (action == "ua")
+    {
+        end_behavior = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UA;
+        end_flavor = SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD;
+    }
     else
     {
-        SWSS_LOG_ERROR("Invalid endpoing behavior function");
+        SWSS_LOG_ERROR("Invalid endpoint behavior function");
         return false;
     }
     return true;

--- a/tests/test_srv6.py
+++ b/tests/test_srv6.py
@@ -56,6 +56,7 @@ class TestSrv6Mysid(object):
         # create MySID entries
         mysid1='16:8:8:8:baba:2001:10::'
         mysid2='16:8:8:8:baba:2001:20::'
+        mysid3='16:8:8:8:fcbb:bb01:800::'
 
         # create MySID END
         fvs = swsscommon.FieldValuePairs([('action', 'end')])
@@ -90,13 +91,29 @@ class TestSrv6Mysid(object):
             elif fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
                 assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_DT46"
 
+        # create MySID uN
+        fvs = swsscommon.FieldValuePairs([('action', 'un')])
+        key = self.create_mysid(mysid3, fvs)
+
+        # check ASIC MySID database
+        mysid = json.loads(key)
+        assert mysid["sid"] == "fcbb:bb01:800::"
+        tbl = swsscommon.Table(self.adb.db_connection, "ASIC_STATE:SAI_OBJECT_TYPE_MY_SID_ENTRY")
+        (status, fvs) = tbl.get(key)
+        assert status == True
+        for fv in fvs:
+            if fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR":
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_UN"
+            elif fv[0] == "SAI_MY_SID_ENTRY_ATTR_ENDPOINT_BEHAVIOR_FLAVOR":
+                assert fv[1] == "SAI_MY_SID_ENTRY_ENDPOINT_BEHAVIOR_FLAVOR_PSP_AND_USD"
+
         # delete MySID
         self.remove_mysid(mysid1)
         self.remove_mysid(mysid2)
+        self.remove_mysid(mysid3)
 
         # remove vrf
         self.remove_vrf("VrfDt46")
-
 
 class TestSrv6(object):
     def setup_db(self, dvs):


### PR DESCRIPTION
uSID (microsid) support in swss/orchagent
-	uSID “action” mapping to end-point behavior and end-point behavior-flavor
-	uSID actions: uN, uA, uDX and uDT

Current srv6orch already has appropriate infrastructure in place. Only missing piece, to support uSID, is actions mapping to end-point behavior and behavior-flavor. This commit is to add that. Related SAI support also already is in place.

swss/tests
-	Add a test-case for uSID "action" in test_srv6.py


Signed-off-by: shitanshu.shah@intel.com
