### PR TITLE
[202012][vnetorch] fix use-after-free in removeBfdSession()

### DIFF
--- a/orchagent/vnetorch.cpp
+++ b/orchagent/vnetorch.cpp
@@ -1579,7 +1579,8 @@ void VNetRouteOrch::delEndpointMonitor(const string& vnet, NextHopGroupKey& next
         if (nexthop_info_[vnet].find(ip) != nexthop_info_[vnet].end()) {
             if (--nexthop_info_[vnet][ip].ref_count == 0)
             {
-                removeBfdSession(vnet, nhk, nexthop_info_[vnet][ip].monitor_addr);
+                IpAddress monitor_addr = nexthop_info_[vnet][ip].monitor_addr;
+                removeBfdSession(vnet, nhk, monitor_addr);
             }
         }
     }


### PR DESCRIPTION
Fixed the following memory usage issue:
* [vnetorch] removeBfdSession(): the monitor_addr is invalid after the "nexthop_info_[vnet].erase(endpoint_addr)"

**What I did**
Cherry-pick of https://github.com/Azure/sonic-swss/pull/2352
Only 1 out of 2 fixes is applicable to 202012
**Why I did it**
To fix memory usage issue
**How I verified it**

**Details if related**
