### PR TITLE
Fix `mux_acl_rule` adding issue

### DIFF
--- a/orchagent/aclorch.cpp
+++ b/orchagent/aclorch.cpp
@@ -3694,7 +3694,14 @@ bool AclOrch::addAclTable(AclTable &newTable)
             return true;
         }
     }
-
+    // Update matching field according to ACL stage
+    newTable.addStageMandatoryMatchFields();
+    
+    // Add mandatory ACL action if not present
+    // We need to call addMandatoryActions here because addAclTable is directly called in other orchs.
+    // The action_list is already added if the ACL table creation is triggered by CONFIGDD, but calling addMandatoryActions
+    // twice will make no effect
+    newTable.addMandatoryActions();
     if (createBindAclTable(newTable, table_oid))
     {
         m_AclTables[table_oid] = newTable;
@@ -4171,11 +4178,8 @@ void AclOrch::doAclTableTask(Consumer &consumer)
             }
 
             newTable.validateAddType(*tableType);
-
-            newTable.addStageMandatoryMatchFields();
-
+            // Add mandatory ACL action if not present
             newTable.addMandatoryActions();
-
             // validate and create/update ACL Table
             if (bAllAttributesOk && newTable.validate())
             {


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
This PR is to fix the issue of adding `mux_acl_rule` into `IngressTableDrop`.
The error log is
```
 Jun 25 08:02:37.159020 svcstr-7050-acs-4 ERR swss#orchagent: :- validateAclRuleMatch: Match SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS in rule mux_acl_rule is not supported by table IngressTableDrop
``` 
PR #2341 added support for different matching field in different stage (INGRESS/EGRESS). For example, `SAI_ACL_ENTRY_ATTR_FIELD_IN_PORTS ` is only supported at `INGRESS` stage.

However, PR #2341 only handled one path for creating ACL table, that is by CONFIG_DB entry.
There is a case that `addAclTable` is directly called from other `orch`, such as `MuxOrch`.  In that case, the stage dependent matcing field is not added. As a resule, we will see the above error logs.
To address the issue, I moved the call of `addStageMandatoryMatchFields` from `doAclTableTask` to `addAclTable` to ensure `addStageMandatoryMatchFields` is always called.
Please be noted that `addMandatoryActions` is called from both `doAclTableTask` and `addAclTable` to ensure the validation of ACL table is passing.

**Why I did it**
To fix ACL rule issue for mux.

**How I verified it**
1. Verified by running `test_pfcwd`
2. Verified by checking syslog


**Details if related**
