### PR TITLE
Fix qos map test in vs test

### DIFF
--- a/tests/test_qos_map.py
+++ b/tests/test_qos_map.py
@@ -417,9 +417,6 @@ class TestDscpToTcMap(object):
                         dscp_to_tc_map_id = id
                         break
             switch_oid = dvs.getSwitchOid()
-            # Check switch level DSCP_TO_TC_MAP doesn't before PORT_QOS_MAP|global is created
-            fvs = self.asic_db.get_entry(self.ASIC_SWITCH_STR, switch_oid)
-            assert("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP" not in fvs)
 
             # Insert switch level map entry 
             self.port_qos_table.set("global", [("dscp_to_tc_map", "AZURE")])


### PR DESCRIPTION


<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR is to fix `test_qos_map` in vstest.
The test is failing because the entry is created by qos template after PR https://github.com/Azure/sonic-buildimage/pull/11087
```
"PORT_QOS_MAP": {
        "global": {
            "dscp_to_tc_map": "AZURE"
        }
}
```
So we will have the entry initially, and as a result, the assert will fail
```
assert("SAI_SWITCH_ATTR_QOS_DSCP_TO_TC_MAP" not in fvs)
```

This PR fixed the issue by removing the initial assert.

**Why I did it**

Fix https://github.com/Azure/sonic-swss/issues/2342
This PR is to fix `test_qos_map` in vstest.

**How I verified it**
Run vstest. Now all passed.
```
collected 9 items                                                                                                                                                                                     

test_qos_map.py::TestDot1p::test_dot1p_cfg PASSED                                                                                                                                               [ 11%]
test_qos_map.py::TestDot1p::test_port_dot1p PASSED                                                                                                                                              [ 22%]
test_qos_map.py::TestCbf::test_dscp_to_fc PASSED                                                                                                                                                [ 33%]
test_qos_map.py::TestCbf::test_exp_to_fc PASSED                                                                                                                                                 [ 44%]
test_qos_map.py::TestCbf::test_per_port_cbf_binding PASSED                                                                                                                                      [ 55%]
test_qos_map.py::TestMplsTc::test_mpls_tc_cfg PASSED                                                                                                                                            [ 66%]
test_qos_map.py::TestMplsTc::test_port_mpls_tc PASSED                                                                                                                                           [ 77%]
test_qos_map.py::TestDscpToTcMap::test_dscp_to_tc_map_applied_to_switch PASSED                                                                                                                  [ 88%]
test_qos_map.py::test_nonflaky_dummy PASSED           
```
**Details if related**
