### PR TITLE
Revert hwinfo count change

### DIFF
--- a/orchagent/saihelper.cpp
+++ b/orchagent/saihelper.cpp
@@ -378,11 +378,10 @@ sai_status_t initSaiPhyApi(swss::gearbox_phy_t *phy)
        SWSS_LOG_ERROR( "hwinfo string attribute is too long." );
        return SAI_STATUS_FAILURE;
     }
-    memset(hwinfo, 0, HWINFO_MAX_SIZE + 1);
     strncpy(hwinfo, phy->hwinfo.c_str(), phy->hwinfo.length());
 
     attr.id = SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO;
-    attr.value.s8list.count = (uint32_t) phy->hwinfo.length() + 1;
+    attr.value.s8list.count = (uint32_t) phy->hwinfo.length();
     attr.value.s8list.list = (int8_t *) hwinfo;
     attrs.push_back(attr);
 


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Revert change from https://github.com/Azure/sonic-swss/pull/2367 which increases count associated with SAI_SWITCH_ATTR_SWITCH_HARDWARE_INFO by 1, as well as the memset.

**Why I did it**
Original intention of this change was to accommodate sairedis behaviour when copying null-terminated string; original behaviour is that the null-terminator would not be copied and so receiver of the hwinfo (PAI) would see non-null terminated string.

Reverting this change so that old behaviour is maintained and PAI driver is responsible for not relying on string to be null terminated.

**How I verified it**

**Details if related**
