### PR TITLE
[vxlan]Fixing L2MC vlan member caching issue

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4779,7 +4779,11 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
         {
             SWSS_LOG_ERROR("Failed to set l2mc flood type combined "
                            " to vlan %hu for unknown unicast flooding", vlan.m_vlan_info.vlan_id);
-            return false;
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+            if (handle_status != task_success)
+            {
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         vlan.m_vlan_info.uuc_flood_type = SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED;
     }
@@ -4794,7 +4798,12 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
         {
             SWSS_LOG_ERROR("Failed to set l2mc flood type combined "
                            " to vlan %hu for broadcast flooding", vlan.m_vlan_info.vlan_id);
-            return false;
+            task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+            if (handle_status != task_success)
+            {
+                m_portList[vlan.m_alias] = vlan;
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         vlan.m_vlan_info.bc_flood_type = SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED;
     }
@@ -4805,7 +4814,12 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to create l2mc flood group");
-            return false;
+            task_process_status handle_status = handleSaiCreateStatus(SAI_API_L2MC_GROUP, status);
+            if (handle_status != task_success)
+            {
+                m_portList[vlan.m_alias] = vlan;
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
 
         if (vlan.m_vlan_info.uuc_flood_type == SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED)
@@ -4819,7 +4833,12 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
                 SWSS_LOG_ERROR("Failed to set l2mc group %" PRIx64
                                " to vlan %hu for unknown unicast flooding",
                                l2mc_group_id, vlan.m_vlan_info.vlan_id);
-                return false;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+                if (handle_status != task_success)
+                {
+                    m_portList[vlan.m_alias] = vlan;
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
         if (vlan.m_vlan_info.bc_flood_type == SAI_VLAN_FLOOD_CONTROL_TYPE_COMBINED)
@@ -4833,7 +4852,12 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
                 SWSS_LOG_ERROR("Failed to set l2mc group %" PRIx64
                                " to vlan %hu for broadcast flooding",
                                l2mc_group_id, vlan.m_vlan_info.vlan_id);
-                return false;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+                if (handle_status != task_success)
+                {
+                    m_portList[vlan.m_alias] = vlan;
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
         }
         vlan.m_vlan_info.l2mc_group_id = l2mc_group_id;
@@ -4873,7 +4897,12 @@ bool PortsOrch::addVlanFloodGroups(Port &vlan, Port &port, string end_point_ip)
     {
         SWSS_LOG_ERROR("Failed to create l2mc group member for adding tunnel %s to vlan %hu",
                        end_point_ip.c_str(), vlan.m_vlan_info.vlan_id);
-        return false;
+        task_process_status handle_status = handleSaiCreateStatus(SAI_API_L2MC_GROUP, status);
+        if (handle_status != task_success)
+        {
+            m_portList[vlan.m_alias] = vlan;
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     vlan.m_vlan_info.l2mc_members[end_point_ip] = l2mc_group_member;
     m_portList[vlan.m_alias] = vlan;
@@ -4900,7 +4929,11 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
     {
         SWSS_LOG_ERROR("Failed to remove end point ip %s from vlan %hu",
                        end_point_ip.c_str(), vlan.m_vlan_info.vlan_id);
-        return false;
+        task_process_status handle_status = handleSaiRemoveStatus(SAI_API_L2MC_GROUP, status);
+        if (handle_status != task_success)
+        {
+            return parseHandleSaiStatusFailure(handle_status);
+        }
     }
     decreaseBridgePortRefCount(port);
     vlan.m_vlan_info.l2mc_members.erase(end_point_ip);
@@ -4920,7 +4953,12 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
                 SWSS_LOG_ERROR("Failed to set null l2mc group "
                                " to vlan %hu for unknown unicast flooding",
                                vlan.m_vlan_info.vlan_id);
-                return false;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+                if (handle_status != task_success)
+                {
+                    m_portList[vlan.m_alias] = vlan;
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
             attr.id = SAI_VLAN_ATTR_UNKNOWN_UNICAST_FLOOD_CONTROL_TYPE;
             attr.value.s32 = SAI_VLAN_FLOOD_CONTROL_TYPE_ALL;
@@ -4930,7 +4968,12 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
                 SWSS_LOG_ERROR("Failed to set flood control type all"
                                " to vlan %hu for unknown unicast flooding",
                                vlan.m_vlan_info.vlan_id);
-                return false;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+                if (handle_status != task_success)
+                {
+                    m_portList[vlan.m_alias] = vlan;
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
             vlan.m_vlan_info.uuc_flood_type = SAI_VLAN_FLOOD_CONTROL_TYPE_ALL;
         }
@@ -4945,7 +4988,12 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
                 SWSS_LOG_ERROR("Failed to set null l2mc group "
                                " to vlan %hu for broadcast flooding",
                                vlan.m_vlan_info.vlan_id);
-                return false;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+                if (handle_status != task_success)
+                {
+                    m_portList[vlan.m_alias] = vlan;
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
             attr.id = SAI_VLAN_ATTR_BROADCAST_FLOOD_CONTROL_TYPE;
             attr.value.s32 = SAI_VLAN_FLOOD_CONTROL_TYPE_ALL;
@@ -4955,7 +5003,12 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
                 SWSS_LOG_ERROR("Failed to set flood control type all"
                                " to vlan %hu for broadcast flooding",
                                vlan.m_vlan_info.vlan_id);
-                return false;
+                task_process_status handle_status = handleSaiSetStatus(SAI_API_VLAN, status);
+                if (handle_status != task_success)
+                {
+                    m_portList[vlan.m_alias] = vlan;
+                    return parseHandleSaiStatusFailure(handle_status);
+                }
             }
             vlan.m_vlan_info.bc_flood_type = SAI_VLAN_FLOOD_CONTROL_TYPE_ALL;
         }
@@ -4963,10 +5016,16 @@ bool PortsOrch::removeVlanEndPointIp(Port &vlan, Port &port, string end_point_ip
         if (status != SAI_STATUS_SUCCESS)
         {
             SWSS_LOG_ERROR("Failed to remove l2mc group %" PRIx64, l2mc_group_id);
-            return false;
+            task_process_status handle_status = handleSaiRemoveStatus(SAI_API_L2MC_GROUP, status);
+            if (handle_status != task_success)
+            {
+                m_portList[vlan.m_alias] = vlan;
+                return parseHandleSaiStatusFailure(handle_status);
+            }
         }
         vlan.m_vlan_info.l2mc_group_id = SAI_NULL_OBJECT_ID;
     }
+    m_portList[vlan.m_alias] = vlan;
     return true;
 }
 

--- a/tests/test_evpn_tunnel_p2mp.py
+++ b/tests/test_evpn_tunnel_p2mp.py
@@ -102,6 +102,17 @@ class TestVxlanOrchP2MP(object):
         vxlan_obj.remove_evpn_remote_vni(dvs, 'Vlan100', '8.8.8.8')
         vxlan_obj.check_vlan_extension_delete_p2mp(dvs, '100', '6.6.6.6', '8.8.8.8')
 
+        print("Testing remote endpoint again to 8.8.8.8")
+        vxlan_obj.create_evpn_remote_vni(dvs, 'Vlan100', '8.8.8.8', '1000')
+        print("Testing remote endpoint creation to 8.8.8.8")
+
+        print("Testing VLAN 100 extension to 8.8.8.8")
+        vxlan_obj.check_vlan_extension_p2mp(dvs, '100', '6.6.6.6', '8.8.8.8')
+
+        print("Testing Last Vlan removal and remote endpoint delete for 8.8.8.8")
+        vxlan_obj.remove_evpn_remote_vni(dvs, 'Vlan100', '8.8.8.8')
+        vxlan_obj.check_vlan_extension_delete_p2mp(dvs, '100', '6.6.6.6', '8.8.8.8')
+
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name, '1000', 'Vlan100')
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_1, '1001', 'Vlan101')
         vxlan_obj.remove_vxlan_tunnel_map(dvs, tunnel_name, map_name_2, '1002', 'Vlan102')


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Fixed caching issue when L2MC member is removed. During the L2MC member removal, the local variables are modified but not updated to cache. Since L2MC removal is not updated in cache, the same member being added again will be skipped as duplicate.


**Why I did it**
To fix the above mentioned issues. Without the fix, the same L2MC member removal and add will not work.


**How I verified it**
Flapped the remote end point and verified if it L2MC member is created again


**Details if related**
