### PR TITLE
[Overlay] Add BGP profile to Vnet routes

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -172,6 +172,28 @@ bool VNetVrfObject::addRoute(IpPrefix& ipPrefix, NextHopGroupKey& nexthops)
     return true;
 }
 
+void VNetVrfObject::addProfile(IpPrefix& ipPrefix, string& profile)
+{
+    profile_[ipPrefix] = profile;
+}
+
+void VNetVrfObject::removeProfile(IpPrefix& ipPrefix)
+{
+    if (profile_.find(ipPrefix) != profile_.end())
+    {
+        profile_.erase(ipPrefix);
+    }
+}
+
+string VNetVrfObject::getProfile(IpPrefix& ipPrefix)
+{
+    if (profile_.find(ipPrefix) != profile_.end())
+    {
+        return profile_[ipPrefix];
+    }
+    return string();
+}
+
 void VNetVrfObject::increaseNextHopRefCount(const nextHop& nh)
 {
     /* Return when there is no next hop (dropped) */
@@ -872,7 +894,7 @@ bool VNetRouteOrch::removeNextHopGroup(const string& vnet, const NextHopGroupKey
 
 template<>
 bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipPrefix,
-                                               NextHopGroupKey& nexthops, string& op,
+                                               NextHopGroupKey& nexthops, string& op, string& profile,
                                                const map<NextHopKey, IpAddress>& monitors)
 {
     SWSS_LOG_ENTER();
@@ -1011,6 +1033,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
                 syncd_nexthop_groups_[vnet][nhg].tunnel_routes.erase(ipPrefix);
             }
             vrf_obj->removeRoute(ipPrefix);
+            vrf_obj->removeProfile(ipPrefix);
         }
 
         syncd_nexthop_groups_[vnet][nexthops].tunnel_routes.insert(ipPrefix);
@@ -1019,7 +1042,12 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         syncd_nexthop_groups_[vnet][nexthops].ref_count++;
         vrf_obj->addRoute(ipPrefix, nexthops);
 
-        postRouteState(vnet, ipPrefix, nexthops);
+        if (!profile.empty())
+        {
+            vrf_obj->addProfile(ipPrefix, profile);
+        }
+
+        postRouteState(vnet, ipPrefix, nexthops, profile);
     }
     else if (op == DEL_COMMAND)
     {
@@ -1071,6 +1099,7 @@ bool VNetRouteOrch::doRouteTask<VNetVrfObject>(const string& vnet, IpPrefix& ipP
         }
 
         vrf_obj->removeRoute(ipPrefix);
+        vrf_obj->removeProfile(ipPrefix);
 
         removeRouteState(vnet, ipPrefix);
     }
@@ -1608,7 +1637,7 @@ void VNetRouteOrch::delEndpointMonitor(const string& vnet, NextHopGroupKey& next
     }
 }
 
-void VNetRouteOrch::postRouteState(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops)
+void VNetRouteOrch::postRouteState(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& profile)
 {
     const string state_db_key = vnet + state_db_key_delimiter + ipPrefix.to_string();
     vector<FieldValueTuple> fvVector;
@@ -1633,7 +1662,7 @@ void VNetRouteOrch::postRouteState(const string& vnet, IpPrefix& ipPrefix, NextH
     {
         if (route_state == "active")
         {
-            addRouteAdvertisement(ipPrefix);
+            addRouteAdvertisement(ipPrefix, profile);
         }
         else
         {
@@ -1649,11 +1678,18 @@ void VNetRouteOrch::removeRouteState(const string& vnet, IpPrefix& ipPrefix)
     removeRouteAdvertisement(ipPrefix);
 }
 
-void VNetRouteOrch::addRouteAdvertisement(IpPrefix& ipPrefix)
+void VNetRouteOrch::addRouteAdvertisement(IpPrefix& ipPrefix, string& profile)
 {
     const string key = ipPrefix.to_string();
     vector<FieldValueTuple> fvs;
-    fvs.push_back(FieldValueTuple("", ""));
+    if (profile.empty())
+    {
+        fvs.push_back(FieldValueTuple("", ""));
+    }
+    else
+    {
+        fvs.push_back(FieldValueTuple("profile", profile));
+    }
     state_vnet_rt_adv_table_->set(key, fvs);
 }
 
@@ -1864,7 +1900,8 @@ void VNetRouteOrch::updateVnetTunnel(const BfdUpdate& update)
         // Post configured in State DB
         for (auto ip_pfx : syncd_nexthop_groups_[vnet][nexthops].tunnel_routes)
         {
-            postRouteState(vnet, ip_pfx, nexthops);
+            string profile = vrf_obj->getProfile(ip_pfx);
+            postRouteState(vnet, ip_pfx, nexthops, profile);
         }
     }
 }
@@ -1877,6 +1914,7 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
     vector<string> mac_list;
     vector<string> vni_list;
     vector<IpAddress> monitor_list;
+    string profile = "";
 
     for (const auto& name: request.getAttrFieldNames())
     {
@@ -1897,6 +1935,10 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
         else if (name == "endpoint_monitor")
         {
             monitor_list = request.getAttrIPList(name);
+        }
+        else if (name == "profile")
+        {
+            profile = request.getAttrString(name);
         }
         else
         {
@@ -1961,7 +2003,7 @@ bool VNetRouteOrch::handleTunnel(const Request& request)
 
     if (vnet_orch_->isVnetExecVrf())
     {
-        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx, nhg, op, monitors);
+        return doRouteTask<VNetVrfObject>(vnet_name, ip_pfx, nhg, op, profile, monitors);
     }
 
     return true;

--- a/orchagent/vnetorch.h
+++ b/orchagent/vnetorch.h
@@ -139,6 +139,7 @@ struct nextHop
 
 typedef std::map<IpPrefix, NextHopGroupKey> TunnelRoutes;
 typedef std::map<IpPrefix, nextHop> RouteMap;
+typedef std::map<IpPrefix, string> ProfileMap;
 
 class VNetVrfObject : public VNetObject
 {
@@ -181,6 +182,10 @@ public:
     bool addRoute(IpPrefix& ipPrefix, nextHop& nh);
     bool removeRoute(IpPrefix& ipPrefix);
 
+    void addProfile(IpPrefix& ipPrefix, string& profile);
+    void removeProfile(IpPrefix& ipPrefix);
+    string getProfile(IpPrefix& ipPrefix);
+
     size_t getRouteCount() const;
     bool getRouteNextHop(IpPrefix& ipPrefix, nextHop& nh);
     bool hasRoute(IpPrefix& ipPrefix);
@@ -201,6 +206,7 @@ private:
 
     TunnelRoutes tunnels_;
     RouteMap routes_;
+    ProfileMap profile_;
 };
 
 typedef std::unique_ptr<VNetObject> VNetObject_T;
@@ -275,6 +281,7 @@ const request_description_t vnet_route_description = {
         { "vni",                    REQ_T_STRING },
         { "mac_address",            REQ_T_STRING },
         { "endpoint_monitor",       REQ_T_IP_LIST },
+        { "profile",                REQ_T_STRING },
     },
     { }
 };
@@ -356,16 +363,16 @@ private:
     void removeBfdSession(const string& vnet, const NextHopKey& endpoint, const IpAddress& ipAddr);
     void setEndpointMonitor(const string& vnet, const map<NextHopKey, IpAddress>& monitors, NextHopGroupKey& nexthops);
     void delEndpointMonitor(const string& vnet, NextHopGroupKey& nexthops);
-    void postRouteState(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops);
+    void postRouteState(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& profile);
     void removeRouteState(const string& vnet, IpPrefix& ipPrefix);
-    void addRouteAdvertisement(IpPrefix& ipPrefix);
+    void addRouteAdvertisement(IpPrefix& ipPrefix, string& profile);
     void removeRouteAdvertisement(IpPrefix& ipPrefix);
 
     void updateVnetTunnel(const BfdUpdate&);
     bool updateTunnelRoute(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& op);
 
     template<typename T>
-    bool doRouteTask(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& op,
+    bool doRouteTask(const string& vnet, IpPrefix& ipPrefix, NextHopGroupKey& nexthops, string& op, string& profile,
                     const std::map<NextHopKey, IpAddress>& monitors=std::map<NextHopKey, IpAddress>());
 
     template<typename T>


### PR DESCRIPTION
**What I did**
Add BGP profile support to Vnet routes

**Why I did it**
If a profile is specified in Vnet routes, it must be reflected in the STATE_DB routes for advertising:

```
HGETALL "ADVERTISE_NETWORK_TABLE|150.62.192.1/32"
1) "profile"
2) "FROM_SLB_ROUTES"
```

**How I verified it**
With VS tests

**Details if related**
