### PR TITLE
[sonic-swss]:modify neigh dump

### DIFF
--- a/fdbsyncd/fdbsyncd.cpp
+++ b/fdbsyncd/fdbsyncd.cpp
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
                 SWSS_LOG_ERROR("Error in RTM_GETLINK dump");
             }
 
-            netlink.dumpRequest(RTM_GETNEIGH);
+            netlink.dumpRequest(RTM_GETNEIGH, AF_BRIDGE);
 
             s.addSelectable(sync.getFdbStateTable());
             s.addSelectable(sync.getMclagRemoteFdbStateTable());


### PR DESCRIPTION
Specify the address family when dump getNeigh netlink

Signed-off-by: inspursdn <inspursdn@github.com>


**What I did**
Specify the address family when dump getNeigh netlink

**Why I did it**
The original code cannot dump getNeigh netlink

**How I verified it**
tested on broadcom 

**Details if related**
https://github.com/Azure/sonic-swss-common/pull/641