### PR TITLE
[orchagent]: Enhance initSaiPhyApi

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -359,9 +359,6 @@ sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)
     sai_status_t status;
     char fwPath[PATH_MAX];
     char hwinfo[HWINFO_MAX_SIZE + 1];
-    char hwinfoIntf[IFNAMSIZ + 1];
-    unsigned int hwinfoPhyid;
-    int ret;
 
     SWSS_LOG_ENTER();
 
@@ -377,19 +374,11 @@ sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)
     attr.value.u32 = 0;
     attrs.push_back(attr);
 
-    ret = sscanf(phy->hwinfo.c_str(), "%" STR(IFNAMSIZ) "[^/]/%u", hwinfoIntf, &hwinfoPhyid);
-    if (ret != 2) {
-        SWSS_LOG_ERROR("BOX: hardware info doesn't match the 'interface_name/phyid' "
-                       "format");
-        return SAI_STATUS_FAILURE;
+    if( phy->hwinfo.length() > HWINFO_MAX_SIZE ) {
+       SWSS_LOG_ERROR( "hwinfo string attribute is too long." );
+       return SAI_STATUS_FAILURE;
     }
-
-    if (hwinfoPhyid > std::numeric_limits<uint16_t>::max()) {
-        SWSS_LOG_ERROR("BOX: phyid is bigger than maximum limit");
-        return SAI_STATUS_FAILURE;
-    }
-
-    strcpy(hwinfo, phy->hwinfo.c_str());
+    strncpy(hwinfo, phy->hwinfo.c_str(), HWINFO_MAX_SIZE);
 
     attr.id = SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO;
     attr.value.s8list.count = (uint32_t) phy->hwinfo.length();

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -443,12 +443,17 @@ sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)
 
     attr.id = SAI_SWITCH_ATTR_FIRMWARE_MAJOR_VERSION;
     status = sai_switch_api->get_switch_attribute(phyOid, 1, &attr);
-    if (status == SAI_STATUS_SUCCESS) {
+    if (status == SAI_STATUS_SUCCESS)
+    {
        phy->firmware_major_version = string(attr.value.chardata);
-    } else if( status == SAI_STATUS_NOT_SUPPORTED ) {
-       phy->firmware_major_version = "";
+    }
+    else if ( status == SAI_STATUS_NOT_SUPPORTED )
+    {
+       phy->firmware_major_version = "N/A";
        status = SAI_STATUS_SUCCESS;
-    } else {
+    }
+    else
+    {
         SWSS_LOG_ERROR("BOX: Failed to get firmware major version:%d rtn:%d", phy->phy_id, status);
         return status;
     }

--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -443,15 +443,14 @@ sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)
 
     attr.id = SAI_SWITCH_ATTR_FIRMWARE_MAJOR_VERSION;
     status = sai_switch_api->get_switch_attribute(phyOid, 1, &attr);
-    if (status != SAI_STATUS_SUCCESS)
-    {
+    if (status == SAI_STATUS_SUCCESS) {
+       phy->firmware_major_version = string(attr.value.chardata);
+    } else if( status == SAI_STATUS_NOT_SUPPORTED ) {
+       phy->firmware_major_version = "";
+       status = SAI_STATUS_SUCCESS;
+    } else {
         SWSS_LOG_ERROR("BOX: Failed to get firmware major version:%d rtn:%d", phy->phy_id, status);
         return status;
     }
-    else
-    {
-        phy->firmware_major_version = string(attr.value.chardata);
-    }
-
     return status;
 }


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
- Added support for PHYs that do not have firmware support and would return SAI_STATUS_NOT SUPPORTED when attempting to retrieve SAI_SWITCH_ATTR_FIRMWARE_MAJOR_VERSION
- Removed format check on gearbox_config.json hwinfo string

**Why I did it**
- Some PHYs (e.g. BCM54182) do not have firmware support and will return SAI_STATUS_NOT SUPPORTED when attempting to retrieve SAI_SWITCH_ATTR_FIRMWARE_MAJOR_VERSION. This should not fail initSaiPhyApi.
- SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO is defined to be a string but the exact format is vendor specific. Thus, the current format check in initSaiPhyApi should not be present.

**How I verified it**
Tested on Arista platform with BCM54182 and appropriate PAI driver

**Details if related**
