### PR TITLE
Replace swsssdk with swsscommon

### DIFF
--- a/fpmsyncd/bgp_eoiu_marker.py
+++ b/fpmsyncd/bgp_eoiu_marker.py
@@ -17,7 +17,6 @@ Description: bgp_eoiu_marker.py -- populating bgp eoiu marker flags in stateDB d
 """
 
 import sys
-import swsssdk
 import time
 import syslog
 import traceback
@@ -80,7 +79,7 @@ class BgpStateCheck():
     # Only two families: 'ipv4' and 'ipv6'
     # state is "unknown" / "reached" / "consumed"
     def set_bgp_eoiu_marker(self, family, state):
-        db = swsssdk.SonicV2Connector(host='127.0.0.1')
+        db = swsscommon.SonicV2Connector(host='127.0.0.1')
         db.connect(db.STATE_DB, False)
         key = "BGP_STATE_TABLE|%s|eoiu" % family
         db.set(db.STATE_DB, key, 'state', state)
@@ -90,7 +89,7 @@ class BgpStateCheck():
         return
 
     def clean_bgp_eoiu_marker(self):
-        db = swsssdk.SonicV2Connector(host='127.0.0.1')
+        db = swsscommon.SonicV2Connector(host='127.0.0.1')
         db.connect(db.STATE_DB, False)
         db.delete(db.STATE_DB, "BGP_STATE_TABLE|IPv4|eoiu")
         db.delete(db.STATE_DB, "BGP_STATE_TABLE|IPv6|eoiu")

--- a/neighsyncd/restore_neighbors.py
+++ b/neighsyncd/restore_neighbors.py
@@ -13,7 +13,6 @@ Description: restore_neighbors.py -- restoring neighbor table into kernel during
 """
 
 import sys
-import swsssdk
 import netifaces
 import time
 from pyroute2 import IPRoute, NetlinkError
@@ -117,7 +116,7 @@ def is_intf_up(intf, db):
 #  2, need check interface state twice due to the split map
 
 def read_neigh_table_to_maps():
-    db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    db = swsscommon.SonicV2Connector(host='127.0.0.1')
     db.connect(db.APPL_DB, False)
 
     intf_neigh_map = {}
@@ -207,7 +206,7 @@ def build_arp_ns_pkt(family, smac, src_ip, dst_ip):
 
 # Set the statedb "NEIGH_RESTORE_TABLE|Flags", so neighsyncd can start reconciliation
 def set_statedb_neigh_restore_done():
-    db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    db = swsscommon.SonicV2Connector(host='127.0.0.1')
     db.connect(db.STATE_DB, False)
     db.set(db.STATE_DB, 'NEIGH_RESTORE_TABLE|Flags', 'restored', 'true')
     db.close(db.STATE_DB)
@@ -228,7 +227,7 @@ def restore_update_kernel_neighbors(intf_neigh_map, timeout=DEF_TIME_OUT):
     ipclass = IPRoute()
     start_time = time.monotonic()
     is_intf_up.counter = 0
-    db = swsssdk.SonicV2Connector(host='127.0.0.1')
+    db = swsscommon.SonicV2Connector(host='127.0.0.1')
     db.connect(db.STATE_DB, False)
     while (time.monotonic() - start_time) < timeout:
         for intf, family_neigh_map in list(intf_neigh_map.items()):


### PR DESCRIPTION
**What I did**
Replace py-swsssdk with sonic-swss-common

**Why I did it**
To deprecate py-swsssdk, need replace it from code.

**How I verified it**
Pass all UT.

**Details if related**
