### PR TITLE
[macsecmgr]: Fix cleanup macsec objs if container stop

### DIFF
--- a/cfgmgr/macsecmgrd.cpp
+++ b/cfgmgr/macsecmgrd.cpp
@@ -46,10 +46,10 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
-bool received_sigterm = false;
+static bool received_sigterm = false;
 static struct sigaction old_sigaction;
 
-void sig_handler(int signo)
+static void sig_handler(int signo)
 {
     SWSS_LOG_ENTER();
 

--- a/cfgmgr/macsecmgrd.cpp
+++ b/cfgmgr/macsecmgrd.cpp
@@ -1,4 +1,5 @@
 #include <unistd.h>
+#include <signal.h>
 #include <vector>
 #include <sstream>
 #include <fstream>
@@ -45,6 +46,20 @@ string gResponsePublisherRecordFile;
 /* Global database mutex */
 mutex gDbMutex;
 
+bool received_sigterm = false;
+static struct sigaction old_sigaction;
+
+void sig_handler(int signo)
+{
+    SWSS_LOG_ENTER();
+
+    if (old_sigaction.sa_handler != SIG_IGN && old_sigaction.sa_handler != SIG_DFL) {
+        old_sigaction.sa_handler(signo);
+    }
+
+    received_sigterm = true;
+    return;
+}
 
 int main(int argc, char **argv)
 {
@@ -53,6 +68,15 @@ int main(int argc, char **argv)
     {
         Logger::linkToDbNative("macsecmgrd");
         SWSS_LOG_NOTICE("--- Starting macsecmgrd ---");
+
+        /* Register the signal handler for SIGTERM */
+        struct sigaction sigact = {};
+        sigact.sa_handler = sig_handler;
+        if (sigaction(SIGTERM, &sigact, &old_sigaction))
+        {
+            SWSS_LOG_ERROR("failed to setup SIGTERM action handler");
+            exit(EXIT_FAILURE);
+        }
 
         swss::DBConnector cfgDb("CONFIG_DB", 0);
         swss::DBConnector stateDb("STATE_DB", 0);
@@ -73,7 +97,7 @@ int main(int argc, char **argv)
         }
 
         SWSS_LOG_NOTICE("starting main loop");
-        while (true)
+        while (!received_sigterm)
         {
             Selectable *sel;
             int ret;

--- a/orchagent/macsecorch.cpp
+++ b/orchagent/macsecorch.cpp
@@ -1482,22 +1482,22 @@ bool MACsecOrch::deleteMACsecPort(
 
     bool result = true;
 
-    auto sc = macsec_port.m_egress_scs.begin();
-    while (sc != macsec_port.m_egress_scs.end())
-    {
-        const std::string port_sci = swss::join(':', port_name, MACsecSCI(sc->first));
-        sc ++;
-        if (deleteMACsecSC(port_sci, SAI_MACSEC_DIRECTION_EGRESS) != task_success)
-        {
-            result &= false;
-        }
-    }
-    sc = macsec_port.m_ingress_scs.begin();
+    auto sc = macsec_port.m_ingress_scs.begin();
     while (sc != macsec_port.m_ingress_scs.end())
     {
         const std::string port_sci = swss::join(':', port_name, MACsecSCI(sc->first));
         sc ++;
         if (deleteMACsecSC(port_sci, SAI_MACSEC_DIRECTION_INGRESS) != task_success)
+        {
+            result &= false;
+        }
+    }
+    sc = macsec_port.m_egress_scs.begin();
+    while (sc != macsec_port.m_egress_scs.end())
+    {
+        const std::string port_sci = swss::join(':', port_name, MACsecSCI(sc->first));
+        sc ++;
+        if (deleteMACsecSC(port_sci, SAI_MACSEC_DIRECTION_EGRESS) != task_success)
         {
             result &= false;
         }


### PR DESCRIPTION
Signed-off-by: Ze Gan <ganze718@gmail.com>

<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
1. Introduce SIGTERM handlers in macsecmgrd.
- When the macsecmgrd exit with signal SIGTERM, all existing MACsec objs will clean up.
2. Adjust the cleanup order to follow the wpa_supplicant did (Remove Ingress objs firstly and Egress objs then).

**Why I did it**
When “docker stop”, macsecmgrd need also to cleanup all exiting MACsec objs.

**How I verified it**
Try "sudo config feature state macsec disabled`, the MACsec objs were removed. 
**Details if related**
