### PR TITLE
Fix for System interface for remote asic LAG not getting created if received prior to SYSTEM_LAG creation from Chassis DB

### DIFF
--- a/orchagent/intfsorch.cpp
+++ b/orchagent/intfsorch.cpp
@@ -645,7 +645,7 @@ void IntfsOrch::doTask(Consumer &consumer)
 
         if(table_name == CHASSIS_APP_SYSTEM_INTERFACE_TABLE_NAME)
         {
-            if(!isRemoteSystemPortIntf(alias))
+            if(isLocalSystemPortIntf(alias))
             {
                 //Synced local interface. Skip
                 it = consumer.m_toSync.erase(it);
@@ -1541,6 +1541,22 @@ bool IntfsOrch::isRemoteSystemPortIntf(string alias)
         }
 
         return(port.m_system_port_info.type == SAI_SYSTEM_PORT_TYPE_REMOTE);
+    }
+    //Given alias is system port alias of the local port/LAG
+    return false;
+}
+
+bool IntfsOrch::isLocalSystemPortIntf(string alias)
+{
+    Port port;
+    if(gPortsOrch->getPort(alias, port))
+    {
+        if (port.m_type == Port::LAG)
+        {
+            return(port.m_system_lag_info.switch_id == gVoqMySwitchId);
+        }
+
+        return(port.m_system_port_info.type != SAI_SYSTEM_PORT_TYPE_REMOTE);
     }
     //Given alias is system port alias of the local port/LAG
     return false;

--- a/orchagent/intfsorch.h
+++ b/orchagent/intfsorch.h
@@ -68,6 +68,7 @@ public:
     bool updateSyncdIntfPfx(const string &alias, const IpPrefix &ip_prefix, bool add = true);
 
     bool isRemoteSystemPortIntf(string alias);
+    bool isLocalSystemPortIntf(string alias);
 
 private:
 

--- a/orchagent/neighorch.cpp
+++ b/orchagent/neighorch.cpp
@@ -1203,7 +1203,7 @@ void NeighOrch::doVoqSystemNeighTask(Consumer &consumer)
 
         string alias = key.substr(0, found);
 
-        if(!gIntfsOrch->isRemoteSystemPortIntf(alias))
+        if(gIntfsOrch->isLocalSystemPortIntf(alias))
         {
             //Synced local neighbor. Skip
             it = consumer.m_toSync.erase(it);


### PR DESCRIPTION

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Changed interface and neighbor orch code in orchagent which handle updates from Chassis DB for system interface and remote neighbors. Fixes https://github.com/Azure/sonic-buildimage/issues/11290

**Why I did it**
If an update from the Chassis DB for a system interface or a remote neighbor is received prior to receiving an update for the creation of the SYSTEM LAG or SYSTEM_PORT - the current code incorrectly treats this as an update from the local asic and ignores it. As a result the SYSTEM_INTERFACE or the Remote neighbor is not creating when this specific sequence of updates are received.

This change correctly verifies that an update is from the local asic before ignoring it.

**How I verified it**
Prior to the fix - adding a the system_interface to the Chassis DB before adding the corresponding System LAG would result in the ROUTER_INTERFACE never getting created by SAI. After the fix the ROUTER_INTERFACE is correctly created for this scenario.

The sonic-mgmt supervisor reset tests that were failing prior to this fix - passed after the fix was applied.

**Details if related**
