### PR TITLE
Create ACL table fails due to incorrect check for supported ACL actions

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -153,7 +153,7 @@ static const acl_capabilities_t defaultAclActionsSupported =
     }
 };
 
-static acl_table_action_list_lookup_t defaultAclActionList = 
+static acl_table_action_list_lookup_t defaultAclActionList =
 {
     {
         // L3
@@ -326,7 +326,7 @@ static acl_table_action_list_lookup_t defaultAclActionList =
 // The match fields for certain ACL table type are not exactly the same between INGRESS and EGRESS.
 // For example, we can only match IN_PORT for PFCWD table type at INGRESS.
 // Hence we need to specify stage particular matching fields in stageMandatoryMatchFields
-static acl_table_match_field_lookup_t stageMandatoryMatchFields = 
+static acl_table_match_field_lookup_t stageMandatoryMatchFields =
 {
     {
         // TABLE_TYPE_PFCWD
@@ -2045,7 +2045,7 @@ bool AclTable::addMandatoryActions()
         // Add the default action list
         for (auto action : defaultAclActionList[type.getName()][stage])
         {
-            if (m_pAclOrch->isAclActionSupported(stage, acl_action))
+            if (m_pAclOrch->isAclActionSupported(stage, action))
             {
                 SWSS_LOG_INFO("Added default action for table type %s stage %s",
                                     type.getName().c_str(),


### PR DESCRIPTION
Create ACL table fails due to incorrect check for supported ACL actions #11235

Fixes https://github.com/Azure/sonic-buildimage/issues/11235

Signed-off-by: rck-innovium <rck@innovium.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed error https://github.com/Azure/sonic-buildimage/issues/11235

**Why I did it**

Egress ACL table creation was failing.

root@sonic-dut:~#config acl add table DATA_EGRESS_IPV4_TEST L3 -s egress

Error:
Jun 23 02:23:09.467384 sonic-dut ERR swss#orchagent: :- validate: Action SAI_ACL_ACTION_TYPE_REDIRECT is not supported on table DATA_EGRESS_IPV4_TEST
Jun 23 02:23:09.467384 sonic-dut ERR swss#orchagent: :- doAclTableTask: Failed to create ACL table DATA_EGRESS_IPV4_TEST, invalid configur

**How I verified it**

root@sonic-dut:~#config acl add table DATA_EGRESS_IPV4_TEST L3 -s egress


Jun 23 20:49:22.050411 sonic-dut INFO caclmgrd[1278536]: ACL change detected for namespace ''
Jun 23 20:49:22.050473 sonic-dut NOTICE swss#orchagent: :- doAclTableTask: Successfully updated existing ACL table DATA_EGRESS_IPV4_TEST
Jun 23 20:49:22.050546 sonic-dut INFO caclmgrd[1278536]: Spawning ACL update thread for namepsace '' ...
Jun 23 20:49:22.551196 sonic-dut INFO caclmgrd[1278536]: ACL config for namespace '' has not changed for 0.5 seconds. Applying updates ...

```
root@sonic-dut:~# show acl table DATA_EGRESS_IPV4_TEST
Name                   Type    Binding      Description            Stage
---------------------  ------  -----------  ---------------------  -------
DATA_EGRESS_IPV4_TEST  L3      Ethernet0    DATA_EGRESS_IPV4_TEST  egress
                               Ethernet8
                               Ethernet16
                               Ethernet24
                               Ethernet32
                               Ethernet40
                               Ethernet48
                               Ethernet56
                               Ethernet64
                               Ethernet72
                               Ethernet80
                               Ethernet88
                               Ethernet96
                               Ethernet104
                               Ethernet112
                               Ethernet120
                               Ethernet128
                               Ethernet136
                               Ethernet144
                               Ethernet152
                               Ethernet160
                               Ethernet168
                               Ethernet176
                               Ethernet184
                               Ethernet192
                               Ethernet200
                               Ethernet208
                               Ethernet216
                               Ethernet224
                               Ethernet232
                               Ethernet240
                               Ethernet248
root@sonic-dut:~#
```
**Details if related**
